### PR TITLE
Standardize policy methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,8 +32,10 @@ class ApplicationController < ActionController::Base
     not_found
   end
 
-  rescue_from ActionPolicy::Unauthorized do |_exception|
-    render 'shared/error/not_authorized', status: :unauthorized, layout: 'application'
+  rescue_from ActionPolicy::Unauthorized do |exception|
+    render 'shared/error/not_authorized', status: :unauthorized, layout: 'application', locals: {
+      authorization_message: exception.result.message
+    }
   end
 
   rescue_from ActiveRecord::RecordNotFound do |exception|

--- a/app/controllers/concerns/membership_actions.rb
+++ b/app/controllers/concerns/membership_actions.rb
@@ -10,15 +10,15 @@ module MembershipActions
     before_action proc { available_users }, only: %i[new create]
     before_action proc { access_levels }, only: %i[new create index update]
     before_action proc { context_crumbs }, only: %i[index new]
-    before_action proc { authorize_view_members }, only: %i[index]
-    before_action proc { authorize_modify_members }, only: %i[new]
   end
 
   def index
+    authorize! @namespace, to: :member_listing?
     @members = Member.where(namespace_id: @namespace.id)
   end
 
   def new
+    authorize! @namespace, to: :create_member? unless @namespace.parent.nil? && @namespace.owner == current_user
     @new_member = Member.new(namespace_id: @namespace.id)
 
     respond_to do |format|

--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -39,13 +39,5 @@ module Groups
       @group ||= Group.find_by_full_path(request.params[:group_id]) # rubocop:disable Rails/DynamicFindBy
       @group
     end
-
-    def authorize_view_members
-      authorize_view_group!
-    end
-
-    def authorize_modify_members
-      authorize_modify_group!
-    end
   end
 end

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -6,9 +6,9 @@ module Groups
     layout 'groups'
     before_action :context_crumbs, only: %i[index]
     before_action :group, only: %i[index]
-    before_action :authorize_view_group!, only: %i[index]
 
     def index
+      authorize! @group, to: :sample_listing?
       respond_to do |format|
         format.html do
           @has_samples = Sample.joins(project: [:namespace]).exists?(namespace: { parent_id: @group.self_and_descendant_ids }) # rubocop:disable Layout/LineLength

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -27,7 +27,7 @@ class GroupsController < Groups::ApplicationController
   end
 
   def edit
-    authorize! @group, to: :update?
+    authorize! @group
   end
 
   def create

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,26 +5,30 @@ class GroupsController < Groups::ApplicationController
   layout :resolve_layout
   before_action :group, only: %i[edit show destroy update]
   before_action :context_crumbs, except: %i[index new create show]
-  before_action :authorize_modify_group!, only: %i[edit]
-  before_action :authorize_view_group!, only: %i[show]
-  before_action :authorize_create_subgroup!, only: %i[new]
   before_action :authorized_namespaces, only: %i[edit new update create]
 
   def index
     @groups = authorized_scope(Group, type: :relation).order(updated_at: :desc)
   end
 
-  def show; end
+  def show
+    authorize! @group
+  end
 
   def new
     @group = Group.find(params[:parent_id]) if params[:parent_id]
+
+    authorize! @group, to: :create_subgroup? if params[:parent_id]
+
     @new_group = Group.new(parent_id: @group&.id)
     respond_to do |format|
       format.html { render_new }
     end
   end
 
-  def edit; end
+  def edit
+    authorize! @group, to: :update?
+  end
 
   def create
     @new_group = Groups::CreateService.new(current_user, group_params).execute

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,7 +12,7 @@ class GroupsController < Groups::ApplicationController
   end
 
   def show
-    authorize! @group
+    authorize! @group, to: :read?
   end
 
   def new

--- a/app/controllers/profiles/accounts_controller.rb
+++ b/app/controllers/profiles/accounts_controller.rb
@@ -6,7 +6,7 @@ module Profiles
   class AccountsController < Profiles::ApplicationController
     # Get account page
     def show
-      authorize! @user
+      authorize! @user, to: :read?
     end
 
     def destroy

--- a/app/controllers/profiles/accounts_controller.rb
+++ b/app/controllers/profiles/accounts_controller.rb
@@ -6,10 +6,11 @@ module Profiles
   class AccountsController < Profiles::ApplicationController
     # Get account page
     def show
-      # No necessary code here
+      authorize! @user
     end
 
     def destroy
+      authorize! @user
       @user.destroy
       redirect_to new_user_session_url
     end

--- a/app/controllers/profiles/application_controller.rb
+++ b/app/controllers/profiles/application_controller.rb
@@ -4,7 +4,6 @@ module Profiles
   # Base Controller for the users profile
   class ApplicationController < ApplicationController
     before_action :set_user
-    before_action :authorize_user_profile_access!
 
     layout 'profiles'
 

--- a/app/controllers/profiles/passwords_controller.rb
+++ b/app/controllers/profiles/passwords_controller.rb
@@ -6,11 +6,12 @@ module Profiles
   class PasswordsController < Profiles::ApplicationController
     # Get password page
     def edit
-      # No necessary code here
+      authorize! @user
     end
 
     # Update the user's password
     def update
+      authorize! @user
       respond_to do |format|
         if @user.update_password_with_password(update_password_params)
           # Sign in the user bypassing validation in case their password changed

--- a/app/controllers/profiles/personal_access_tokens_controller.rb
+++ b/app/controllers/profiles/personal_access_tokens_controller.rb
@@ -7,10 +7,12 @@ module Profiles
     before_action :active_access_tokens
 
     def index
+      authorize! @user
       @personal_access_token = PersonalAccessToken.new(scopes: [])
     end
 
     def create
+      authorize! @user
       @personal_access_token = PersonalAccessToken.new(personal_access_token_params.merge(user: current_user))
 
       respond_to do |format|
@@ -29,6 +31,7 @@ module Profiles
     end
 
     def revoke
+      authorize! @user
       @personal_access_token = current_user.personal_access_tokens.find(params[:id])
 
       if @personal_access_token.revoke!

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,7 +6,7 @@ class ProfilesController < Profiles::ApplicationController
 
   # Get the profile page
   def show
-    authorize! @user
+    authorize! @user, to: :read?
     # No necessary code here
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,14 +3,16 @@
 # Controller for the user profile page
 class ProfilesController < Profiles::ApplicationController
   before_action :set_user
-  before_action :authorize_user_profile_access!
 
   # Get the profile page
   def show
+    authorize! @user
     # No necessary code here
   end
 
   def update
+    authorize! @user
+
     respond_to do |format|
       if @user.update(update_params)
         # Sign in the user bypassing validation in case their password changed

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -40,13 +40,5 @@ module Projects
       @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
       @project.namespace
     end
-
-    def authorize_view_members
-      authorize_view_project!
-    end
-
-    def authorize_modify_members
-      authorize_modify_project!
-    end
   end
 end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -14,7 +14,7 @@ module Projects
     end
 
     def show
-      authorize! @sample.project, to: :show_sample?
+      authorize! @sample.project, to: :read_sample?
     end
 
     def new

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -6,20 +6,26 @@ module Projects
     before_action :sample, only: %i[show edit update destroy]
     before_action :project
     before_action :context_crumbs
-    before_action :authorize_view_project!, only: %i[show index]
-    before_action :authorize_modify_project!, only: %i[new edit]
 
     def index
+      authorize! @project, to: :sample_listing?
+
       @samples = Sample.where(project_id: @project.id)
     end
 
-    def show; end
+    def show
+      authorize! @sample.project, to: :show_sample?
+    end
 
     def new
+      authorize! @project, to: :create_sample?
+
       @sample = Sample.new
     end
 
-    def edit; end
+    def edit
+      authorize! @sample.project, to: :update_sample?
+    end
 
     def create
       @sample = Samples::CreateService.new(current_user, @project, sample_params).execute

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,8 +5,6 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   layout :resolve_layout
   before_action :project, only: %i[show edit update activity transfer destroy]
   before_action :context_crumbs, except: %i[index new create show]
-  before_action :authorize_modify_project!, only: %i[edit]
-  before_action :authorize_view_project!, only: %i[show]
   before_action :authorized_namespaces, only: %i[edit new update create transfer]
 
   def index
@@ -23,7 +21,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   end
 
   def show
-    # No necessary code here
+    authorize! @project
   end
 
   def new
@@ -32,7 +30,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   end
 
   def edit
-    # No necessary code here
+    authorize! @project
   end
 
   def create

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,7 +21,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   end
 
   def show
-    authorize! @project
+    authorize! @project, to: :read?
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,6 +27,8 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   def new
     @project = Project.new
     @project.build_namespace(parent_id: params[:namespace_id] || current_user.namespace.id)
+
+    authorize! @project
   end
 
   def edit
@@ -58,6 +60,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   end
 
   def activity
+    authorize! @project
     # No necessary code here
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@
 # Controller actions for Users
 class UsersController < ApplicationController
   before_action :user
+  before_action :authorize_user_profile_access!
 
   def show
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,9 +3,9 @@
 # Controller actions for Users
 class UsersController < ApplicationController
   before_action :user
-  before_action :authorize_user_profile_access!
 
   def show
+    authorize! @user
     respond_to do |format|
       format.html do
         render 'users/show'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   before_action :user
 
   def show
-    authorize! @user
+    authorize! @user, to: :read?
     respond_to do |format|
       format.html do
         render 'users/show'

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,7 +14,7 @@ module Types
 
     field :current_user, Types::UserType, null: true, description: 'Get information about current user.'
 
-    field :group, Types::GroupType, null: true, authorize: true, resolver: Resolvers::GroupResolver,
+    field :group, Types::GroupType, null: true, authorize: { to: :read? }, resolver: Resolvers::GroupResolver,
                                     description: 'Find a group.'
     field :groups, Types::GroupType.connection_type, null: false, resolver: Resolvers::GroupsResolver,
                                                      description: 'Find groups.'

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -22,9 +22,6 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   delegate :project, to: :project_namespace
 
   class << self
-    # TODO: Remove this once authorization is setup and
-    # the policy class will handle which access levels
-    # to return
     def access_levels(member)
       case member.access_level
       when AccessLevel::OWNER

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -16,20 +16,4 @@ class ApplicationPolicy < ActionPolicy::Base
   #    record.user_id == user.id
   #  end
   #
-
-  def can_modify?(obj)
-    Member.can_modify?(user, obj)
-  end
-
-  def can_view?(obj)
-    Member.can_view?(user, obj)
-  end
-
-  def can_destroy?(obj)
-    Member.can_destroy?(user, obj)
-  end
-
-  def can_transfer?(obj)
-    Member.namespace_owners_include_user?(user, obj)
-  end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -27,7 +27,7 @@ class GroupPolicy < NamespacePolicy
   end
 
   def transfer_to_namespace?
-    return true if can_transfer?(record)
+    return true if can_transfer?(record) == true
 
     details[:name] = record.name
     false

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -2,11 +2,19 @@
 
 # Policy for groups authorization
 class GroupPolicy < NamespacePolicy
-  alias_rule :create?, :edit?, :update?, :new?, to: :manage?
+  alias_rule :edit?, :update?, to: :manage?
   alias_rule :show?, :index?, to: :view?
