### PR TITLE
Feature: Member Access Level Update

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -239,3 +239,7 @@
 .pagy-info {
   @apply text-sm font-normal text-gray-500 dark:text-gray-400;
 }
+
+div.field_with_errors > :is(select) {
+  @apply border-red-700 text-red-900 placeholder-red-300;
+}

--- a/app/components/viral/alert_component.rb
+++ b/app/components/viral/alert_component.rb
@@ -17,6 +17,8 @@ module Viral
         'text-red-800 border-red-300 bg-red-50 dark:text-red-400 dark:bg-gray-800 dark:border-red-800'
       when 'notice'
         'text-blue-800 border-blue-300 bg-blue-50 dark:text-blue-400 dark:bg-gray-800 dark:border-blue-800'
+      when 'success'
+        'text-green-800 border border-green-300 bg-green-50 dark:text-green-400 dark:bg-gray-800 dark:border-green-800'
       else
         'border-gray-300 bg-gray-50 dark:bg-gray-800 dark:border-gray-600'
       end

--- a/app/controllers/concerns/membership_actions.rb
+++ b/app/controllers/concerns/membership_actions.rb
@@ -54,12 +54,14 @@ module MembershipActions
     respond_to do |format|
       if updated
         format.turbo_stream do
-          render locals: { member: @member, access_levels: @access_levels, type: 'success',
-                           message: t('.success', user_email: @member.user.email) }
+          render status: :ok, locals: { member: @member, access_levels: @access_levels, type: 'success',
+                                        message: t('.success', user_email: @member.user.email) }
         end
       else
         format.turbo_stream do
-          render locals: { member: @member, type: 'alert', message: @member.errors.full_messages.first }
+          render status: :bad_request,
+                 locals: { member: @member, type: 'alert',
+                           message: @member.errors.full_messages.first }
         end
       end
     end

--- a/app/controllers/concerns/membership_actions.rb
+++ b/app/controllers/concerns/membership_actions.rb
@@ -54,7 +54,8 @@ module MembershipActions
     respond_to do |format|
       if updated
         format.turbo_stream do
-          render locals: { member: @member, access_levels: @access_levels }
+          render locals: { member: @member, access_levels: @access_levels, type: 'success',
+                           message: t('.success', user_email: @member.user.email) }
         end
       else
         format.turbo_stream do

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -25,8 +25,6 @@ module Members
       end
 
       member.update(params)
-
-      raise MemberUpdateError, member.errors.full_messages.first if member.errors
     rescue Members::UpdateService::MemberUpdateError => e
       member.errors.add(:base, e.message)
       false

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -24,7 +24,7 @@ module Members
 
       if Member.user_has_namespace_maintainer_access?(current_user,
                                                       namespace) &&
-         (params[:access_level] > Member::AccessLevel::MAINTAINER)
+         (params[:access_level].to_i > Member::AccessLevel::MAINTAINER)
         raise MemberUpdateError, I18n.t('services.members.update.role_not_allowed')
       end
 

