### PR TITLE
enhancement: Updates to flash notification

### DIFF
--- a/app/assets/icons/heroicons/check_circle_solid.svg
+++ b/app/assets/icons/heroicons/check_circle_solid.svg
@@ -1,0 +1,4 @@
+<svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path clip-rule="evenodd" fill-rule="evenodd"
+          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"></path>
+</svg>

--- a/app/assets/icons/heroicons/exclamation_circle_solid.svg
+++ b/app/assets/icons/heroicons/exclamation_circle_solid.svg
@@ -1,0 +1,4 @@
+<svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path clip-rule="evenodd" fill-rule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"></path>
+</svg>

--- a/app/assets/icons/heroicons/information_circle_solid.svg
+++ b/app/assets/icons/heroicons/information_circle_solid.svg
@@ -1,0 +1,4 @@
+<svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path clip-rule="evenodd" fill-rule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"></path>
+</svg>

--- a/app/assets/icons/heroicons/x_circle_solid.svg
+++ b/app/assets/icons/heroicons/x_circle_solid.svg
@@ -1,0 +1,4 @@
+<svg fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path clip-rule="evenodd" fill-rule="evenodd"
+          d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z"></path>
+</svg>

--- a/app/components/viral/flash_component.html.erb
+++ b/app/components/viral/flash_component.html.erb
@@ -1,6 +1,7 @@
 <div
   data-controller="viral--flash"
   data-viral--flash-timeout-value="<%= timeout %>"
+  data-viral--flash-type-value="<%= type %>"
   class="flex items-center w-full max-w-xs p-4 mb-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800"
   role="alert"
 >

--- a/app/components/viral/flash_component.html.erb
+++ b/app/components/viral/flash_component.html.erb
@@ -9,22 +9,22 @@
   <% when "success" %>
     <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-green-500 bg-green-100 rounded-lg dark:bg-green-800 dark:text-green-200">
       <%= viral_icon(name: "check_circle_solid", classes: "w-5 h-5") %>
-      <span class="sr-only">Check icon</span>
+      <span class="sr-only"><%= t("components.flash.success_icon") %></span>
     </div>
   <% when "error" %>
     <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-red-500 bg-red-100 rounded-lg dark:bg-red-800 dark:text-red-200">
       <%= viral_icon(name: "x_circle_solid", classes: "w-5 h-5") %>
-      <span class="sr-only">X icon</span>
+      <span class="sr-only"><%= t("components.flash.error_icon") %></span>
     </div>
   <% when "warning" %>
     <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-orange-500 bg-orange-100 rounded-lg dark:bg-orange-700 dark:text-orange-200">
       <%= viral_icon(name: "exclamation_circle_solid", classes: "w-5 h-5") %>
-      <span class="sr-only">Exclamation icon</span>
+      <span class="sr-only"><%= t("components.flash.warning_icon") %></span>
     </div>
   <% when "info" %>
     <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-blue-500 bg-blue-100 rounded-lg dark:bg-blue-800 dark:text-blue-200">
       <%= viral_icon(name: "information_circle_solid", classes: "w-5 h-5") %>
-      <span class="sr-only">Information icon</span>
+      <span class="sr-only"><%= t("components.flash.information_icon") %></span>
     </div>
   <% end %>
   <div class="ml-3 text-sm font-normal"><%= data %></div>

--- a/app/components/viral/flash_component.html.erb
+++ b/app/components/viral/flash_component.html.erb
@@ -1,29 +1,34 @@
 <div
   data-controller="viral--flash"
   data-viral--flash-timeout-value="<%= timeout %>"
-  class="flex rounded-lg shadow-lg w-96"
+  class="flex items-center w-full max-w-xs p-4 mb-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800"
+  role="alert"
 >
