### PR TITLE
Selection controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'action_policy-graphql'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'lookbook', '>= 2.0.0.rc.1'
 end
 
 group :development do
@@ -103,7 +104,6 @@ group :development do
   # LookBook
   gem 'actioncable'
   gem 'listen'
-  gem 'lookbook', '>= 2.0.0.rc.1'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,6 @@ gem 'action_policy-graphql'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem 'lookbook', '>= 2.0.0.rc.1'
 end
 
 group :development do
@@ -104,6 +103,7 @@ group :development do
   # LookBook
   gem 'actioncable'
   gem 'listen'
+  gem 'lookbook', '>= 2.0.0.rc.1'
 end
 
 group :test do

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -10,33 +10,36 @@ export default class extends Controller {
   };
 
   connect() {
-    this.localStorageValue = new Map(
-      JSON.parse(localStorage.getItem(this.storageKeyValue))
-    );
-
-    if (this.localStorageValue.size === 0) {
+    if (localStorage.getItem(this.storageKeyValue)) {
       this.rowSelectionTargets.map((row) => {
-        this.localStorageValue.set(row.value, row.checked);
-      });
-      this.save();
-    } else {
-      this.rowSelectionTargets.map((row) => {
-        if (this.localStorageValue.get(row.value)) {
+        if (
+          new Map(JSON.parse(localStorage.getItem(this.storageKeyValue))).get(
+            row.value
+          )
+        ) {
           row.checked = true;
         }
       });
+    } else {
+      let newLocalStorageValue = new Map();
+      this.rowSelectionTargets.map((row) => {
+        newLocalStorageValue.set(row.value, row.checked);
+      });
+      this.save(newLocalStorageValue);
     }
   }
 
   toggle(event) {
-    this.localStorageValue.set(event.target.value, event.target.checked);
-    this.save();
+    let newLocalStorageValue = new Map(
+      JSON.parse(localStorage.getItem(this.storageKeyValue))
+    ).set(event.target.value, event.target.checked);
+    this.save(newLocalStorageValue);
   }
 
-  save() {
+  save(localStorageValue) {
     localStorage.setItem(
       this.storageKeyValue,
-      JSON.stringify([...this.localStorageValue])
+      JSON.stringify([...localStorageValue])
     );
   }
 }

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -10,10 +10,10 @@ export default class extends Controller {
   };
 
   connect() {
-    if (localStorage.getItem(this.storageKeyValue)) {
+    if (sessionStorage.getItem(this.storageKeyValue)) {
       this.rowSelectionTargets.map((row) => {
         if (
-          new Map(JSON.parse(localStorage.getItem(this.storageKeyValue))).get(
+          new Map(JSON.parse(sessionStorage.getItem(this.storageKeyValue))).get(
             row.value
           )
         ) {
@@ -21,25 +21,25 @@ export default class extends Controller {
         }
       });
     } else {
-      let newLocalStorageValue = new Map();
+      let newStorageValue = new Map();
       this.rowSelectionTargets.map((row) => {
-        newLocalStorageValue.set(row.value, row.checked);
+        newStorageValue.set(row.value, row.checked);
       });
-      this.save(newLocalStorageValue);
+      this.save(newStorageValue);
     }
   }
 
   toggle(event) {
-    let newLocalStorageValue = new Map(
-      JSON.parse(localStorage.getItem(this.storageKeyValue))
+    let newStorageValue = new Map(
+      JSON.parse(sessionStorage.getItem(this.storageKeyValue))
     ).set(event.target.value, event.target.checked);
-    this.save(newLocalStorageValue);
+    this.save(newStorageValue);
   }
 
-  save(localStorageValue) {
-    localStorage.setItem(
+  save(storageValue) {
+    sessionStorage.setItem(
       this.storageKeyValue,
-      JSON.stringify([...localStorageValue])
+      JSON.stringify([...storageValue])
     );
   }
 }

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -12,29 +12,40 @@ export default class extends Controller {
   connect() {
     this.element.setAttribute("data-controller-connected", "true");
 
-    if (sessionStorage.getItem(this.storageKeyValue)) {
+    const storageValue = JSON.parse(
+      sessionStorage.getItem(this.storageKeyValue)
+    );
+
+    if (storageValue) {
       this.rowSelectionTargets.map((row) => {
-        if (
-          new Map(JSON.parse(sessionStorage.getItem(this.storageKeyValue))).get(
-            row.value
-          )
-        ) {
+        if (storageValue.indexOf(row.value) > -1) {
           row.checked = true;
         }
       });
     } else {
-      let newStorageValue = new Map();
+      const newStorageValue = [];
       this.rowSelectionTargets.map((row) => {
-        newStorageValue.set(row.value, row.checked);
+        if (row.checked) {
+          newStorageValue.push(row.value);
+        }
       });
       this.save(newStorageValue);
     }
   }
 
   toggle(event) {
-    let newStorageValue = new Map(
-      JSON.parse(sessionStorage.getItem(this.storageKeyValue))
-    ).set(event.target.value, event.target.checked);
+    const newStorageValue = JSON.parse(
+      sessionStorage.getItem(this.storageKeyValue)
+    );
+
+    if (event.target.checked) {
+      newStorageValue.push(event.target.value);
+    } else {
+      const index = newStorageValue.indexOf(event.target.value);
+      if (index > -1) {
+        newStorageValue.splice(index, 1);
+      }
+    }
     this.save(newStorageValue);
   }
 

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -23,13 +23,7 @@ export default class extends Controller {
         }
       });
     } else {
-      const newStorageValue = [];
-      this.rowSelectionTargets.map((row) => {
-        if (row.checked) {
-          newStorageValue.push(row.value);
-        }
-      });
-      this.save(newStorageValue);
+      this.save([]);
     }
   }
 

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -2,12 +2,16 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = ["rowSelection"];
+  static values = {
+    storageKey: {
+      type: String,
+      default: location.protocol + "//" + location.host + location.pathname,
+    },
+  };
 
   connect() {
-    this.localStorageKey =
-      location.protocol + "//" + location.host + location.pathname;
     this.localStorageValue = new Map(
-      JSON.parse(localStorage.getItem(this.localStorageKey))
+      JSON.parse(localStorage.getItem(this.storageKeyValue))
     );
 
     if (this.localStorageValue.size === 0) {
@@ -31,7 +35,7 @@ export default class extends Controller {
 
   save() {
     localStorage.setItem(
-      this.localStorageKey,
+      this.storageKeyValue,
       JSON.stringify([...this.localStorageValue])
     );
   }

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -10,6 +10,8 @@ export default class extends Controller {
   };
 
   connect() {
+    this.element.setAttribute("data-controller-connected", "true");
+
     if (sessionStorage.getItem(this.storageKeyValue)) {
       this.rowSelectionTargets.map((row) => {
         if (

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["rowSelection"];
+
+  connect() {
+    this.localStorageKey =
+      location.protocol + "//" + location.host + location.pathname;
+    this.localStorageValue = new Map(
+      JSON.parse(localStorage.getItem(this.localStorageKey))
+    );
+
+    if (this.localStorageValue.size === 0) {
+      this.rowSelectionTargets.map((row) => {
+        this.localStorageValue.set(row.value, row.checked);
+      });
+      this.save();
+    } else {
+      this.rowSelectionTargets.map((row) => {
+        if (this.localStorageValue.get(row.value)) {
+          row.checked = true;
+        }
+      });
+    }
+  }
+
+  toggle(event) {
+    this.localStorageValue.set(event.target.value, event.target.checked);
+    this.save();
+  }
+
+  save() {
+    localStorage.setItem(
+      this.localStorageKey,
+      JSON.stringify([...this.localStorageValue])
+    );
+  }
+}

--- a/test/components/previews/selection_preview.rb
+++ b/test/components/previews/selection_preview.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 class SelectionPreview < ViewComponent::Preview
-  # The selection controller stores the values of checkboxes in local storage. The local storage key is the url.
-  # When a user toggles a checkbox, the value is updated in local storage.
+  # The selection controller stores the values of checkboxes in session storage. The default storage key is the
+  # url. When a user toggles a checkbox, the value is updated in session storage.
   def default; end
 
-  # The selection controller stores the values of checkboxes in local storage. The local storage key is the url.
-  # This example uses the selection controller within a table to select/deselect rows.
-  # When a user toggles a checkbox, the value is updated in local storage.
+  # The selection controller stores the values of checkboxes in session storage. The default storage key is the
+  # url. This example uses a set storage key.
+  def with_a_storage_key; end
+
+  # The selection controller stores the values of checkboxes in session storage. The default storage key is the
+  # url. This example uses the selection controller within a table to select/deselect rows.
+  # When a user toggles a checkbox, the value is updated in session storage.
   def within_a_table; end
 end

--- a/test/components/previews/selection_preview.rb
+++ b/test/components/previews/selection_preview.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SelectionPreview < Lookbook::Preview
+class SelectionPreview < ViewComponent::Preview
   # The selection controller stores the values of checkboxes in local storage. The local storage key is the url.
   # When a user toggles a checkbox, the value is updated in local storage.
   def default; end

--- a/test/components/previews/selection_preview.rb
+++ b/test/components/previews/selection_preview.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SelectionPreview < Lookbook::Preview
+  # The selection controller stores the values of checkboxes in local storage. The local storage key is the url.
+  # When a user toggles a checkbox, the value is updated in local storage.
+  def default; end
+
+  # The selection controller stores the values of checkboxes in local storage. The local storage key is the url.
+  # This example uses the selection controller within a table to select/deselect rows.
+  # When a user toggles a checkbox, the value is updated in local storage.
+  def within_a_table; end
+end

--- a/test/components/previews/selection_preview/default.html.erb
+++ b/test/components/previews/selection_preview/default.html.erb
@@ -1,0 +1,11 @@
+<div data-controller="selection">
+  <input
+    type="checkbox"
+    id="item1"
+    name="item1"
+    value="item1"
+    data-action="input->selection#toggle"
+    data-selection-target="rowSelection"
+  />
+  <label for="item1">Item1</label>
+</div>

--- a/test/components/previews/selection_preview/default.html.erb
+++ b/test/components/previews/selection_preview/default.html.erb
@@ -1,11 +1,17 @@
 <div data-controller="selection">
-  <input
-    type="checkbox"
-    id="item1"
-    name="item1"
-    value="item1"
-    data-action="input->selection#toggle"
-    data-selection-target="rowSelection"
-  />
-  <label for="item1">Item1</label>
+  <% (0...3).each do |index| %>
+    <div>
+      <input
+        type="checkbox"
+        id="item<%=index%>"
+        name="item<%=index%>"
+        value="item<%=index%>"
+        data-action="input->selection#toggle"
+        data-selection-target="rowSelection"
+      />
+      <label for="item<%=index%>">
+        <%= "Item#{index}" %>
+      </label>
+    </div>
+  <% end %>
 </div>

--- a/test/components/previews/selection_preview/default.html.erb
+++ b/test/components/previews/selection_preview/default.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="selection">
   <% (0...3).each do |index| %>
-    <div>
+    <div class="flex items-center mb-4">
       <input
         type="checkbox"
         id="item<%=index%>"
@@ -8,9 +8,27 @@
         value="item<%=index%>"
         data-action="input->selection#toggle"
         data-selection-target="rowSelection"
+        class="
+          w-4
+          h-4
+          text-blue-600
+          bg-gray-100
+          border-gray-300
+          rounded
+          focus:ring-blue-500
+          dark:focus:ring-blue-600
+          dark:ring-offset-gray-800
+          dark:focus:ring-offset-gray-800
+          focus:ring-2
+          dark:bg-gray-700
+          dark:border-gray-600
+        "
       />
-      <label for="item<%=index%>">
-        <%= "Item#{index}" %>
+      <label
+        for="item<%=index%>"
+        class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+      >
+        <%= "Item #{index}" %>
       </label>
     </div>
   <% end %>

--- a/test/components/previews/selection_preview/with_a_storage_key.html.erb
+++ b/test/components/previews/selection_preview/with_a_storage_key.html.erb
@@ -1,0 +1,38 @@
+<div
+  data-controller="selection"
+  data-selection-storage-key-value="selectionStorageKey"
+>
+  <% (0...3).each do |index| %>
+    <div class="flex items-center mb-4">
+      <input
+        type="checkbox"
+        id="item<%=index%>"
+        name="item<%=index%>"
+        value="item<%=index%>"
+        data-action="input->selection#toggle"
+        data-selection-target="rowSelection"
+        class="
+          w-4
+          h-4
+          text-blue-600
+          bg-gray-100
+          border-gray-300
+          rounded
+          focus:ring-blue-500
+          dark:focus:ring-blue-600
+          dark:ring-offset-gray-800
+          dark:focus:ring-offset-gray-800
+          focus:ring-2
+          dark:bg-gray-700
+          dark:border-gray-600
+        "
+      />
+      <label
+        for="item<%=index%>"
+        class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+      >
+        <%= "Item #{index}" %>
+      </label>
+    </div>
+  <% end %>
+</div>

--- a/test/components/previews/selection_preview/within_a_table.html.erb
+++ b/test/components/previews/selection_preview/within_a_table.html.erb
@@ -13,7 +13,7 @@
     "
   >
     <tr>
-      <th scope="col" class="p-4"/>
+      <th scope="col" class="p-4">Selections</th>
       <th scope="col" class="px-6 py-3">
         Rows
       </th>
@@ -50,7 +50,17 @@
             <label for="row<%=index%>" class="sr-only">checkbox</label>
           </div>
         </td>
-        <td class="px-6 py-4"><%= "Row #{index}" %></td>
+        <th
+          scope="row"
+          class="
+            px-6
+            py-4
+            font-medium
+            text-gray-900
+            whitespace-nowrap
+            dark:text-white
+          "
+        ><%= "Row #{index}" %></th>
       </tr>
     <% end %>
   </tbody>

--- a/test/components/previews/selection_preview/within_a_table.html.erb
+++ b/test/components/previews/selection_preview/within_a_table.html.erb
@@ -1,18 +1,56 @@
-<table data-controller="selection">
+<table
+  data-controller="selection"
+  class="w-full text-sm text-left text-gray-500 dark:text-gray-400"
+>
+  <thead
+    class="
+      text-xs
+      text-gray-700
+      uppercase
+      bg-gray-50
+      dark:bg-gray-700
+      dark:text-gray-400
+    "
+  >
+    <tr>
+      <th scope="col" class="p-4"/>
+      <th scope="col" class="px-6 py-3">
+        Rows
+      </th>
+    </tr>
+  </thead>
   <tbody>
     <% (0...3).each do |index| %>
-      <tr>
-        <td>
-          <input
-            type="checkbox"
-            id="row<%=index%>"
-            name="row<%=index%>"
-            value="row<%=index%>"
-            data-action="input->selection#toggle"
-            data-selection-target="rowSelection"
-          >
+      <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+        <td class="w-4 p-4">
+          <div class="flex items-center">
+            <input
+              type="checkbox"
+              id="row<%=index%>"
+              name="row<%=index%>"
+              value="row<%=index%>"
+              data-action="input->selection#toggle"
+              data-selection-target="rowSelection"
+              class="
+                w-4
+                h-4
+                text-blue-600
+                bg-gray-100
+                border-gray-300
+                rounded
+                focus:ring-blue-500
+                dark:focus:ring-blue-600
+                dark:ring-offset-gray-800
+                dark:focus:ring-offset-gray-800
+                focus:ring-2
+                dark:bg-gray-700
+                dark:border-gray-600
+              "
+            >
+            <label for="row<%=index%>" class="sr-only">checkbox</label>
+          </div>
         </td>
-        <td><%= "Row#{index}" %></td>
+        <td class="px-6 py-4"><%= "Row #{index}" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/test/components/previews/selection_preview/within_a_table.html.erb
+++ b/test/components/previews/selection_preview/within_a_table.html.erb
@@ -1,0 +1,17 @@
+<table data-controller="selection">
+  <tbody>
+    <tr>
+      <td>
+        <input
+          type="checkbox"
+          id="row1"
+          name="row1"
+          value="row1"
+          data-action="input->selection#toggle"
+          data-selection-target="rowSelection"
+        >
+      </td>
+      <td>Row 1</td>
+    </tr>
+  </tbody>
+</table>

--- a/test/components/previews/selection_preview/within_a_table.html.erb
+++ b/test/components/previews/selection_preview/within_a_table.html.erb
@@ -1,17 +1,19 @@
 <table data-controller="selection">
   <tbody>
-    <tr>
-      <td>
-        <input
-          type="checkbox"
-          id="row1"
-          name="row1"
-          value="row1"
-          data-action="input->selection#toggle"
-          data-selection-target="rowSelection"
-        >
-      </td>
-      <td>Row 1</td>
-    </tr>
+    <% (0...3).each do |index| %>
+      <tr>
+        <td>
+          <input
+            type="checkbox"
+            id="row<%=index%>"
+            name="row<%=index%>"
+            value="row<%=index%>"
+            data-action="input->selection#toggle"
+            data-selection-target="rowSelection"
+          >
+        </td>
+        <td><%= "Row#{index}" %></td>
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/test/components/viral/system/selection_test.rb
+++ b/test/components/viral/system/selection_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module System
+  class SelectionTest < ApplicationSystemTestCase
+    test 'default' do
+      visit('rails/view_components/selection/default')
+      check 'item0'
+      uncheck 'item1'
+      check 'item2'
+      visit('rails/view_components/selection/default')
+      within('.Viral-Preview > [data-controller-connected="true"]') do
+        assert find_field('item0').checked?
+        assert_not find_field('item1').checked?
+        assert find_field('item2').checked?
+      end
+    end
+
+    test 'with a table' do
+      visit('rails/view_components/selection/within_a_table')
+      uncheck 'row0'
+      check 'row1'
+      uncheck 'row2'
+      visit('rails/view_components/selection/within_a_table')
+      within('.Viral-Preview > [data-controller-connected="true"]') do
+        assert_not find_field('row0').checked?
+        assert find_field('row1').checked?
+        assert_not find_field('row2').checked?
+      end
+    end
+  end
+end

--- a/test/components/viral/system/selection_test.rb
+++ b/test/components/viral/system/selection_test.rb
@@ -6,10 +6,27 @@ module System
   class SelectionTest < ApplicationSystemTestCase
     test 'default' do
       visit('rails/view_components/selection/default')
-      check 'item0'
-      uncheck 'item1'
-      check 'item2'
+      within('.Viral-Preview > [data-controller-connected="true"]') do
+        check 'item0'
+        uncheck 'item1'
+        check 'item2'
+      end
       visit('rails/view_components/selection/default')
+      within('.Viral-Preview > [data-controller-connected="true"]') do
+        assert find_field('item0').checked?
+        assert_not find_field('item1').checked?
+        assert find_field('item2').checked?
+      end
+    end
+
+    test 'with a storage key' do
+      visit('rails/view_components/selection/with_a_storage_key')
+      within('.Viral-Preview > [data-controller-connected="true"]') do
+        check 'item0'
+        uncheck 'item1'
+        check 'item2'
+      end
+      visit('rails/view_components/selection/with_a_storage_key')
       within('.Viral-Preview > [data-controller-connected="true"]') do
         assert find_field('item0').checked?
         assert_not find_field('item1').checked?
@@ -19,9 +36,11 @@ module System
 
     test 'with a table' do
       visit('rails/view_components/selection/within_a_table')
-      uncheck 'row0'
-      check 'row1'
-      uncheck 'row2'
+      within('.Viral-Preview > [data-controller-connected="true"]') do
+        uncheck 'row0'
+        check 'row1'
+        uncheck 'row2'
+      end
       visit('rails/view_components/selection/within_a_table')
       within('.Viral-Preview > [data-controller-connected="true"]') do
         assert_not find_field('row0').checked?


### PR DESCRIPTION
## What does this PR do and why?
The selection controller is used to store a list of checkbox values in a hash within local storage. The url being the local storage key.
Pulled from https://github.com/phac-nml/irida-next/pull/90.

## Screenshots or screen recordings
![image](https://github.com/phac-nml/irida-next/assets/325703/f5bf2c5c-f44b-492e-9319-72a8d71313d9)

## How to set up and validate locally
1. Navigate to http://localhost:3000/rails/lookbook.
2. Click on "Selection" previews.
3. Ensure the checkbox values are stored in local storage with the key being the url.
4. Ensure the latest value is populated on page refresh.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the PR acceptance checklist for this PR.