--- a/app/views/groups/members/_access_level.html.erb
+++ b/app/views/groups/members/_access_level.html.erb
@@ -8,7 +8,7 @@
     access_levels,
     {},
     {
-      id: "member-#{member.id}-access-level",
+      id: "member-#{member.id}-access-level-select",
       value: member.access_level,
       onchange: "this.form.submit();",
       "aria-label": "Access Level"

--- a/app/views/groups/members/_access_level.html.erb
+++ b/app/views/groups/members/_access_level.html.erb
@@ -1,18 +1,17 @@
-<%= form_with(model: member, url: group_member_path(id: member.id), method: :patch,
-                        data: {
-                          remote: true
-                        }
-                      ) do |form| %>
-  <%= form.select(
-    :access_level,
-    access_levels,
-    {},
-    {
-      id: "member-#{member.id}-access-level-select",
-      value: member.access_level,
-      onchange: "this.form.submit();",
-      "aria-label": "Access Level"
-    }
-  ) %>
-  <input type="hidden" name="format" value="turbo_stream"/>
-<% end %>
+<% invalid_access_level = member.errors.include?(:access_level) %>
+<div class="form-field <%= 'invalid' if invalid_access_level %>">
+  <%= form_with(model: member, url: group_member_path(id: member.id), method: :patch) do |form| %>
+    <%= form.select(
+      :access_level,
+      access_levels,
+      {},
+      {
+        id: "member-#{member.id}-access-level-select",
+        value: member.access_level,
+        onchange: "this.form.requestSubmit();",
+        "aria-label": "Access Level"
+      }
+    ) %>
+    <input type="hidden" name="format" value="turbo_stream"/>
+  <% end %>
+</div>

--- a/app/views/groups/members/_access_level.html.erb
+++ b/app/views/groups/members/_access_level.html.erb
@@ -1,0 +1,18 @@
+<%= form_with(model: member, url: group_member_path(id: member.id), method: :patch,
+                        data: {
+                          remote: true
+                        }
+                      ) do |form| %>
+  <%= form.select(
+    :access_level,
+    access_levels,
+    {},
+    {
+      id: "member-#{member.id}-access-level",
+      value: member.access_level,
+      onchange: "this.form.submit();",
+      "aria-label": "Access Level"
+    }
+  ) %>
+  <input type="hidden" name="format" value="turbo_stream"/>
+<% end %>

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -24,7 +24,7 @@
               dark:divide-gray-700
             "
           >
-            <%= turbo_frame_tag("member-update-error") %>
+            <%= turbo_frame_tag("member-update-alert") %>
             <% @members.each do |member| %>
               <tr
                 class="

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -34,7 +34,26 @@
                 "
               >
                 <td class="p-4 whitespace-nowrap">
-                  <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %></div>
+                  <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %>
+                  <% if current_user == member.user %>
+                    <span
+                      class="
+                        bg-green-200
+                        text-green-800
+                        text-xs
+                        font-medium
+                        ml-2
+                        px-2.5
+                        py-0.5
+                        rounded-full
+                        dark:bg-green-900
+                        dark:text-green-300
+                      "
+                    >
+                      It's you
+                    </span>
+                  <% end %>
+                  </div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
                   <% if member.user != current_user && Member.exists?(namespace_id: member.namespace.self_and_ancestor_ids, user: current_user, access_level: [Member::AccessLevel::MAINTAINER, Member::AccessLevel::OWNER]) %>

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -38,28 +38,29 @@
               >
                 <td class="p-4 whitespace-nowrap">
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %>
-                  <% if current_user == member.user %>
-                    <span
-                      class="
-                        bg-green-200
-                        text-green-800
-                        text-xs
-                        font-medium
-                        ml-2
-                        px-2.5
-                        py-0.5
-                        rounded-full
-                        dark:bg-green-900
-                        dark:text-green-300
-                      "
-                    >
-                      <%= t(:'activerecord.models.member.its_you') %>
-                    </span>
-                  <% end %>
+                    <% if current_user == member.user %>
+                      <span
+                        class="
+                          bg-green-200
+                          text-green-800
+                          text-xs
+                          font-medium
+                          ml-2
+                          px-2.5
+                          py-0.5
+                          rounded-full
+                          dark:bg-green-900
+                          dark:text-green-300
+                        "
+                      >
+                        <%= t(:"activerecord.models.member.its_you") %>
+                      </span>
+                    <% end %>
                   </div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
-                  <% if member.user != current_user && allowed_to?(:allowed_to_modify_group?, @namespace) %>
+                  <% if member.user != current_user && allowed_to?(:allowed_to_modify_group?, @namespace) &&
+                   member.access_level <= @access_levels.values.last %>
                     <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
                       <%= render partial: "groups/members/access_level",
                       locals: {

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -22,6 +22,7 @@
               dark:divide-gray-700
             "
           >
+            <%= turbo_frame_tag("member-update-error") %>
             <% @members.each do |member| %>
               <tr
                 class="
@@ -37,7 +38,20 @@
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %></div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
-                  <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= t(:".access_level.level_#{member.access_level}") %></div>
+                  <div class="form-field">
+                    <% if member.user != current_user && (Member.exists?(namespace_id: member.namespace.ancestor_ids, user: current_user, access_level: [Member::AccessLevel::MAINTAINER, Member::AccessLevel::OWNER]) ||
+                     member.access_level < Member::AccessLevel::OWNER) %>
+                      <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
+                        <%= render partial: "groups/members/access_level",
+                        locals: {
+                          member: member,
+                          access_levels: @access_levels
+                        } %>
+                      <% end %>
+                    <% else %>
+                      <%= t(:".access_level.level_#{member.access_level}") %>
+                    <% end %>
+                  </div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= t(:".access_granted_by", grantor_email: member.created_by.email) %></div>

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -22,7 +22,6 @@
               dark:divide-gray-700
             "
           >
-            <%= turbo_frame_tag("member-update-error") %>
             <% @members.each do |member| %>
               <tr
                 class="
@@ -38,23 +37,28 @@
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %></div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
-                  <div class="form-field">
-                    <% if member.user != current_user && (Member.exists?(namespace_id: member.namespace.ancestor_ids, user: current_user, access_level: [Member::AccessLevel::MAINTAINER, Member::AccessLevel::OWNER]) ||
-                     member.access_level < Member::AccessLevel::OWNER) %>
-                      <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
-                        <%= render partial: "groups/members/access_level",
-                        locals: {
-                          member: member,
-                          access_levels: @access_levels
-                        } %>
-                      <% end %>
-                    <% else %>
-                      <%= t(:".access_level.level_#{member.access_level}") %>
+                  <% if member.user != current_user && Member.exists?(namespace_id: member.namespace.self_and_ancestor_ids, user: current_user, access_level: [Member::AccessLevel::MAINTAINER, Member::AccessLevel::OWNER]) %>
+                    <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
+                      <%= render partial: "groups/members/access_level",
+                      locals: {
+                        member: member,
+                        access_levels: @access_levels
+                      } %>
                     <% end %>
-                  </div>
+                    <%= turbo_frame_tag("member-#{member.id}-access-level-error") %>
+                  <% else %>
+                    <%= t(:".access_level.level_#{member.access_level}") %>
+                  <% end %>
                 </td>
                 <td class="p-4 whitespace-nowrap">
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= t(:".access_granted_by", grantor_email: member.created_by.email) %></div>
+                </td>
+                <td class="p-4 whitespace-nowrap">
+                  <div class="text-sm font-normal text-gray-500 dark:text-gray-400">
+                    <%= turbo_frame_tag("member-#{member.id}-access-level-updated") do %>
+                      <%= member.updated_at %>
+                    <% end %>
+                  </div>
                 </td>
                 <td class="px-4 py-3 text-right">
                   <%= viral_dropdown(icon: "ellipsis_vertical",

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -22,6 +22,7 @@
               dark:divide-gray-700
             "
           >
+            <%= turbo_frame_tag("member-update-error") %>
             <% @members.each do |member| %>
               <tr
                 class="
@@ -64,7 +65,6 @@
                         access_levels: @access_levels
                       } %>
                     <% end %>
-                    <%= turbo_frame_tag("member-#{member.id}-access-level-error") %>
                   <% else %>
                     <%= t(:".access_level.level_#{member.access_level}") %>
                   <% end %>

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -14,6 +14,7 @@
   <div class="flex flex-col">
     <div class="overflow-x-auto">
       <div class="shadow">
+        <%= turbo_frame_tag("member-update-alert") %>
         <table class="min-w-full table-fixed dark:divide-gray-600">
           <tbody
             class="
@@ -24,7 +25,6 @@
               dark:divide-gray-700
             "
           >
-            <%= turbo_frame_tag("member-update-alert") %>
             <% @members.each do |member| %>
               <tr
                 class="

--- a/app/views/groups/members/update.turbo_stream.erb
+++ b/app/views/groups/members/update.turbo_stream.erb
@@ -8,4 +8,4 @@
                     } %>
 
 <%= turbo_stream.update "member-#{member.id}-access-level-updated",
-                    member.updated_at %>
+                    I18n.l(member.updated_at, format: :default) %>

--- a/app/views/groups/members/update.turbo_stream.erb
+++ b/app/views/groups/members/update.turbo_stream.erb
@@ -1,11 +1,19 @@
-<% if member.errors.full_messages.count > 0 %>
-  <%= turbo_stream.append "member-update-error", viral_alert(type:, message:) %>
-<% else %>
-  <%= turbo_stream.update "member-#{member.id}-access-level",
-                      partial: "groups/members/access_level",
+<% if member.errors.include?(:access_level) %>
+  <%= turbo_stream.update "member-#{member.id}-access-level-error",
+                      partial: "shared/form/field_errors",
                       locals: {
-                        member:,
-                        access_levels: @access_levels
+                        errors: member.errors.full_messages_for(:access_level)
                       } %>
-
+<% else %>
+  <%= turbo_stream.update "member-#{member.id}-access-level-error", "" %>
 <% end %>
+
+<%= turbo_stream.update "member-#{member.id}-access-level",
+                    partial: "groups/members/access_level",
+                    locals: {
+                      member:,
+                      access_levels: @access_levels
+                    } %>
+
+<%= turbo_stream.update "member-#{member.id}-access-level-updated",
+                    member.updated_at %>

--- a/app/views/groups/members/update.turbo_stream.erb
+++ b/app/views/groups/members/update.turbo_stream.erb
@@ -1,9 +1,4 @@
-<% if member.errors.include?(:access_level) %>
-  <%= turbo_stream.update "member-update-error",
-    viral_alert(type: 'alert', message:member.errors.full_messages.first) %>
-<% else %>
-  <%= turbo_stream.update "member-update-error", "" %>
-<% end %>
+<%= turbo_stream.update "member-update-alert", viral_alert(type:, message:) %>
 
 <%= turbo_stream.update "member-#{member.id}-access-level",
                     partial: "groups/members/access_level",

--- a/app/views/groups/members/update.turbo_stream.erb
+++ b/app/views/groups/members/update.turbo_stream.erb
@@ -1,0 +1,11 @@
+<% if member.errors.full_messages.count > 0 %>
+  <%= turbo_stream.append "member-update-error", viral_alert(type:, message:) %>
+<% else %>
+  <%= turbo_stream.update "member-#{member.id}-access-level",
+                      partial: "groups/members/access_level",
+                      locals: {
+                        member:,
+                        access_levels: @access_levels
+                      } %>
+
+<% end %>

--- a/app/views/groups/members/update.turbo_stream.erb
+++ b/app/views/groups/members/update.turbo_stream.erb
@@ -1,11 +1,8 @@
 <% if member.errors.include?(:access_level) %>
-  <%= turbo_stream.update "member-#{member.id}-access-level-error",
-                      partial: "shared/form/field_errors",
-                      locals: {
-                        errors: member.errors.full_messages_for(:access_level)
-                      } %>
+  <%= turbo_stream.update "member-update-error",
+    viral_alert(type: 'alert', message:member.errors.full_messages.first) %>
 <% else %>
-  <%= turbo_stream.update "member-#{member.id}-access-level-error", "" %>
+  <%= turbo_stream.update "member-update-error", "" %>
 <% end %>
 
 <%= turbo_stream.update "member-#{member.id}-access-level",

--- a/app/views/projects/members/_access_level.html.erb
+++ b/app/views/projects/members/_access_level.html.erb
@@ -1,0 +1,18 @@
+<%= form_with(model: member, url: namespace_project_member_path(id: member.id), method: :patch,
+                        data: {
+                          remote: true
+                        }
+                      ) do |form| %>
+  <%= form.select(
+    :access_level,
+    access_levels,
+    {},
+    {
+      id: "member-#{member.id}-access-level",
+      value: member.access_level,
+      onchange: "this.form.submit();",
+      "aria-label": "Access Level"
+    }
+  ) %>
+  <input type="hidden" name="format" value="turbo_stream"/>
+<% end %>

--- a/app/views/projects/members/_access_level.html.erb
+++ b/app/views/projects/members/_access_level.html.erb
@@ -1,18 +1,17 @@
-<%= form_with(model: member, url: namespace_project_member_path(id: member.id), method: :patch,
-                        data: {
-                          remote: true
-                        }
-                      ) do |form| %>
-  <%= form.select(
-    :access_level,
-    access_levels,
-    {},
-    {
-      id: "member-#{member.id}-access-level-select",
-      value: member.access_level,
-      onchange: "this.form.submit();",
-      "aria-label": "Access Level"
-    }
-  ) %>
-  <input type="hidden" name="format" value="turbo_stream"/>
-<% end %>
+<% invalid_access_level = member.errors.include?(:access_level) %>
+<div class="form-field <%= 'invalid' if invalid_access_level %>">
+  <%= form_with(model: member, url: namespace_project_member_path(id: member.id), method: :patch) do |form| %>
+    <%= form.select(
+      :access_level,
+      access_levels,
+      {},
+      {
+        id: "member-#{member.id}-access-level-select",
+        value: member.access_level,
+        onchange: "this.form.requestSubmit();",
+        "aria-label": "Access Level"
+      }
+    ) %>
+    <input type="hidden" name="format" value="turbo_stream"/>
+  <% end %>
+</div>

--- a/app/views/projects/members/_access_level.html.erb
+++ b/app/views/projects/members/_access_level.html.erb
@@ -8,7 +8,7 @@
     access_levels,
     {},
     {
-      id: "member-#{member.id}-access-level",
+      id: "member-#{member.id}-access-level-select",
       value: member.access_level,
       onchange: "this.form.submit();",
       "aria-label": "Access Level"

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -21,7 +21,26 @@
               class="text-sm font-normal text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-400"
             >
               <td class="p-4 whitespace-nowrap">
-                <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %></div>
+                <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %>
+                  <% if current_user == member.user %>
+                    <span
+                      class="
+                        bg-green-200
+                        text-green-800
+                        text-xs
+                        font-medium
+                        ml-2
+                        px-2.5
+                        py-0.5
+                        rounded-full
+                        dark:bg-green-900
+                        dark:text-green-300
+                      "
+                    >
+                      It's you
+                    </span>
+                  <% end %>
+                </div>
               </td>
               <td class="p-4 whitespace-nowrap">
                   <% if member.user != current_user &&

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -16,6 +16,7 @@
           <tbody
             class="bg-white divide-y divide-gray-200 dark:bg-gray-800 dark:divide-gray-700"
           >
+          <%= turbo_frame_tag("member-update-error") %>
           <% @members.each do |member| %>
             <tr
               class="text-sm font-normal text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-400"
@@ -24,7 +25,19 @@
                 <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %></div>
               </td>
               <td class="p-4 whitespace-nowrap">
-                <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= t(:"projects.members.index.access_level.level_#{member.access_level}") %></div>
+                <div class="form-field">
+                    <% if member.user != current_user  %>
+                      <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
+                        <%= render partial: "projects/members/access_level",
+                        locals: {
+                          member: member,
+                          access_levels: @access_levels
+                        } %>
+                      <% end %>
+                    <% else %>
+                    <%= t(:"projects.members.index.access_level.level_#{member.access_level}") %>
+                  <% end %>
+                </div>
               </td>
               <td class="p-4 whitespace-nowrap">
                 <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= t(

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -24,7 +24,7 @@
               dark:divide-gray-700
             "
           >
-            <%= turbo_frame_tag("member-update-error") %>
+            <%= turbo_frame_tag("member-update-alert") %>
             <% @members.each do |member| %>
               <tr
                 class="

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -16,6 +16,7 @@
           <tbody
             class="bg-white divide-y divide-gray-200 dark:bg-gray-800 dark:divide-gray-700"
           >
+          <%= turbo_frame_tag("member-update-error") %>
           <% @members.each do |member| %>
             <tr
               class="text-sm font-normal text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-400"
@@ -53,7 +54,6 @@
                         access_levels: @access_levels
                       } %>
                     <% end %>
-                    <%= turbo_frame_tag("member-#{member.id}-access-level-error") %>
                   <% else %>
                   <%= t(:"projects.members.index.access_level.level_#{member.access_level}") %>
                 <% end %>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -16,7 +16,6 @@
           <tbody
             class="bg-white divide-y divide-gray-200 dark:bg-gray-800 dark:divide-gray-700"
           >
-          <%= turbo_frame_tag("member-update-error") %>
           <% @members.each do |member| %>
             <tr
               class="text-sm font-normal text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-400"
@@ -25,25 +24,33 @@
                 <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= member.user.email %></div>
               </td>
               <td class="p-4 whitespace-nowrap">
-                <div class="form-field">
-                    <% if member.user != current_user  %>
-                      <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
-                        <%= render partial: "projects/members/access_level",
-                        locals: {
-                          member: member,
-                          access_levels: @access_levels
-                        } %>
-                      <% end %>
-                    <% else %>
-                    <%= t(:"projects.members.index.access_level.level_#{member.access_level}") %>
-                  <% end %>
-                </div>
+                  <% if member.user != current_user &&
+                  (Member.exists?(namespace: member.namespace.parent&.self_and_ancestor_ids, user: current_user, access_level: [Member::AccessLevel::MAINTAINER, Member::AccessLevel::OWNER]) ||
+                     Member.exists?(namespace: member.namespace.self_and_ancestor_ids, user: current_user, access_level: [Member::AccessLevel::MAINTAINER, Member::AccessLevel::OWNER])) %>
+                    <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
+                      <%= render partial: "projects/members/access_level",
+                      locals: {
+                        member: member,
+                        access_levels: @access_levels
+                      } %>
+                    <% end %>
+                    <%= turbo_frame_tag("member-#{member.id}-access-level-error") %>
+                  <% else %>
+                  <%= t(:"projects.members.index.access_level.level_#{member.access_level}") %>
+                <% end %>
               </td>
               <td class="p-4 whitespace-nowrap">
                 <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= t(
                                                                                         :"projects.members.index.access_granted_by",
                                                                                         grantor_email: member.created_by.email
                                                                                       ) %></div>
+              </td>
+              <td class="p-4 whitespace-nowrap">
+                <div class="text-sm font-normal text-gray-500 dark:text-gray-400">
+                  <%= turbo_frame_tag("member-#{member.id}-access-level-updated") do %>
+                    <%= member.updated_at %>
+                  <% end %>
+                </div>
               </td>
               <td class="px-4 py-3 text-right">
                 <%= viral_dropdown(icon: "ellipsis_vertical", classes: "member-settings-ellipsis", aria: { label: t(:'projects.members.index.actions.member_dropdown_aria_label', member: member.user.email) }) do |dropdown| %>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -53,13 +53,14 @@
                           dark:text-green-300
                         "
                       >
-                        <%= t(:'activerecord.models.member.its_you') %>
+                        <%= t(:"activerecord.models.member.its_you") %>
                       </span>
                     <% end %>
                   </div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
-                  <% if member.user != current_user && allowed_to?(:allowed_to_modify_project_namespace?, @namespace) %>
+                  <% if member.user != current_user && allowed_to?(:allowed_to_modify_project_namespace?, @namespace) &&
+                    member.access_level <= @access_levels.values.last %>
                     <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
                       <%= render partial: "projects/members/access_level",
                       locals: {

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -14,6 +14,7 @@
   <div class="flex flex-col">
     <div class="overflow-x-auto">
       <div class="shadow">
+        <%= turbo_frame_tag("member-update-alert") %>
         <table class="min-w-full table-fixed dark:divide-gray-600">
           <tbody
             class="
@@ -24,7 +25,6 @@
               dark:divide-gray-700
             "
           >
-            <%= turbo_frame_tag("member-update-alert") %>
             <% @members.each do |member| %>
               <tr
                 class="

--- a/app/views/projects/members/update.turbo_stream.erb
+++ b/app/views/projects/members/update.turbo_stream.erb
@@ -1,0 +1,11 @@
+<% if member.errors.full_messages.count > 0 %>
+  <%= turbo_stream.append "member-update-error", viral_alert(type:, message:) %>
+<% else %>
+  <%= turbo_stream.update "member-#{member.id}-access-level",
+                      partial: "projects/members/access_level",
+                      locals: {
+                        member:,
+                        access_levels: @access_levels
+                      } %>
+
+<% end %>

--- a/app/views/projects/members/update.turbo_stream.erb
+++ b/app/views/projects/members/update.turbo_stream.erb
@@ -8,4 +8,4 @@
                     } %>
 
 <%= turbo_stream.update "member-#{member.id}-access-level-updated",
-                    member.updated_at %>
+                    I18n.l(member.updated_at, format: :default) %>

--- a/app/views/projects/members/update.turbo_stream.erb
+++ b/app/views/projects/members/update.turbo_stream.erb
@@ -1,12 +1,10 @@
 <% if member.errors.include?(:access_level) %>
-  <%= turbo_stream.update "member-#{member.id}-access-level-error",
-                      partial: "shared/form/field_errors",
-                      locals: {
-                        errors: member.errors.full_messages_for(:access_level)
-                      } %>
+  <%= turbo_stream.update "member-update-error",
+    viral_alert(type: 'alert', message:member.errors.full_messages.first) %>
 <% else %>
-  <%= turbo_stream.update "member-#{member.id}-access-level-error", "" %>
+  <%= turbo_stream.update "member-update-error", "" %>
 <% end %>
+
 
 <%= turbo_stream.update "member-#{member.id}-access-level",
                     partial: "projects/members/access_level",

--- a/app/views/projects/members/update.turbo_stream.erb
+++ b/app/views/projects/members/update.turbo_stream.erb
@@ -1,10 +1,4 @@
-<% if member.errors.include?(:access_level) %>
-  <%= turbo_stream.update "member-update-error",
-    viral_alert(type: 'alert', message:member.errors.full_messages.first) %>
-<% else %>
-  <%= turbo_stream.update "member-update-error", "" %>
-<% end %>
-
+<%= turbo_stream.update "member-update-alert", viral_alert(type:, message:) %>
 
 <%= turbo_stream.update "member-#{member.id}-access-level",
                     partial: "projects/members/access_level",

--- a/app/views/projects/members/update.turbo_stream.erb
+++ b/app/views/projects/members/update.turbo_stream.erb
@@ -1,11 +1,19 @@
-<% if member.errors.full_messages.count > 0 %>
-  <%= turbo_stream.append "member-update-error", viral_alert(type:, message:) %>
-<% else %>
-  <%= turbo_stream.update "member-#{member.id}-access-level",
-                      partial: "projects/members/access_level",
+<% if member.errors.include?(:access_level) %>
+  <%= turbo_stream.update "member-#{member.id}-access-level-error",
+                      partial: "shared/form/field_errors",
                       locals: {
-                        member:,
-                        access_levels: @access_levels
+                        errors: member.errors.full_messages_for(:access_level)
                       } %>
-
+<% else %>
+  <%= turbo_stream.update "member-#{member.id}-access-level-error", "" %>
 <% end %>
+
+<%= turbo_stream.update "member-#{member.id}-access-level",
+                    partial: "projects/members/access_level",
+                    locals: {
+                      member:,
+                      access_levels: @access_levels
+                    } %>
+
+<%= turbo_stream.update "member-#{member.id}-access-level-updated",
+                    member.updated_at %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,6 +297,8 @@ en:
           button_add_aria_label: Add new group member button
           link_remove_aria_label: "Remove group member %{member} button"
           member_dropdown_aria_label: "Dropdown options for group member %{member}"
+      update:
+        success: "Group member %{user_email} updated successfully"
       new:
         title: Add New Member
         add_member_to_group: Add member to group
@@ -357,6 +359,8 @@ en:
           button_add_aria_label: Add new project member button
           link_remove_aria_label: "Remove project member %{member} button"
           member_dropdown_aria_label: "Dropdown options for project member %{member}"
+      update:
+        success: "Project member %{user_email} updated successfully"
       new:
         title: Add New Member
         add_member_to_project: Add member to project

--- a/config/routes/group.rb
+++ b/config/routes/group.rb
@@ -15,7 +15,7 @@ constraints(::Constraints::GroupUrlConstrainer.new) do
         module: :groups,
         as: :group,
         constraints: { group_id: Irida::PathRegex.full_namespace_route_regex }) do
-    resources :members, only: %i[create destroy index new]
+    resources :members, only: %i[create destroy index new update]
     resources :samples, only: %i[index]
   end
 

--- a/config/routes/project.rb
+++ b/config/routes/project.rb
@@ -16,7 +16,7 @@ constraints(::Constraints::ProjectUrlConstrainer.new) do
       get :activity
       get :edit
       post :transfer
-      resources :members, only: %i[create destroy index new]
+      resources :members, only: %i[create destroy index new update]
       resources :samples
     end
   end

--- a/test/controllers/concerns/groups_membership_actions_concern_test.rb
+++ b/test/controllers/concerns/groups_membership_actions_concern_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class GroupsMembershipActionsConcernTest < ActionDispatch::IntegrationTest
+class GroupsMembershipActionsConcernTest < ActionDispatch::IntegrationTest # rubocop:disable Metrics/ClassLength
   include Devise::Test::IntegrationHelpers
 
   test 'group members index' do
@@ -115,5 +115,63 @@ class GroupsMembershipActionsConcernTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :redirect
+  end
+
+  test 'update group member access role' do
+    sign_in users(:john_doe)
+
+    group = groups(:group_five)
+    group_member = members(:group_five_member_michelle_doe)
+
+    patch group_member_path(group, group_member),
+          params: { member: {
+            access_level: Member::AccessLevel::ANALYST
+          }, format: :turbo_stream }
+
+    assert_equal Member.find_by(user_id: group_member.user.id,
+                                namespace_id: group_member.namespace.id).access_level,
+                 Member::AccessLevel::ANALYST
+
+    assert_response :success
+  end
+
+  test 'update project member access role to lower level than group' do
+    sign_in users(:john_doe)
+
+    group = groups(:subgroup_one_group_five)
+    group_member = members(:subgroup_one_group_five_member_james_doe)
+
+    assert_no_changes -> { group_member.access_level } do
+      patch group_member_path(group, group_member),
+            params: { member: {
+              access_level: Member::AccessLevel::ANALYST
+            }, format: :turbo_stream }
+    end
+
+    assert_not_equal Member.find_by(user_id: group_member.user.id,
+                                    namespace_id: group_member.namespace.id).access_level,
+                     Member::AccessLevel::ANALYST
+
+    assert_response :bad_request
+  end
+
+  test 'update project member access role to non existent access level' do
+    sign_in users(:john_doe)
+
+    group = groups(:subgroup_one_group_five)
+    group_member = members(:subgroup_one_group_five_member_james_doe)
+
+    assert_no_changes -> { group_member.access_level } do
+      patch group_member_path(group, group_member),
+            params: { member: {
+              access_level: 100_000
+            }, format: :turbo_stream }
+    end
+
+    assert_not_equal Member.find_by(user_id: group_member.user.id,
+                                    namespace_id: group_member.namespace.id).access_level,
+                     100_000
+
+    assert_response :bad_request
   end
 end

--- a/test/controllers/concerns/groups_membership_actions_concern_test.rb
+++ b/test/controllers/concerns/groups_membership_actions_concern_test.rb
@@ -117,8 +117,26 @@ class GroupsMembershipActionsConcernTest < ActionDispatch::IntegrationTest # rub
     assert_response :redirect
   end
 
-  test 'update group member access role' do
+  test 'update group member access role as owner' do
     sign_in users(:john_doe)
+
+    group = groups(:group_five)
+    group_member = members(:group_five_member_michelle_doe)
+
+    patch group_member_path(group, group_member),
+          params: { member: {
+            access_level: Member::AccessLevel::ANALYST
+          }, format: :turbo_stream }
+
+    assert_equal Member.find_by(user_id: group_member.user.id,
+                                namespace_id: group_member.namespace.id).access_level,
+                 Member::AccessLevel::ANALYST
+
+    assert_response :success
+  end
+
+  test 'update group member access role as maintainer' do
+    sign_in users(:micha_doe)
 
     group = groups(:group_five)
     group_member = members(:group_five_member_michelle_doe)

--- a/test/controllers/concerns/projects_membership_actions_concern_test.rb
+++ b/test/controllers/concerns/projects_membership_actions_concern_test.rb
@@ -147,8 +147,27 @@ class ProjectsMembershipActionsConcernTest < ActionDispatch::IntegrationTest # r
     assert_equal 2, project.namespace.project_members.count
   end
 
-  test 'update project member access role' do
+  test 'update project member access role with current user as owner' do
     sign_in users(:john_doe)
+
+    project = projects(:project22)
+    namespace = groups(:group_five)
+    project_member = members(:project_twenty_two_member_michelle_doe)
+
+    patch namespace_project_member_path(namespace, project, project_member),
+          params: { member: {
+            access_level: Member::AccessLevel::ANALYST
+          }, format: :turbo_stream }
+
+    assert_equal Member.find_by(user_id: project_member.user.id,
+                                namespace_id: project_member.namespace.id).access_level,
+                 Member::AccessLevel::ANALYST
+
+    assert_response :success
+  end
+
+  test 'update project member access role with current user as maintainer' do
+    sign_in users(:micha_doe)
 
     project = projects(:project22)
     namespace = groups(:group_five)

--- a/test/controllers/concerns/projects_membership_actions_concern_test.rb
+++ b/test/controllers/concerns/projects_membership_actions_concern_test.rb
@@ -146,4 +146,65 @@ class ProjectsMembershipActionsConcernTest < ActionDispatch::IntegrationTest # r
     assert_redirected_to namespace_project_members_path(namespace, project)
     assert_equal 2, project.namespace.project_members.count
   end
+
+  test 'update project member access role' do
+    sign_in users(:john_doe)
+
+    project = projects(:project22)
+    namespace = groups(:group_five)
+    project_member = members(:project_twenty_two_member_michelle_doe)
+
+    patch namespace_project_member_path(namespace, project, project_member),
+          params: { member: {
+            access_level: Member::AccessLevel::ANALYST
+          }, format: :turbo_stream }
+
+    assert_equal Member.find_by(user_id: project_member.user.id,
+                                namespace_id: project_member.namespace.id).access_level,
+                 Member::AccessLevel::ANALYST
+
+    assert_response :success
+  end
+
+  test 'update project member access role to lower level than group' do
+    sign_in users(:john_doe)
+
+    project = projects(:project22)
+    namespace = groups(:group_five)
+    project_member = members(:project_twenty_two_member_james_doe)
+
+    assert_no_changes -> { project_member.access_level } do
+      patch namespace_project_member_path(namespace, project, project_member),
+            params: { member: {
+              access_level: Member::AccessLevel::ANALYST
+            }, format: :turbo_stream }
+    end
+
+    assert_not_equal Member.find_by(user_id: project_member.user.id,
+                                    namespace_id: project_member.namespace.id).access_level,
+                     Member::AccessLevel::ANALYST
+
+    assert_response :bad_request
+  end
+
+  test 'update project member access role to non existent access level' do
+    sign_in users(:john_doe)
+
+    project = projects(:project22)
+    namespace = groups(:group_five)
+    project_member = members(:project_twenty_two_member_james_doe)
+
+    assert_no_changes -> { project_member.access_level } do
+      patch namespace_project_member_path(namespace, project, project_member),
+            params: { member: {
+              access_level: 100_000
+            }, format: :turbo_stream }
+    end
+
+    assert_not_equal Member.find_by(user_id: project_member.user.id,
+                                    namespace_id: project_member.namespace.id).access_level,
+                     100_000
+
+    assert_response :bad_request
+  end
 end

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -53,3 +53,18 @@ david_doe_group_four:
   type: Group
   description: David's first group
   owner_id: <%= ActiveRecord::FixtureSet.identify(:david_doe) %>
+
+group_five:
+  name: Group 5
+  path: group-5
+  type: Group
+  description: Group 5 description
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+
+subgroup_one_group_five:
+  name: Subgroup 1 Group 5
+  path: subgroup-1-group-5
+  type: Group
+  description: Subgroup 1 Group 5
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -68,3 +68,10 @@ subgroup_one_group_five:
   description: Subgroup 1 Group 5
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
+
+group_six:
+  name: Group 6
+  path: group-6
+  type: Group
+  description: Group 6 description
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -150,6 +150,12 @@ group_five_member_michelle_doe:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
   access_level: <%= Member::AccessLevel::GUEST %>
 
+group_five_member_micha_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:micha_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
+  access_level: <%= Member::AccessLevel::MAINTAINER %>
+
 project_twenty_two_member_john_doe:
   user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
@@ -167,6 +173,12 @@ project_twenty_two_member_michelle_doe:
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>
   access_level: <%= Member::AccessLevel::GUEST %>
+
+project_twenty_two_member_micha_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:micha_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>
+  access_level: <%= Member::AccessLevel::MAINTAINER %>
 
 
 subgroup_one_group_five_member_james_doe:

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -131,3 +131,46 @@ group_four_member_david_doe:
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:david_doe) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:david_doe_group_four) %>
   access_level: <%= Member::AccessLevel::OWNER %>
