### PR TITLE
Internal: Fix Migrations

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,7 +4,11 @@
 class Group < Namespace
   has_many :group_members, foreign_key: :namespace_id, inverse_of: :namespace,
                            class_name: 'Member', dependent: :destroy
-
+  has_many :project_namespaces,
+           lambda {
+             where(type: Namespaces::ProjectNamespace.sti_name)
+           },
+           class_name: 'Namespace', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
   has_many :users, through: :group_members
 
   def self.sti_name

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,7 +2,7 @@
 
 # Namespace for Groups
 class Group < Namespace
-  has_many :group_members, foreign_key: :namespace_id, inverse_of: :namespace,
+  has_many :group_members, foreign_key: :namespace_id, inverse_of: :group,
                            class_name: 'Member', dependent: :destroy
   has_many :project_namespaces,
            lambda {

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -9,7 +9,9 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   belongs_to :owner, class_name: 'User', optional: true
 
   belongs_to :parent, class_name: 'Namespace', optional: true
-  has_many :children, -> { where(type: Group.sti_name) }, class_name: 'Namespace', foreign_key: :parent_id # rubocop:disable Rails/InverseOf,Rails/HasManyOrHasOneDependent
+  has_many :children, lambda {
+                        where(type: Group.sti_name)
+                      }, class_name: 'Namespace', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
 
   validates :owner, presence: true, if: ->(n) { n.owner_required? }
   validates :name, presence: true, length: { minimum: 3, maximum: 255 }

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -9,9 +9,11 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   belongs_to :owner, class_name: 'User', optional: true
 
   belongs_to :parent, class_name: 'Namespace', optional: true
-  has_many :children, lambda {
-                        where(type: Group.sti_name)
-                      }, class_name: 'Namespace', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
+  has_many :children,
+           lambda {
+             where(type: Group.sti_name)
+           },
+           class_name: 'Namespace', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
 
   validates :owner, presence: true, if: ->(n) { n.owner_required? }
   validates :name, presence: true, length: { minimum: 3, maximum: 255 }

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -4,7 +4,7 @@ module Namespaces
   # Namespace for Projects
   class ProjectNamespace < Namespace
     has_one :project, inverse_of: :namespace, foreign_key: :namespace_id, dependent: :destroy
-    has_many :project_members, foreign_key: :namespace_id, inverse_of: :namespace,
+    has_many :project_members, foreign_key: :namespace_id, inverse_of: :project_namespace,
                                class_name: 'Member', dependent: :destroy
     has_many :users, through: :project_members
 

--- a/app/models/namespaces/user_namespace.rb
+++ b/app/models/namespaces/user_namespace.rb
@@ -3,6 +3,11 @@
 module Namespaces
   # Namespace for Users
   class UserNamespace < Namespace
+    has_many :project_namespaces,
+             lambda {
+               where(type: Namespaces::ProjectNamespace.sti_name)
+             }, class_name: 'Namespace', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
+
     def self.sti_name
       'User'
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,7 +5,7 @@ class Project < ApplicationRecord
   has_many :samples, inverse_of: :project, dependent: :destroy
 
   belongs_to :creator, class_name: 'User'
-  belongs_to :namespace, autosave: true, class_name: 'Namespaces::ProjectNamespace'
+  belongs_to :namespace, autosave: true, class_name: 'Namespaces::ProjectNamespace', dependent: :destroy
   accepts_nested_attributes_for :namespace
 
   delegate :description, to: :namespace

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   has_many :personal_access_tokens, dependent: :destroy
 
   # Groups
-  has_many :members, dependent: :destroy
+  has_many :members, inverse_of: :user, dependent: :destroy
   has_many :groups, through: :members
 
   before_validation :ensure_namespace

--- a/db/migrate/20230208193900_create_namespaces.rb
+++ b/db/migrate/20230208193900_create_namespaces.rb
@@ -6,7 +6,7 @@ class CreateNamespaces < ActiveRecord::Migration[7.0]
     create_table :namespaces do |t|
       t.string :name
       t.string :path
-      t.references :owner, foreign_key: { to_table: :users }, index: true
+      t.references :owner, index: true
       t.string :type
       t.string :description
       t.references :parent, foreign_key: { to_table: :namespaces }, index: true

--- a/db/migrate/20230208193900_create_namespaces.rb
+++ b/db/migrate/20230208193900_create_namespaces.rb
@@ -6,10 +6,10 @@ class CreateNamespaces < ActiveRecord::Migration[7.0]
     create_table :namespaces do |t|
       t.string :name
       t.string :path
-      t.integer :owner_id
+      t.references :owner, foreign_key: { to_table: :users }, index: true
       t.string :type
       t.string :description
-      t.integer :parent_id
+      t.references :parent, foreign_key: { to_table: :namespaces }, index: true
 
       t.timestamps
     end

--- a/db/migrate/20230227172418_create_projects.rb
+++ b/db/migrate/20230227172418_create_projects.rb
@@ -4,7 +4,7 @@
 class CreateProjects < ActiveRecord::Migration[7.0]
   def change
     create_table :projects do |t|
-      t.references :creator, foreign_key: { to_table: :users }, index: true
+      t.references :creator, index: true
       t.references :namespace, foreign_key: true, index: true
 
       t.timestamps

--- a/db/migrate/20230227172418_create_projects.rb
+++ b/db/migrate/20230227172418_create_projects.rb
@@ -4,8 +4,8 @@
 class CreateProjects < ActiveRecord::Migration[7.0]
   def change
     create_table :projects do |t|
-      t.integer :creator_id
-      t.integer :namespace_id
+      t.references :creator, foreign_key: { to_table: :users }, index: true
+      t.references :namespace, foreign_key: true, index: true
 
       t.timestamps
     end

--- a/db/migrate/20230228214717_create_members.rb
+++ b/db/migrate/20230228214717_create_members.rb
@@ -4,9 +4,9 @@
 class CreateMembers < ActiveRecord::Migration[7.0]
   def change
     create_table :members do |t|
-      t.integer :user_id
-      t.integer :namespace_id
-      t.integer :created_by_id
+      t.references :user, foreign_key: true, index: true
+      t.references :namespace, foreign_key: true, index: true
+      t.references :created_by, foreign_key: { to_table: :users }
       t.string :type
       t.integer :access_level
 

--- a/db/migrate/20230228214717_create_members.rb
+++ b/db/migrate/20230228214717_create_members.rb
@@ -6,7 +6,7 @@ class CreateMembers < ActiveRecord::Migration[7.0]
     create_table :members do |t|
       t.references :user, foreign_key: true, index: true
       t.references :namespace, foreign_key: true, index: true
-      t.references :created_by, foreign_key: { to_table: :users }
+      t.references :created_by
       t.string :type
       t.integer :access_level
 

--- a/db/migrate/20230316180414_create_samples.rb
+++ b/db/migrate/20230316180414_create_samples.rb
@@ -6,7 +6,7 @@ class CreateSamples < ActiveRecord::Migration[7.0]
     create_table :samples do |t|
       t.string :name
       t.text :description
-      t.references :project, null: false, foreign_key: true
+      t.references :project, null: false, foreign_key: true, index: true
 
       t.timestamps
     end

--- a/db/migrate/20230327202710_create_personal_access_tokens.rb
+++ b/db/migrate/20230327202710_create_personal_access_tokens.rb
@@ -4,10 +4,10 @@
 class CreatePersonalAccessTokens < ActiveRecord::Migration[7.0]
   def change
     create_table :personal_access_tokens do |t|
-      t.references :user, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true, index: true
       t.string :scopes
       t.string :name
-      t.boolean :revoked
+      t.boolean :revoked, default: false, null: false
       t.date :expires_at
       t.string :token_digest
       t.timestamp :last_used_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,31 +15,36 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_221752) do
   enable_extension "plpgsql"
 
   create_table "members", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "namespace_id"
