### PR TITLE
Feature: Alert component for login flash notices

### DIFF
--- a/app/components/viral/alert_component.html.erb
+++ b/app/components/viral/alert_component.html.erb
@@ -1,4 +1,4 @@
-<div class=" flex p-4 mb-4 border-l-4 <%= classes %> " role="alert">
+<div class="flex p-4 mb-4 border-l-4 <%= classes %> " role="alert">
   <span class="flex-shrink-0">
     <%= viral_icon(name: "exclamation_circle", classes: "w-5 h-5 stroke-2") %>
   </span>

--- a/app/components/viral/alert_component.html.erb
+++ b/app/components/viral/alert_component.html.erb
@@ -1,0 +1,8 @@
+<div class=" flex p-4 mb-4 border-l-4 <%= classes %> " role="alert">
+  <span class="flex-shrink-0">
+    <%= viral_icon(name: "exclamation_circle", classes: "w-5 h-5 stroke-2") %>
+  </span>
+  <div class="ml-3 text-sm font-medium">
+    <%= message %>
+  </div>
+</div>

--- a/app/components/viral/alert_component.rb
+++ b/app/components/viral/alert_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Viral
+  # View Component for alert messages (flash messages)
+  class AlertComponent < Component
+    attr_reader :type, :message, :icon, :classes
+
+    def initialize(type: 'info', message: nil)
+      @type = type
+      @message = message
+      @classes = classes_for_alert
+    end
+
+    def classes_for_alert
+      case type
+      when 'alert'
+        'text-red-800 border-red-300 bg-red-50 dark:text-red-400 dark:bg-gray-800 dark:border-red-800'
+      when 'notice'
+        'text-blue-800 border-blue-300 bg-blue-50 dark:text-blue-400 dark:bg-gray-800 dark:border-blue-800'
+      else
+        'border-gray-300 bg-gray-50 dark:bg-gray-800 dark:border-gray-600'
+      end
+    end
+  end
+end

--- a/app/components/viral/alert_component.rb
+++ b/app/components/viral/alert_component.rb
@@ -3,7 +3,7 @@
 module Viral
   # View Component for alert messages (flash messages)
   class AlertComponent < Component
-    attr_reader :type, :message, :icon, :classes
+    attr_reader :type, :message, :classes
 
     def initialize(type: 'info', message: nil)
       @type = type

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -3,6 +3,7 @@
 # ViewHelper for user interface components
 module ViewHelper
   VIRAL_HELPERS = {
+    alert: 'Viral::AlertComponent',
     card: 'Viral::CardComponent',
     dropdown: 'Viral::DropdownComponent',
     flash: 'Viral::FlashComponent',

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,8 @@
+<% flash.each do |type, msg| %>
+  <%= type %>
+  <%= viral_alert(type: type, message: msg) %>
+<% end %>
+
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
   <div class="form-field">
     <%= f.label :email %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,4 @@
 <% flash.each do |type, msg| %>
-  <%= type %>
   <%= viral_alert(type: type, message: msg) %>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,3 @@
-<% flash.each do |type, msg| %>
-  <%= viral_alert(type: type, message: msg) %>
-<% end %>
-
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
   <div class="form-field">
     <%= f.label :email %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="p-4 mb-4 border-l-4 text-red-800 border-red-300 bg-red-50 dark:text-red-400 dark:bg-gray-800 dark:border-red-800" data-turbo-cache="false">
+    <h2 class="mb-2 font-semibold text-red-600">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="max-w-md space-y-1 text-red-500 list-disc list-inside dark:text-gray-400">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -16,6 +16,9 @@
         <h1 class="text-xl font-bold leading-tight tracking-tight text-center text-gray-900 md:text-2xl dark:text-white">IRIDA
           Next</h1>
       </div>
+      <% flash.each do |type, msg| %>
+        <%= viral_alert(type: type, message: msg) %>
+      <% end %>
       <%= yield %>
     </div>
   </section>

--- a/test/components/previews/alert_component_preview.rb
+++ b/test/components/previews/alert_component_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AlertComponentPreview < ViewComponent::Preview
+  def notice_alert
+    render Viral::AlertComponent.new(message: 'This is a notice alert', type: 'notice')
+  end
+
+  def alert_alert
+    render Viral::AlertComponent.new(message: 'This is an alert alert', type: 'alert')
+  end
+end

--- a/test/components/viral/alert_component_test.rb
+++ b/test/components/viral/alert_component_test.rb
@@ -2,10 +2,18 @@
 
 require 'test_helper'
 
-class Viral::AlertComponentTest < ViewComponent::TestCase
-  test 'notice alert' do
-    render_inline(Viral::AlertComponent.new(message: 'This is a notice alert', type: 'notice'))
-    assert_text 'This is a notice alert'
-    assert_selector 'div[data-controller="viral--alert-component"]', count: 1
+module Viral
+  class AlertComponentTest < ViewComponent::TestCase
+    test 'notice alert' do
+      render_inline(Viral::AlertComponent.new(message: 'This is a notice alert', type: 'notice'))
+      assert_text 'This is a notice alert'
+      assert_selector 'div.text-blue-800.border-blue-300.bg-blue-50', count: 1
+    end
+
+    test 'alert alert' do
+      render_inline(Viral::AlertComponent.new(message: 'This is an alert alert', type: 'alert'))
+      assert_text 'This is an alert alert'
+      assert_selector 'div.text-red-800.border-red-300.bg-red-50', count: 1
+    end
   end
 end

--- a/test/components/viral/alert_component_test.rb
+++ b/test/components/viral/alert_component_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Viral::AlertComponentTest < ViewComponent::TestCase
+  test 'notice alert' do
+    render_inline(Viral::AlertComponent.new(message: 'This is a notice alert', type: 'notice'))
+    assert_text 'This is a notice alert'
+    assert_selector 'div[data-controller="viral--alert-component"]', count: 1
+  end
+end


### PR DESCRIPTION
Created an alert component to specifically handle login notices where the flash component is not appropriate.  Has two states:

Notice:

![](https://user-images.githubusercontent.com/11295750/236924598-1a9d3919-8e99-4c41-b291-44b39148290a.png)

![](https://user-images.githubusercontent.com/11295750/236924741-f7909bc6-7d9b-4eac-9f6d-f353702a69d3.png)

Alert:

![](https://user-images.githubusercontent.com/11295750/236924672-1646dea0-9f4c-4ee6-8a79-4154f8e0e1aa.png)

![](https://user-images.githubusercontent.com/11295750/236924812-c6fd7063-0a43-4235-aa94-27427c3e8ab3.png)

![image](https://github.com/phac-nml/irida-next/assets/11295750/3cb4a91e-477e-433a-99ef-2515793264fc)