-  <div class="<%= classes %> py-4 px-6 rounded-l-lg flex items-center">
-    <%= viral_icon(name: icon, classes: "w-8 h-8 text-white dark:text-gray-400") %>
-  </div>
-  <div
-    class="
-      flex
-      items-center
-      justify-between
-      w-full
-      px-4
-      py-6
-      bg-white
-      rounded-r-lg
-      dark:bg-gray-800
-      dark:text-gray-200
-    "
-  >
-    <div><%= data %></div>
-    <button data-action="viral--flash#dismiss">
-      <%= viral_icon(name: "x_mark", classes: "w-5 h-5") %>
-      <span class="sr-only"><%= t(:"general.screen_reader.close") %></span>
-    </button>
-  </div>
+  <% case type.to_s %>
+  <% when "success" %>
+    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-green-500 bg-green-100 rounded-lg dark:bg-green-800 dark:text-green-200">
+      <%= viral_icon(name: "check_circle_solid", classes: "w-5 h-5") %>
+      <span class="sr-only">Check icon</span>
+    </div>
+  <% when "error" %>
+    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-red-500 bg-red-100 rounded-lg dark:bg-red-800 dark:text-red-200">
+      <%= viral_icon(name: "x_circle_solid", classes: "w-5 h-5") %>
+      <span class="sr-only">X icon</span>
+    </div>
+  <% when "warning" %>
+    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-orange-500 bg-orange-100 rounded-lg dark:bg-orange-700 dark:text-orange-200">
+      <%= viral_icon(name: "exclamation_circle_solid", classes: "w-5 h-5") %>
+      <span class="sr-only">Exclamation icon</span>
+    </div>
+  <% when "info" %>
+    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-blue-500 bg-blue-100 rounded-lg dark:bg-blue-800 dark:text-blue-200">
+      <%= viral_icon(name: "information_circle_solid", classes: "w-5 h-5") %>
+      <span class="sr-only">Information icon</span>
+    </div>
+  <% end %>
+  <div class="ml-3 text-sm font-normal"><%= data %></div>
+  <button type="button" data-action="viral--flash#dismiss" class="ml-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8 dark:text-gray-500 dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700" data-dismiss-target="#toast-success" aria-label="Close">
+    <%= viral_icon(name: "x_mark", classes: "w-5 h-5") %>
+    <span class="sr-only"><%= t(:"general.screen_reader.close") %></span>
+  </button>
 </div>

--- a/app/components/viral/flash_component.rb
+++ b/app/components/viral/flash_component.rb
@@ -11,34 +11,6 @@ module Viral
       @type = type
       @data = data
       @timeout = timeout
-      @icon = icon_for_flash
-      @classes = classes_for_flash
-    end
-
-    def classes_for_flash
-      case type.to_s
-      when 'error'
-        'bg-red-600 dark:bg-red-800'
-      when 'success'
-        'bg-green-700 dark:bg-green-900'
-      when 'warning'
-        'bg-yellow-300 dark:bg-yellow-800'
-      else
-        'bg-blue-600 dark:bg-blue-800'
-      end
-    end
-
-    def icon_for_flash
-      case type
-      when 'error'
-        'exclamation_circle'
-      when 'success'
-        'check'
-      when 'warning'
-        'exclamation_triangle'
-      else
-        'information_circle'
-      end
     end
   end
 end

--- a/app/components/viral/flash_component.rb
+++ b/app/components/viral/flash_component.rb
@@ -8,12 +8,12 @@ module Viral
     DEFAULT_TIMEOUT = 3500
 
     def initialize(type:, data:, timeout: DEFAULT_TIMEOUT)
-      @type = set_type(type)
+      @type = type_for_flash(type)
       @data = data
       @timeout = type.to_s == 'error' ? 0 : timeout
     end
 
-    def set_type(type)
+    def type_for_flash(type)
       @type = if type == 'notice'
                 'info'
               else

--- a/app/components/viral/flash_component.rb
+++ b/app/components/viral/flash_component.rb
@@ -10,7 +10,7 @@ module Viral
     def initialize(type:, data:, timeout: DEFAULT_TIMEOUT)
       @type = type
       @data = data
-      @timeout = timeout
+      @timeout = type.to_s == 'error' ? 0 : timeout
     end
   end
 end

--- a/app/components/viral/flash_component.rb
+++ b/app/components/viral/flash_component.rb
@@ -8,9 +8,17 @@ module Viral
     DEFAULT_TIMEOUT = 3500
 
     def initialize(type:, data:, timeout: DEFAULT_TIMEOUT)
-      @type = type
+      @type = set_type(type)
       @data = data
       @timeout = type.to_s == 'error' ? 0 : timeout
+    end
+
+    def set_type(type)
+      @type = if type == 'notice'
+                'info'
+              else
+                type == 'alert' ? 'error' : type
+              end
     end
   end
 end

