### PR TITLE
Bugfix: Access_level nil error when adding a project member under user namespace

### DIFF
--- a/app/controllers/concerns/membership_actions.rb
+++ b/app/controllers/concerns/membership_actions.rb
@@ -49,14 +49,20 @@ module MembershipActions
 
   private
 
-  def access_levels
+  def access_levels # rubocop:disable Metrics/AbcSize
     if @namespace.parent&.user_namespace? && @namespace.parent.owner == current_user
       @access_levels = Member::AccessLevel.access_level_options_owner
     else
-      member = Member.where(user: current_user,
-                            namespace: @namespace.self_and_ancestors)
-                     .or(Member.where(user: current_user,
-                                      namespace: @namespace.parent&.self_and_ancestors)).order(:access_level).last
+      if @namespace.group_namespace?
+        member = Member.where(user: current_user,
+                              namespace: @namespace.self_and_ancestors).order(:access_level).last
+      else
+        member = Member.where(user: current_user,
+                              namespace: @namespace.self_and_ancestors)
+                       .or(Member.where(user: current_user,
+                                        namespace: @namespace.parent&.self_and_ancestors)).order(:access_level).last
+
+      end
       @access_levels = Member.access_levels(member)
     end
   end

--- a/app/controllers/concerns/membership_actions.rb
+++ b/app/controllers/concerns/membership_actions.rb
@@ -50,8 +50,15 @@ module MembershipActions
   private
 
   def access_levels
-    member = Member.where(user: current_user, namespace: @namespace.self_and_ancestors).order(:access_level).last
-    @access_levels = Member.access_levels(member)
+    if @namespace.parent&.user_namespace? && @namespace.parent.owner == current_user
+      @access_levels = Member::AccessLevel.access_level_options_owner
+    else
+      member = Member.where(user: current_user,
+                            namespace: @namespace.self_and_ancestors)
+                     .or(Member.where(user: current_user,
+                                      namespace: @namespace.parent&.self_and_ancestors)).order(:access_level).last
+      @access_levels = Member.access_levels(member)
+    end
   end
 
   def available_users

--- a/app/views/projects/members/new.html.erb
+++ b/app/views/projects/members/new.html.erb
@@ -53,7 +53,7 @@
             </div>
 
             <div>
-              <%= form.submit t(:".add_member_to_group"),
+              <%= form.submit t(:".add_member_to_project"),
                           class: "btn btn-primary mr-1",
                           disabled: !@available_users.count.positive? %>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,7 +346,7 @@ en:
           member_dropdown_aria_label: "Dropdown options for project member %{member}"
       new:
         title: Add New Member
-        add_member_to_group: Add member to project
+        add_member_to_project: Add member to project
         select_user: Select a User
         select_access_level: Select Access Level
       destroy:

--- a/test/system/projects/members_test.rb
+++ b/test/system/projects/members_test.rb
@@ -29,7 +29,7 @@ module Projects
       find('#member_user_id').find(:xpath, 'option[2]').select_option
       find('#member_access_level').find(:xpath, 'option[5]').select_option
 
-      click_button I18n.t(:'projects.members.new.add_member_to_group')
+      click_button I18n.t(:'projects.members.new.add_member_to_project')
 
       assert_text I18n.t(:'projects.members.create.success')
       assert_selector 'h1', text: I18n.t(:'projects.members.index.title')
@@ -64,6 +64,44 @@ module Projects
                          namespace_type: @project.namespace.class.model_name.human)
       assert_selector 'h1', text: I18n.t(:'projects.members.index.title')
       assert_selector 'tr', count: @members_count
+    end
+
+    test 'can create a project under namespace and add a new member to project' do
+      project_name = 'New Project'
+      project_description = 'New Project Description'
+
+      visit projects_url
+
+      click_on I18n.t(:'projects.index.create_project_button')
+
+      assert_selector 'h1', text: I18n.t(:'projects.new.title')
+
+      within %(div[data-controller="slugify"][data-controller-connected="true"]) do
+        fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.name'), with: project_name
+        assert_selector %(input[data-slugify-target="path"]) do |input|
+          assert_equal 'new-project', input['value']
+        end
+        fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.description'), with: project_description
+        click_on I18n.t(:'projects.new.submit')
+      end
+
+      assert_selector 'h1', text: project_name
+      assert_text project_description
+
+      click_link 'Members'
+
+      click_link I18n.t(:'projects.members.index.add')
+
+      assert_selector 'h2', text: I18n.t(:'projects.members.new.title')
+
+      find('#member_user_id').find(:xpath, 'option[2]').select_option
+      find('#member_access_level').find(:xpath, 'option[5]').select_option
+
+      click_button I18n.t(:'projects.members.new.add_member_to_project')
+
+      assert_text I18n.t(:'projects.members.create.success')
+      assert_selector 'h1', text: I18n.t(:'projects.members.index.title')
+      assert_selector 'tr', count: 1
     end
   end
 end


### PR DESCRIPTION
Fixed bug:
- which prevented project owner under their own user_namespace from adding a project member due to a nil error.
- added test to ensure the owner could add a project member

Fixed translation key