### PR TITLE
Docker: Add Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ USER rails:rails
 ARG DATABASE_URL
 ARG SECRET_KEY_BASE
 
+ENTRYPOINT [ "bin/docker-entrypoint.sh" ]
+
 # Start Server
 EXPOSE 3000
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-run_pending_migrations=${RUN_PENDING_MIGRATIONS:-false}
+run_pending_migrations="${RUN_PENDING_MIGRATIONS:-false}"
 # run any pending migrations if RUN_PENDING_MIGRATIONS=true
-if ( $run_pending_migrations = "true" ); then
+if [[ $run_pending_migrations = "true" || $run_pending_migrations = "True" || $run_pending_migrations = "1" ]]; then
     echo "Running pending migrations"
     bin/rails db:migrate
 fi

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+run_pending_migrations=${RUN_PENDING_MIGRATIONS:-false}
+# run any pending migrations if RUN_PENDING_MIGRATIONS=true
+if ( $run_pending_migrations = "true" ); then
+    echo "Running pending migrations"
+    bin/rails db:migrate
+fi
+
+# Exec the container's main process (what's set as CMD in the Dockerfile)
+exec "$@"


### PR DESCRIPTION
Adds in `bin/entrypoint.sh` that accepts an env variable `RUN_PENDING_MIGRATIONS` that when set to `true`, `True`, or `1` it runs `bin/rails db:migrate` before running normal docker command.