### PR TITLE
Internal: Set up htmlbeautifier for formatting erb files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "shopify.ruby-lsp",
         "koichisasada.vscode-rdbg",
         "connorshea.vscode-ruby-test-adapter",
-        "hbenl.vscode-test-explorer"
+        "hbenl.vscode-test-explorer",
+        "aliariff.vscode-erb-beautify"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,11 @@
   "files.insertFinalNewline": true,
   "editor.rulers": [
     120
-  ]
+  ],
+  "[erb]": {
+    "editor.defaultFormatter": "aliariff.vscode-erb-beautify",
+  },
+  "files.associations": {
+    "*.html.erb": "erb"
+  }
 }

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
+  gem 'htmlbeautifier'
   gem 'web-console'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       websocket-driver (>= 0.6, < 0.8)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    htmlbeautifier (1.4.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -278,6 +279,7 @@ DEPENDENCIES
   cuprite
   debug
   devise
+  htmlbeautifier
   importmap-rails
   jbuilder
   pg

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -7,19 +7,16 @@
       </h2>
       <div data-controller="groups-new">
         <%= form_with(model: @group, url: group_path(@group), method: :patch) do |form| %>
-
           <%= render partial: 'form_fields', locals: {
             form: form,
             group: @group,
           } %>
-
           <div class="my-2">
             <%= form.submit t(:'groups.edit.details.submit'), class: "btn btn-primary" %>
           </div>
         <% end %>
       </div>
     </div>
-
     <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm 2xl:col-span-2 dark:border-gray-700 sm:p-6 dark:bg-gray-800">
       <div id="settings-accordion" data-accordion="collapse">
         <h2 id="settings-delete-heading" class="text-xl font-semibold leading-tight text-gray-900 dark:text-white flex justify-between items-center">
@@ -28,7 +25,6 @@
             <svg data-accordion-icon xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75l3 3m0 0l3-3m-3 3v-7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-
           </button>
         </h2>
         <div id="accordion-collapse-body-1" class="hidden pt-4" aria-labelledby="settings-delete-heading">

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -7,12 +7,10 @@
   <div class="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
     <div data-controller="groups-new" class="card">
       <%= form_with(model: @new_group, url: groups_path, method: :post) do |form| %>
-
         <%= render partial: 'form_fields', locals: {
           form: form,
           group: @new_group
         } %>
-
         <div class="my-2">
           <%= form.submit t(:'groups.create.submit'), class: "btn btn-primary mr-1" %>
           <%= link_to t(:'groups.create.cancel'), groups_path, class: "btn btn-default" %>


### PR DESCRIPTION
Add in `.vscode` folder with recommended extensions, settings for using `htmlbeautifier` as the default formatter for erb files.