### PR TITLE
Internal: Namespace Traversal Updates

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,7 +7,7 @@ class GroupsController < ApplicationController
   before_action :context_crumbs, except: %i[index new create show]
 
   def index
-    @groups = Group.all.include_route
+    @groups = current_user.groups.self_and_descendants.include_route
   end
 
   def show

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,7 @@ class ProjectsController < ApplicationController # rubocop:disable Metrics/Class
   before_action :project, only: %i[show edit update activity transfer destroy]
   before_action :context_crumbs, except: %i[index new create show]
   def index
-    @pagy, @projects = pagy(Project.where(namespace: { parent: User.first.groups.self_and_descendants.select(:id) }).include_route.order(updated_at: :desc))
+    @pagy, @projects = pagy(projects.order(updated_at: :desc))
 
     respond_to do |format|
       format.html
@@ -105,6 +105,10 @@ class ProjectsController < ApplicationController # rubocop:disable Metrics/Class
 
     path = [params[:namespace_id], params[:project_id]].join('/')
     @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
+  end
+
+  def projects
+    Project.where(namespace: { parent: current_user.groups.self_and_descendant_ids }).include_route
   end
 
   def resolve_layout

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -108,7 +108,8 @@ class ProjectsController < ApplicationController # rubocop:disable Metrics/Class
   end
 
   def projects
-    Project.where(namespace: { parent: current_user.groups.self_and_descendant_ids }).include_route
+    Project.where(namespace: { parent: current_user.groups.self_and_descendant_ids })
+           .or(Project.where(namespace: { parent: current_user.namespace })).include_route
   end
 
   def resolve_layout

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,7 @@ class ProjectsController < ApplicationController # rubocop:disable Metrics/Class
   before_action :project, only: %i[show edit update activity transfer destroy]
   before_action :context_crumbs, except: %i[index new create show]
   def index
-    @pagy, @projects = pagy(Project.all.include_route.order(updated_at: :desc))
+    @pagy, @projects = pagy(Project.where(namespace: { parent: User.first.groups.self_and_descendants.select(:id) }).include_route.order(updated_at: :desc))
 
     respond_to do |format|
       format.html

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -54,15 +54,20 @@ class Member < ApplicationRecord
 
   # Find the user's group member with a highest access level
   def highest_group_member
-    Member.where(namespace: namespace.ancestors, user_id:).order(:access_level).last
+    if namespace.project_namespace?
+      Member.where(namespace_id: namespace.parent.self_and_ancestor_ids, user_id:).order(:access_level).last
+    else
+      Member.where(namespace_id: namespace.ancestor_ids, user_id:).order(:access_level).last
+    end
   end
 
   # Method to ensure we don't leave a group or project without an owner
   def last_namespace_owner_member
     return if destroyed_by_association
     return if access_level != Member::AccessLevel::OWNER
