### PR TITLE
Feature: Group to Group link - model

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -11,6 +11,32 @@ class Group < Namespace
            class_name: 'Namespace', foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
   has_many :users, through: :group_members
 
+  has_many :shared_group_links, foreign_key: :shared_with_group_id, class_name: 'GroupGroupLink' # rubocop:disable Rails/HasManyOrHasOneDependent, Rails/InverseOf
+  has_many :shared_with_group_links, foreign_key: :shared_group_id, class_name: 'GroupGroupLink' do # rubocop:disable Rails/HasManyOrHasOneDependent, Rails/InverseOf
+    def of_ancestors
+      group = proxy_association.owner
+
+      return GroupGroupLink.none unless group.has_parent?
+
+      GroupGroupLink.where(shared_group_id: group.ancestors.reorder(nil).select(:id))
+    end
+
+    def of_ancestors_and_self
+      group = proxy_association.owner
+
+      source_ids =
+        if group.has_parent?
+          group.self_and_ancestors.reorder(nil).select(:id)
+        else
+          group.id
+        end
+
+      GroupGroupLink.where(shared_group_id: source_ids)
+    end
+  end
+  has_many :shared_groups, through: :shared_group_links, source: :shared_group
+  has_many :shared_with_groups, through: :shared_with_group_links, source: :shared_with_group
+
   def self.sti_name
     'Group'
   end

--- a/app/models/group_group_link.rb
+++ b/app/models/group_group_link.rb
@@ -5,8 +5,7 @@ class GroupGroupLink < ApplicationRecord
   belongs_to :shared_group, class_name: 'Group'
   belongs_to :shared_with_group, class_name: 'Group'
 
-  validates :shared_group_id, uniqueness: { scope: [:shared_with_group_id],
-                                            message: 'The group has already been shared with this group' }
+  validates :shared_group_id, uniqueness: { scope: [:shared_with_group_id] }
 
   validates :group_access_level, inclusion: { in: Member::AccessLevel.all_values_with_owner },
                                  presence: true

--- a/app/models/group_group_link.rb
+++ b/app/models/group_group_link.rb
@@ -3,6 +3,8 @@
 # entity class for GroupGroupLink
 class GroupGroupLink < ApplicationRecord
   has_logidze
+  acts_as_paranoid
+
   belongs_to :shared_group, class_name: 'Group'
   belongs_to :shared_with_group, class_name: 'Group'
 

--- a/app/models/group_group_link.rb
+++ b/app/models/group_group_link.rb
@@ -2,6 +2,7 @@
 
 # entity class for GroupGroupLink
 class GroupGroupLink < ApplicationRecord
+  has_logidze
   belongs_to :shared_group, class_name: 'Group'
   belongs_to :shared_with_group, class_name: 'Group'
 

--- a/app/models/group_group_link.rb
+++ b/app/models/group_group_link.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# entity class for GroupGroupLink
+class GroupGroupLink < ApplicationRecord
+  belongs_to :shared_group, class_name: 'Group'
+  belongs_to :shared_with_group, class_name: 'Group'
+
+  validates :shared_group_id, uniqueness: { scope: [:shared_with_group_id],
+                                            message: 'The group has already been shared with this group' }
+
+  validates :group_access_level, inclusion: { in: Member::AccessLevel.all_values_with_owner },
+                                 presence: true
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,16 @@ en:
           attributes:
             scopes:
               inclusion: can only contain available scopes
+        group_group_link:
+          attributes:
+            shared_group_id:
+              blank: Shared group must exist
+              taken: The group has already been shared with this group
+            shared_with_group_id:
+              blank: Shared with group must exist
+              taken: The group has already been shared with this group
+            group_access_level:
+              inclusion: "provided is not included in the list of valid access levels"
     exceptions:
       personal_access_token:
         not_found: "Could not find personal access token with id %{token_id}"

--- a/db/migrate/20230626172250_create_group_group_links.rb
+++ b/db/migrate/20230626172250_create_group_group_links.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# migration to add table to store shared group to group links
+class CreateGroupGroupLinks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :group_group_links do |t|
+      t.bigint :shared_group_id, null: false
+      t.bigint :shared_with_group_id,  null: false
+      t.date :expires_at
+      t.integer :group_access_level, null: false
+
+      t.timestamps
+    end
+    add_index :group_group_links, %i[shared_group_id shared_with_group_id],
+              unique: true,
+              name: 'index_group_link_shared_group_id_with_shared_with_group_id'
+  end
+end

