### PR TITLE
Internal: Remove ruby-lsp from Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,14 +37,15 @@
 /public/packs
 /public/packs-test
 /node_modules
-/yarn-error.log
-yarn-debug.log*
-.yarn-integrity
 coverage
 
+# Ignore IDE folders
 *.code-workspace
 .vscode
 .idea
+
+# Ignore Ruby LSP folder
+.ruby-lsp
 
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -75,8 +75,6 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-
-  gem 'ruby-lsp', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,6 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
-    language_server-protocol (3.17.0.3)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -155,7 +154,6 @@ GEM
     parser (3.2.1.0)
       ast (~> 2.4.1)
     pg (1.4.6)
-    prettier_print (1.2.1)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -214,10 +212,6 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    ruby-lsp (0.4.2)
-      language_server-protocol (~> 3.17.0)
-      sorbet-runtime
-      syntax_tree (>= 6.0.2, < 7)
     ruby-progressbar (1.11.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -225,7 +219,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet-runtime (0.5.10731)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -235,8 +228,6 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
-    syntax_tree (6.1.1)
-      prettier_print (>= 1.2.0)
     tailwindcss-rails (2.0.22-arm64-darwin)
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.22-x86_64-darwin)
@@ -289,7 +280,6 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.2)
   rubocop
   rubocop-rails
-  ruby-lsp
   simplecov
   sprockets-rails
   stimulus-rails


### PR DESCRIPTION
No longer required by vscode-ruby-lsp extension, it will auto install locally in `.ruby-lsp` folder.