+
+group_five_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+group_five_member_james_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:james_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+group_five_member_michelle_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:michelle_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
+  access_level: <%= Member::AccessLevel::GUEST %>
+
+project_twenty_two_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+project_twenty_two_member_james_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:james_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+project_twenty_two_member_michelle_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:michelle_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>
+  access_level: <%= Member::AccessLevel::GUEST %>
+
+
+subgroup_one_group_five_member_james_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:james_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_one_group_five) %>
+  access_level: <%= Member::AccessLevel::OWNER %>

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -180,9 +180,26 @@ project_twenty_two_member_micha_doe:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>
   access_level: <%= Member::AccessLevel::MAINTAINER %>
 
-
 subgroup_one_group_five_member_james_doe:
   user_id: <%= ActiveRecord::FixtureSet.identify(:james_doe) %>
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_one_group_five) %>
   access_level: <%= Member::AccessLevel::OWNER %>
+
+group_six_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_six) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+group_six_member_james_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:james_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_six) %>
+  access_level: <%= Member::AccessLevel::GUEST %>
+
+project_twenty_three_member_james_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:james_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project23_namespace) %>
+  access_level: <%= Member::AccessLevel::GUEST %>

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -176,6 +176,14 @@ project21_namespace:
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
+project22_namespace:
+  name: Project 22
+  path: project-22
+  description: Project 22 description
+  type: Project
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+
 john_doe_project4_namespace:
   name: Project 4
   path: project-4

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -184,6 +184,14 @@ project22_namespace:
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
+project23_namespace:
+  name: Project 23
+  path: project-23
+  description: Project 23 description
+  type: Project
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:group_six) %>
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+
 john_doe_project4_namespace:
   name: Project 4
   path: project-4

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -95,3 +95,7 @@ project21:
 project22:
   creator_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>
