### PR TITLE
Update: Projects Index Action

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,12 +5,17 @@ class ProjectsController < ApplicationController # rubocop:disable Metrics/Class
   layout :resolve_layout
   before_action :project, only: %i[show edit update activity transfer destroy]
   before_action :context_crumbs, except: %i[index new create show]
-  def index
-    @pagy, @projects = pagy(projects.order(updated_at: :desc))
 
+  def index
     respond_to do |format|
-      format.html
-      format.turbo_stream
+      format.html do
+        @has_projects = Project.joins(:namespace).exists?(namespace: { parent: current_user.namespace }) ||
+                        Project.joins(:namespace)
+                               .exists?(namespace: { parent: current_user.groups.self_and_descendant_ids })
+      end
+      format.turbo_stream do
+        @pagy, @projects = pagy(projects.order(updated_at: :desc))
+      end
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,7 +14,7 @@ class Project < ApplicationRecord
   delegate :human_name, to: :namespace
   delegate :full_path, to: :namespace
 
-  scope :include_route, -> { includes(namespace: :route) }
+  scope :include_route, -> { includes(namespace: [{ parent: :route }, :route]) }
 
   def to_param
     path

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -9,7 +9,7 @@
 >
   <td class="p-4 whitespace-nowrap">
     <%= link_to project.human_name,
-    namespace_project_path(project.namespace, project),
+    namespace_project_path(project.namespace.parent, project),
     data: {
       turbo: false
     },

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -9,11 +9,11 @@
 >
   <td class="p-4 whitespace-nowrap">
     <%= link_to project.human_name,
-                project_path(project),
-                data: {
-                  turbo: false
-                },
-                class: "text-grey-900 dark:text-grey-100 font-semibold hover:underline" %>
+    namespace_project_path(project.namespace, project),
+    data: {
+      turbo: false
+    },
+    class: "text-grey-900 dark:text-grey-100 font-semibold hover:underline" %>
     <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= project.description %></div>
   </td>
   <td class="p-4 whitespace-nowrap text-right">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,36 +11,38 @@
 <% end %>
 
 <div class="bg-white dark:bg-gray-800">
-  <div class="flex flex-col">
-    <%= turbo_frame_tag "projects_list", src: projects_url(format: :turbo_stream, page: params[:page]), loading: :lazy do %>
-      <table class="min-w-full table-fixed dark:divide-gray-600">
-        <tbody
-          class="
-            bg-white
-            divide-y
-            divide-gray-200
-            dark:bg-gray-800
-            dark:divide-gray-700
-          "
-        >
-          <% 15.times do %>
-            <tr>
-              <td class="animate-pulse p-4">
-                <div class="flex-1 space-y-6 py-1">
-                  <div class="space-y-3">
-                    <div class="h-2 bg-slate-200 rounded w-48"></div>
-                    <div class="h-2 bg-slate-200 rounded w-32"></div>
+  <div class="flex flex-col" data-turbo-temporary>
+    <% if @has_projects %>
+      <%= turbo_frame_tag "projects_list", src: projects_url(format: :turbo_stream, page: params[:page]), loading: :lazy do %>
+        <table class="min-w-full table-fixed dark:divide-gray-600">
+          <tbody
+            class="
+              bg-white
+              divide-y
+              divide-gray-200
+              dark:bg-gray-800
+              dark:divide-gray-700
+            "
+          >
+            <% 15.times do %>
+              <tr>
+                <td class="animate-pulse p-4">
+                  <div class="flex-1 space-y-6 py-1">
+                    <div class="space-y-3">
+                      <div class="h-2 bg-slate-200 rounded w-48"></div>
+                      <div class="h-2 bg-slate-200 rounded w-32"></div>
+                    </div>
                   </div>
-                </div>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
+      <%= turbo_frame_tag "projects_pagination",
+      data: {
+        controller: "turbo-frame-history"
+      } %>
     <% end %>
-    <%= turbo_frame_tag "projects_pagination",
-    data: {
-      controller: "turbo-frame-history"
-    } %>
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -128,6 +128,11 @@ if Rails.env.development?
       email: 'user8@email.com',
       password: 'password1',
       password_confirmation: 'password1'
+    },
+    {
+      email: 'user9@email.com',
+      password: 'password1',
+      password_confirmation: 'password1'
     }
   ]
 


### PR DESCRIPTION
This PR updates the Projects index action to only load a page of projects when the user has access to Projects, and only when processing the turbo_stream request.

Prior to this PR a page of projects was loaded when processing the html request, but the index.html.erb action was not utilizing the page as we defer loading of the table via turbo_stream request.

This PR also updates the db/seeds.rb to seed a user with email `user9@email.com` who does not have access to any projects. This user can be used to test accessing the Projects Index without any projects to see that it does not attempt to load a page of projects.