### PR TITLE
Feature: GraphQL Relay Node Interface

### DIFF
--- a/app/graphql/irida_schema.rb
+++ b/app/graphql/irida_schema.rb
@@ -22,10 +22,13 @@ class IridaSchema < GraphQL::Schema # rubocop:disable GraphQL/ObjectDescription
   end
 
   # Union and Interface Resolution
-  def self.resolve_type(type, object, ctx)
-    return if type.respond_to?(:assignable?) && type.assignable?(object)
-
-    super
+  def self.resolve_type(_type, object, _ctx)
+    case object
+    when Group
+      Types::GroupType
+    else
+      raise("Unexpected object: #{obj}")
+    end
   end
 
   # Stop validating when it encounters this many errors:
@@ -34,7 +37,7 @@ class IridaSchema < GraphQL::Schema # rubocop:disable GraphQL/ObjectDescription
   # Relay-style Object Identification:
 
   # Return a string UUID for `object`
-  def self.id_from_object(object, _type: nil, _ctx: nil)
+  def self.id_from_object(object, _type = nil, _ctx = nil)
     raise "#{object} does not implement `to_global_id`." unless object.respond_to?(:to_global_id)
 
     object.to_global_id

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1,7 +1,7 @@
 """
 A group
 """
-type Group {
+type Group implements Node {
   """
   List of descendant groups of this group.
   """
@@ -48,7 +48,7 @@ type Group {
   fullPath: ID!
 
   """
-  ID of the namespace.
+  ID of the object.
   """
   id: ID!
 
@@ -119,6 +119,16 @@ type Mutation {
 }
 
 """
+An object with an ID.
+"""
+interface Node {
+  """
+  ID of the object.
+  """
+  id: ID!
+}
+
+"""
 Information about pagination in a connection.
 """
 type PageInfo {
@@ -186,6 +196,26 @@ type Query {
     """
     last: Int
   ): GroupConnection!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
 }
 
 """

--- a/app/graphql/types/namespace_type.rb
+++ b/app/graphql/types/namespace_type.rb
@@ -3,13 +3,22 @@
 module Types
   # Namespace Type
   class NamespaceType < Types::BaseObject
+    implements GraphQL::Types::Relay::Node
     description 'A namespace'
 
     field :description, String, null: false, description: 'Description of the namespace.'
     field :full_name, String, null: false, description: 'Full name of the namespace.'
     field :full_path, ID, null: false, description: 'Full path of the namespace.' # rubocop:disable GraphQL/ExtractType
-    field :id, ID, null: false, description: 'ID of the namespace.'
     field :name, String, null: false, description: 'Name of the namespace.'
     field :path, String, null: false, description: 'Path of the namespace.'
+
+    def self.authorized?(object, context)
+      super &&
+        allowed_to?(
+          :read?,
+          object,
+          context: { user: context[:current_user] }
+        )
+    end
   end
 end

--- a/test/graphql/node_query_test.rb
+++ b/test/graphql/node_query_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NodeQueryTest < ActiveSupport::TestCase
+  NODE_QUERY = <<~GRAPHQL
+    query($id: ID!) {
+      node(id: $id) {
+        id
+      }
+    }
+  GRAPHQL
+
+  NODE_GROUP_QUERY = <<~GRAPHQL
+    query($id: ID!) {
+      node(id: $id) {
+        id
+        ... on Group {
+          name
+        }
+      }
+    }
+  GRAPHQL
+
+  def setup
+    @user = users(:john_doe)
+  end
+
+  test 'node query should work for group' do
+    group = groups(:group_one)
+
+    result = IridaSchema.execute(NODE_QUERY, context: { current_user: @user },
+                                             variables: { id: group.to_global_id.to_s })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['node']
+
+    assert_not_empty data, 'node type should work'
+    assert_equal group.to_global_id.to_s, data['id'], 'id should be GlobalID'
+  end
+
+  test 'node query should not return an unauthorized group' do
+    group = groups(:david_doe_group_four)
+
+    result = IridaSchema.execute(NODE_QUERY, context: { current_user: @user },
+                                             variables: { id: group.to_global_id.to_s })
+
+    assert_not_nil result['errors'], 'should not work and have errors.'
+
+    error_message = result['errors'][0]['message']
+    assert_equal 'An object of type Group was hidden due to permissions', error_message
+  end
+
+  test 'node query for group should be able to return group attributes' do
+    group = groups(:group_one)
+
+    result = IridaSchema.execute(NODE_GROUP_QUERY, context: { current_user: @user },
+                                                   variables: { id: group.to_global_id.to_s })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['node']
+
+    assert_not_empty data, 'node type should work'
+    assert_equal group.to_global_id.to_s, data['id'], 'id should be GlobalID'
+    assert_equal group.name, data['name']
+  end
+end

--- a/test/graphql/nodes_query_test.rb
+++ b/test/graphql/nodes_query_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NodesQueryTest < ActiveSupport::TestCase
+  NODES_QUERY = <<~GRAPHQL
+    query($ids: [ID!]!) {
+      nodes(ids: $ids) {
+        id
+      }
+    }
+  GRAPHQL
+
+  NODES_GROUPS_QUERY = <<~GRAPHQL
+    query($ids: [ID!]!) {
+      nodes(ids: $ids) {
+        id
+        ... on Group {
+          name
+        }
+      }
+    }
+  GRAPHQL
+
+  def setup
+    @user = users(:john_doe)
+  end
+
+  test 'nodes query should work when passed a list of group ids' do
+    group = groups(:group_one)
+
+    result = IridaSchema.execute(NODES_QUERY, context: { current_user: @user },
+                                              variables: { ids: [group.to_global_id.to_s] })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['nodes']
+
+    assert_not_empty data, 'nodes type should work'
+    assert_equal 1, data.length
+  end
+
+  test 'nodes query should not return an unauthorized group' do
+    group = groups(:david_doe_group_four)
+
+    result = IridaSchema.execute(NODES_QUERY, context: { current_user: @user },
+                                              variables: { ids: [group.to_global_id.to_s] })
+
+    assert_not_nil result['errors'], 'should not work and have errors.'
+
+    error_message = result['errors'][0]['message']
+    assert_equal 'An object of type Group was hidden due to permissions', error_message
+  end
+
+  test 'nodes query for group should be able to return group attributes' do
+    group = groups(:group_one)
+
+    result = IridaSchema.execute(NODES_GROUPS_QUERY, context: { current_user: @user },
+                                                     variables: { ids: [group.to_global_id.to_s] })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['nodes']
+
+    assert_not_empty data, 'nodes type should work'
+    assert_equal 1, data.length
+
+    assert_equal group.name, data[0]['name']
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the Group type to implement the Relay Node interface. This allows us to query Groups via Node or Nodes queries. This will be really useful later on when we add additional types as it will give our clients the ability to query different types of objects within a single query.

To achieve this I updated the Group type to implement the [Node interface](https://graphql-ruby.org/schema/object_identification.html#node-interface).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Login with 'user1@email.com` and then navigate to `http://localhost:3000/graphiql`
2. Query for a group that the user has access through the node interface
     ```graphql
     {
       node(id: "gid://irida/Group/18") {
         ... on Group {
           name
         }
       }
     }
     ```
3. See the result:
     ```json
     {
       "data": {
         "node": {
           "name": "Bartonella"
         }
       }
     }
     ```
4. Query for a group that the user does not have access to through the node interface
     ```graphql
     {
       node(id: "gid://irida/Group/18") {
         ... on Group {
           name
         }
       }
     }
     ```
5. See an error message
     ```json
     {
       "data": {
         "node": null
       },
       "errors": [
         {
           "message": "An object of type Group was hidden due to permissions",
           "locations": [
             {
               "line": 2,
               "column": 3
             }
           ],
           "path": [
             "node"
           ]
         }
       ]
     }
     ```
6. Look at the docs and try the nodes interface the same way, while searching for the same groups.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the PR acceptance checklist for this PR.