+
+project23:
+  creator_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project23_namespace) %>

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -91,3 +91,7 @@ project20:
 project21:
   creator_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project21_namespace) %>
+
+project22:
+  creator_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace) %>

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -81,3 +81,18 @@ david_doe_group_four_route:
   name: Group 4
   path: group-4
   source: david_doe_group_four (Namespace)
+
+group_five_route:
+  name: Group 5
+  path: group-5
+  source: group_five (Namespace)
+
+project22_namespace_route:
+  name: Group 5 / Project 22
+  path: group-5/project-22
+  source: project22_namespace (Namespace)
+
+subgroup_one_group_five_route:
+  name: Group 5 / Subgroup 1 Group 5
+  path: group-5/subgroup-1-group-5
+  source: subgroup_one_group_five (Namespace)

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -96,3 +96,13 @@ subgroup_one_group_five_route:
   name: Group 5 / Subgroup 1 Group 5
   path: group-5/subgroup-1-group-5
   source: subgroup_one_group_five (Namespace)
+
+group_six_route:
+  name: Group 6
+  path: group-6
+  source: group_six (Namespace)
+
+project23_namespace_route:
+  name: Group 6 / Project 23
+  path: group-6/project-23
+  source: project23_namespace (Namespace)

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -37,7 +37,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
     # John Doe has access to 14 groups
