### PR TITLE
Tests: fix flaky tooltip component test

### DIFF
--- a/test/components/viral/system/tooltip_component_test.rb
+++ b/test/components/viral/system/tooltip_component_test.rb
@@ -6,10 +6,12 @@ module System
   class TooltipComponentTest < ApplicationSystemTestCase
     test 'tooltip appears on hover' do
       visit('/rails/view_components/tooltip_component/default')
-      assert_selector '[data-viral--tooltip-component-target="target"]', visible: false
-      find('a', text: 'Hover me').hover
-      assert_text I18n.t('auth.scopes.api')
-      assert_selector '[data-viral--tooltip-component-target="target"]', visible: true
+      within('.Viral-Preview > [data-controller-connected="true"]') do
+        assert_selector '[data-viral--tooltip-component-target="target"]', visible: false
+        find('a', text: 'Hover me').hover
+        assert_text I18n.t('auth.scopes.api')
+        assert_selector '[data-viral--tooltip-component-target="target"]', visible: true
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes the flaky tooltip component test.

The test is flaky because sometimes the javascript is not initialized as quickly as the test would like. This uses `within('.Viral-Preview > [data-controller-connected="true"]')` to ensure that the javascript has been intialized before performing the test.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
1. Execute the test with `bin/rails test test/components/viral/system/tooltip_component_test.rb`
2. See that it passes