### PR TITLE
Feature: Simplify routing for namespaces and users

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -52,6 +52,10 @@ class Namespace < ApplicationRecord
     result
   end
 
+  def to_param
+    full_path
+  end
+
   def human_name
     full_name
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
   before_validation :ensure_namespace
   before_save :ensure_namespace
 
+  delegate :full_path, to: :namespace
+
   # rubocop:disable Metrics/MethodLength
   def update_password_with_password(params)
     current_password = params.delete(:current_password)
@@ -34,6 +36,10 @@ class User < ApplicationRecord
     result
   end
   # rubocop:enable Metrics/MethodLength
+
+  def to_param
+    full_path
+  end
 
   private
 

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -9,7 +9,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:john_doe)
 
     group = groups(:group_one)
-    get group_path(group.full_path)
+    get group_path(group)
     assert_response :success
   end
 
@@ -17,7 +17,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:john_doe)
 
     subgroup = groups(:subgroup1)
-    get group_path(subgroup.full_path)
+    get group_path(subgroup)
     assert_response :success
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -8,7 +8,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   test 'should show the user' do
     sign_in users(:john_doe)
 
-    get user_path(users(:john_doe).namespace.full_path)
+    get user_path(users(:john_doe))
     assert_response :success
   end
 end


### PR DESCRIPTION
Added in `to_param` to namespaces and users. This will allow us to call `group_path(@group)` instead of `group_path(@group.full_path)` since we are not using numeric ids in the paths.