-    assert_equal scoped_groups.count, 16
+    assert_equal scoped_groups.count, 17
 
     user = users(:david_doe)
     policy = GroupPolicy.new(user:)

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -37,7 +37,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
     # John Doe has access to 14 groups
-    assert_equal scoped_groups.count, 14
+    assert_equal scoped_groups.count, 16
 
     user = users(:david_doe)
     policy = GroupPolicy.new(user:)

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -43,7 +43,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   test 'scope' do
     scoped_projects = @policy.apply_scope(Project, type: :relation)
     # John Doe has access to 23 projects
-    assert_equal scoped_projects.count, 24
+    assert_equal scoped_projects.count, 25
 
     user = users(:david_doe)
     policy = ProjectPolicy.new(user:)

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -43,7 +43,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   test 'scope' do
     scoped_projects = @policy.apply_scope(Project, type: :relation)
     # John Doe has access to 23 projects
-    assert_equal scoped_projects.count, 23
+    assert_equal scoped_projects.count, 24
 
     user = users(:david_doe)
     policy = ProjectPolicy.new(user:)

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -17,7 +17,7 @@ class ProjectsTest < ApplicationSystemTestCase
     assert_no_selector 'a', text: I18n.t(:'components.pagination.previous')
 
     click_on I18n.t(:'components.pagination.next')