-    return if Member.where(namespace: namespace.self_and_ancestors,
-                           access_level: Member::AccessLevel::OWNER).many?
+    return if Member.where(namespace:, access_level: Member::AccessLevel::OWNER).many?
+    return if Member.where(namespace: namespace.parent&.self_and_ancestor_ids,
+                           access_level: Member::AccessLevel::OWNER).any?
 
     errors.add(:base,
                I18n.t('activerecord.errors.models.member.destroy.last_member',

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -68,7 +68,6 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
                           .to_sql
 
       unscoped
-        .distinct
         .joins(:route)
         .where(Arel.sql(format('routes.path similar to (%s)', fuzzy_path_select)))
     end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -127,6 +127,10 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.class.joins(:route).where(route_path.matches_any([full_path, "#{full_path}/%"]))
   end
 
+  def self_and_descendant_ids
+    self_and_descendants.as_ids
+  end
+
   def to_param
     full_path
   end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -49,8 +49,11 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
       select(Arel.sql('namespaces.id'))
     end
 
-    def self_and_ancestors
+    def self_and_ancestors # rubocop:disable Metrics/AbcSize
       self_paths = joins(:route).pluck('routes.path')
+
+      return none if self_paths.empty?
+
       ancestral_paths = []
       self_paths.each do |path|
         path.split('/').each_with_index do |_part, index|
@@ -70,6 +73,9 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     def self_and_descendants
       self_paths = joins(:route).pluck('routes.path')
+
+      return none if self_paths.empty?
+
       fuzzy_paths = self_paths.map { |path| "#{path}/%" }
 
       paths = self_paths | fuzzy_paths

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -61,27 +61,6 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
         .where(Arel.sql(format('routes.id in (%s)', route_id_select)))
     end
 
-    def self_and_ancestors_old
-      self_paths = joins(:route).pluck('routes.path')
-
-      return none if self_paths.empty?
-
-      ancestral_paths = []
-      self_paths.each do |path|
-        path.split('/').each_with_index do |_part, index|
-          ancestral_paths << path.split('/')[0..index].join('/')
-        end
-      end
-
-      paths = self_paths | ancestral_paths
-
-      route_path = Route.arel_table[:path]
-
-      unscoped
-        .joins(:route)
-        .where(route_path.in(paths))
-    end
-
     def self_and_descendants
       # build sql expression to construct a fuzzy_path string for querying self and descendants by path
       fuzzy_path_select = joins(:route)

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -81,6 +81,10 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
         .joins(:route)
         .where(route_path.matches_any(paths))
     end
+
+    def self_and_descendant_ids
+      self_and_descendants.as_ids
+    end
   end
 
   def ancestors

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,10 @@ class User < ApplicationRecord
 
   has_many :personal_access_tokens, dependent: :destroy
 
+  # Groups
+  has_many :members, dependent: :destroy
+  has_many :groups, through: :members
+
   before_validation :ensure_namespace
   before_save :ensure_namespace
 

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -30,7 +30,10 @@ class BaseService
 
   def namespace_owners_include_user?(namespace)
     Member.exists?(
-      namespace: namespace.self_and_ancestors, user: current_user,
+      namespace:, user: current_user,
+      access_level: Member::AccessLevel::OWNER
+    ) || Member.exists?(
+      namespace: namespace.parent&.self_and_ancestor_ids, user: current_user,
       access_level: Member::AccessLevel::OWNER
     )
   end

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -41,7 +41,7 @@ group_three:
 
 subgroup_one_group_three:
   name: Subgroup 1 Group 3
-  path: subgorup-1-group-3
+  path: subgroup-1-group-3
   type: Group
   description: Subgroup 1 Group 3
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -30,6 +30,12 @@ group_two_member_john_doe:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_two) %>
   access_level: <%= Member::AccessLevel::OWNER %>
 
+group_three_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_three) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
 group_three_member_michelle_doe:
   user_id: <%= ActiveRecord::FixtureSet.identify(:michelle_doe) %>
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -25,12 +25,12 @@ class GroupTest < ActiveSupport::TestCase
     assert_not_nil @subgroup.errors[:parent_id], 'no validation error for parent'
   end
 
-  test '#ancestor_ids' do
-    assert_equal [@group.id], @subgroup_one.ancestor_ids
-  end
-
   test '#ancestors' do
     assert_equal [@group], @subgroup_one.ancestors
+  end
+
+  test '#ancestor_ids' do
+    assert_equal [@group.id], @subgroup_one.ancestor_ids.pluck(:id)
   end
 
   test '#self_and_ancestors' do
@@ -39,23 +39,15 @@ class GroupTest < ActiveSupport::TestCase
     assert_equal 2, @subgroup_one.self_and_ancestors.count
   end
 
-  test '#descendant_ids' do
-    assert_includes @group_three.descendant_ids, groups(:subgroup_one_group_three).id
-    assert_includes @group_three.descendant_ids, namespaces_project_namespaces(:project4_namespace).id
-    assert_equal 2, @group_three.descendant_ids.count
-  end
-
   test '#descendants' do
     assert_includes @group_three.descendants, groups(:subgroup_one_group_three)
-    assert_includes @group_three.descendants, namespaces_project_namespaces(:project4_namespace)
-    assert_equal 2, @group_three.descendants.count
+    assert_equal 1, @group_three.descendants.count
   end
 
   test '#self_and_descendants' do
     assert_includes @group_three.self_and_descendants, @group_three
     assert_includes @group_three.self_and_descendants, groups(:subgroup_one_group_three)
-    assert_includes @group_three.self_and_descendants, namespaces_project_namespaces(:project4_namespace)
-    assert_equal 3, @group_three.self_and_descendants.count
+    assert_equal 2, @group_three.self_and_descendants.count
   end
 
   test '#human_name' do

--- a/test/models/namespace_test.rb
+++ b/test/models/namespace_test.rb
@@ -8,4 +8,21 @@ class NamespaceTest < ActiveSupport::TestCase
     assert_not namespace.valid?, 'namespace is valid without a type'
     assert_not_nil namespace.errors[:type], 'no validation error for type present'
   end
+
+  test '#self_and_ancestors when collection is empty' do
+    assert_equal [], Namespace.none.self_and_ancestors
+  end
+
+  test '#self_and_ancestors when collection is non empty' do
+    assert_equal [groups(:group_one)], Group.where(id: groups(:group_one).id).self_and_ancestors
+  end
+
+  test '#self_and_decendants when collection is empty' do
+    assert_equal [], Namespace.none.self_and_descendants
+  end
+
+  test '#self_and_descendants when collection is non empty' do
+    assert_equal [groups(:group_three), groups(:subgroup_one_group_three)],
+                 Group.where(id: groups(:group_three).id).self_and_descendants
+  end
 end

