### PR TITLE
GraphQL Authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'pg'
 
 # Authorization
 gem 'action_policy'
+gem 'action_policy-graphql'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,10 @@ GEM
   specs:
     action_policy (0.6.5)
       ruby-next-core (>= 0.14.0)
+    action_policy-graphql (0.5.3)
+      action_policy (>= 0.5.0)
+      graphql (>= 1.9.3)
+      ruby-next-core (>= 0.10.0)
     actioncable (7.0.4.3)
       actionpack (= 7.0.4.3)
       activesupport (= 7.0.4.3)
@@ -315,6 +319,7 @@ PLATFORMS
 
 DEPENDENCIES
   action_policy
+  action_policy-graphql
   actioncable
   bootsnap
   capybara

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -60,6 +60,7 @@ class GraphqlController < ApplicationController
     logger.error err.message
     logger.error err.backtrace.join("\n")
 
-    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: :internal_server_error
+    render json: { errors: [{ message: err.message, backtrace: err.backtrace }], data: {} },
+           status: :internal_server_error
   end
 end

--- a/app/graphql/irida_schema.rb
+++ b/app/graphql/irida_schema.rb
@@ -60,4 +60,28 @@ class IridaSchema < GraphQL::Schema # rubocop:disable GraphQL/ObjectDescription
 
     gid
   end
+
+  def self.unauthorized_object(error)
+    # Add a top-level error to the response instead of returning nil:
+    raise GraphQL::ExecutionError, "An object of type #{error.type.graphql_name} was hidden due to permissions"
+  end
+
+  def self.unauthorized_field(error)
+    # Add a top-level error to the response instead of returning nil:
+    raise GraphQL::ExecutionError,
+          "The field #{error.field.graphql_name} on an object of type #{error.type.graphql_name} was hidden due to permissions"
+  end
+
+  rescue_from(ActionPolicy::Unauthorized) do |exp|
+    raise GraphQL::ExecutionError.new(
+      # use result.message (backed by i18n) as an error message
+      exp.result.message,
+      # use GraphQL error extensions to provide more context
+      extensions: {
+        code: :unauthorized,
+        fullMessages: exp.result.reasons.full_messages,
+        details: exp.result.reasons.details
+      }
+    )
+  end
 end

--- a/app/graphql/irida_schema.rb
+++ b/app/graphql/irida_schema.rb
@@ -69,7 +69,8 @@ class IridaSchema < GraphQL::Schema # rubocop:disable GraphQL/ObjectDescription
   def self.unauthorized_field(error)
     # Add a top-level error to the response instead of returning nil:
     raise GraphQL::ExecutionError,
-          "The field #{error.field.graphql_name} on an object of type #{error.type.graphql_name} was hidden due to permissions"
+          "The field #{error.field.graphql_name} on an object of type " \
+          "#{error.type.graphql_name} was hidden due to permissions"
   end
 
   rescue_from(ActionPolicy::Unauthorized) do |exp|

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -3,6 +3,8 @@
 module Mutations
   # Base Mutation
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    include ActionPolicy::GraphQL::Behaviour
+
     argument_class Types::BaseArgument
     field_class Types::BaseField
     input_object_class Types::BaseInputObject

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -3,6 +3,8 @@
 module Resolvers
   # Base Resolver
   class BaseResolver < GraphQL::Schema::Resolver
+    include ActionPolicy::GraphQL::Behaviour
+
     argument_class ::Types::BaseArgument
   end
 end

--- a/app/graphql/resolvers/groups_resolver.rb
+++ b/app/graphql/resolvers/groups_resolver.rb
@@ -6,7 +6,7 @@ module Resolvers
     type Types::GroupType.connection_type, null: true
 
     def resolve
-      Group.all
+      authorized_scope Group, type: :relation
     end
   end
 end

--- a/app/graphql/resolvers/nested_groups_resolver.rb
+++ b/app/graphql/resolvers/nested_groups_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
       return Group.none if parent.blank?
 
       if args[:include_parent_descendants]
-        parent.descendants.where(type: Group.sti_name)
+        parent.descendants
       else
         parent.children
       end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -86,6 +86,11 @@ type GroupConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+
