### PR TITLE
refactor: Updated tests to remove finding by selectors

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,8 @@ en:
       member:
         access_level: Access Level
         user_id: User
+      user:
+        email: Email
     errors:
       models:
         namespace:

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -19,11 +19,9 @@ class ProfileTest < ApplicationSystemTestCase
     visit profile_path
 
     within %(form[action="/-/profile"]) do
-      assert_selector %(input[id="user_email"]) do |input|
-        assert_equal @user.email, input['value']
-      end
+      assert_equal @user.email, find_field(I18n.t('activerecord.attributes.user.email')).value
 
-      fill_in 'Email', with: 'fred_doe@gmail.com'
+      fill_in I18n.t('activerecord.attributes.user.email'), with: 'fred_doe@gmail.com'
       click_button I18n.t(:'profiles.show.email.submit')
     end
 

--- a/test/system/projects/members_test.rb
+++ b/test/system/projects/members_test.rb
@@ -87,9 +87,8 @@ module Projects
 
       within %(div[data-controller="slugify"][data-controller-connected="true"]) do
         fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.name'), with: project_name
-        assert_selector %(input[data-slugify-target="path"]) do |input|
-          assert_equal 'new-project', input['value']
-        end
+        assert_equal 'new-project',
+                     find_field(I18n.t(:'activerecord.attributes.namespaces/project_namespace.path')).value
         fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.description'), with: project_description
         click_on I18n.t(:'projects.new.submit')
       end

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -37,9 +37,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
     within %(div[data-controller="slugify"][data-controller-connected="true"]) do
       fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.name'), with: project_name
-      assert_selector %(input[data-slugify-target="path"]) do |input|
-        assert_equal 'new-project', input['value']
-      end
+      assert_equal 'new-project', find_field(I18n.t(:'activerecord.attributes.namespaces/project_namespace.path')).value
       fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.description'), with: project_description
       click_on I18n.t(:'projects.new.submit')
     end
@@ -56,9 +54,8 @@ class ProjectsTest < ApplicationSystemTestCase
 
     within %(div[data-controller="slugify"][data-controller-connected="true"]) do
       fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.name'), with: project_name
-      assert_selector %(input[data-slugify-target="path"]) do |input|
-        assert_equal 'updated-project', input['value']
-      end
+      assert_equal 'updated-project',
+                   find_field(I18n.t(:'activerecord.attributes.namespaces/project_namespace.path')).value
       click_on I18n.t(:'projects.edit.general.submit')
     end
     assert_selector 'h1', text: project_name


### PR DESCRIPTION
## What does the PR do and why?

This PR cleans up our UI system tests that were previously finding an input field by it's selector and they asserting the value of the field.  This PR changes the sytax to use the [cabybara  find\_field](https://github.com/teamcapybara/capybara#finding) method.

## Screenshots and Recordings

Since this is just an update to testing syntax, there are no updates or recordigns.

## How to set up and validate locally

 Since this is just an update to the UI system tests, run tests within `test/system` and ensure all pass