--- a/db/migrate/20230630152409_add_logidze_to_group_group_links.rb
+++ b/db/migrate/20230630152409_add_logidze_to_group_group_links.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# migration to add logidze logging column
+class AddLogidzeToGroupGroupLinks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :group_group_links, :log_data, :jsonb
+
+    reversible do |dir|
+      dir.up do
+        create_trigger :logidze_on_group_group_links, on: :group_group_links
+      end
+
+      dir.down do
+        execute <<~SQL.squish
+          DROP TRIGGER IF EXISTS "logidze_on_group_group_links" on "group_group_links";
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20230630153935_add_deleted_at_to_group_group_link.rb
+++ b/db/migrate/20230630153935_add_deleted_at_to_group_group_link.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# migration to add deleted_at column to group_group_links
+class AddDeletedAtToGroupGroupLink < ActiveRecord::Migration[7.0]
+  def change
+    add_column :group_group_links, :deleted_at, :datetime
+    add_index :group_group_links, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_145212) do
   enable_extension "hstore"
   enable_extension "plpgsql"
 
+  create_table "group_group_links", force: :cascade do |t|
+    t.bigint "shared_group_id", null: false
+    t.bigint "shared_with_group_id", null: false
+    t.date "expires_at"
+    t.integer "group_access_level", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shared_group_id", "shared_with_group_id"], name: "index_group_link_shared_group_id_with_shared_with_group_id", unique: true
+  end
+
   create_table "members", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "namespace_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_28_145212) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_30_152409) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_145212) do
     t.integer "group_access_level", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "log_data"
     t.index ["shared_group_id", "shared_with_group_id"], name: "index_group_link_shared_group_id_with_shared_with_group_id", unique: true
   end
 
@@ -520,5 +521,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_145212) do
   SQL
   create_trigger :logidze_on_personal_access_tokens, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_group_group_links, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_group_group_links BEFORE INSERT OR UPDATE ON public.group_group_links FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_30_152409) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_30_153935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_152409) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "log_data"
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_group_group_links_on_deleted_at"
     t.index ["shared_group_id", "shared_with_group_id"], name: "index_group_link_shared_group_id_with_shared_with_group_id", unique: true
   end
 

--- a/db/triggers/logidze_on_group_group_links_v01.sql
+++ b/db/triggers/logidze_on_group_group_links_v01.sql
@@ -1,0 +1,6 @@
+CREATE TRIGGER "logidze_on_group_group_links"
+BEFORE UPDATE OR INSERT ON "group_group_links" FOR EACH ROW
+WHEN (coalesce(current_setting('logidze.disabled', true), '') <> 'on')
+-- Parameters: history_size_limit (integer), timestamp_column (text), filtered_columns (text[]),
+-- include_columns (boolean), debounce_time_ms (integer)
+EXECUTE PROCEDURE logidze_logger(null, 'updated_at');

--- a/test/models/group_group_link_test.rb
+++ b/test/models/group_group_link_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GroupGroupLinkTest < ActiveSupport::TestCase
+  def setup
+    @group = groups(:group_one)
+    @group_to_share = groups(:david_doe_group_four)
+  end
+
+  test 'group to group link is valid' do
+    group_group_link = GroupGroupLink.new(shared_group_id: @group_to_share.id, shared_with_group_id: @group.id,
+                                          group_access_level: Member::AccessLevel::ANALYST)
+
+    assert group_group_link.save
+  end
+
+  test 'cannot create multiple group to group links with the same groups' do
+    group_group_link = GroupGroupLink.new(shared_group_id: @group_to_share.id, shared_with_group_id: @group.id,
+                                          group_access_level: Member::AccessLevel::ANALYST)
+
+    assert group_group_link.save
+
+    group_group_link = GroupGroupLink.new(shared_group_id: @group_to_share.id, shared_with_group_id: @group.id,
+                                          group_access_level: Member::AccessLevel::ANALYST)
+
+    assert_not group_group_link.save
+    assert group_group_link.errors.messages.values.flatten.include?(
+      I18n.t('activerecord.errors.models.group_group_link.attributes.shared_group_id.taken')
+    )
+  end
+
+  test '#validates access level out of range' do
+    group_group_link = GroupGroupLink.new(shared_group_id: @group_to_share.id, shared_with_group_id: @group.id,
+                                          group_access_level: Member::AccessLevel::ANALYST + 100_000)
+
+    assert_not group_group_link.save
+    group_group_link.errors.full_messages.include?(
+      'Group access level provided is not included in the list of valid access levels'
+    )
+  end
+
+  test '#validates valid group to share' do
+    group_group_link = GroupGroupLink.new(shared_group_id: nil, shared_with_group_id: @group.id,
+                                          group_access_level: Member::AccessLevel::ANALYST)
+
+    assert_not group_group_link.save
+    assert group_group_link.errors.full_messages.include?(
+      'Shared group must exist'
+    )
+  end
+
+  test '#validates valid group to share with' do
+    group_group_link = GroupGroupLink.new(shared_group_id: @group_to_share.id, shared_with_group_id: nil,
+                                          group_access_level: Member::AccessLevel::ANALYST)
+
+    assert_not group_group_link.save
+    assert group_group_link.errors.full_messages.include?(
+      'Shared with group must exist'
+    )
+  end
+end