+  """
+  Identifies the total count of items in the connection.
+  """
+  totalCount: Int!
 }
 
 """

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 module Types
+  # Base Connection Type
   class BaseConnection < Types::BaseObject
     # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides
     include GraphQL::Types::Relay::ConnectionBehaviors
+
+    field :total_count, Integer, null: false, description: 'Identifies the total count of items in the connection.'
+
+    def total_count
+      object.items.size
+    end
   end
 end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -3,6 +3,8 @@
 module Types
   # BaseObject
   class BaseObject < GraphQL::Schema::Object
+    include ActionPolicy::GraphQL::Behaviour
+
     edge_type_class(Types::BaseEdge)
     connection_type_class(Types::BaseConnection)
     field_class Types::BaseField

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,7 +14,8 @@ module Types
 
     field :current_user, Types::UserType, null: true, description: 'Get information about current user.'
 
-    field :group, Types::GroupType, null: true, resolver: Resolvers::GroupResolver, description: 'Find a group.'
+    field :group, Types::GroupType, null: true, authorize: true, resolver: Resolvers::GroupResolver,
+                                    description: 'Find a group.'
     field :groups, Types::GroupType.connection_type, null: false, resolver: Resolvers::GroupsResolver,
                                                      description: 'Find groups.'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,8 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  action_policy:
+    unauthorized: You are not authorized to perform this action
   activerecord:
     attributes:
       group:

--- a/test/graphql/group_query_test.rb
+++ b/test/graphql/group_query_test.rb
@@ -17,6 +17,7 @@ class GroupQueryTest < ActiveSupport::TestCase
             name
             path
           }
+          totalCount
         }
       }
     }
@@ -57,5 +58,20 @@ class GroupQueryTest < ActiveSupport::TestCase
     assert_equal group.name, data['name']
 
     assert_equal group.to_global_id.to_s, data['id'], 'id should be GlobalID'
+  end
+
+  test 'group query should not return a result when unauthorized' do
+    group = groups(:group_one)
+
+    result = IridaSchema.execute(GROUP_QUERY, context: { current_user: users(:jane_doe) },
+                                              variables: { groupPath: group.full_path })
+
+    assert_nil result['data']['group']
+
+    assert_not_nil result['errors'], 'shouldn\'t work and have errors.'
+
+    error_message = result['errors'][0]['message']
+
+    assert_equal I18n.t('action_policy.unauthorized'), error_message
   end
 end

--- a/test/graphql/groups_query_test.rb
+++ b/test/graphql/groups_query_test.rb
@@ -12,6 +12,7 @@ class GroupsQueryTest < ActiveSupport::TestCase
           description
           id
         }
+        totalCount
       }
     }
   GRAPHQL
@@ -30,5 +31,20 @@ class GroupsQueryTest < ActiveSupport::TestCase
 
     assert_not_empty data, 'groups type should work'
     assert_not_empty data['nodes']
+  end
+
+  test 'groups query only returns scoped groups' do
+    groups_count = @user.groups.self_and_descendant_ids.count
+    result = IridaSchema.execute(GROUPS_QUERY, context: { current_user: @user },
+                                               variables: { first: 20 })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['groups']
+
+    assert_not_empty data, 'groups type should work'
+    assert_not_empty data['nodes']
+
+    assert_equal groups_count, data['totalCount']
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in [Action Policy GraphQL](https://github.com/palkan/action_policy-graphql), for using our Action Policy Authorizations in the GraphQL API.

Specifically that means that Users are only able to view and list Groups that they are authorized to do so.

In addition this added a `totalCount` field to the Relay Connections so that it is easy to determine that the correct number of Groups are queried/return.

Note: This PR adds a gem so make sure to run `bundle` before testing.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

If you login as `admin@email.com` and try to query for the `borrelia` group, which you don't have access to you will get the following:

![image](https://github.com/phac-nml/irida-next/assets/492127/ad49cb02-7132-484e-ace4-914485a1f4c1)

If you login as `admin@email.com` and try to query for all the groups, you will have a totalCount of 15 which matches the number of groups displayed through the web ui.

![image](https://github.com/phac-nml/irida-next/assets/492127/0d41dbbf-27cf-4998-9aa2-5791423c97b4)



## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
1. Login as `admin@email.com`
1. Open the graphiql interface `http://localhost:3000/graphiql`
1. Query for a Group that you can access.
   * ```graphql
     {
       group(fullpath: "bacillus") {
         id
         name
         path
       }
     }
     ```
1. See that you get a valid result
1. Query for a Group that you cannot access.
   * ```graphql
     {
       group(fullpath: "borrelia") {
         id
         name
         path
       }
     }
     ```
1. See that you get an authorization error