-    assert_selector 'tr', count: 3
+    assert_selector 'tr', count: 4
     click_on I18n.t(:'components.pagination.previous')
     assert_selector 'tr', count: 20
 

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -17,7 +17,7 @@ class ProjectsTest < ApplicationSystemTestCase
     assert_no_selector 'a', text: I18n.t(:'components.pagination.previous')
 
     click_on I18n.t(:'components.pagination.next')
-    assert_selector 'tr', count: 4
+    assert_selector 'tr', count: 5
     click_on I18n.t(:'components.pagination.previous')
     assert_selector 'tr', count: 20
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Added in functionality to allow a member's access level to be updated from the group and project members listing page using turbo_stream. Using turbo_stream allows us to update just the access level select box for the particular member that is being updated rather than having to do a full page reload. 

A few other UI related things were added in such as an 'It's you' tag next to any member listing which matches the current user, as well as, an updated_at column to the projects and group members tables/ 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Error when attempting to set a lower access level for user than they have in a parent group:**
![image](https://github.com/phac-nml/irida-next/assets/25466211/6801f565-846f-495e-bcb3-535aa1c9317c)

**Success message when an update is successful:**
![image](https://github.com/phac-nml/irida-next/assets/25466211/f7bfd5fc-170c-40ba-868b-ab6c2bc90bd0)

**It's you tag next to the member which matches the current user and the updated_at column:**
![image](https://github.com/phac-nml/irida-next/assets/25466211/2599f42f-7f3a-4ff2-be1b-b65bacfe73fd)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

To test this out:

1) Create a group and add a few members with different access levels
2) Create a project under the above group and add members with the same roles
3) Try to update a project member's access level to any other role other than owner when they have membership in the group as an owner
4) You should be presented with an error such as in the first image under the screenshots section
5) Try updating other members access levels which don't have a higher access role in a parent group. They should update without error. To ensure that the role is actually being updated you can keep an eye on the server logs in the terminal. You should see a logging statement such as `UPDATE "members" SET "access_level" = $1, "updated_at" = $2 WHERE "members"."id" = $3`. You should also be presented with a success message as in the second image under the screenshot section

For further information on how permissions work in IRIDA Next, view the docs for  [Member Permissions](https://phac-nml.github.io/irida-next/docs/user/organization/members/member-permissions)

**Things to verify:**

1) A maintainer can update other member's access levels up to the `Maintainer` access level. Can sign in using `user6@email.com` which is only a maintainer on groups and projects to test this out.
2) A maintainer or owner cannot update their own access levels
3) A maintainer cannot update a member that has the `owner` access level
4) Setting an invalid value for a select option (using chrome -> inspect element) for one of the access levels and then updating the user to that access level should result in an error
5) A Member's access level in a project which is a part of a group can only be set to a minimum of this inherited access level
6) If a member's access level is the same in both a parent group and project, then if the member's access level in the group is updated to a higher access level, then the member's access level should also be updated to match their access level in the parent group