### PR TITLE
Feature: Sessionless authentication

### DIFF
--- a/app/controllers/concerns/sessionless_authentication.rb
+++ b/app/controllers/concerns/sessionless_authentication.rb
@@ -12,6 +12,8 @@ module SessionlessAuthentication
     pat = user.personal_access_tokens.find_by_token(access_token) # rubocop:disable Rails/DynamicFindBy
     return unless pat&.active?
 
+    pat.touch(:last_used_at) # rubocop:disable Rails/SkipsModelValidations
+
     sessionless_sign_in(user)
   end
 

--- a/app/controllers/concerns/sessionless_authentication.rb
+++ b/app/controllers/concerns/sessionless_authentication.rb
@@ -37,7 +37,7 @@ module SessionlessAuthentication
 
   def token_from_basic_header(header, pattern)
     encoded_header = header.gsub(pattern, '')
-    decode_basic_credentials_token(encoded_header) if is_base64?(encoded_header)
+    decode_basic_credentials_token(encoded_header) if base64?(encoded_header)
   end
 
   def decode_basic_credentials_token(encoded_header)
@@ -46,14 +46,14 @@ module SessionlessAuthentication
 
   def username_from_basic_header(header, pattern)
     encoded_header = header.gsub(pattern, '')
-    decode_basic_credentials_username(encoded_header) if is_base64?(encoded_header)
+    decode_basic_credentials_username(encoded_header) if ibase64?(encoded_header)
   end
 
   def decode_basic_credentials_username(encoded_header)
     Base64.decode64(encoded_header).split(/:/, 2).first
   end
 
-  def is_base64?(value)
+  def base64?(value)
     Base64.strict_encode64(Base64.decode64(value)) == value
   end
 end

--- a/app/controllers/concerns/sessionless_authentication.rb
+++ b/app/controllers/concerns/sessionless_authentication.rb
@@ -37,7 +37,7 @@ module SessionlessAuthentication
 
   def token_from_basic_header(header, pattern)
     encoded_header = header.gsub(pattern, '')
-    decode_basic_credentials_token(encoded_header)
+    decode_basic_credentials_token(encoded_header) if is_base64?(encoded_header)
   end
 
   def decode_basic_credentials_token(encoded_header)
@@ -46,10 +46,14 @@ module SessionlessAuthentication
 
   def username_from_basic_header(header, pattern)
     encoded_header = header.gsub(pattern, '')
-    decode_basic_credentials_username(encoded_header)
+    decode_basic_credentials_username(encoded_header) if is_base64?(encoded_header)
   end
 
   def decode_basic_credentials_username(encoded_header)
     Base64.decode64(encoded_header).split(/:/, 2).first
+  end
+
+  def is_base64?(value)
+    Base64.strict_encode64(Base64.decode64(value)) == value
   end
 end

--- a/app/controllers/concerns/sessionless_authentication.rb
+++ b/app/controllers/concerns/sessionless_authentication.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Authentication methods for sessionless access (e.g. Graphql)
+module SessionlessAuthentication
+  def authenticate_sessionless_user!
+    access_token = token_from_basic_authorization(request)
+    username = username_from_basic_authorization(request)
+
+    user = User.find_by(email: username)
+    return unless user
+
+    pat = user.personal_access_tokens.find_by_token(access_token) # rubocop:disable Rails/DynamicFindBy
+    return unless pat&.active?
+
+    sessionless_sign_in(user)
+  end
+
+  def sessionless_sign_in(user)
+    sign_in(user, store: false)
+  end
+
+  private
+
+  def token_from_basic_authorization(request)
+    pattern = /^Basic /i
+    header = request.authorization
+    token_from_basic_header(header, pattern) if header&.match(pattern)
+  end
+
+  def username_from_basic_authorization(request)
+    pattern = /^Basic /i
+    header = request.authorization
+    username_from_basic_header(header, pattern) if header&.match(pattern)
+  end
+
+  def token_from_basic_header(header, pattern)
+    encoded_header = header.gsub(pattern, '')
+    decode_basic_credentials_token(encoded_header)
+  end
+
+  def decode_basic_credentials_token(encoded_header)
+    Base64.decode64(encoded_header).split(/:/, 2).last
+  end
+
+  def username_from_basic_header(header, pattern)
+    encoded_header = header.gsub(pattern, '')
+    decode_basic_credentials_username(encoded_header)
+  end
+
+  def decode_basic_credentials_username(encoded_header)
+    Base64.decode64(encoded_header).split(/:/, 2).first
+  end
+end