-    t.integer "created_by_id"
+    t.bigint "user_id"
+    t.bigint "namespace_id"
+    t.bigint "created_by_id"
     t.integer "access_level"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "index_members_on_created_by_id"
+    t.index ["namespace_id"], name: "index_members_on_namespace_id"
     t.index ["user_id", "namespace_id"], name: "index_members_on_user_id_and_namespace_id", unique: true
+    t.index ["user_id"], name: "index_members_on_user_id"
   end
 
   create_table "namespaces", force: :cascade do |t|
     t.string "name"
     t.string "path"
-    t.integer "owner_id"
+    t.bigint "owner_id"
     t.string "type"
     t.string "description"
-    t.integer "parent_id"
+    t.bigint "parent_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_namespaces_on_owner_id"
+    t.index ["parent_id"], name: "index_namespaces_on_parent_id"
   end
 
   create_table "personal_access_tokens", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "scopes"
     t.string "name"
-    t.boolean "revoked"
+    t.boolean "revoked", default: false, null: false
     t.date "expires_at"
     t.string "token_digest"
     t.datetime "last_used_at", precision: nil
@@ -50,10 +55,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_221752) do
   end
 
   create_table "projects", force: :cascade do |t|
-    t.integer "creator_id"
-    t.integer "namespace_id"
+    t.bigint "creator_id"
+    t.bigint "namespace_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_projects_on_creator_id"
+    t.index ["namespace_id"], name: "index_projects_on_namespace_id"
   end
 
   create_table "routes", force: :cascade do |t|
