### PR TITLE
Fix: Project routes which broke tests

### DIFF
--- a/config/routes/project.rb
+++ b/config/routes/project.rb
@@ -7,7 +7,7 @@ constraints(::Constraints::ProjectUrlConstrainer.new) do
         module: :projects,
         as: :namespace_project) do
     get '/', action: :show
-    post '/', action: :update
+    patch '/', action: :update
     put '/', action: :update
 
     # Begin on /-/ scope.


### PR DESCRIPTION
For some reason Project routes were failing in main when no Projects existed in the database. I submitted a few commits to main to fix this, but forgot that doing so would break the tests. This PR fixes the routes so they work regardless of database state and fixes the tests.