--- a/app/controllers/concerns/sessionless_authentication.rb
+++ b/app/controllers/concerns/sessionless_authentication.rb
@@ -46,7 +46,7 @@ module SessionlessAuthentication
 
   def username_from_basic_header(header, pattern)
     encoded_header = header.gsub(pattern, '')
-    decode_basic_credentials_username(encoded_header) if ibase64?(encoded_header)
+    decode_basic_credentials_username(encoded_header) if base64?(encoded_header)
   end
 
   def decode_basic_credentials_username(encoded_header)

--- a/app/controllers/concerns/sessionless_authentication.rb
+++ b/app/controllers/concerns/sessionless_authentication.rb
@@ -25,13 +25,13 @@ module SessionlessAuthentication
 
   def token_from_basic_authorization(request)
     pattern = /^Basic /i
-    header = request.authorization
+    header = request.authorization&.strip
     token_from_basic_header(header, pattern) if header&.match(pattern)
   end
 
   def username_from_basic_authorization(request)
     pattern = /^Basic /i
-    header = request.authorization
+    header = request.authorization&.strip
     username_from_basic_header(header, pattern) if header&.match(pattern)
   end
 

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -2,10 +2,18 @@
 
 # Graphql Controller
 class GraphqlController < ApplicationController
+  include SessionlessAuthentication
+
+  # Unauthenticated users have access to the API for public data
+  skip_before_action :authenticate_user!
+
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,
   # but you'll have to authenticate your user separately