--- a/test/models/namespaces/project_namespace_test.rb
+++ b/test/models/namespaces/project_namespace_test.rb
@@ -12,20 +12,16 @@ class ProjectNamespaceTest < ActiveSupport::TestCase
     assert @project_namespace.valid?
   end
 
-  test '#ancestor_ids' do
-    assert_equal [@group_one.id], @project_namespace.ancestor_ids
+  test '#ancestors' do
+    assert_equal [], @project_namespace.ancestors
   end
 
-  test '#ancestors' do
-    assert_equal [@group_one], @project_namespace.ancestors
+  test '#ancestor_ids' do
+    assert_equal [], @project_namespace.ancestor_ids
   end
 
   test '#self_and_ancestors' do
-    assert_equal [@project_namespace, @group_one], @project_namespace.self_and_ancestors
-  end
-
-  test '#descendant_ids' do
-    assert_equal [],  @project_namespace.descendant_ids
+    assert_equal [@project_namespace], @project_namespace.self_and_ancestors
   end
 
   test '#descendants' do

--- a/test/models/namespaces/user_namespace_test.rb
+++ b/test/models/namespaces/user_namespace_test.rb
@@ -11,41 +11,24 @@ class UserNamespaceTest < ActiveSupport::TestCase
     assert @user_namespace.valid?
   end
 
-  test '#ancestor_ids' do
-    assert_equal [], @user_namespace.ancestor_ids
-  end
-
   test '#ancestors' do
     assert_equal [], @user_namespace.ancestors
+  end
+
+  test '#ancestor_ids' do
+    assert_equal [], @user_namespace.ancestor_ids
   end
 
   test '#self_and_ancestors' do
     assert_equal [@user_namespace], @user_namespace.self_and_ancestors
   end
 
-  test '#descendant_ids' do
-    assert_equal [
-      namespaces_project_namespaces(:john_doe_project2_namespace).id,
-      namespaces_project_namespaces(:john_doe_project3_namespace).id
-    ],
-                 @user_namespace.descendant_ids
-  end
-
   test '#descendants' do
-    assert_equal [
-      namespaces_project_namespaces(:john_doe_project2_namespace),
-      namespaces_project_namespaces(:john_doe_project3_namespace)
-    ],
-                 @user_namespace.descendants
+    assert_equal [], @user_namespace.descendants
   end
 
   test '#self_and_descendants' do
-    assert_equal [
-      @user_namespace,
-      namespaces_project_namespaces(:john_doe_project2_namespace),
-      namespaces_project_namespaces(:john_doe_project3_namespace)
-    ],
-                 @user_namespace.self_and_descendants
+    assert_equal [@user_namespace], @user_namespace.self_and_descendants
   end
 
   test '#human_name' do

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -4,14 +4,16 @@ require 'application_system_test_case'
 
 class GroupsTest < ApplicationSystemTestCase
   def setup
-    login_as users(:john_doe)
+    @user = users(:john_doe)
+    @groups_count = @user.groups.self_and_descendant_ids.count
+    login_as @user
   end
 
   test 'can see the list of groups' do
     visit groups_url
 
     assert_selector 'h1', text: I18n.t(:'groups.show.title')
-    assert_selector 'tr', count: groups.count
+    assert_selector 'tr', count: @groups_count
     assert_text groups(:group_one).name
     assert_text groups(:subgroup1).name
   end
@@ -102,6 +104,6 @@ class GroupsTest < ApplicationSystemTestCase
     end
 
     assert_selector 'h1', text: I18n.t(:'groups.show.title')
-    assert_selector 'tr', count: groups.count - 1
+    assert_selector 'tr', count: @groups_count - 1
   end
 end

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -17,7 +17,7 @@ class ProjectsTest < ApplicationSystemTestCase
     assert_no_selector 'a', text: I18n.t(:'components.pagination.previous')
 
     click_on I18n.t(:'components.pagination.next')
-    assert_selector 'tr', count: 1
+    assert_selector 'tr', count: 2
     click_on I18n.t(:'components.pagination.previous')
     assert_selector 'tr', count: 20
 

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -17,7 +17,7 @@ class ProjectsTest < ApplicationSystemTestCase
     assert_no_selector 'a', text: I18n.t(:'components.pagination.previous')
 
     click_on I18n.t(:'components.pagination.next')
-    assert_selector 'tr', count: 2
+    assert_selector 'tr', count: 1
     click_on I18n.t(:'components.pagination.previous')
     assert_selector 'tr', count: 20
 


### PR DESCRIPTION
Updated Namespace instance lineage methods (e.g. `ancestors`, `descendants`, etc) to only return instances of the current class (e.g. `Group` when calling on a `Group` instance, etc).

Added in Namespace class lineage methods, so that we can get all the Namespaces of a specific type that a User has access to.

Updated Groups Index and Projects Index to only show the corresponding models that the current_user has access to through `membership`.