@@ -90,6 +97,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_221752) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "members", "namespaces"
+  add_foreign_key "members", "users"
+  add_foreign_key "members", "users", column: "created_by_id"
+  add_foreign_key "namespaces", "namespaces", column: "parent_id"
+  add_foreign_key "namespaces", "users", column: "owner_id"
   add_foreign_key "personal_access_tokens", "users"
+  add_foreign_key "projects", "namespaces"
+  add_foreign_key "projects", "users", column: "creator_id"
   add_foreign_key "samples", "projects"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,11 +99,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_221752) do
 
   add_foreign_key "members", "namespaces"
   add_foreign_key "members", "users"
-  add_foreign_key "members", "users", column: "created_by_id"
   add_foreign_key "namespaces", "namespaces", column: "parent_id"
-  add_foreign_key "namespaces", "users", column: "owner_id"
   add_foreign_key "personal_access_tokens", "users"
   add_foreign_key "projects", "namespaces"
-  add_foreign_key "projects", "users", column: "creator_id"
   add_foreign_key "samples", "projects"
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -76,7 +76,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
   test 'should delete a group' do
     sign_in users(:john_doe)
 
-    group = groups(:group_one)
+    group = groups(:group_two)
     assert_difference('Group.count', -1) do
       delete group_path(group)
     end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -91,7 +91,7 @@ class GroupTest < ActiveSupport::TestCase
     self_and_descendant_project_namespaces = Namespaces::ProjectNamespace.where(parent: @group_three.self_and_descendants)
     projects_count = self_and_descendant_project_namespaces.count
     members_count = Member.where(namespace: @group_three.self_and_descendants).count +