-  # protect_from_forgery with: :null_session
+  protect_from_forgery with: :null_session, only: :execute
+
+  # must come first: current_user is set up here
+  before_action(only: [:execute]) { authenticate_sessionless_user! }
 
   def execute
     variables = prepare_variables(params[:variables])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -86,8 +86,10 @@ if Rails.env.development?
       password: 'password1',
       password_confirmation: 'password1',
       personal_access_tokens: [
-        { name: 'API r/w Token', scopes: ['api'], token_digest: 'zs83sKD3jeysfnr_kgu9' },
-        { name: 'API read only Token', scopes: ['read_api'], token_digest: 'yK1euURqVRtQ1D-3uKsW' }
+        { name: 'API r/w Token', scopes: ['api'],
+          token_digest: Devise.token_generator.digest(PersonalAccessToken, :token_digest, 'zs83sKD3jeysfnr_kgu9') },
+        { name: 'API read only Token', scopes: ['read_api'],
+          token_digest: Devise.token_generator.digest(PersonalAccessToken, :token_digest, 'yK1euURqVRtQ1D-3uKsW') }
       ]
     },
     {

--- a/test/controllers/concerns/sessionless_authentication_concern_test.rb
+++ b/test/controllers/concerns/sessionless_authentication_concern_test.rb
@@ -62,4 +62,17 @@ class SessionlessAuthenticationConcernTest < ActionDispatch::IntegrationTest
     assert response_hash['current_user'].key?('email')
     assert_not_equal users(:john_doe).email, response_hash['current_user']['email']
   end
+
+  test 'request with malformed HTTP Basic Authorization header does not set current_user' do
+    @basic_auth = Base64.encode64('MALFORMED')
+    @authorization_header = "Basic #{@basic_auth}"
+
+    post fake_action_path, headers: { Authorization: @authorization_header }
+    assert_response :success
+    response_hash = response.parsed_body
+
+    assert response_hash.key?('current_user')
+    assert response_hash['current_user'].key?('email')
+    assert_nil response_hash['current_user']['email']
+  end
 end

--- a/test/controllers/concerns/sessionless_authentication_concern_test.rb
+++ b/test/controllers/concerns/sessionless_authentication_concern_test.rb
@@ -38,10 +38,10 @@ class SessionlessAuthenticationConcernTest < ActionDispatch::IntegrationTest
   end
 
   test 'request with valid HTTP Basic Authorization header sets current_user' do
-    @basic_auth = Base64.encode64("#{users(:john_doe).email}:JQ2w5maQc4zgvC8GGMEp")
-    @authorization_header = "Basic #{@basic_auth}"
+    basic_auth = Base64.encode64("#{users(:john_doe).email}:JQ2w5maQc4zgvC8GGMEp")
+    authorization_header = "Basic #{basic_auth}"
 
-    post fake_action_path, headers: { Authorization: @authorization_header }
+    post fake_action_path, headers: { Authorization: authorization_header }
     assert_response :success
     response_hash = response.parsed_body
 
@@ -51,10 +51,10 @@ class SessionlessAuthenticationConcernTest < ActionDispatch::IntegrationTest
   end
 
   test 'request with invalid HTTP Basic Authorization header does not set current_user' do
-    @basic_auth = Base64.encode64("#{users(:jane_doe).email}:JQ2w5maQc4zgvC8GGMEp")
-    @authorization_header = "Basic #{@basic_auth}"
+    basic_auth = Base64.encode64("#{users(:jane_doe).email}:JQ2w5maQc4zgvC8GGMEp")
+    authorization_header = "Basic #{basic_auth}"
 
-    post fake_action_path, headers: { Authorization: @authorization_header }
+    post fake_action_path, headers: { Authorization: authorization_header }
     assert_response :success
     response_hash = response.parsed_body
 
@@ -64,10 +64,10 @@ class SessionlessAuthenticationConcernTest < ActionDispatch::IntegrationTest
   end
 
   test 'request with malformed HTTP Basic Authorization header does not set current_user' do
-    @basic_auth = Base64.encode64('MALFORMED')
-    @authorization_header = "Basic #{@basic_auth}"
+    basic_auth = Base64.encode64('MALFORMED')
+    authorization_header = "Basic #{basic_auth}"
 
-    post fake_action_path, headers: { Authorization: @authorization_header }
+    post fake_action_path, headers: { Authorization: authorization_header }
     assert_response :success
     response_hash = response.parsed_body
 

--- a/test/controllers/concerns/sessionless_authentication_concern_test.rb
+++ b/test/controllers/concerns/sessionless_authentication_concern_test.rb
@@ -17,8 +17,6 @@ class SessionlessAuthController < ApplicationController
 end
 
 class SessionlessAuthenticationConcernTest < ActionDispatch::IntegrationTest
-  include Devise::Test::IntegrationHelpers
-
   setup do
     Rails.application.routes.draw do
       post 'fake_action' => 'sessionless_auth#fake_action'

--- a/test/controllers/concerns/sessionless_authentication_concern_test.rb
+++ b/test/controllers/concerns/sessionless_authentication_concern_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SessionlessAuthController < ApplicationController
+  include SessionlessAuthentication
+
+  skip_before_action :authenticate_user!
+
+  protect_from_forgery with: :null_session, only: :execute
+
+  before_action { authenticate_sessionless_user! }
+
+  def fake_action
+    render json: { current_user: { email: current_user&.email } }
+  end
+end
+
+class SessionlessAuthenticationConcernTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Rails.application.routes.draw do
+      post 'fake_action' => 'sessionless_auth#fake_action'
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+  end
+
+  test 'request without HTTP Basic Authorization header does not set current_user' do
+    post fake_action_path
+    assert_response :success
+    response_hash = response.parsed_body
+
+    assert response_hash.key?('current_user')
+    assert response_hash['current_user'].key?('email')
+    assert_nil response_hash['current_user']['email']
+  end
+
+  test 'request with valid HTTP Basic Authorization header sets current_user' do
+    @basic_auth = Base64.encode64("#{users(:john_doe).email}:JQ2w5maQc4zgvC8GGMEp")
+    @authorization_header = "Basic #{@basic_auth}"
+
+    post fake_action_path, headers: { Authorization: @authorization_header }
+    assert_response :success
+    response_hash = response.parsed_body
+
+    assert response_hash.key?('current_user')
+    assert response_hash['current_user'].key?('email')
+    assert_equal users(:john_doe).email, response_hash['current_user']['email']
+  end
+
+  test 'request with invalid HTTP Basic Authorization header does not set current_user' do
+    @basic_auth = Base64.encode64("#{users(:jane_doe).email}:JQ2w5maQc4zgvC8GGMEp")
+    @authorization_header = "Basic #{@basic_auth}"
+
+    post fake_action_path, headers: { Authorization: @authorization_header }
+    assert_response :success
+    response_hash = response.parsed_body
+
+    assert response_hash.key?('current_user')
+    assert response_hash['current_user'].key?('email')
+    assert_not_equal users(:john_doe).email, response_hash['current_user']['email']
+  end
+end

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -5,51 +5,46 @@ require 'test_helper'
 class GraphqlControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test 'should require login' do
-    post api_graphql_url
-    assert_redirected_to new_user_session_url
+  setup do
+    @basic_auth = Base64.encode64("#{users(:john_doe).email}:JQ2w5maQc4zgvC8GGMEp")
+    @authorization_header = "Basic #{@basic_auth}"
   end
 
   test 'should execute the graphql query' do
-    sign_in users(:john_doe)
-
-    post api_graphql_path, params: { query: '{ __schema }' }
+    post api_graphql_path, params: { query: '{ __schema }' },
+                           headers: { Authorization: @authorization_header }
 
     assert_response :success
   end
 
   test 'should execute the graphql query when using variables' do
-    sign_in users(:john_doe)
-
-    post api_graphql_path, params: { query: '{ $query }', variables: { query: '__schema' } }
+    post api_graphql_path, params: { query: '{ $query }', variables: { query: '__schema' } },
+                           headers: { Authorization: @authorization_header }
 
     assert_response :success
   end
 
   test 'should execute the graphql query when variables empty' do
-    sign_in users(:john_doe)
-
-    post api_graphql_path, params: { query: '{ __schema }', variables: '' }
+    post api_graphql_path, params: { query: '{ __schema }', variables: '' },
+                           headers: { Authorization: @authorization_header }
 
     assert_response :success
   end
 
   test 'should execute the graphql query when variables is an empty hash' do
-    sign_in users(:john_doe)
-
-    post api_graphql_path, params: { query: '{ __schema }', variables: '{}' }
+    post api_graphql_path, params: { query: '{ __schema }', variables: '{}' },
+                           headers: { Authorization: @authorization_header }
 
     assert_response :success
   end
 
   test 'should report error when graphql query is invalid' do
-    sign_in users(:john_doe)
-
-    post api_graphql_path, params: { query: '{ does_not_exist {invalid} }' }
+    post api_graphql_path, params: { query: '{ does_not_exist {invalid} }' },
+                           headers: { Authorization: @authorization_header }
 
     assert_response :success
 
-    response_hash = JSON.parse(response.body)
+    response_hash = response.parsed_body
 
     assert response_hash.key?('errors')
     assert_equal 'Field \'does_not_exist\' doesn\'t exist on type \'Query\'', response_hash['errors'][0]['message']


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR introduces sessionless authentication, specifically to be used by external tools accessing the Graphql API. Without this change, users could only interact with our Graphql api while the app was running in `development` mode and if they accessed it via the `graphiql` interface available at `http://localhost:3000/graphiql`.

This uses [Basic HTTP Authentication](https://datatracker.ietf.org/doc/html/rfc7617), in the form of `$USEREMAIL:$ACCESSTOKEN` that is Base64 encoded.

e.g. `admin@email.com:yK1euURqVRtQ1D-3uKsW` becomes `YWRtaW5AZW1haWwuY29tOnlLMWV1VVJxVlJ0UTFELTN1S3NX`

Which would be used like the following:

e.g. `Authorization: Basic YWRtaW5AZW1haWwuY29tOnlLMWV1VVJxVlJ0UTFELTN1S3NX`

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
1. Login as a user
2. Go to `Edit profile` and then click on `Access Tokens`
3. Add a new personal access token with `api` or `read_api` scope.
4. Copy the value of the new access token
5. Use a tool to Base64 Encode the username + access token as described above
6. Execute the following command `curl http://localhost:3000/api/graphql --header "Authorization: Basic YWRtaW5AZW1haWwuY29tOnlLMWV1VVJxVlJ0UTFELTN1S3NX" --header "Content-Type: application/json" --request POST --data "{\"query\": \"query {currentUser {email}}\"}"`
7. You should receive a response like `{"data":{"currentUser":{"email":"admin@email.com"}}}`