--- a/app/components/viral/flash_controller.js
+++ b/app/components/viral/flash_controller.js
@@ -4,10 +4,11 @@ import { Controller } from "@hotwired/stimulus";
  * This controller is responsible for dismissing flash messages after a timeout
  */
 export default class extends Controller {
-  static values = { timeout: Number };
+  static values = { timeout: Number, type: String };
 
   connect() {
-    if (this.timeoutValue > 0) {
+    // Always force errors to not have a timeout
+    if (this.typeValue !== "error" && this.timeoutValue > 0) {
       this.run();
       this.element.addEventListener("mouseenter", this.pause.bind(this));
       this.element.addEventListener("mouseleave", this.run.bind(this));

--- a/app/components/viral/flash_controller.js
+++ b/app/components/viral/flash_controller.js
@@ -8,13 +8,31 @@ export default class extends Controller {
 
   connect() {
     if (this.timeoutValue > 0) {
-      setTimeout(() => {
+      this.run();
+      this.element.addEventListener("mouseenter", this.pause.bind(this));
+      this.element.addEventListener("mouseleave", this.run.bind(this));
+    }
+  }
+
+  run() {
+    this.startedTime = new Date().getTime();
+    if (this.timeoutValue > 0) {
+      this.timeout = setTimeout(() => {
         this.dismiss();
       }, this.timeoutValue);
     }
   }
 
+  pause() {
+    if (this.timeoutValue > 0) {
+      clearTimeout(this.timeout);
+      this.timeoutValue -= new Date().getTime() - this.startedTime;
+    }
+  }
+
   dismiss() {
+    this.element.removeEventListener("mouseenter", this.pause);
+    this.element.removeEventListener("mouseleave", this.run);
     this.element.remove();
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,6 +215,11 @@ en:
       title: Confirmation required
       cancel: Cancel
       confirm: Confirm
+    flash:
+      success_icon: Check icon
+      error_icon: X icon
+      warning_icon: Exclamation icon
+      information_icon: Information icon
   layouts:
     application:
       site_title: IRIDA Next

--- a/test/components/viral/flash_component_test.rb
+++ b/test/components/viral/flash_component_test.rb
@@ -8,28 +8,28 @@ module Viral
       message = 'Successful Message!'
       render_inline(Viral::FlashComponent.new(type: 'success', data: message))
       assert_text message
-      assert_selector '.bg-green-700'
+      assert_selector '.text-green-500.bg-green-100'
     end
 
     test 'error message' do
       message = 'Error Message!'
       render_inline(Viral::FlashComponent.new(type: 'error', data: message))
       assert_text message
-      assert_selector '.bg-red-600'
+      assert_selector '.text-red-500.bg-red-100'
     end
 
     test 'warning message' do
       message = 'Warning Message!'
       render_inline(Viral::FlashComponent.new(type: 'warning', data: message))
       assert_text message
-      assert_selector '.bg-yellow-300'
+      assert_selector '.text-orange-500.bg-orange-100'
     end
 
     test 'info message' do
       message = 'Info Message!'
       render_inline(Viral::FlashComponent.new(type: 'info', data: message))
       assert_text message
-      assert_selector '.bg-blue-600'
+      assert_selector '.text-blue-500.bg-blue-100'
     end
   end
 end

--- a/test/components/viral/system/flash_component_test.rb
+++ b/test/components/viral/system/flash_component_test.rb
@@ -9,7 +9,7 @@ module System
       message = 'Success Message!'
 
       assert_text message
-      assert_selector '.bg-green-700'
+      assert_selector '.text-green-500.bg-green-100'
       find('[data-action="viral--flash#dismiss"]').click
       assert_no_text message
     end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

1. Update the look of the flash component to match the[ Flowbite Toast component](https://flowbite.com/docs/components/toast/).
2. When a timeout is set on a flash message, the user can now how to keep it on the screen.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Error**
![image](https://github.com/phac-nml/irida-next/assets/11295750/45cb4429-7197-4700-a7fb-7c66e9bb15d9)

**Info**
![image](https://github.com/phac-nml/irida-next/assets/11295750/1b268221-890a-486e-8c98-bfc0361525e2)

**Success**
![image](https://github.com/phac-nml/irida-next/assets/11295750/7a61f659-815d-4fc2-8f7d-63913c89bbef)

**Warning**
![image](https://github.com/phac-nml/irida-next/assets/11295750/b3285783-7105-407e-8625-4c72a955769f)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

- All flash components can be viewed in [Lookbook](http://localhost:3000/rails/lookbook/inspect/viral_flash/error_flash)
- To test the hover delayed close, run IRIDA Next (clean db seed)
  * Login as user1
  * Go to the settings of a project the user has permissions on (e.g. [Outbreak 2022](http://localhost:3000/streptococcus/streptococcus-pyogenes/outbreak-2022/-/edit))
  * Transfer to users namespace under advanced settings.
  * After the transfer is complete, the user is redirected to the projects new namespace and a success flash message is displayed.
  * Normally the message stays on for 3.5 seconds, if you hover over during that time it  pauses the countdown.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated
  the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