+  alias_rule :new?, to: :create?
 
   def view?
     return true if can_view?(record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def create?
+    return true if can_modify?(record) == true
 
     details[:name] = record.name
     false

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -2,43 +2,8 @@
 
 # Policy for groups authorization
 class GroupPolicy < NamespacePolicy
-  def show?
-    return true if Member.can_view?(user, record) == true
-
-    details[:name] = record.name
-    false
-  end
-
-  def new?
-    return true if Member.can_create?(user, record) == true
-
-    details[:name] = record.name
-    false
-  end
-
-  def edit?
-    return true if Member.can_modify?(user, record) == true
-
-    details[:name] = record.name
-    false
-  end
-
   def create?
     return true if Member.can_create?(user, record) == true
-
-    details[:name] = record.name
-    false
-  end
-
-  def update?
-    return true if Member.can_modify?(user, record) == true
-
-    details[:name] = record.name
-    false
-  end
-
-  def destroy?
-    return true if Member.can_destroy?(user, record) == true
 
     details[:name] = record.name
     false
@@ -51,8 +16,50 @@ class GroupPolicy < NamespacePolicy
     false
   end
 
+  def destroy?
+    return true if Member.can_destroy?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def edit?
+    return true if Member.can_modify?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def new?
+    return true if Member.can_create?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def show?
+    return true if Member.can_view?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
   def transfer_into_namespace?
     return true if Member.can_transfer_into_namespace?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def update?
+    return true if Member.can_modify?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def member_listing?
+    return true if Member.can_view?(user, record) == true
 
     details[:name] = record.name
     false
@@ -65,13 +72,6 @@ class GroupPolicy < NamespacePolicy
     false
   end
 
-  def update_member?
-    return true if Member.can_modify?(user, record) == true
-
-    details[:name] = record.name
-    false
-  end
-
   def destroy_member?
     return true if Member.can_modify?(user, record) == true
 
@@ -79,8 +79,8 @@ class GroupPolicy < NamespacePolicy
     false
   end
 
-  def member_listing?
-    return true if Member.can_view?(user, record) == true
+  def update_member?
+    return true if Member.can_modify?(user, record) == true
 
     details[:name] = record.name
     false

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -37,7 +37,7 @@ class GroupPolicy < NamespacePolicy
     false
   end
 
-  def show?
+  def read?
     return true if Member.can_view?(user, record) == true
 
     details[:name] = record.name

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -2,40 +2,92 @@
 
 # Policy for groups authorization
 class GroupPolicy < NamespacePolicy
-  alias_rule :edit?, :update?, to: :manage?
-  alias_rule :show?, :index?, to: :view?
-  alias_rule :new?, to: :create?
+  def show?
+    return true if Member.can_view?(user, record) == true
 
-  def view?
-    return true if can_view?(record) == true
+    details[:name] = record.name
+    false
+  end
+
+  def new?
+    return true if Member.can_create?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def edit?
+    return true if Member.can_modify?(user, record) == true
 
     details[:name] = record.name
     false
   end
 
   def create?
-    return true if can_modify?(record) == true
+    return true if Member.can_create?(user, record) == true
 
     details[:name] = record.name
     false
   end
 
-  def manage?
-    return true if can_modify?(record) == true
+  def update?
+    return true if Member.can_modify?(user, record) == true
 
     details[:name] = record.name
     false
   end
 
   def destroy?
-    return true if can_destroy?(record) == true
+    return true if Member.can_destroy?(user, record) == true
 
     details[:name] = record.name
     false
   end
 
-  def transfer_to_namespace?
-    return true if can_transfer?(record) == true
+  def create_subgroup?
+    return true if Member.can_create?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def transfer_into_namespace?
+    return true if Member.can_transfer_into_namespace?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def create_member?
+    return true if Member.can_create?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def update_member?
+    return true if Member.can_modify?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def destroy_member?
+    return true if Member.can_modify?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def member_listing?
+    return true if Member.can_view?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def sample_listing?
+    return true if Member.can_view?(user, record) == true
 
     details[:name] = record.name
     false

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -2,24 +2,35 @@
 
 # Policy for groups authorization
 class GroupPolicy < NamespacePolicy
-  alias_rule :create?, :edit?, :update?, :new?, to: :allowed_to_modify_group?
-  alias_rule :show?, :index?, to: :allowed_to_view_group?
-  alias_rule :destroy?, to: :allowed_to_destroy?
+  alias_rule :create?, :edit?, :update?, :new?, to: :manage?
+  alias_rule :show?, :index?, to: :view?
 
-  def allowed_to_view_group?
-    can_view?(record)
+  def view?
+    return true if can_view?(record) == true
+
+    details[:name] = record.name
+    false
   end
 
-  def allowed_to_modify_group?
-    can_modify?(record)
+  def manage?
+    return true if can_modify?(record) == true
+
+    details[:name] = record.name
+    false
   end
 
-  def allowed_to_destroy?
-    can_destroy?(record)
+  def destroy?
+    return true if can_destroy?(record) == true
+
+    details[:name] = record.name
+    false
   end
 
   def transfer_to_namespace?
-    can_transfer?(record)
+    return true if can_transfer?(record)
+
+    details[:name] = record.name
+    false
   end
 
   scope_for :relation do |_relation|

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -3,20 +3,57 @@
 module Namespaces
   # Policy for authorization under project_namespace
   class ProjectNamespacePolicy < NamespacePolicy
-    alias_rule :update?, to: :manage?
-    alias_rule :new?, to: :create?
-
-    def create?
+    def new?
       return true if record.parent.user_namespace? && record.parent.owner == user
-      return true if can_modify?(record) == true
+      return true if Member.can_create?(user, record) == true
 
       details[:name] = record.name
       false
     end
 
-    def manage?
+    def create?
       return true if record.parent.user_namespace? && record.parent.owner == user
-      return true if can_modify?(record) == true
+      return true if Member.can_create?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
+
+    def update?
+      return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if Member.can_modify?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
+
+    def create_member?
+      return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if Member.can_create?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
+
+    def update_member?
+      return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if Member.can_modify?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
+
+    def destroy_member?
+      return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if Member.can_modify?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
+
+    def member_listing?
+      return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if Member.can_view?(user, record) == true
 
       details[:name] = record.name
       false

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -3,7 +3,16 @@
 module Namespaces
   # Policy for authorization under project_namespace
   class ProjectNamespacePolicy < NamespacePolicy
-    alias_rule :new?, :create?, :update?, to: :manage?
+    alias_rule :update?, to: :manage?
+    alias_rule :new?, to: :create?
+
+    def create?
+      return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if can_modify?(record) == true
+
+      details[:name] = record.name
+      false
+    end
 
     def manage?
       return true if record.parent.user_namespace? && record.parent.owner == user

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -3,13 +3,14 @@
 module Namespaces
   # Policy for authorization under project_namespace
   class ProjectNamespacePolicy < NamespacePolicy
-    alias_rule :new?, :create?, :update?, to: :allowed_to_modify_project_namespace?
-    alias_rule :index?, to: :allowed_to_view_project_namespace?
+    alias_rule :new?, :create?, :update?, to: :manage?
 
-    def allowed_to_modify_project_namespace?
+    def manage?
       return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if can_modify?(record) == true
 
-      can_modify?(record)
+      details[:name] = record.name
+      false
     end
   end
 end

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -3,22 +3,6 @@
 module Namespaces
   # Policy for authorization under project_namespace
   class ProjectNamespacePolicy < NamespacePolicy
-    def new?
-      return true if record.parent.user_namespace? && record.parent.owner == user
-      return true if Member.can_create?(user, record) == true
-
-      details[:name] = record.name
-      false
-    end
-
-    def create?
-      return true if record.parent.user_namespace? && record.parent.owner == user
-      return true if Member.can_create?(user, record) == true
-
-      details[:name] = record.name
-      false
-    end
-
     def update?
       return true if record.parent.user_namespace? && record.parent.owner == user
       return true if Member.can_modify?(user, record) == true

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -11,17 +11,17 @@ module Namespaces
       false
     end
 
-    def create_member?
+    def member_listing?
       return true if record.parent.user_namespace? && record.parent.owner == user
-      return true if Member.can_create?(user, record) == true
+      return true if Member.can_view?(user, record) == true
 
       details[:name] = record.name
       false
     end
 
-    def update_member?
+    def create_member?
       return true if record.parent.user_namespace? && record.parent.owner == user
-      return true if Member.can_modify?(user, record) == true
+      return true if Member.can_create?(user, record) == true
 
       details[:name] = record.name
       false
@@ -35,9 +35,9 @@ module Namespaces
       false
     end
 
-    def member_listing?
+    def update_member?
       return true if record.parent.user_namespace? && record.parent.owner == user
-      return true if Member.can_view?(user, record) == true
+      return true if Member.can_modify?(user, record) == true
 
       details[:name] = record.name
       false

--- a/app/policies/namespaces/user_namespace_policy.rb
+++ b/app/policies/namespaces/user_namespace_policy.rb
@@ -3,17 +3,20 @@
 module Namespaces
   # Policy for authorization under user_namespace
   class UserNamespacePolicy < NamespacePolicy
-    alias_rule :new?, :create?, to: :allowed_to_modify_projects_under_namespace?
+    alias_rule :new?, :create?, to: :manage?
 
-    def allowed_to_modify_projects_under_namespace?
+    def manage?
       return true if record.owner == user
+      return true if can_modify?(record) == true
 
-      can_modify?(record)
+      details[:name] = record.name
+      false
     end
 
     def transfer_to_namespace?
       return true if record.owner == user
 
+      details[:name] = record.name
       false
     end
   end

--- a/app/policies/namespaces/user_namespace_policy.rb
+++ b/app/policies/namespaces/user_namespace_policy.rb
@@ -3,9 +3,9 @@
 module Namespaces
   # Policy for authorization under user_namespace
   class UserNamespacePolicy < NamespacePolicy
-    alias_rule :new?, :create?, to: :manage?
+    alias_rule :new?, to: :create?
 
-    def manage?
+    def create?
       return true if record.owner == user
       return true if can_modify?(record) == true
 

--- a/app/policies/namespaces/user_namespace_policy.rb
+++ b/app/policies/namespaces/user_namespace_policy.rb
@@ -3,17 +3,23 @@
 module Namespaces
   # Policy for authorization under user_namespace
   class UserNamespacePolicy < NamespacePolicy
-    alias_rule :new?, to: :create?
-
-    def create?
+    def new?
       return true if record.owner == user
-      return true if can_modify?(record) == true
+      return true if Member.can_create?(user, record) == true
 
       details[:name] = record.name
       false
     end
 
-    def transfer_to_namespace?
+    def create?
+      return true if record.owner == user
+      return true if Member.can_create?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
+
+    def transfer_into_namespace?
       return true if record.owner == user
 
       details[:name] = record.name

--- a/app/policies/namespaces/user_namespace_policy.rb
+++ b/app/policies/namespaces/user_namespace_policy.rb
@@ -3,17 +3,8 @@
 module Namespaces
   # Policy for authorization under user_namespace
   class UserNamespacePolicy < NamespacePolicy
-    def new?
-      return true if record.owner == user
-      return true if Member.can_create?(user, record) == true
-
-      details[:name] = record.name
-      false
-    end
-
     def create?
       return true if record.owner == user
-      return true if Member.can_create?(user, record) == true
 
       details[:name] = record.name
       false

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -26,14 +26,6 @@ class ProjectPolicy < NamespacePolicy
     false
   end
 
-  def create?
-    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if Member.can_create?(user, record.namespace) == true
-
-    details[:name] = record.name
-    false
-  end
-
   def update?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_modify?(user, record.namespace) == true

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -2,13 +2,21 @@
 
 # Policy for projects authorization
 class ProjectPolicy < NamespacePolicy
-  alias_rule :create?, :edit?, :update?, :new?,
-             to: :manage?
+  alias_rule :edit?, :update?, to: :manage?
   alias_rule :index?, :show?, :activity?, to: :view?
+  alias_rule :new?, to: :create?
 
   def view?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if can_view?(record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def create?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if can_modify?(record.namespace) == true
 
     details[:name] = record.name
     false

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -76,7 +76,7 @@ class ProjectPolicy < NamespacePolicy
 
   def create_sample?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if Member.namespace_owners_include_user?(user, record.namespace) == true
+    return true if Member.can_create?(user, record.namespace) == true
 
     details[:name] = record.name
     false
@@ -84,7 +84,7 @@ class ProjectPolicy < NamespacePolicy
 
   def update_sample?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if Member.namespace_owners_include_user?(user, record.namespace) == true
+    return true if Member.can_modify?(user, record.namespace) == true
 
     details[:name] = record.name
     false

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -2,29 +2,49 @@
 
 # Policy for projects authorization
 class ProjectPolicy < NamespacePolicy
-  alias_rule :edit?, :update?, to: :manage?
-  alias_rule :index?, :show?, :activity?, to: :view?
-  alias_rule :new?, to: :create?
-
-  def view?
+  def show?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if can_view?(record.namespace) == true
+    return true if Member.can_view?(user, record.namespace) == true
 
     details[:name] = record.name
+    false
+  end
+
+  def edit?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_modify?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def new?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_create?(user, record.namespace) == true
+
+    details[:name] = record.namespace.parent.name
     false
   end
 
   def create?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if can_modify?(record.namespace) == true
+    return true if Member.can_create?(user, record.namespace) == true
 
     details[:name] = record.name
     false
   end
 
-  def manage?
+  def update?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if can_modify?(record.namespace) == true
+    return true if Member.can_modify?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def activity?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_view?(user, record.namespace) == true
 
     details[:name] = record.name
     false
@@ -32,7 +52,7 @@ class ProjectPolicy < NamespacePolicy
 
   def destroy?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if can_destroy?(record.namespace) == true
+    return true if Member.can_destroy?(user, record.namespace) == true
 
     details[:name] = record.name
     false
@@ -40,7 +60,47 @@ class ProjectPolicy < NamespacePolicy
 
   def transfer?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if can_transfer?(record.namespace)
+    return true if Member.can_transfer?(user, record.namespace)
+
+    details[:name] = record.name
+    false
+  end
+
+  def sample_listing?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_view?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def create_sample?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.namespace_owners_include_user?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def update_sample?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.namespace_owners_include_user?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def destroy_sample?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.namespace_owners_include_user?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def show_sample?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_view?(user, record.namespace) == true
 
     details[:name] = record.name
     false

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -2,9 +2,17 @@
 
 # Policy for projects authorization
 class ProjectPolicy < NamespacePolicy
-  def show?
+  def activity?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_view?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def destroy?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_destroy?(user, record.namespace) == true
 
     details[:name] = record.name
     false
@@ -26,25 +34,9 @@ class ProjectPolicy < NamespacePolicy
     false
   end
 
-  def update?
-    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if Member.can_modify?(user, record.namespace) == true
-
-    details[:name] = record.name
-    false
-  end
-
-  def activity?
+  def show?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_view?(user, record.namespace) == true
-
-    details[:name] = record.name
-    false
-  end
-
-  def destroy?
-    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if Member.can_destroy?(user, record.namespace) == true
 
     details[:name] = record.name
     false
@@ -53,6 +45,14 @@ class ProjectPolicy < NamespacePolicy
   def transfer?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_transfer?(user, record.namespace)
+
+    details[:name] = record.name
+    false
+  end
+
+  def update?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_modify?(user, record.namespace) == true
 
     details[:name] = record.name
     false
@@ -74,14 +74,6 @@ class ProjectPolicy < NamespacePolicy
     false
   end
 
-  def update_sample?
-    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if Member.can_modify?(user, record.namespace) == true
-
-    details[:name] = record.name
-    false
-  end
-
   def destroy_sample?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.namespace_owners_include_user?(user, record.namespace) == true
@@ -93,6 +85,14 @@ class ProjectPolicy < NamespacePolicy
   def show_sample?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_view?(user, record.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def update_sample?
+    return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if Member.can_modify?(user, record.namespace) == true
 
     details[:name] = record.name
     false

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -34,7 +34,7 @@ class ProjectPolicy < NamespacePolicy
     false
   end
 
-  def show?
+  def read?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_view?(user, record.namespace) == true
 
@@ -82,7 +82,7 @@ class ProjectPolicy < NamespacePolicy
     false
   end
 
-  def show_sample?
+  def read_sample?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_view?(user, record.namespace) == true
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -3,33 +3,39 @@
 # Policy for projects authorization
 class ProjectPolicy < NamespacePolicy
   alias_rule :create?, :edit?, :update?, :new?,
-             to: :allowed_to_modify_project?
-  alias_rule :index?, :show?, :activity?, to: :allowed_to_view_project?
-  alias_rule :destroy?, to: :allowed_to_destroy?
-  alias_rule :transfer?, to: :allowed_to_transfer?
+             to: :manage?
+  alias_rule :index?, :show?, :activity?, to: :view?
 
-  def allowed_to_view_project?
+  def view?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if can_view?(record.namespace) == true
 
-    can_view?(record.namespace)
+    details[:name] = record.name
+    false
   end
 
-  def allowed_to_modify_project?
+  def manage?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if can_modify?(record.namespace) == true
 
-    can_modify?(record.namespace)
+    details[:name] = record.name
+    false
   end
 
-  def allowed_to_destroy?
+  def destroy?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if can_destroy?(record.namespace) == true
 
-    can_destroy?(record.namespace)
+    details[:name] = record.name
+    false
   end
 
-  def allowed_to_transfer?
+  def transfer?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
+    return true if can_transfer?(record.namespace)
 
-    can_transfer?(record.namespace)
+    details[:name] = record.name
+    false
   end
 
   scope_for :relation do |relation|

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,9 +2,25 @@
 
 # Policy for profiles authorization
 class UserPolicy < ApplicationPolicy
-  alias_rule :show?, :create?, :update?, :edit?, :index?, :destroy?, :revoke?, to: :manage?
+  alias_rule :update?, :edit?, :destroy?, :revoke?, to: :manage?
+  alias_rule :show?, :index?, to: :view?
+  alias_rule :new?, to: :create?
 
   def manage?
+    return true if record == user
+
+    details[:name] = record.email
+    false
+  end
+
+  def create?
+    return true if record == user
+
+    details[:name] = record.email
+    false
+  end
+
+  def view?
     return true if record == user
 
     details[:name] = record.email

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,7 +2,11 @@
 
 # Policy for profiles authorization
 class UserPolicy < ApplicationPolicy
-  def update?
+  def create?
+    return true if record == user
+  end
+
+  def destroy?
     return true if record == user
   end
 
@@ -10,7 +14,11 @@ class UserPolicy < ApplicationPolicy
     return true if record == user
   end
 
-  def destroy?
+  def index?
+    return true if record == user
+  end
+
+  def new?
     return true if record == user
   end
 
@@ -25,15 +33,7 @@ class UserPolicy < ApplicationPolicy
     false
   end
 
-  def index?
-    return true if record == user
-  end
-
-  def new?
-    return true if record == user
-  end
-
-  def create?
+  def update?
     return true if record == user
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,11 +2,49 @@
 
 # Policy for profiles authorization
 class UserPolicy < ApplicationPolicy
-  alias_rule :update?, :edit?, :destroy?, :revoke?, to: :manage?
-  alias_rule :show?, :index?, to: :view?
-  alias_rule :new?, to: :create?
+  def update?
+    return true if record == user
 
-  def manage?
+    details[:name] = record.email
+    false
+  end
+
+  def edit?
+    return true if record == user
+
+    details[:name] = record.email
+    false
+  end
+
+  def destroy?
+    return true if record == user
+
+    details[:name] = record.email
+    false
+  end
+
+  def revoke?
+    return true if record == user
+
+    details[:name] = record.email
+    false
+  end
+
+  def show?
+    return true if record == user
+
+    details[:name] = record.email
+    false
+  end
+
+  def index?
+    return true if record == user
+
+    details[:name] = record.email
+    false
+  end
+
+  def new?
     return true if record == user
 
     details[:name] = record.email
@@ -14,13 +52,6 @@ class UserPolicy < ApplicationPolicy
   end
 
   def create?
-    return true if record == user
-
-    details[:name] = record.email
-    false
-  end
-
-  def view?
     return true if record == user
 
     details[:name] = record.email

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,9 +2,12 @@
 
 # Policy for profiles authorization
 class UserPolicy < ApplicationPolicy
-  alias_rule :show?, :create?, :update?, :edit?, :index?, :destroy?, :revoke?, to: :profile_owner?
+  alias_rule :show?, :create?, :update?, :edit?, :index?, :destroy?, :revoke?, to: :manage?
 
-  def profile_owner?
-    record == user
+  def manage?
+    return true if record == user
+
+    details[:name] = record.email
+    false
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -26,7 +26,7 @@ class UserPolicy < ApplicationPolicy
     return true if record == user
   end
 
-  def show?
+  def read?
     return true if record == user
 
     details[:name] = record.email

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -4,30 +4,18 @@
 class UserPolicy < ApplicationPolicy
   def update?
     return true if record == user
-
-    details[:name] = record.email
-    false
   end
 
   def edit?
     return true if record == user
-
-    details[:name] = record.email
-    false
   end
 
   def destroy?
     return true if record == user
-
-    details[:name] = record.email
-    false
   end
 
   def revoke?
     return true if record == user
-
-    details[:name] = record.email
-    false
   end
 
   def show?
@@ -39,22 +27,13 @@ class UserPolicy < ApplicationPolicy
 
   def index?
     return true if record == user
-
-    details[:name] = record.email
-    false
   end
 
   def new?
     return true if record == user
-
-    details[:name] = record.email
-    false
   end
 
   def create?
     return true if record == user
-
-    details[:name] = record.email
-    false
   end
 end

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -11,7 +11,7 @@ module Groups
     end
 
     def execute
-      action_allowed_for_user(group.parent, :create?) unless group.parent.nil?
+      authorize! group.parent, to: :create_subgroup? if params[:parent_id]
 
       group.save
 

--- a/app/services/groups/destroy_service.rb
+++ b/app/services/groups/destroy_service.rb
@@ -11,7 +11,7 @@ module Groups
     end
 
     def execute
-      action_allowed_for_user(group, :destroy?)
+      authorize! @group, to: :destroy?
       group.destroy
     end
   end

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -11,8 +11,7 @@ module Groups
     end
 
     def execute
-      action_allowed_for_user(group, :update?)
-
+      authorize! @group, to: :update?
       group.update(params)
     end
   end

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -13,7 +13,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize
-      action_allowed_for_user(namespace, :manage?) unless namespace.parent.nil? && namespace.owner == current_user
+      authorize! @namespace, to: :create_member? unless namespace.parent.nil? && namespace.owner == current_user
 
       if member.namespace.owner != current_user &&
          (Member.user_has_namespace_maintainer_access?(current_user,

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -12,10 +12,8 @@ module Members
       @member = Member.new(params.merge(created_by: current_user, namespace:))
     end
 
-    def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-      auth_method = namespace.group_namespace? ? :manage? : :manage?
-
-      action_allowed_for_user(namespace, auth_method) unless namespace.parent.nil? && namespace.owner == current_user
+    def execute # rubocop:disable Metrics/AbcSize
+      action_allowed_for_user(namespace, :manage?) unless namespace.parent.nil? && namespace.owner == current_user
 
       if member.namespace.owner != current_user &&
          (Member.user_has_namespace_maintainer_access?(current_user,

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -13,7 +13,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-      auth_method = namespace.group_namespace? ? :allowed_to_modify_group? : :allowed_to_modify_project_namespace?
+      auth_method = namespace.group_namespace? ? :manage? : :manage?
 
       action_allowed_for_user(namespace, auth_method) unless namespace.parent.nil? && namespace.owner == current_user
 

--- a/app/services/members/destroy_service.rb
+++ b/app/services/members/destroy_service.rb
@@ -13,7 +13,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      action_allowed_for_user(namespace, :manage?)
+      authorize! @namespace, to: :destroy_member?
 
       unless current_user != member.user
         raise MemberDestroyError, I18n.t('services.members.destroy.cannot_remove_self',

--- a/app/services/members/destroy_service.rb
+++ b/app/services/members/destroy_service.rb
@@ -13,8 +13,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      auth_method = namespace.group_namespace? ? :manage? : :manage?
-      action_allowed_for_user(namespace, auth_method)
+      action_allowed_for_user(namespace, :manage?)
 
       unless current_user != member.user
         raise MemberDestroyError, I18n.t('services.members.destroy.cannot_remove_self',

--- a/app/services/members/destroy_service.rb
+++ b/app/services/members/destroy_service.rb
@@ -13,7 +13,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      auth_method = namespace.group_namespace? ? :allowed_to_modify_group? : :allowed_to_modify_project_namespace?
+      auth_method = namespace.group_namespace? ? :manage? : :manage?
       action_allowed_for_user(namespace, auth_method)
 
       unless current_user != member.user

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -14,7 +14,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize
-      auth_method = namespace.group_namespace? ? :allowed_to_modify_group? : :allowed_to_modify_project_namespace?
+      auth_method = namespace.group_namespace? ? :manage? : :manage?
       action_allowed_for_user(namespace, auth_method)
 
       unless current_user != member.user

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -14,7 +14,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize
-      action_allowed_for_user(namespace, :manage?)
+      authorize! @namespace, to: :update_member?
 
       unless current_user != member.user
         raise MemberUpdateError, I18n.t('services.members.update.cannot_update_self',

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -14,8 +14,7 @@ module Members
     end
 
     def execute # rubocop:disable Metrics/AbcSize
-      auth_method = namespace.group_namespace? ? :manage? : :manage?
-      action_allowed_for_user(namespace, auth_method)
+      action_allowed_for_user(namespace, :manage?)
 
       unless current_user != member.user
         raise MemberUpdateError, I18n.t('services.members.update.cannot_update_self',

--- a/app/services/projects/create_service.rb
+++ b/app/services/projects/create_service.rb
@@ -26,7 +26,7 @@ module Projects
     def create_associations(project) # rubocop:disable Metrics/AbcSize
       project.build_namespace(namespace_params.merge(owner: current_user))
       # We want to authorize that the user can create a project in the parent namespace
-      action_allowed_for_user(project.namespace.parent, :create?)
+      authorize! project.namespace.parent, to: :create?
 
       project.save
 

--- a/app/services/projects/destroy_service.rb
+++ b/app/services/projects/destroy_service.rb
@@ -4,7 +4,7 @@ module Projects
   # Service used to Delete Projects
   class DestroyService < BaseProjectService
     def execute
-      action_allowed_for_user(project, :destroy?)
+      authorize! project, to: :destroy?
 
       project.namespace.destroy!
     end

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -16,10 +16,10 @@ module Projects
       end
 
       # Authorize if user can transfer project
-      action_allowed_for_user(project, :transfer?)
+      authorize! @project, to: :transfer?
 
       # Authorize if user can transfer project to namespace
-      action_allowed_for_user(@new_namespace, :transfer_to_namespace?)
+      authorize! @new_namespace, to: :transfer_into_namespace?
 
       transfer(project)
 

--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -4,9 +4,9 @@ module Projects
   # Service used to Update Projects
   class UpdateService < BaseProjectService
     def execute
-      namespace_params = params.delete(:namespace_attributes)
+      authorize! project.namespace, to: :update?
 
-      action_allowed_for_user(project.namespace, :update?)
+      namespace_params = params.delete(:namespace_attributes)
 
       project.namespace.update(namespace_params)
     end

--- a/app/services/samples/create_service.rb
+++ b/app/services/samples/create_service.rb
@@ -12,7 +12,8 @@ module Samples
     end
 
     def execute
-      action_allowed_for_user(@project, :manage?)
+      authorize! @project, to: :create_sample?
+
       sample.save
       sample
     end

--- a/app/services/samples/create_service.rb
+++ b/app/services/samples/create_service.rb
@@ -12,7 +12,7 @@ module Samples
     end
 
     def execute
-      action_allowed_for_user(@project, :allowed_to_modify_project?)
+      action_allowed_for_user(@project, :manage?)
       sample.save
       sample
     end

--- a/app/services/samples/destroy_service.rb
+++ b/app/services/samples/destroy_service.rb
@@ -11,7 +11,7 @@ module Samples
     end
 
     def execute
-      action_allowed_for_user(sample.project, :destroy?)
+      authorize! sample.project, to: :destroy_sample?
 
       sample.destroy
     end

--- a/app/services/samples/update_service.rb
+++ b/app/services/samples/update_service.rb
@@ -11,7 +11,7 @@ module Samples
     end
 
     def execute
-      action_allowed_for_user(sample.project, :allowed_to_modify_project?)
+      action_allowed_for_user(sample.project, :manage?)
 
       sample.update(params)
     end

--- a/app/services/samples/update_service.rb
+++ b/app/services/samples/update_service.rb
@@ -11,7 +11,7 @@ module Samples
     end
 
     def execute
-      action_allowed_for_user(sample.project, :manage?)
+      authorize! sample.project, to: :update_sample?
 
       sample.update(params)
     end

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -45,7 +45,7 @@
       </div>
     </div>
 
-    <% if allowed_to?(:allowed_to_destroy?, @group) %>
+    <% if allowed_to?(:destroy?, @group) %>
       <div
         class="
           p-4

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::PageHeaderComponent.new(title: t(:'.title'), subtitle: t(:'.subtitle', namespace_type: @namespace.class.model_name.human, namespace_name: @namespace.name)) do |component| %>
   <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
-    <% if allowed_to?(:allowed_to_modify_group?, @namespace) %>
+    <% if allowed_to?(:manage?, @namespace) %>
       <%= link_to t(:".add"),
       new_group_member_path(@namespace),
       class: "btn btn-primary",
@@ -44,7 +44,7 @@
                 <td class="p-4 whitespace-nowrap">
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= t(:".access_granted_by", grantor_email: member.created_by.email) %></div>
                 </td>
-                <% if allowed_to?(:allowed_to_modify_group?, @namespace) %>
+                <% if allowed_to?(:manage?, @namespace) %>
                   <td class="px-4 py-3 text-right">
                     <%= viral_dropdown(icon: "ellipsis_vertical",
                                      classes: "member-settings-ellipsis",

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::PageHeaderComponent.new(title: t(:'.title'), subtitle: t(:'.subtitle', namespace_type: @namespace.class.model_name.human, namespace_name: @namespace.name)) do |component| %>
   <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
-    <% if allowed_to?(:manage?, @namespace) %>
+    <% if allowed_to?(:create_member?, @namespace) %>
       <%= link_to t(:".add"),
       new_group_member_path(@namespace),
       class: "btn btn-primary",
@@ -59,7 +59,7 @@
                   </div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
-                  <% if member.user != current_user && allowed_to?(:allowed_to_modify_group?, @namespace) &&
+                  <% if member.user != current_user && allowed_to?(:update_member?, @namespace) &&
                    member.access_level <= @access_levels.values.last %>
                     <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
                       <%= render partial: "groups/members/access_level",
@@ -82,7 +82,7 @@
                     <% end %>
                   </div>
                 </td>
-                <% if allowed_to?(:manage?, @namespace) %>
+                <% if allowed_to?(:destroy_member?, @namespace) %>
                   <td class="px-4 py-3 text-right">
                     <%= viral_dropdown(icon: "ellipsis_vertical",
                                      classes: "member-settings-ellipsis",

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -27,7 +27,7 @@
             icon: "users",
             label: t(:"groups.sidebar.members")
           ) %>
-          <% if allowed_to?(:manage?, @group) %>
+          <% if allowed_to?(:update?, @group) %>
             <%= render section.with_item(
               url: edit_group_path(@group),
               icon: "cog_6_tooth",

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -27,7 +27,7 @@
             icon: "users",
             label: t(:"groups.sidebar.members")
           ) %>
-          <% if allowed_to?(:allowed_to_modify_group?, @group) %>
+          <% if allowed_to?(:manage?, @group) %>
             <%= render section.with_item(
               url: edit_group_path(@group),
               icon: "cog_6_tooth",

--- a/app/views/layouts/projects.html.erb
+++ b/app/views/layouts/projects.html.erb
@@ -27,7 +27,7 @@
               icon: "beaker",
               label: t(:"projects.sidebar.samples")
             ) %>
-            <% if allowed_to?(:allowed_to_modify_project?, @project) %>
+            <% if allowed_to?(:manage?, @project) %>
               <%= render section.with_item(
                 url: project_edit_path(@project),
                 icon: "cog_6_tooth",

--- a/app/views/layouts/projects.html.erb
+++ b/app/views/layouts/projects.html.erb
@@ -27,7 +27,7 @@
               icon: "beaker",
               label: t(:"projects.sidebar.samples")
             ) %>
-            <% if allowed_to?(:manage?, @project) %>
+            <% if allowed_to?(:update?, @project) %>
               <%= render section.with_item(
                 url: project_edit_path(@project),
                 icon: "cog_6_tooth",

--- a/app/views/projects/activity.html.erb
+++ b/app/views/projects/activity.html.erb
@@ -1,0 +1,1 @@
+<h1>Project Activity</h1>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::PageHeaderComponent.new(title: t('.title'), subtitle: t('.subtitle', namespace_type: @namespace.class.model_name.human, namespace_name: @namespace.name)) do |component| %>
   <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
-    <% if allowed_to?(:manage?, @namespace) %>
+    <% if allowed_to?(:create_member?, @namespace) %>
       <%= link_to t(:".add"),
       new_namespace_project_member_path,
       class: "btn btn-primary",
@@ -59,7 +59,7 @@
                   </div>
                 </td>
                 <td class="p-4 whitespace-nowrap">
-                  <% if member.user != current_user && allowed_to?(:allowed_to_modify_project_namespace?, @namespace) &&
+                  <% if member.user != current_user && allowed_to?(:update_member?, @namespace) &&
                     member.access_level <= @access_levels.values.last %>
                     <%= turbo_frame_tag("member-#{member.id}-access-level") do %>
                       <%= render partial: "projects/members/access_level",
@@ -85,7 +85,7 @@
                     <% end %>
                   </div>
                 </td>
-                <% if allowed_to?(:manage?, @namespace) %>
+                <% if allowed_to?(:destroy_member?, @namespace) %>
                   <td class="px-4 py-3 text-right">
                     <%= viral_dropdown(icon: "ellipsis_vertical", classes: "member-settings-ellipsis", aria: { label: t(:'projects.members.index.actions.member_dropdown_aria_label', member: member.user.email) }) do |dropdown| %>
                       <%= dropdown.item(

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::PageHeaderComponent.new(title: t('.title'), subtitle: t('.subtitle', namespace_type: @namespace.class.model_name.human, namespace_name: @namespace.name)) do |component| %>
   <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
-    <% if allowed_to?(:allowed_to_modify_project_namespace?, @namespace) %>
+    <% if allowed_to?(:manage?, @namespace) %>
       <%= link_to t(:".add"),
       new_namespace_project_member_path,
       class: "btn btn-primary",
@@ -47,7 +47,7 @@
                       grantor_email: member.created_by.email
                     ) %></div>
                 </td>
-                <% if allowed_to?(:allowed_to_modify_project_namespace?, @namespace) %>
+                <% if allowed_to?(:manage?, @namespace) %>
                   <td class="px-4 py-3 text-right">
                     <%= viral_dropdown(icon: "ellipsis_vertical", classes: "member-settings-ellipsis", aria: { label: t(:'projects.members.index.actions.member_dropdown_aria_label', member: member.user.email) }) do |dropdown| %>
                       <%= dropdown.item(

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::PageHeaderComponent.new(title: t('.title'), subtitle: t(".subtitle")) do |component| %>
   <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
-    <% if allowed_to?(:allowed_to_modify_project?, @project) %>
+    <% if allowed_to?(:manage?, @project) %>
       <%= link_to t("projects.samples.index.new_button"),
       new_namespace_project_sample_path,
       class: "btn btn-primary",
@@ -31,7 +31,7 @@
                   class: "text-grey-900 dark:text-grey-100 font-semibold hover:underline" %>
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= sample.description %></div>
                 </td>
-                <% if allowed_to?(:allowed_to_modify_project?, @project) %>
+                <% if allowed_to?(:manage?, @project) %>
                   <td class="px-4 py-3">
                     <div class="flex items-center justify-end">
                       <%= viral_dropdown(icon: "ellipsis_vertical", aria: { label: t(:'projects.samples.index.actions.dropdown_aria_label', sample_name: sample.name) }) do |dropdown| %>

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::PageHeaderComponent.new(title: t('.title'), subtitle: t(".subtitle")) do |component| %>
   <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
-    <% if allowed_to?(:manage?, @project) %>
+    <% if allowed_to?(:create_sample?, @project) %>
       <%= link_to t("projects.samples.index.new_button"),
       new_namespace_project_sample_path,
       class: "btn btn-primary",
@@ -31,7 +31,7 @@
                   class: "text-grey-900 dark:text-grey-100 font-semibold hover:underline" %>
                   <div class="text-sm font-normal text-gray-500 dark:text-gray-400"><%= sample.description %></div>
                 </td>
-                <% if allowed_to?(:manage?, @project) %>
+                <% if allowed_to?(:update_sample?, @project) %>
                   <td class="px-4 py-3">
                     <div class="flex items-center justify-end">
                       <%= viral_dropdown(icon: "ellipsis_vertical", aria: { label: t(:'projects.samples.index.actions.dropdown_aria_label', sample_name: sample.name) }) do |dropdown| %>
@@ -39,7 +39,7 @@
                           label: t(:"projects.samples.index.edit_button"),
                           url: edit_namespace_project_sample_path(id: sample.id)
                         ) %>
-                        <% if allowed_to?(:destroy?, @project) %>
+                        <% if allowed_to?(:destroy_sample?, @project) %>
                           <%= dropdown.item(
                             label: t(:"projects.samples.index.remove_button"),
                             url: namespace_project_sample_path(id: sample.id),

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -7,7 +7,7 @@
         edit_namespace_project_sample_path(id: @sample.id),
         class: "btn btn-primary mr-1" %>
       <% end %>
-      <% if allowed_to?(:allowed_to_destroy?, @project) %>
+      <% if allowed_to?(:destroy?, @project) %>
         <%= link_to t("projects.samples.show.remove_button"),
         namespace_project_sample_path(id: @sample.id),
         data: {

--- a/app/views/shared/error/not_authorized.html.erb
+++ b/app/views/shared/error/not_authorized.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h1><%= t("application.errors.access_denied") %></h1>
   <p>
-    <%= t("application.errors.not_authorized") %>
+    <%= authorization_message %>
   </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
       edit?: You are not authorized to update this resource on this server.
       index?: You are not authorized to view the listing of resourcs on this server.
       new?: You are not authorized to create this resource on this server.
-      show?: You are not authorized to view this resource on this server.
+      read?: You are not authorized to view this resource on this server.
       transfer?: You are not authorized to transfer the requested resource.
       transfer_into_namespace?: You are not authorized to transfer to the requested namespace.
       update?: You are not authorized to update this resource on this server.
@@ -50,7 +50,7 @@ en:
         destroy?: You are not authorized to remove group %{name} from this server.
         edit?: You are not authorized to modify group %{name} on this server.
         new?: You are not authorized to create a project under group %{name} on this server.
-        show?: You are not authorized to view group %{name} on this server.
+        read?: You are not authorized to view group %{name} on this server.
         transfer_into_namespace?: You are not authorized to transfer into the group namespace %{name} on this server.
         update?: You are not authorized to update group %{name} on this server.
         member_listing?: You are not authorized to view members for group %{name} on this server.
@@ -63,13 +63,13 @@ en:
         destroy?: You are not authorized to remove project %{name} from this server.
         edit?: You are not authorized to modify project %{name} on this server.
         new?: You are not authorized to create a project under the %{name} namespace on this server.
-        show?: You are not authorized to view project %{name} on this server.
+        read?: You are not authorized to view project %{name} on this server.
         transfer?: You are not authorized to transfer project %{name} on this server.
         update?: You are not authorized to update project %{name} on this server.
         sample_listing?: You are not authorized to view samples for project %{name} on this server.
         create_sample?: You are not authorized to create samples for project %{name} on this server.
         destroy_sample?: You are not authorized to remove samples from project %{name} on this server.
-        show_sample?: You are not authorized to view this sample for project %{name} on this server.
+        read_sample?: You are not authorized to view this sample for project %{name} on this server.
         update_sample?: You are not authorized to update samples for project %{name} on this server.
       namespaces/project_namespace:
         update?: You are not authorized to update the namespace for project %{name} on this server.
@@ -87,7 +87,7 @@ en:
         index?: You are not authorized to view listing of users on this server.
         new?: You are not authorized to create a user on this server.
         revoke?: You are not authorized to revoke personal access tokens for user %{name} on this server.
-        show?: You are not authorized to view profile for user %{name} on this server.
+        read?: You are not authorized to view profile for user %{name} on this server.
         update?: You are not authorized to update user %{name} on this server.
     unauthorized: You are not authorized to perform this action
   activerecord:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,21 +37,20 @@ en:
       destroy?: You are not authorized to remove the requested resource from this server.
       transfer_to_namespace?: You are not authorized to transfer to the requested namespace
       group:
-        view?: You are not authorized to view group %{name} on this server.
-        manage?: You are not authorized to manage group %{name} on this server.
-        destroy?: You are not authorized to remove group %{name} on this server.
+        view?: You are not authorized to view group %{name} or it's associations on this server.
+        manage?: You are not authorized to manage group %{name} or it's associations on this server.
+        destroy?: You are not authorized to remove group %{name} or it's associations on this server.
         transfer_to_namespace?: You are not authorized to transfer into namespace %{name}
       project:
-        view?: You are not authorized to view project %{name} on this server.
-        manage?: You are not authorized to manage project %{name} on this server.
-        destroy?: You are not authorized to remove project %{name} on this server.
+        view?: You are not authorized to view project %{name} or it's associations on this server.
+        manage?: You are not authorized to manage project %{name} or it's associations on this server.
+        destroy?: You are not authorized to remove project %{name} or it's associations on this server.
         transfer?: You are not authorized to transfer project %{name}
-      namespaces:
-        project_namespace:
-          manage?: You are not authorized to manage the namespace for project %{name}
-        user_namespace:
-          manage?: You are not authorized to manage the namespace for user %{name}
-          transfer_to_namespace?: You are not authorized to transfer to the user namespace
+      namespaces/project_namespace:
+        manage?: You are not authorized to manage the namespace for project %{name}
+      namespaces/user_namespace:
+        manage?: You are not authorized to manage the namespace for user %{name}
+        transfer_to_namespace?: You are not authorized to transfer to the user namespace
       user:
         manage?: You are not authorized to manage user %{name}
     unauthorized: You are not authorized to perform this action

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,28 +39,55 @@ en:
       view?: You are not authorized to view the requested resource on this server
       manage?: You are not authorized to manage the requested resource on this server.
       destroy?: You are not authorized to remove the requested resource from this server.
-      transfer_to_namespace?: You are not authorized to transfer to the requested namespace
+      transfer_into_namespace?: You are not authorized to transfer to the requested namespace
       group:
-        create?: You are not authorized to create group %{name} or it's associations on this server.
-        view?: You are not authorized to view group %{name} or it's associations on this server.
-        manage?: You are not authorized to manage group %{name} or it's associations on this server.
-        destroy?: You are not authorized to remove group %{name} or it's associations on this server.
-        transfer_to_namespace?: You are not authorized to transfer into namespace %{name}
+        show?: You are not authorized to view group %{name} on this server.
+        edit?: You are not authorized to modify group %{name} on this server.
+        update?: You are not authorized to update group %{name} on this server.
+        destroy?: You are not authorized to remove group %{name} from this server.
+        create?: You are not authorized to create a project under group %{name} on this server.
+        create_subgroup?: You are not authorized to create a subgroup within group %{name} on this server.
+        transfer_into_namespace?: You are not authorized to transfer into the group namespace %{name} on this server.
+        create_member?: You are not authorized to create members for group %{name} on this server.
+        update_member?: You are not authorized to update members for group %{name} on this server.
+        destroy_member?: You are not authorized to remove members for group %{name} on this server.
+        member_listing?: You are not authorized to view members for group %{name} on this server.
+        sample_listing?: You are not authorized to view samples for group %{name} on this server.
       project:
-        create?: You are not authorized to create project %{name} or it's associations on this server.
-        view?: You are not authorized to view project %{name} or it's associations on this server.
-        manage?: You are not authorized to manage project %{name} or it's associations on this server.
-        destroy?: You are not authorized to remove project %{name} or it's associations on this server.
-        transfer?: You are not authorized to transfer project %{name}
+        show?: You are not authorized to view project %{name} on this server.
+        edit?: You are not authorized to modify %{name} on this server.
+        update?: You are not authorized to update project %{name} on this server.
+        destroy?: You are not authorized to remove project %{name} from this server.
+        new?: You are not authorized to create a project under the %{name} namespace on this server.
+        create?: You are not authorized to create a project under the %{name} namespace on this server.
+        activity?: You are not authorized to view the activity for project %{name} on this server.
+        transfer?: You are not authorized to transfer project %{name} on this server.
+        sample_listing?: You are not authorized to view samples for project %{name} on this server.
+        create_sample?: You are not authorized to create samples for project %{name} on this server.
+        update_sample?: You are not authorized to update samples for project %{name} on this server.
+        destroy_sample?: You are not authorized to remove samples from project %{name} on this server.
+        show_sample?: You are not authorized to view this sample for project %{name} on this server.
       namespaces/project_namespace:
-        create?: You are not authorized to create resources under this namespace
-        manage?: You are not authorized to manage the namespace for project %{name}
+        create?: You are not authorized to create resources under the namespace %{name} on this server.
+        new?: You are not authorized to create resources under the namespace %{name} on this server.
+        update?: You are not authorized to update resources under the namespace %{name} on this server.
+        create_member?: You are not authorized to create members for the namespace %{name} on this server.
+        update_member?: You are not authorized to update members for the namespace %{name} on this server.
+        destroy_member?: You are not authorized to remove members from the namespace %{name} on this server.
+        member_listing?: You are not authorized to view members for the namespace %{name} on this server.
       namespaces/user_namespace:
+        new?: You are not authorized to create resources under the %{name} namespace
         create?: You are not authorized to create resources under the %{name} namespace
-        transfer_to_namespace?: You are not authorized to transfer to the user %{name} namespace
+        transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace
       user:
-        create?: You are not authorized to create user %{name}
-        manage?: You are not authorized to manage user %{name}
+        update?: You are not authorized to update user %{name} on this server.
+        edit?: You are not authorized to update user %{name} on this server.
+        destroy?: You are not authorized to remove user %{name} from this server.
+        revoke?: You are not authorized to revoke personal access tokens for user %{name} on this server.
+        show?: You are not authorized to view profile for user %{name} on this server.
+        index?: You are not authorized to view listing of users on this server.
+        new?: You are not authorized to create a user on this server.
+        create?: You are not authorized to create a user on this server.
     unauthorized: You are not authorized to perform this action
   activerecord:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
         sample_listing?: You are not authorized to view samples for group %{name} on this server.
       project:
         show?: You are not authorized to view project %{name} on this server.
-        edit?: You are not authorized to modify %{name} on this server.
+        edit?: You are not authorized to modify project %{name} on this server.
         update?: You are not authorized to update project %{name} on this server.
         destroy?: You are not authorized to remove project %{name} from this server.
         new?: You are not authorized to create a project under the %{name} namespace on this server.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,31 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  action_policy:
+    policy:
+      view?: You are not authorized to view the requested resource on this server
+      manage?: You are not authorized to manage the requested resource on this server.
+      destroy?: You are not authorized to remove the requested resource from this server.
+      transfer_to_namespace?: You are not authorized to transfer to the requested namespace
+      group:
+        view?: You are not authorized to view group %{name} on this server.
+        manage?: You are not authorized to manage group %{name} on this server.
+        destroy?: You are not authorized to remove group %{name} on this server.
+        transfer_to_namespace?: You are not authorized to transfer into namespace %{name}
+      project:
+        view?: You are not authorized to view project %{name} on this server.
+        manage?: You are not authorized to manage project %{name} on this server.
+        destroy?: You are not authorized to remove project %{name} on this server.
+        transfer?: You are not authorized to transfer project %{name}
+      namespaces:
+        project_namespace:
+          manage?: You are not authorized to manage the namespace for project %{name}
+        user_namespace:
+          manage?: You are not authorized to manage the namespace for user %{name}
+          transfer_to_namespace?: You are not authorized to transfer to the user namespace
+      user:
+        manage?: You are not authorized to manage user %{name}
+    unauthorized: You are not authorized to perform this action
   activerecord:
     attributes:
       group:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,26 +35,31 @@ en:
       default: "%Y-%m-%d %H:%M:%S"
   action_policy:
     policy:
+      create?: You are not authorized to create this resource on this server
       view?: You are not authorized to view the requested resource on this server
       manage?: You are not authorized to manage the requested resource on this server.
       destroy?: You are not authorized to remove the requested resource from this server.
       transfer_to_namespace?: You are not authorized to transfer to the requested namespace
       group:
+        create?: You are not authorized to create group %{name} or it's associations on this server.
         view?: You are not authorized to view group %{name} or it's associations on this server.
         manage?: You are not authorized to manage group %{name} or it's associations on this server.
         destroy?: You are not authorized to remove group %{name} or it's associations on this server.
         transfer_to_namespace?: You are not authorized to transfer into namespace %{name}
       project:
+        create?: You are not authorized to create project %{name} or it's associations on this server.
         view?: You are not authorized to view project %{name} or it's associations on this server.
         manage?: You are not authorized to manage project %{name} or it's associations on this server.
         destroy?: You are not authorized to remove project %{name} or it's associations on this server.
         transfer?: You are not authorized to transfer project %{name}
       namespaces/project_namespace:
+        create?: You are not authorized to create resources under this namespace
         manage?: You are not authorized to manage the namespace for project %{name}
       namespaces/user_namespace:
-        manage?: You are not authorized to manage the namespace for user %{name}
-        transfer_to_namespace?: You are not authorized to transfer to the user namespace
+        create?: You are not authorized to create resources under the %{name} namespace
+        transfer_to_namespace?: You are not authorized to transfer to the user %{name} namespace
       user:
+        create?: You are not authorized to create user %{name}
         manage?: You are not authorized to manage user %{name}
     unauthorized: You are not authorized to perform this action
   activerecord:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,59 +35,60 @@ en:
       default: "%Y-%m-%d %H:%M:%S"
   action_policy:
     policy:
-      create?: You are not authorized to create this resource on this server
-      view?: You are not authorized to view the requested resource on this server
-      manage?: You are not authorized to manage the requested resource on this server.
+      create?: You are not authorized to create this resource on this server.
       destroy?: You are not authorized to remove the requested resource from this server.
-      transfer_into_namespace?: You are not authorized to transfer to the requested namespace
+      edit?: You are not authorized to update this resource on this server.
+      index?: You are not authorized to view the listing of resourcs on this server.
+      new?: You are not authorized to create this resource on this server.
+      show?: You are not authorized to view this resource on this server.
+      transfer?: You are not authorized to transfer the requested resource.
+      transfer_into_namespace?: You are not authorized to transfer to the requested namespace.
+      update?: You are not authorized to update this resource on this server.
       group:
-        show?: You are not authorized to view group %{name} on this server.
-        edit?: You are not authorized to modify group %{name} on this server.
-        update?: You are not authorized to update group %{name} on this server.
-        destroy?: You are not authorized to remove group %{name} from this server.
         create?: You are not authorized to create a project under group %{name} on this server.
         create_subgroup?: You are not authorized to create a subgroup within group %{name} on this server.
+        destroy?: You are not authorized to remove group %{name} from this server.
+        edit?: You are not authorized to modify group %{name} on this server.
+        new?: You are not authorized to create a project under group %{name} on this server.
+        show?: You are not authorized to view group %{name} on this server.
         transfer_into_namespace?: You are not authorized to transfer into the group namespace %{name} on this server.
-        create_member?: You are not authorized to create members for group %{name} on this server.
-        update_member?: You are not authorized to update members for group %{name} on this server.
-        destroy_member?: You are not authorized to remove members for group %{name} on this server.
+        update?: You are not authorized to update group %{name} on this server.
         member_listing?: You are not authorized to view members for group %{name} on this server.
+        create_member?: You are not authorized to create members for group %{name} on this server.
+        destroy_member?: You are not authorized to remove members for group %{name} on this server.
+        update_member?: You are not authorized to update members for group %{name} on this server.
         sample_listing?: You are not authorized to view samples for group %{name} on this server.
       project:
-        show?: You are not authorized to view project %{name} on this server.
-        edit?: You are not authorized to modify project %{name} on this server.
-        update?: You are not authorized to update project %{name} on this server.
-        destroy?: You are not authorized to remove project %{name} from this server.
-        new?: You are not authorized to create a project under the %{name} namespace on this server.
-        create?: You are not authorized to create a project under the %{name} namespace on this server.
         activity?: You are not authorized to view the activity for project %{name} on this server.
+        destroy?: You are not authorized to remove project %{name} from this server.
+        edit?: You are not authorized to modify project %{name} on this server.
+        new?: You are not authorized to create a project under the %{name} namespace on this server.
+        show?: You are not authorized to view project %{name} on this server.
         transfer?: You are not authorized to transfer project %{name} on this server.
+        update?: You are not authorized to update project %{name} on this server.
         sample_listing?: You are not authorized to view samples for project %{name} on this server.
         create_sample?: You are not authorized to create samples for project %{name} on this server.
-        update_sample?: You are not authorized to update samples for project %{name} on this server.
         destroy_sample?: You are not authorized to remove samples from project %{name} on this server.
         show_sample?: You are not authorized to view this sample for project %{name} on this server.
+        update_sample?: You are not authorized to update samples for project %{name} on this server.
       namespaces/project_namespace:
-        create?: You are not authorized to create resources under the namespace %{name} on this server.
-        new?: You are not authorized to create resources under the namespace %{name} on this server.
-        update?: You are not authorized to update resources under the namespace %{name} on this server.
-        create_member?: You are not authorized to create members for the namespace %{name} on this server.
-        update_member?: You are not authorized to update members for the namespace %{name} on this server.
-        destroy_member?: You are not authorized to remove members from the namespace %{name} on this server.
-        member_listing?: You are not authorized to view members for the namespace %{name} on this server.
+        update?: You are not authorized to update the namespace for project %{name} on this server.
+        member_listing?: You are not authorized to view members for the project namespace %{name} on this server.
+        create_member?: You are not authorized to create members for the project namespace %{name} on this server.
+        destroy_member?: You are not authorized to remove members from the project namespace %{name} on this server.
+        update_member?: You are not authorized to update members for the project namespace %{name} on this server.
       namespaces/user_namespace:
-        new?: You are not authorized to create resources under the %{name} namespace
-        create?: You are not authorized to create resources under the %{name} namespace
+        create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace
       user:
-        update?: You are not authorized to update user %{name} on this server.
-        edit?: You are not authorized to update user %{name} on this server.
+        create?: You are not authorized to create a user on this server.
         destroy?: You are not authorized to remove user %{name} from this server.
-        revoke?: You are not authorized to revoke personal access tokens for user %{name} on this server.
-        show?: You are not authorized to view profile for user %{name} on this server.
+        edit?: You are not authorized to update user %{name} on this server.
         index?: You are not authorized to view listing of users on this server.
         new?: You are not authorized to create a user on this server.
-        create?: You are not authorized to create a user on this server.
+        revoke?: You are not authorized to revoke personal access tokens for user %{name} on this server.
+        show?: You are not authorized to view profile for user %{name} on this server.
+        update?: You are not authorized to update user %{name} on this server.
     unauthorized: You are not authorized to perform this action
   activerecord:
     attributes:

--- a/docs-site/docs/user/organization/members/member-permissions.md
+++ b/docs-site/docs/user/organization/members/member-permissions.md
@@ -58,8 +58,8 @@ When you add a member to a subgroup where they are also a member of one of the p
 | Edit Project Member   |       |         | ✓(1)       | ✓     |
 | Remove Project Member |       |         | ✓(1)       | ✓     |
 | View Project Members  | ✓     | ✓       | ✓          | ✓     |
-| Create Samples        |       |         |            | ✓     |
-| Edit Samples          |       |         |            | ✓     |
+| Create Samples        |       |         | ✓          | ✓     |
+| Edit Samples          |       |         | ✓          | ✓     |
 | Delete Samples        |       |         |            | ✓     |
 
 1. A user with the **Maintainer** role can only modify members upto and including their role

--- a/lib/irida/auth.rb
+++ b/lib/irida/auth.rb
@@ -13,36 +13,5 @@ module Irida
         API_SCOPES
       end
     end
-
-    def authorize_modify_group!
-      action_allowed_for_user(@group)
-    end
-
-    def authorize_view_group!
-      action_allowed_for_user(@group)
-    end
-
-    def authorize_create_subgroup!
-      action_allowed_for_user(@group) unless @group.nil?
-    end
-
-    def authorize_modify_project!
-      action_allowed_for_user(@project)
-    end
-
-    def authorize_view_project!
-      action_allowed_for_user(@project)
-    end
-
-    def authorize_user_profile_access!
-      action_allowed_for_user(@user)
-    end
-
-    protected
-
-    def action_allowed_for_user(auth_object, auth_method = nil)
-      authorize! auth_object if auth_method.nil?
-      authorize! auth_object, to: auth_method
-    end
   end
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class GroupsControllerTest < ActionDispatch::IntegrationTest
+class GroupsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Metrics/ClassLength
   include Devise::Test::IntegrationHelpers
 
   test 'should get index' do

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -134,4 +134,22 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unauthorized
   end
+
+  test 'should not show the group edit page' do
+    sign_in users(:david_doe)
+    group = groups(:group_one)
+
+    get edit_group_path(group)
+
+    assert_response :unauthorized
+  end
+
+  test 'should show the group edit page' do
+    sign_in users(:john_doe)
+    group = groups(:group_one)
+
+    get edit_group_path(group)
+
+    assert_response :success
+  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class ProjectsControllerTest < ActionDispatch::IntegrationTest
+class ProjectsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Metrics/ClassLength
   include Devise::Test::IntegrationHelpers
 
   test 'should get index' do
@@ -17,6 +17,13 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     get project_path(projects(:project1))
     assert_response :success
+  end
+
+  test 'should not show the project' do
+    sign_in users(:micha_doe)
+
+    get project_path(projects(:project1))
+    assert_response :unauthorized
   end
 
   test 'should show 404 if project does not exist' do
@@ -91,6 +98,15 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
          params: { new_namespace_id: groups(:subgroup1).id }
 
     assert_redirected_to project_path(projects(:project2).reload)
+  end
+
+  test 'should not transfer a project' do
+    sign_in users(:john_doe)
+
+    post project_transfer_path(projects(:project2)),
+         params: { new_namespace_id: groups(:david_doe_group_four).id }
+
+    assert_response :unauthorized
   end
 
   test 'should fail to transfer a project with wrong params' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -11,4 +11,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get user_path(users(:john_doe))
     assert_response :success
   end
+
+  test 'should not show the user' do
+    sign_in users(:john_doe)
+
+    get user_path(users(:james_doe))
+    assert_response :unauthorized
+  end
 end

--- a/test/fixtures/namespaces/user_namespaces.yml
+++ b/test/fixtures/namespaces/user_namespaces.yml
@@ -12,6 +12,12 @@ jane_doe_namespace:
   type: User
   owner_id: <%= ActiveRecord::FixtureSet.identify(:jane_doe) %>
 
+james_doe_namespace:
+  name: james.doe@localhost
+  path: james.doe_at_localhost
+  type: User
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:james_doe) %>
+
 david_doe_namespace:
   name: david.doe@localhost
   path: david.doe_at_localhost

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -27,6 +27,11 @@ jane_doe_namespace_route:
   path: jane.doe_at_localhost
   source: jane_doe_namespace (Namespace)
 
+james_doe_namespace_route:
+  name: james.doe@localhost
+  path: james.doe_at_localhost
+  source: james_doe_namespace (Namespace)
+
 project1_namespace_route:
   name: Group 1 / Project 1
   path: group-1/project-1

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -21,3 +21,8 @@ sample23:
   name: Project 3 Sample 23
   description: Sample 23 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:project4) %>
+
+sample24:
+  name: John Doe Project 2 Sample 1
+  description: John Doe Project 2 Sample 1 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:john_doe_project2) %>

--- a/test/graphql/group_query_test.rb
+++ b/test/graphql/group_query_test.rb
@@ -72,6 +72,6 @@ class GroupQueryTest < ActiveSupport::TestCase
 
     error_message = result['errors'][0]['message']
 
-    assert_equal I18n.t('action_policy.policy.group.show?', name: group.name), error_message
+    assert_equal I18n.t('action_policy.policy.group.read?', name: group.name), error_message
   end
 end

--- a/test/graphql/group_query_test.rb
+++ b/test/graphql/group_query_test.rb
@@ -72,6 +72,6 @@ class GroupQueryTest < ActiveSupport::TestCase
 
     error_message = result['errors'][0]['message']
 
-    assert_equal I18n.t('action_policy.policy.group.view?', name: group.name), error_message
+    assert_equal I18n.t('action_policy.policy.group.show?', name: group.name), error_message
   end
 end

--- a/test/graphql/group_query_test.rb
+++ b/test/graphql/group_query_test.rb
@@ -72,6 +72,6 @@ class GroupQueryTest < ActiveSupport::TestCase
 
     error_message = result['errors'][0]['message']
 
-    assert_equal I18n.t('action_policy.unauthorized'), error_message
+    assert_equal I18n.t('action_policy.policy.group.view?', name: group.name), error_message
   end
 end

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -9,28 +9,28 @@ class GroupPolicyTest < ActiveSupport::TestCase
     @policy = GroupPolicy.new(@group, user: @user)
   end
 
-  test '#allowed_to_view_group?' do
-    assert @policy.allowed_to_view_group?
+  test '#view?' do
+    assert @policy.view?
   end
 
-  test '#allowed_to_modify_group?' do
-    assert @policy.allowed_to_modify_group?
+  test '#manage?' do
+    assert @policy.manage?
   end
 
-  test '#allowed_to_destroy?' do
-    assert @policy.allowed_to_destroy?
+  test '#destroy?' do
+    assert @policy.destroy?
   end
 
   test 'aliases' do
-    assert_equal :allowed_to_modify_group?, @policy.resolve_rule(:create?)
-    assert_equal :allowed_to_modify_group?, @policy.resolve_rule(:edit?)
-    assert_equal :allowed_to_modify_group?, @policy.resolve_rule(:update?)
-    assert_equal :allowed_to_modify_group?, @policy.resolve_rule(:new?)
+    assert_equal :manage?, @policy.resolve_rule(:create?)
+    assert_equal :manage?, @policy.resolve_rule(:edit?)
+    assert_equal :manage?, @policy.resolve_rule(:update?)
+    assert_equal :manage?, @policy.resolve_rule(:new?)
 
-    assert_equal :allowed_to_view_group?, @policy.resolve_rule(:show?)
-    assert_equal :allowed_to_view_group?, @policy.resolve_rule(:index?)
+    assert_equal :view?, @policy.resolve_rule(:show?)
+    assert_equal :view?, @policy.resolve_rule(:index?)
 
-    assert_equal :allowed_to_destroy?, @policy.resolve_rule(:destroy?)
+    assert_equal :destroy?, @policy.resolve_rule(:destroy?)
   end
 
   test 'scope' do

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -17,15 +17,20 @@ class GroupPolicyTest < ActiveSupport::TestCase
     assert @policy.manage?
   end
 
+  test '#create?' do
+    assert @policy.create?
+  end
+
   test '#destroy?' do
     assert @policy.destroy?
   end
 
   test 'aliases' do
-    assert_equal :manage?, @policy.resolve_rule(:create?)
+    assert_equal :create?, @policy.resolve_rule(:create?)
+    assert_equal :create?, @policy.resolve_rule(:new?)
+
     assert_equal :manage?, @policy.resolve_rule(:edit?)
     assert_equal :manage?, @policy.resolve_rule(:update?)
-    assert_equal :manage?, @policy.resolve_rule(:new?)
 
     assert_equal :view?, @policy.resolve_rule(:show?)
     assert_equal :view?, @policy.resolve_rule(:index?)

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -9,8 +9,8 @@ class GroupPolicyTest < ActiveSupport::TestCase
     @policy = GroupPolicy.new(@group, user: @user)
   end
 
-  test '#show?' do
-    assert @policy.show?
+  test '#read?' do
+    assert @policy.read?
   end
 
   test '#new?' do

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -9,33 +9,56 @@ class GroupPolicyTest < ActiveSupport::TestCase
     @policy = GroupPolicy.new(@group, user: @user)
   end
 
-  test '#view?' do
-    assert @policy.view?
+  test '#show?' do
+    assert @policy.show?
   end
 
-  test '#manage?' do
-    assert @policy.manage?
+  test '#new?' do
+    assert @policy.new?
+  end
+
+  test '#edit?' do
+    assert @policy.edit?
   end
 
   test '#create?' do
     assert @policy.create?
   end
 
+  test '#update?' do
+    assert @policy.update?
+  end
+
   test '#destroy?' do
     assert @policy.destroy?
   end
 
-  test 'aliases' do
-    assert_equal :create?, @policy.resolve_rule(:create?)
-    assert_equal :create?, @policy.resolve_rule(:new?)
+  test '#create_subgroup?' do
+    assert @policy.create_subgroup?
+  end
 
-    assert_equal :manage?, @policy.resolve_rule(:edit?)
-    assert_equal :manage?, @policy.resolve_rule(:update?)
+  test '#transfer_into_namespace?' do
+    assert @policy.transfer_into_namespace?
+  end
 
-    assert_equal :view?, @policy.resolve_rule(:show?)
-    assert_equal :view?, @policy.resolve_rule(:index?)
+  test '#create_member?' do
+    assert @policy.create_member?
+  end
 
-    assert_equal :destroy?, @policy.resolve_rule(:destroy?)
+  test '#update_member?' do
+    assert @policy.update_member?
+  end
+
+  test '#destroy_member?' do
+    assert @policy.destroy_member?
+  end
+
+  test '#member_listing?' do
+    assert @policy.member_listing?
+  end
+
+  test '#sample_listing?' do
+    assert @policy.sample_listing?
   end
 
   test 'scope' do

--- a/test/policies/namespaces/project_namespace_policy_test.rb
+++ b/test/policies/namespaces/project_namespace_policy_test.rb
@@ -10,14 +10,14 @@ module Namespaces
       @policy = Namespaces::ProjectNamespacePolicy.new(@project.namespace, user: @user)
     end
 
-    test '#allowed_to_modify_project_namespace?' do
-      assert @policy.allowed_to_modify_project_namespace?
+    test '#manage?' do
+      assert @policy.manage?
     end
 
     test 'aliases' do
-      assert_equal :allowed_to_modify_project_namespace?, @policy.resolve_rule(:new?)
-      assert_equal :allowed_to_modify_project_namespace?, @policy.resolve_rule(:create?)
-      assert_equal :allowed_to_modify_project_namespace?, @policy.resolve_rule(:update?)
+      assert_equal :manage?, @policy.resolve_rule(:new?)
+      assert_equal :manage?, @policy.resolve_rule(:create?)
+      assert_equal :manage?, @policy.resolve_rule(:update?)
     end
   end
 end

--- a/test/policies/namespaces/project_namespace_policy_test.rb
+++ b/test/policies/namespaces/project_namespace_policy_test.rb
@@ -10,19 +10,32 @@ module Namespaces
       @policy = Namespaces::ProjectNamespacePolicy.new(@project.namespace, user: @user)
     end
 
-    test '#manage?' do
-      assert @policy.manage?
+    test '#new?' do
+      assert @policy.new?
     end
 
     test '#create?' do
       assert @policy.create?
     end
 
-    test 'aliases' do
-      assert_equal :create?, @policy.resolve_rule(:new?)
-      assert_equal :create?, @policy.resolve_rule(:create?)
+    test '#update?' do
+      assert @policy.update?
+    end
 
-      assert_equal :manage?, @policy.resolve_rule(:update?)
+    test '#create_member?' do
+      assert @policy.create_member?
+    end
+
+    test '#update_member?' do
+      assert @policy.update_member?
+    end
+
+    test '#destroy_member?' do
+      assert @policy.destroy_member?
+    end
+
+    test '#member_listing?' do
+      assert @policy.member_listing?
     end
   end
 end

--- a/test/policies/namespaces/project_namespace_policy_test.rb
+++ b/test/policies/namespaces/project_namespace_policy_test.rb
@@ -10,14 +10,6 @@ module Namespaces
       @policy = Namespaces::ProjectNamespacePolicy.new(@project.namespace, user: @user)
     end
 
-    test '#new?' do
-      assert @policy.new?
-    end
-
-    test '#create?' do
-      assert @policy.create?
-    end
-
     test '#update?' do
       assert @policy.update?
     end

--- a/test/policies/namespaces/project_namespace_policy_test.rb
+++ b/test/policies/namespaces/project_namespace_policy_test.rb
@@ -14,9 +14,14 @@ module Namespaces
       assert @policy.manage?
     end
 
+    test '#create?' do
+      assert @policy.create?
+    end
+
     test 'aliases' do
-      assert_equal :manage?, @policy.resolve_rule(:new?)
-      assert_equal :manage?, @policy.resolve_rule(:create?)
+      assert_equal :create?, @policy.resolve_rule(:new?)
+      assert_equal :create?, @policy.resolve_rule(:create?)
+
       assert_equal :manage?, @policy.resolve_rule(:update?)
     end
   end

--- a/test/policies/namespaces/user_namespace_policy_test.rb
+++ b/test/policies/namespaces/user_namespace_policy_test.rb
@@ -10,17 +10,16 @@ module Namespaces
       @policy = Namespaces::UserNamespacePolicy.new(@project.namespace, user: @user)
     end
 
+    test '#new?' do
+      assert @policy.new?
+    end
+
     test '#create?' do
       assert @policy.create?
     end
 
-    test '#transfer_to_namespace?' do
-      assert @policy.transfer_to_namespace?
-    end
-
-    test 'aliases' do
-      assert_equal :create?, @policy.resolve_rule(:new?)
-      assert_equal :create?, @policy.resolve_rule(:create?)
+    test '#transfer_into_namespace?' do
+      assert @policy.transfer_into_namespace?
     end
   end
 end

--- a/test/policies/namespaces/user_namespace_policy_test.rb
+++ b/test/policies/namespaces/user_namespace_policy_test.rb
@@ -10,8 +10,8 @@ module Namespaces
       @policy = Namespaces::UserNamespacePolicy.new(@project.namespace, user: @user)
     end
 
-    test '#allowed_to_modify_projects_under_namespace?' do
-      assert @policy.allowed_to_modify_projects_under_namespace?
+    test '#manage?' do
+      assert @policy.manage?
     end
 
     test '#transfer_to_namespace?' do
@@ -19,8 +19,8 @@ module Namespaces
     end
 
     test 'aliases' do
-      assert_equal :allowed_to_modify_projects_under_namespace?, @policy.resolve_rule(:new?)
-      assert_equal :allowed_to_modify_projects_under_namespace?, @policy.resolve_rule(:create?)
+      assert_equal :manage?, @policy.resolve_rule(:new?)
+      assert_equal :manage?, @policy.resolve_rule(:create?)
     end
   end
 end

--- a/test/policies/namespaces/user_namespace_policy_test.rb
+++ b/test/policies/namespaces/user_namespace_policy_test.rb
@@ -10,8 +10,8 @@ module Namespaces
       @policy = Namespaces::UserNamespacePolicy.new(@project.namespace, user: @user)
     end
 
-    test '#manage?' do
-      assert @policy.manage?
+    test '#create?' do
+      assert @policy.create?
     end
 
     test '#transfer_to_namespace?' do
@@ -19,8 +19,8 @@ module Namespaces
     end
 
     test 'aliases' do
-      assert_equal :manage?, @policy.resolve_rule(:new?)
-      assert_equal :manage?, @policy.resolve_rule(:create?)
+      assert_equal :create?, @policy.resolve_rule(:new?)
+      assert_equal :create?, @policy.resolve_rule(:create?)
     end
   end
 end

--- a/test/policies/namespaces/user_namespace_policy_test.rb
+++ b/test/policies/namespaces/user_namespace_policy_test.rb
@@ -10,10 +10,6 @@ module Namespaces
       @policy = Namespaces::UserNamespacePolicy.new(@project.namespace, user: @user)
     end
 
-    test '#new?' do
-      assert @policy.new?
-    end
-
     test '#create?' do
       assert @policy.create?
     end

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -10,16 +10,28 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     @details = {}
   end
 
-  test '#view?' do
-    assert @policy.view?
+  test '#show?' do
+    assert @policy.show?
   end
 
-  test '#manage?' do
-    assert @policy.manage?
+  test '#edit?' do
+    assert @policy.edit?
+  end
+
+  test '#new?' do
+    assert @policy.new?
   end
 
   test '#create?' do
     assert @policy.create?
+  end
+
+  test '#update?' do
+    assert @policy.update?
+  end
+
+  test '#activity?' do
+    assert @policy.activity?
   end
 
   test '#destroy?' do
@@ -30,20 +42,24 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     assert @policy.transfer?
   end
 
-  test 'aliases' do
-    assert_equal :create?, @policy.resolve_rule(:create?)
-    assert_equal :create?, @policy.resolve_rule(:new?)
+  test '#sample_listing?' do
+    assert @policy.sample_listing?
+  end
 
-    assert_equal :manage?, @policy.resolve_rule(:edit?)
-    assert_equal :manage?, @policy.resolve_rule(:update?)
+  test '#create_sample?' do
+    assert @policy.create_sample?
+  end
 
-    assert_equal :view?, @policy.resolve_rule(:index?)
-    assert_equal :view?, @policy.resolve_rule(:show?)
-    assert_equal :view?, @policy.resolve_rule(:activity?)
+  test '#update_sample?' do
+    assert @policy.update_sample?
+  end
 
-    assert_equal :destroy?, @policy.resolve_rule(:destroy?)
+  test '#destroy_sample?' do
+    assert @policy.destroy_sample?
+  end
 
-    assert_equal :transfer?, @policy.resolve_rule(:transfer?)
+  test '#show_sample?' do
+    assert @policy.destroy_sample?
   end
 
   test 'scope' do

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -7,37 +7,38 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     @user = users(:john_doe)
     @project = projects(:project1)
     @policy = ProjectPolicy.new(@project, user: @user)
+    @details = {}
   end
 
-  test '#allowed_to_view_project?' do
-    assert @policy.allowed_to_view_project?
+  test '#view?' do
+    assert @policy.view?
   end
 
-  test '#allowed_to_modify_project?' do
-    assert @policy.allowed_to_modify_project?
+  test '#manage?' do
+    assert @policy.manage?
   end
 
-  test '#allowed_to_destroy?' do
-    assert @policy.allowed_to_destroy?
+  test '#destroy?' do
+    assert @policy.destroy?
   end
 
-  test '#allowed_to_transfer?' do
-    assert @policy.allowed_to_transfer?
+  test '#transfer?' do
+    assert @policy.transfer?
   end
 
   test 'aliases' do
-    assert_equal :allowed_to_modify_project?, @policy.resolve_rule(:create?)
-    assert_equal :allowed_to_modify_project?, @policy.resolve_rule(:edit?)
-    assert_equal :allowed_to_modify_project?, @policy.resolve_rule(:update?)
-    assert_equal :allowed_to_modify_project?, @policy.resolve_rule(:new?)
+    assert_equal :manage?, @policy.resolve_rule(:create?)
+    assert_equal :manage?, @policy.resolve_rule(:edit?)
+    assert_equal :manage?, @policy.resolve_rule(:update?)
+    assert_equal :manage?, @policy.resolve_rule(:new?)
 
-    assert_equal :allowed_to_view_project?, @policy.resolve_rule(:index?)
-    assert_equal :allowed_to_view_project?, @policy.resolve_rule(:show?)
-    assert_equal :allowed_to_view_project?, @policy.resolve_rule(:activity?)
+    assert_equal :view?, @policy.resolve_rule(:index?)
+    assert_equal :view?, @policy.resolve_rule(:show?)
+    assert_equal :view?, @policy.resolve_rule(:activity?)
 
-    assert_equal :allowed_to_destroy?, @policy.resolve_rule(:destroy?)
+    assert_equal :destroy?, @policy.resolve_rule(:destroy?)
 
-    assert_equal :allowed_to_transfer?, @policy.resolve_rule(:transfer?)
+    assert_equal :transfer?, @policy.resolve_rule(:transfer?)
   end
 
   test 'scope' do

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -18,6 +18,10 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     assert @policy.manage?
   end
 
+  test '#create?' do
+    assert @policy.create?
+  end
+
   test '#destroy?' do
     assert @policy.destroy?
   end
@@ -27,10 +31,11 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   end
 
   test 'aliases' do
-    assert_equal :manage?, @policy.resolve_rule(:create?)
+    assert_equal :create?, @policy.resolve_rule(:create?)
+    assert_equal :create?, @policy.resolve_rule(:new?)
+
     assert_equal :manage?, @policy.resolve_rule(:edit?)
     assert_equal :manage?, @policy.resolve_rule(:update?)
-    assert_equal :manage?, @policy.resolve_rule(:new?)
 
     assert_equal :view?, @policy.resolve_rule(:index?)
     assert_equal :view?, @policy.resolve_rule(:show?)

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -10,8 +10,8 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     @details = {}
   end
 
-  test '#show?' do
-    assert @policy.show?
+  test '#read?' do
+    assert @policy.read?
   end
 
   test '#edit?' do
@@ -54,7 +54,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     assert @policy.destroy_sample?
   end
 
-  test '#show_sample?' do
+  test '#read_sample?' do
     assert @policy.destroy_sample?
   end
 

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -22,10 +22,6 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     assert @policy.new?
   end
 
-  test '#create?' do
-    assert @policy.create?
-  end
-
   test '#update?' do
     assert @policy.update?
   end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -24,8 +24,8 @@ class UserPolicyTest < ActiveSupport::TestCase
     assert @policy.revoke?
   end
 
-  test '#show?' do
-    assert @policy.show?
+  test '#read?' do
+    assert @policy.read?
   end
 
   test '#index?' do

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -12,12 +12,23 @@ class UserPolicyTest < ActiveSupport::TestCase
     assert @policy.manage?
   end
 
+  test '#view?' do
+    assert @policy.view?
+  end
+
+  test '#create?' do
+    assert @policy.create?
+  end
+
   test 'aliases' do
-    assert_equal :manage?, @policy.resolve_rule(:show?)
-    assert_equal :manage?, @policy.resolve_rule(:create?)
+    assert_equal :view?, @policy.resolve_rule(:show?)
+    assert_equal :view?, @policy.resolve_rule(:index?)
+
+    assert_equal :create?, @policy.resolve_rule(:create?)
+    assert_equal :create?, @policy.resolve_rule(:new?)
+
     assert_equal :manage?, @policy.resolve_rule(:update?)
     assert_equal :manage?, @policy.resolve_rule(:edit?)
-    assert_equal :manage?, @policy.resolve_rule(:index?)
     assert_equal :manage?, @policy.resolve_rule(:destroy?)
     assert_equal :manage?, @policy.resolve_rule(:revoke?)
   end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -8,28 +8,35 @@ class UserPolicyTest < ActiveSupport::TestCase
     @policy = UserPolicy.new(@user, user: @user)
   end
 
-  test '#manage?' do
-    assert @policy.manage?
+  test '#update?' do
+    assert @policy.update?
   end
 
-  test '#view?' do
-    assert @policy.view?
+  test '#edit?' do
+    assert @policy.edit?
+  end
+
+  test '#destroy?' do
+    assert @policy.destroy?
+  end
+
+  test '#revoke?' do
+    assert @policy.revoke?
+  end
+
+  test '#show?' do
+    assert @policy.show?
+  end
+
+  test '#index?' do
+    assert @policy.index?
+  end
+
+  test '#new?' do
+    assert @policy.new?
   end
 
   test '#create?' do
     assert @policy.create?
-  end
-
-  test 'aliases' do
-    assert_equal :view?, @policy.resolve_rule(:show?)
-    assert_equal :view?, @policy.resolve_rule(:index?)
-
-    assert_equal :create?, @policy.resolve_rule(:create?)
-    assert_equal :create?, @policy.resolve_rule(:new?)
-
-    assert_equal :manage?, @policy.resolve_rule(:update?)
-    assert_equal :manage?, @policy.resolve_rule(:edit?)
-    assert_equal :manage?, @policy.resolve_rule(:destroy?)
-    assert_equal :manage?, @policy.resolve_rule(:revoke?)
   end
 end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -8,17 +8,17 @@ class UserPolicyTest < ActiveSupport::TestCase
     @policy = UserPolicy.new(@user, user: @user)
   end
 
-  test '#profile_owner?' do
-    assert @policy.profile_owner?
+  test '#manage?' do
+    assert @policy.manage?
   end
 
   test 'aliases' do
-    assert_equal :profile_owner?, @policy.resolve_rule(:show?)
-    assert_equal :profile_owner?, @policy.resolve_rule(:create?)
-    assert_equal :profile_owner?, @policy.resolve_rule(:update?)
-    assert_equal :profile_owner?, @policy.resolve_rule(:edit?)
-    assert_equal :profile_owner?, @policy.resolve_rule(:index?)
-    assert_equal :profile_owner?, @policy.resolve_rule(:destroy?)
-    assert_equal :profile_owner?, @policy.resolve_rule(:revoke?)
+    assert_equal :manage?, @policy.resolve_rule(:show?)
+    assert_equal :manage?, @policy.resolve_rule(:create?)
+    assert_equal :manage?, @policy.resolve_rule(:update?)
+    assert_equal :manage?, @policy.resolve_rule(:edit?)
+    assert_equal :manage?, @policy.resolve_rule(:index?)
+    assert_equal :manage?, @policy.resolve_rule(:destroy?)
+    assert_equal :manage?, @policy.resolve_rule(:revoke?)
   end
 end

--- a/test/services/groups/create_service_test.rb
+++ b/test/services/groups/create_service_test.rb
@@ -34,9 +34,9 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: group.name), exception.result.message
+      assert_equal I18n.t(:'action_policy.policy.group.create?', name: group.name), exception.result.message
     end
 
     test 'create subgroup within a parent group that the user is a part of with OWNER role' do
@@ -68,9 +68,9 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: group.name), exception.result.message
+      assert_equal I18n.t(:'action_policy.policy.group.create?', name: group.name), exception.result.message
     end
 
     test 'valid authorization to create group' do
@@ -78,7 +78,7 @@ module Groups
       valid_params = { name: 'group1', path: 'group1', parent_id: group.id }
       user = users(:michelle_doe)
 
-      assert_authorized_to(:manage?, group,
+      assert_authorized_to(:create?, group,
                            with: GroupPolicy,
                            context: { user: }) do
         Groups::CreateService.new(user, valid_params).execute

--- a/test/services/groups/create_service_test.rb
+++ b/test/services/groups/create_service_test.rb
@@ -25,7 +25,8 @@ module Groups
     end
 
     test 'create group with valid params but no namespace permissions' do
-      valid_params = { name: 'group1', path: 'group1', parent_id: groups(:group_one).id }
+      group = groups(:group_one)
+      valid_params = { name: 'group1', path: 'group1', parent_id: group.id }
       user = users(:michelle_doe)
 
       exception = assert_raises(ActionPolicy::Unauthorized) do
@@ -35,6 +36,7 @@ module Groups
       assert_equal GroupPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: group.name), exception.result.message
     end
 
     test 'create subgroup within a parent group that the user is a part of with OWNER role' do
@@ -57,7 +59,8 @@ module Groups
     end
 
     test 'create subgroup within a parent group that the user is a part of with role < MAINTAINER' do
-      valid_params = { name: 'group1', path: 'group1', parent_id: groups(:subgroup_one_group_three).id }
+      group = groups(:subgroup_one_group_three)
+      valid_params = { name: 'group1', path: 'group1', parent_id: group.id }
       user = users(:ryan_doe)
 
       exception = assert_raises(ActionPolicy::Unauthorized) do
@@ -67,6 +70,7 @@ module Groups
       assert_equal GroupPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: group.name), exception.result.message
     end
 
     test 'valid authorization to create group' do

--- a/test/services/groups/create_service_test.rb
+++ b/test/services/groups/create_service_test.rb
@@ -33,7 +33,7 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_modify_group?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -65,7 +65,7 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_modify_group?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -74,7 +74,7 @@ module Groups
       valid_params = { name: 'group1', path: 'group1', parent_id: group.id }
       user = users(:michelle_doe)
 
-      assert_authorized_to(:allowed_to_modify_group?, group,
+      assert_authorized_to(:manage?, group,
                            with: GroupPolicy,
                            context: { user: }) do
         Groups::CreateService.new(user, valid_params).execute

--- a/test/services/groups/create_service_test.rb
+++ b/test/services/groups/create_service_test.rb
@@ -34,9 +34,9 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :create?, exception.rule
+      assert_equal :create_subgroup?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.create?', name: group.name), exception.result.message
+      assert_equal I18n.t(:'action_policy.policy.group.create_subgroup?', name: group.name), exception.result.message
     end
 
     test 'create subgroup within a parent group that the user is a part of with OWNER role' do
@@ -68,17 +68,17 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :create?, exception.rule
+      assert_equal :create_subgroup?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.create?', name: group.name), exception.result.message
+      assert_equal I18n.t(:'action_policy.policy.group.create_subgroup?', name: group.name), exception.result.message
     end
 
-    test 'valid authorization to create group' do
+    test 'valid authorization to create subgroup' do
       group = groups(:group_one)
       valid_params = { name: 'group1', path: 'group1', parent_id: group.id }
       user = users(:michelle_doe)
 
-      assert_authorized_to(:create?, group,
+      assert_authorized_to(:create_subgroup?, group,
                            with: GroupPolicy,
                            context: { user: }) do
         Groups::CreateService.new(user, valid_params).execute

--- a/test/services/groups/destroy_service_test.rb
+++ b/test/services/groups/destroy_service_test.rb
@@ -24,12 +24,12 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_destroy?, exception.rule
+      assert_equal :destroy?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to destroy group' do
-      assert_authorized_to(:allowed_to_destroy?, @group,
+      assert_authorized_to(:destroy?, @group,
                            with: GroupPolicy,
                            context: { user: @user }) do
         Groups::DestroyService.new(@group, @user).execute

--- a/test/services/groups/destroy_service_test.rb
+++ b/test/services/groups/destroy_service_test.rb
@@ -26,6 +26,7 @@ module Groups
       assert_equal GroupPolicy, exception.policy
       assert_equal :destroy?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.group.destroy?', name: @group.name), exception.result.message
     end
 
     test 'valid authorization to destroy group' do

--- a/test/services/groups/update_service_test.rb
+++ b/test/services/groups/update_service_test.rb
@@ -34,15 +34,15 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :update?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: @group.name), exception.result.message
+      assert_equal I18n.t(:'action_policy.policy.group.update?', name: @group.name), exception.result.message
     end
 
     test 'valid authorization to update group' do
       valid_params = { name: 'new-group1-name', path: 'new-group1-path' }
 
-      assert_authorized_to(:manage?, @group,
+      assert_authorized_to(:update?, @group,
                            with: GroupPolicy,
                            context: { user: @user }) do
         Groups::UpdateService.new(@group, @user, valid_params).execute

--- a/test/services/groups/update_service_test.rb
+++ b/test/services/groups/update_service_test.rb
@@ -34,14 +34,14 @@ module Groups
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_modify_group?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to update group' do
       valid_params = { name: 'new-group1-name', path: 'new-group1-path' }
 
-      assert_authorized_to(:allowed_to_modify_group?, @group,
+      assert_authorized_to(:manage?, @group,
                            with: GroupPolicy,
                            context: { user: @user }) do
         Groups::UpdateService.new(@group, @user, valid_params).execute

--- a/test/services/groups/update_service_test.rb
+++ b/test/services/groups/update_service_test.rb
@@ -36,6 +36,7 @@ module Groups
       assert_equal GroupPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: @group.name), exception.result.message
     end
 
     test 'valid authorization to update group' do

--- a/test/services/members/create_service_test.rb
+++ b/test/services/members/create_service_test.rb
@@ -59,7 +59,7 @@ module Members
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_modify_group?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -116,7 +116,7 @@ module Members
       group = groups(:subgroup1)
       valid_params = { user:, access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:allowed_to_modify_group?, group,
+      assert_authorized_to(:manage?, group,
                            with: GroupPolicy,
                            context: { user: @user }) do
         Members::CreateService.new(@user, group, valid_params).execute
@@ -128,7 +128,7 @@ module Members
       valid_params = { user:,
                        access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:allowed_to_modify_project_namespace?, @project_namespace,
+      assert_authorized_to(:manage?, @project_namespace,
                            with: Namespaces::ProjectNamespacePolicy,
                            context: { user: @user }) do
         Members::CreateService.new(@user, @project_namespace, valid_params).execute

--- a/test/services/members/create_service_test.rb
+++ b/test/services/members/create_service_test.rb
@@ -59,9 +59,9 @@ module Members
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create_member?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: @group.name),
+      assert_equal I18n.t(:'action_policy.policy.group.create_member?', name: @group.name),
                    exception.result.message
     end
 
@@ -126,9 +126,9 @@ module Members
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create_member?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.manage?', name: project.name),
+      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.create_member?', name: project.name),
                    exception.result.message
     end
 
@@ -137,7 +137,7 @@ module Members
       group = groups(:subgroup1)
       valid_params = { user:, access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:manage?, group,
+      assert_authorized_to(:create_member?, group,
                            with: GroupPolicy,
                            context: { user: @user }) do
         Members::CreateService.new(@user, group, valid_params).execute
@@ -149,7 +149,7 @@ module Members
       valid_params = { user:,
                        access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:manage?, @project_namespace,
+      assert_authorized_to(:create_member?, @project_namespace,
                            with: Namespaces::ProjectNamespacePolicy,
                            context: { user: @user }) do
         Members::CreateService.new(@user, @project_namespace, valid_params).execute

--- a/test/services/members/destroy_service_test.rb
+++ b/test/services/members/destroy_service_test.rb
@@ -38,7 +38,7 @@ module Members
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_modify_group?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -91,7 +91,7 @@ module Members
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :allowed_to_modify_project_namespace?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
   end

--- a/test/services/members/destroy_service_test.rb
+++ b/test/services/members/destroy_service_test.rb
@@ -40,6 +40,7 @@ module Members
       assert_equal GroupPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: @group.name), exception.result.message
     end
 
     test 'remove group member with OWNER role when the current user only has the Maintainer role' do
@@ -93,6 +94,8 @@ module Members
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.manage?', name: @project_namespace.name),
+                   exception.result.message
     end
   end
 end

--- a/test/services/members/destroy_service_test.rb
+++ b/test/services/members/destroy_service_test.rb
@@ -38,9 +38,9 @@ module Members
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :destroy_member?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: @group.name), exception.result.message
+      assert_equal I18n.t(:'action_policy.policy.group.destroy_member?', name: @group.name), exception.result.message
     end
 
     test 'remove group member with OWNER role when the current user only has the Maintainer role' do
@@ -92,9 +92,10 @@ module Members
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :destroy_member?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.manage?', name: @project_namespace.name),
+      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.destroy_member?',
+                          name: @project_namespace.name),
                    exception.result.message
     end
   end

--- a/test/services/members/update_service_test.rb
+++ b/test/services/members/update_service_test.rb
@@ -56,7 +56,7 @@ module Members
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :update_member?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -131,7 +131,7 @@ module Members
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :update_member?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -167,8 +167,8 @@ module Members
     test 'valid authorization to update group member' do
       valid_params = { user: @group_member.user, access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:manage?, @group, with: GroupPolicy,
-                                             context: { user: @user }) do
+      assert_authorized_to(:update_member?, @group, with: GroupPolicy,
+                                                    context: { user: @user }) do
         Members::UpdateService.new(
           @group_member, @group, @user, valid_params
         ).execute
@@ -178,7 +178,7 @@ module Members
     test 'valid authorization to update project member' do
       valid_params = { user: @project_member.user, access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:manage?, @project_namespace,
+      assert_authorized_to(:update_member?, @project_namespace,
                            with: Namespaces::ProjectNamespacePolicy,
                            context: { user: @user }) do
         Members::UpdateService.new(@project_member,

--- a/test/services/members/update_service_test.rb
+++ b/test/services/members/update_service_test.rb
@@ -56,7 +56,7 @@ module Members
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_modify_group?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -117,7 +117,7 @@ module Members
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :allowed_to_modify_project_namespace?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -138,8 +138,8 @@ module Members
     test 'valid authorization to update group member' do
       valid_params = { user: @group_member.user, access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:allowed_to_modify_group?, @group, with: GroupPolicy,
-                                                              context: { user: @user }) do
+      assert_authorized_to(:manage?, @group, with: GroupPolicy,
+                                             context: { user: @user }) do
         Members::UpdateService.new(
           @group_member, @group, @user, valid_params
         ).execute
@@ -149,7 +149,7 @@ module Members
     test 'valid authorization to update project member' do
       valid_params = { user: @project_member.user, access_level: Member::AccessLevel::OWNER }
 
-      assert_authorized_to(:allowed_to_modify_project_namespace?, @project_namespace,
+      assert_authorized_to(:manage?, @project_namespace,
                            with: Namespaces::ProjectNamespacePolicy,
                            context: { user: @user }) do
         Members::UpdateService.new(@project_member,

--- a/test/services/projects/create_service_test.rb
+++ b/test/services/projects/create_service_test.rb
@@ -38,7 +38,7 @@ module Projects
       end
 
       assert_equal Namespaces::UserNamespacePolicy, exception.policy
-      assert_equal :allowed_to_modify_projects_under_namespace?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -89,14 +89,14 @@ module Projects
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :allowed_to_modify_group?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to create project' do
       valid_params = { namespace_attributes: { name: 'proj1', path: 'proj1', parent_id: @parent_namespace.id } }
 
-      assert_authorized_to(:allowed_to_modify_projects_under_namespace?, @parent_namespace,
+      assert_authorized_to(:manage?, @parent_namespace,
                            with: Namespaces::UserNamespacePolicy,
                            context: { user: @user }) do
         Projects::CreateService.new(@user, valid_params).execute

--- a/test/services/projects/create_service_test.rb
+++ b/test/services/projects/create_service_test.rb
@@ -40,6 +40,8 @@ module Projects
       assert_equal Namespaces::UserNamespacePolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.namespaces/user_namespace.manage?', name: @parent_namespace.name),
+                   exception.result.message
     end
 
     test 'create project with valid params under group namespace' do
@@ -80,8 +82,9 @@ module Projects
     end
 
     test 'create project within a parent group that the user is a part of with role < MAINTAINER' do
+      parent_namespace = groups(:subgroup_one_group_three)
       valid_params = { namespace_attributes: { name: 'proj1', path: 'proj1',
-                                               parent_id: groups(:subgroup_one_group_three).id } }
+                                               parent_id: parent_namespace.id } }
       user = users(:ryan_doe)
 
       exception = assert_raises(ActionPolicy::Unauthorized) do
@@ -91,6 +94,8 @@ module Projects
       assert_equal GroupPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: parent_namespace.name),
+                   exception.result.message
     end
 
     test 'valid authorization to create project' do

--- a/test/services/projects/create_service_test.rb
+++ b/test/services/projects/create_service_test.rb
@@ -38,9 +38,9 @@ module Projects
       end
 
       assert_equal Namespaces::UserNamespacePolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.namespaces/user_namespace.manage?', name: @parent_namespace.name),
+      assert_equal I18n.t(:'action_policy.policy.namespaces/user_namespace.create?', name: @parent_namespace.name),
                    exception.result.message
     end
 
@@ -92,16 +92,16 @@ module Projects
       end
 
       assert_equal GroupPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.manage?', name: parent_namespace.name),
+      assert_equal I18n.t(:'action_policy.policy.group.create?', name: parent_namespace.name),
                    exception.result.message
     end
 
     test 'valid authorization to create project' do
       valid_params = { namespace_attributes: { name: 'proj1', path: 'proj1', parent_id: @parent_namespace.id } }
 
-      assert_authorized_to(:manage?, @parent_namespace,
+      assert_authorized_to(:create?, @parent_namespace,
                            with: Namespaces::UserNamespacePolicy,
                            context: { user: @user }) do
         Projects::CreateService.new(@user, valid_params).execute

--- a/test/services/projects/destroy_service_test.rb
+++ b/test/services/projects/destroy_service_test.rb
@@ -25,12 +25,12 @@ module Projects
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :allowed_to_destroy?, exception.rule
+      assert_equal :destroy?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to destroy project' do
-      assert_authorized_to(:allowed_to_destroy?, @project,
+      assert_authorized_to(:destroy?, @project,
                            with: ProjectPolicy,
                            context: { user: @user }) do
         Projects::DestroyService.new(

--- a/test/services/projects/destroy_service_test.rb
+++ b/test/services/projects/destroy_service_test.rb
@@ -27,6 +27,7 @@ module Projects
       assert_equal ProjectPolicy, exception.policy
       assert_equal :destroy?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.project.destroy?', name: @project.name), exception.result.message
     end
 
     test 'valid authorization to destroy project' do

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -72,7 +72,7 @@ module Projects
     test 'authorize allowed to transfer to namespace' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
 
-      assert_authorized_to(:transfer_to_namespace?, new_namespace,
+      assert_authorized_to(:transfer_into_namespace?, new_namespace,
                            with: Namespaces::UserNamespacePolicy,
                            context: { user: @john_doe }) do
         Projects::TransferService.new(@project,

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -36,7 +36,7 @@ module Projects
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :allowed_to_transfer?, exception.rule
+      assert_equal :transfer?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -58,7 +58,7 @@ module Projects
     test 'authorize allowed to transfer project with permission' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
 
-      assert_authorized_to(:allowed_to_transfer?, @project,
+      assert_authorized_to(:transfer?, @project,
                            with: ProjectPolicy,
                            context: { user: @john_doe }) do
         Projects::TransferService.new(@project,

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -38,6 +38,9 @@ module Projects
       assert_equal ProjectPolicy, exception.policy
       assert_equal :transfer?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.project.transfer?',
+                          name: @project.name),
+                   exception.result.message
     end
 
     test 'transfer project without target namespace permission' do

--- a/test/services/projects/update_service_test.rb
+++ b/test/services/projects/update_service_test.rb
@@ -34,16 +34,16 @@ module Projects
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :update?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.manage?', name: @project.name),
+      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.update?', name: @project.name),
                    exception.result.message
     end
 
     test 'valid authorization to update project' do
       valid_params = { namespace_attributes: { name: 'new-project1-name', path: 'new-project1-path' } }
 
-      assert_authorized_to(:manage?, @project.namespace,
+      assert_authorized_to(:update?, @project.namespace,
                            with: Namespaces::ProjectNamespacePolicy,
                            context: { user: @user }) do
         Projects::UpdateService.new(@project, @user,

--- a/test/services/projects/update_service_test.rb
+++ b/test/services/projects/update_service_test.rb
@@ -34,14 +34,14 @@ module Projects
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :allowed_to_modify_project_namespace?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to update project' do
       valid_params = { namespace_attributes: { name: 'new-project1-name', path: 'new-project1-path' } }
 
-      assert_authorized_to(:allowed_to_modify_project_namespace?, @project.namespace,
+      assert_authorized_to(:manage?, @project.namespace,
                            with: Namespaces::ProjectNamespacePolicy,
                            context: { user: @user }) do
         Projects::UpdateService.new(@project, @user,

--- a/test/services/projects/update_service_test.rb
+++ b/test/services/projects/update_service_test.rb
@@ -36,6 +36,8 @@ module Projects
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.manage?', name: @project.name),
+                   exception.result.message
     end
 
     test 'valid authorization to update project' do

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -34,7 +34,7 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :allowed_to_modify_project?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
@@ -68,15 +68,15 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :allowed_to_modify_project?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to create sample' do
       valid_params = { name: 'new-project2-sample', description: 'first sample for project2' }
 
-      assert_authorized_to(:allowed_to_modify_project?, @project, with: ProjectPolicy,
-                                                                  context: { user: @user }) do
+      assert_authorized_to(:manage?, @project, with: ProjectPolicy,
+                                               context: { user: @user }) do
         Samples::CreateService.new(@user, @project,
                                    valid_params).execute
       end

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -34,9 +34,9 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create_sample?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.project.manage?', name: @project.name),
+      assert_equal I18n.t(:'action_policy.policy.project.create_sample?', name: @project.name),
                    exception.result.message
     end
 
@@ -70,17 +70,17 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :create_sample?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.project.manage?', name: project.name),
+      assert_equal I18n.t(:'action_policy.policy.project.create_sample?', name: project.name),
                    exception.result.message
     end
 
     test 'valid authorization to create sample' do
       valid_params = { name: 'new-project2-sample', description: 'first sample for project2' }
 
-      assert_authorized_to(:manage?, @project, with: ProjectPolicy,
-                                               context: { user: @user }) do
+      assert_authorized_to(:create_sample?, @project, with: ProjectPolicy,
+                                                      context: { user: @user }) do
         Samples::CreateService.new(@user, @project,
                                    valid_params).execute
       end

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -36,6 +36,8 @@ module Samples
       assert_equal ProjectPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.project.manage?', name: @project.name),
+                   exception.result.message
     end
 
     test 'create sample in project with valid params when member of a parent group with the OWNER role' do
@@ -70,6 +72,8 @@ module Samples
       assert_equal ProjectPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.project.manage?', name: project.name),
+                   exception.result.message
     end
 
     test 'valid authorization to create sample' do

--- a/test/services/samples/destroy_service_test.rb
+++ b/test/services/samples/destroy_service_test.rb
@@ -23,15 +23,15 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :destroy?, exception.rule
+      assert_equal :destroy_sample?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.project.destroy?', name: @sample.project.name),
+      assert_equal I18n.t(:'action_policy.policy.project.destroy_sample?', name: @sample.project.name),
                    exception.result.message
     end
 
     test 'valid authorization to destroy sample' do
-      assert_authorized_to(:destroy?, @sample.project, with: ProjectPolicy,
-                                                       context: { user: @user }) do
+      assert_authorized_to(:destroy_sample?, @sample.project, with: ProjectPolicy,
+                                                              context: { user: @user }) do
         Samples::DestroyService.new(@sample,
                                     @user).execute
       end

--- a/test/services/samples/destroy_service_test.rb
+++ b/test/services/samples/destroy_service_test.rb
@@ -23,13 +23,13 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :allowed_to_destroy?, exception.rule
+      assert_equal :destroy?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to destroy sample' do
-      assert_authorized_to(:allowed_to_destroy?, @sample.project, with: ProjectPolicy,
-                                                                  context: { user: @user }) do
+      assert_authorized_to(:destroy?, @sample.project, with: ProjectPolicy,
+                                                       context: { user: @user }) do
         Samples::DestroyService.new(@sample,
                                     @user).execute
       end

--- a/test/services/samples/destroy_service_test.rb
+++ b/test/services/samples/destroy_service_test.rb
@@ -25,6 +25,8 @@ module Samples
       assert_equal ProjectPolicy, exception.policy
       assert_equal :destroy?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.project.destroy?', name: @sample.project.name),
+                   exception.result.message
     end
 
     test 'valid authorization to destroy sample' do

--- a/test/services/samples/update_service_test.rb
+++ b/test/services/samples/update_service_test.rb
@@ -39,6 +39,8 @@ module Samples
       assert_equal ProjectPolicy, exception.policy
       assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.project.manage?', name: sample.project.name),
+                   exception.result.message
     end
 
     test 'valid authorization to update sample' do

--- a/test/services/samples/update_service_test.rb
+++ b/test/services/samples/update_service_test.rb
@@ -37,15 +37,15 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :allowed_to_modify_project?, exception.rule
+      assert_equal :manage?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
     test 'valid authorization to update sample' do
       valid_params = { name: 'new-sample3-name', description: 'new-sample3-description' }
 
-      assert_authorized_to(:allowed_to_modify_project?, @sample.project, with: ProjectPolicy,
-                                                                         context: { user: @user }) do
+      assert_authorized_to(:manage?, @sample.project, with: ProjectPolicy,
+                                                      context: { user: @user }) do
         Samples::UpdateService.new(@sample, @user, valid_params).execute
       end
     end

--- a/test/services/samples/update_service_test.rb
+++ b/test/services/samples/update_service_test.rb
@@ -37,17 +37,17 @@ module Samples
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :manage?, exception.rule
+      assert_equal :update_sample?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.project.manage?', name: sample.project.name),
+      assert_equal I18n.t(:'action_policy.policy.project.update_sample?', name: sample.project.name),
                    exception.result.message
     end
 
     test 'valid authorization to update sample' do
       valid_params = { name: 'new-sample3-name', description: 'new-sample3-description' }
 
-      assert_authorized_to(:manage?, @sample.project, with: ProjectPolicy,
-                                                      context: { user: @user }) do
+      assert_authorized_to(:update_sample?, @sample.project, with: ProjectPolicy,
+                                                             context: { user: @user }) do
         Samples::UpdateService.new(@sample, @user, valid_params).execute
       end
     end

--- a/test/system/groups/members_test.rb
+++ b/test/system/groups/members_test.rb
@@ -17,6 +17,14 @@ module Groups
       assert_selector 'tr', count: @members_count
     end
 
+    test 'cannot access group members' do
+      login_as users(:david_doe)
+
+      visit group_members_url(@namespace)
+
+      assert_text I18n.t(:'action_policy.policy.group.view?', name: @namespace.name)
+    end
+
     test 'can add a member to the group' do
       visit group_members_url(@namespace)
       assert_selector 'h1', text: I18n.t(:'groups.members.index.title')

--- a/test/system/groups/members_test.rb
+++ b/test/system/groups/members_test.rb
@@ -23,7 +23,7 @@ module Groups
 
       visit group_members_url(@namespace)
 
-      assert_text I18n.t(:'action_policy.policy.group.view?', name: @namespace.name)
+      assert_text I18n.t(:'action_policy.policy.group.member_listing?', name: @namespace.name)
     end
 
     test 'can add a member to the group' do

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -26,5 +26,13 @@ module Groups
       click_link samples(:sample3).name
       assert_selector 'h1', text: samples(:sample3).name
     end
+
+    test 'cannot access group samples' do
+      login_as users(:david_doe)
+
+      visit group_samples_url(@group)
+
+      assert_text I18n.t(:'action_policy.policy.group.view?', name: @group.name)
+    end
   end
 end

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -32,7 +32,7 @@ module Groups
 
       visit group_samples_url(@group)
 
-      assert_text I18n.t(:'action_policy.policy.group.view?', name: @group.name)
+      assert_text I18n.t(:'action_policy.policy.group.sample_listing?', name: @group.name)
     end
   end
 end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -144,6 +144,6 @@ class GroupsTest < ApplicationSystemTestCase # rubocop:disable Metrics/ClassLeng
     group = groups(:david_doe_group_four)
     visit group_url(group)
 
-    assert_text I18n.t(:'action_policy.policy.group.show?', name: group.name)
+    assert_text I18n.t(:'action_policy.policy.group.read?', name: group.name)
   end
 end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -2,7 +2,7 @@
 
 require 'application_system_test_case'
 
-class GroupsTest < ApplicationSystemTestCase
+class GroupsTest < ApplicationSystemTestCase # rubocop:disable Metrics/ClassLength
   def setup
     @user = users(:john_doe)
     @groups_count = @user.groups.self_and_descendant_ids.count
@@ -132,5 +132,18 @@ class GroupsTest < ApplicationSystemTestCase
     click_link I18n.t(:'groups.sidebar.settings')
 
     assert_selector 'a', text: I18n.t(:'groups.edit.advanced.delete_group.submit'), count: 0
+  end
+
+  test 'can view group' do
+    visit group_url(groups(:group_one))
+
+    assert_selector 'h1', text: 'Group 1'
+  end
+
+  test 'can not view group' do
+    group = groups(:david_doe_group_four)
+    visit group_url(group)
+
+    assert_text I18n.t(:'action_policy.policy.group.view?', name: group.name)
   end
 end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -144,6 +144,6 @@ class GroupsTest < ApplicationSystemTestCase # rubocop:disable Metrics/ClassLeng
     group = groups(:david_doe_group_four)
     visit group_url(group)
 
-    assert_text I18n.t(:'action_policy.policy.group.view?', name: group.name)
+    assert_text I18n.t(:'action_policy.policy.group.show?', name: group.name)
   end
 end

--- a/test/system/projects/members_test.rb
+++ b/test/system/projects/members_test.rb
@@ -18,6 +18,14 @@ module Projects
       assert_selector 'tr', count: @members_count
     end
 
+    test 'cannot access project members' do
+      login_as users(:david_doe)
+
+      visit namespace_project_members_url(@namespace, @project)
+
+      assert_text I18n.t(:'action_policy.policy.project.view?', name: @project.name)
+    end
+
     test 'can add a member to the project' do
       visit namespace_project_members_url(@namespace, @project)
       assert_selector 'h1', text: I18n.t(:'projects.members.index.title')

--- a/test/system/projects/members_test.rb
+++ b/test/system/projects/members_test.rb
@@ -23,7 +23,7 @@ module Projects
 
       visit namespace_project_members_url(@namespace, @project)
 
-      assert_text I18n.t(:'action_policy.policy.project.view?', name: @project.name)
+      assert_text I18n.t(:'action_policy.policy.namespaces/project_namespace.member_listing?', name: @project.name)
     end
 
     test 'can add a member to the project' do

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -28,7 +28,7 @@ module Projects
 
       visit namespace_project_samples_url(namespace_id: @namespace.path, project_id: @project.path)
 
-      assert_text I18n.t(:'action_policy.policy.project.view?', name: @project.name)
+      assert_text I18n.t(:'action_policy.policy.project.sample_listing?', name: @project.name)
     end
 
     test 'should create sample' do

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -23,6 +23,14 @@ module Projects
       assert_selector 'button.Viral-Dropdown--icon', count: 5
     end
 
+    test 'cannot access project samples' do
+      login_as users(:david_doe)
+
+      visit namespace_project_samples_url(namespace_id: @namespace.path, project_id: @project.path)
+
+      assert_text I18n.t(:'action_policy.policy.project.view?', name: @project.name)
+    end
+
     test 'should create sample' do
       visit namespace_project_samples_url(namespace_id: @namespace.path, project_id: @project.path)
       assert_selector 'a', text: I18n.t('projects.samples.index.new_button'), count: 1

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -77,7 +77,7 @@ class ProjectsTest < ApplicationSystemTestCase
     project = projects(:project1)
     visit namespace_project_url(group, project)
 
-    assert_text I18n.t(:'action_policy.policy.project.show?', name: project.name)
+    assert_text I18n.t(:'action_policy.policy.project.read?', name: project.name)
   end
 
   test 'can access edit project' do

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -63,4 +63,35 @@ class ProjectsTest < ApplicationSystemTestCase
     end
     assert_selector 'h1', text: project_name
   end
+
+  test 'can view project' do
+    visit namespace_project_url(groups(:group_one), projects(:project1))
+
+    assert_selector 'h1', text: 'Project 1'
+  end
+
+  test 'can not view project' do
+    login_as users(:david_doe)
+
+    group = groups(:group_one)
+    project = projects(:project1)
+    visit namespace_project_url(group, project)
+
+    assert_text I18n.t(:'action_policy.policy.project.view?', name: project.name)
+  end
+
+  test 'can access edit project' do
+    visit project_edit_path(projects(:project1))
+
+    assert_text I18n.t(:'projects.edit.general.title')
+  end
+
+  test 'cannot access edit project' do
+    login_as users(:david_doe)
+
+    project = projects(:project1)
+    visit project_edit_path(project)
+
+    assert_text I18n.t(:'action_policy.policy.project.manage?', name: project.name)
+  end
 end

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -77,7 +77,7 @@ class ProjectsTest < ApplicationSystemTestCase
     project = projects(:project1)
     visit namespace_project_url(group, project)
 
-    assert_text I18n.t(:'action_policy.policy.project.view?', name: project.name)
+    assert_text I18n.t(:'action_policy.policy.project.show?', name: project.name)
   end
 
   test 'can access edit project' do
@@ -92,6 +92,6 @@ class ProjectsTest < ApplicationSystemTestCase
     project = projects(:project1)
     visit project_edit_path(project)
 
-    assert_text I18n.t(:'action_policy.policy.project.manage?', name: project.name)
+    assert_text I18n.t(:'action_policy.policy.project.edit?', name: project.name)
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updated authorization methods in policies to be standardized so we can provide better messages to the user when they can't access a resource or perform an action.

Standardized policy authorization methods to the following between the policy classes

Note: We can modify the policy authorization messages as we go but this should be good for now.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**When trying to access a group which a user doesn't have access as well as it's associations (samples, members, settings):**

![image](https://github.com/phac-nml/irida-next/assets/25466211/3e4da2a1-4a81-4bd5-a5da-37bc1bf41f19)

![image](https://github.com/phac-nml/irida-next/assets/25466211/a26642e5-0ae0-4684-8180-b0963d46bdad)

**When trying to access a project which a user doesn't have access as well as it's associations (samples, members, settings):**

![image](https://github.com/phac-nml/irida-next/assets/25466211/57d07e95-a58a-45e7-8056-9d9ae0a0142f)

![image](https://github.com/phac-nml/irida-next/assets/25466211/713a39bf-7b70-469b-b6d2-8304380a5165)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1) Login as `admin@email.com`
2) Go to the groups tab
3) Click on the group `Bacillus`
4) Make a note of the urls for the group, the members, samples, and settings
5) Logout and login as `user3@email.com`
6) Try to visit the urls from step 4. You should be presented with the group access error screens as in the screenshots section above
7) Repeat steps 1 through 6 but this time do the same for projects. You should be presented with the project access error screens as in the screenshots section above