--- a/test/models/group_group_link_test.rb
+++ b/test/models/group_group_link_test.rb
@@ -40,7 +40,7 @@ class GroupGroupLinkTest < ActiveSupport::TestCase
     )
   end
 
-  test '#validates valid group to share' do
+  test '#validates invalid group to share' do
     group_group_link = GroupGroupLink.new(shared_group_id: nil, shared_with_group_id: @group.id,
                                           group_access_level: Member::AccessLevel::ANALYST)
 
@@ -50,7 +50,7 @@ class GroupGroupLinkTest < ActiveSupport::TestCase
     )
   end
 
-  test '#validates valid group to share with' do
+  test '#validates invalid group to share with' do
     group_group_link = GroupGroupLink.new(shared_group_id: @group_to_share.id, shared_with_group_id: nil,
                                           group_access_level: Member::AccessLevel::ANALYST)
 

--- a/test/models/group_group_link_test.rb
+++ b/test/models/group_group_link_test.rb
@@ -25,7 +25,7 @@ class GroupGroupLinkTest < ActiveSupport::TestCase
                                           group_access_level: Member::AccessLevel::ANALYST)
 
     assert_not group_group_link.save
-    assert group_group_link.errors.messages.values.flatten.include?(
+    group_group_link.errors.full_messages.include?(
       I18n.t('activerecord.errors.models.group_group_link.attributes.shared_group_id.taken')
     )
   end
@@ -36,7 +36,7 @@ class GroupGroupLinkTest < ActiveSupport::TestCase
 
     assert_not group_group_link.save
     group_group_link.errors.full_messages.include?(
-      'Group access level provided is not included in the list of valid access levels'
+      I18n.t('activerecord.errors.models.group_group_link.attributes.group_access_level.inclusion')
     )
   end
 
@@ -46,7 +46,7 @@ class GroupGroupLinkTest < ActiveSupport::TestCase
 
     assert_not group_group_link.save
     assert group_group_link.errors.full_messages.include?(
-      'Shared group must exist'
+      I18n.t('activerecord.errors.models.group_group_link.attributes.shared_group_id.blank')
     )
   end
 
@@ -56,7 +56,7 @@ class GroupGroupLinkTest < ActiveSupport::TestCase
 
     assert_not group_group_link.save
     assert group_group_link.errors.full_messages.include?(
-      'Shared with group must exist'
+      I18n.t('activerecord.errors.models.group_group_link.attributes.shared_with_group_id.blank')
     )
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds a new model `GroupGroupLink` which will be used to add a group to another group. This is 1 of many prs to get the group to group links working. This PR includes the model, db setup, and model testing. Future PRs will address the service to share, as well as the UI.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Run `db:migrate` to run the migrations
2. Launch rails console through the terminal
3. Create a new `GroupGroupLink`. The three required attributes are `shared_group_id`, `shared_with_group_id`, and `group_access_level`. The `shared_group_id` is the group of the id you would like to share with another group, the `shared_with_group_id` is the group that the group is shared with, and the `group_access_level` is one of the values in `Member::AccessLevel`
4. Add a bunch of other `GroupGroupLink` objects to the database
5. You can now find a) all the groups shared with group A and b) Get all the groups that the group A is shared with. Get the group you want to get `a` and `b` for and then call the methods `shared_with_group_links` and `shared_group_links` on the group object. You should get a listing back of `GroupGroupLink` objects

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated
  the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