-                    Member.where(namespace: self_and_descendant_project_namespaces)).count
+                    Member.where(namespace: self_and_descendant_project_namespaces).count
     assert_difference(
       -> { Group.count } => (self_and_descendants_count * -1),
       -> { Namespaces::ProjectNamespace.count } => (projects_count * -1),

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -88,10 +88,10 @@ class GroupTest < ActiveSupport::TestCase
 
   test '#destroy removes descendant groups, project namespaces, projects, and members' do
     self_and_descendants_count = @group_three.self_and_descendants.count
-    self_and_descendant_project_namespaces = Namespaces::ProjectNamespace.where(parent: @group_three.self_and_descendants)
-    projects_count = self_and_descendant_project_namespaces.count
+    project_namespaces = Namespaces::ProjectNamespace.where(parent: @group_three.self_and_descendants)
+    projects_count = project_namespaces.count
     members_count = Member.where(namespace: @group_three.self_and_descendants).count +
-                    Member.where(namespace: self_and_descendant_project_namespaces).count
+                    Member.where(namespace: project_namespaces).count
     assert_difference(
       -> { Group.count } => (self_and_descendants_count * -1),
       -> { Namespaces::ProjectNamespace.count } => (projects_count * -1),

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -88,8 +88,10 @@ class GroupTest < ActiveSupport::TestCase
 
   test '#destroy removes descendant groups, project namespaces, projects, and members' do
     self_and_descendants_count = @group_three.self_and_descendants.count
-    projects_count = Namespaces::ProjectNamespace.where(parent: @group_three.self_and_descendants).count
-    members_count = Member.where(namespace: @group_three.self_and_descendants).count + Member.where(namespace: Namespaces::ProjectNamespace.where(parent: @group_three.self_and_descendants)).count
+    self_and_descendant_project_namespaces = Namespaces::ProjectNamespace.where(parent: @group_three.self_and_descendants)
+    projects_count = self_and_descendant_project_namespaces.count
+    members_count = Member.where(namespace: @group_three.self_and_descendants).count +
+                    Member.where(namespace: self_and_descendant_project_namespaces)).count
     assert_difference(
       -> { Group.count } => (self_and_descendants_count * -1),
       -> { Namespaces::ProjectNamespace.count } => (projects_count * -1),

--- a/test/models/namespaces/project_namespace_test.rb
+++ b/test/models/namespaces/project_namespace_test.rb
@@ -67,4 +67,15 @@ class ProjectNamespaceTest < ActiveSupport::TestCase
   test '#full_path' do
     assert_equal @project_namespace.route.path, @project_namespace.full_path
   end
+
+  test '#destroy removes dependant project, and members' do
+    members_count = @project_namespace.project_members.count
+    assert_difference(
+      -> { Namespaces::ProjectNamespace.count } => -1,
+      -> { Project.count } => -1,
+      -> { Member.count } => (members_count * -1)
+    ) do
+      @project_namespace.destroy
+    end
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -34,4 +34,10 @@ class ProjectTest < ActiveSupport::TestCase
   test '#full_path' do
     assert_equal @project.namespace.full_path, @project.full_path
   end
+
+  test '#destroy removes dependant project namespace' do
+    assert_difference(-> { Namespaces::ProjectNamespace.count } => -1) do
+      @project.destroy
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -29,4 +29,15 @@ class UserTest < ActiveSupport::TestCase
   test '#personal_access_tokens' do
     assert_equal 4, @user.personal_access_tokens.size
   end
+
+  test '#destroy removes dependant user namespace, and projects' do
+    projects_count = @user.namespace.project_namespaces.count
+    assert_difference(
+      -> { User.count } => -1,
+      -> { Namespaces::ProjectNamespace.count } => (projects_count * -1),
+      -> { Project.count } => (projects_count * -1)
+    ) do
+      @user.destroy
+    end
+  end
 end

--- a/test/services/groups/destroy_service_test.rb
+++ b/test/services/groups/destroy_service_test.rb
@@ -6,7 +6,7 @@ module Groups
   class DestroyServiceTest < ActiveSupport::TestCase
     def setup
       @user = users(:john_doe)
-      @group = groups(:group_one)
+      @group = groups(:group_two)
     end
 
     test 'delete group with correct permissions' do

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -95,7 +95,7 @@ class GroupsTest < ApplicationSystemTestCase
   end
 
   test 'can delete a group' do
-    visit group_url(groups(:subgroup6))
+    visit group_url(groups(:group_two))
 
     click_link I18n.t(:'groups.sidebar.settings')
 


### PR DESCRIPTION
Previously we we're adding foreign keys with `t.integer blah_id` instead of `t.references :blah`. Using the `references` syntax results in the type of `blah_id` to be `:bigint` which matches the type of the id column in the database.

Note: This change will require you to run the following command:

`bin/rails db:drop db:create db:migrate db:seed`