### PR TITLE
Feature: Namespaces Without Descendants Scope

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -87,6 +87,15 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     def self_and_descendant_ids
       self_and_descendants.as_ids
     end
+
+    def without_descendants
+      wildcard_path_select =
+        joins(:route)
+        .select(Arel.sql("concat(routes.path,'/%')")).to_sql
+
+      joins(:route)
+        .where(Arel.sql(format('routes.path not ILIKE all(array(%s))', wildcard_path_select)))
+    end
   end
 
   def ancestors

--- a/test/models/namespace_test.rb
+++ b/test/models/namespace_test.rb
@@ -25,4 +25,24 @@ class NamespaceTest < ActiveSupport::TestCase
     assert_equal [groups(:group_three), groups(:subgroup_one_group_three)],
                  Group.where(id: groups(:group_three).id).self_and_descendants
   end
+
+  test '#without_descendants when collection is empty' do
+    assert_equal [], Namespace.none.without_descendants
+  end
+
+  test '#without_descendants when collection has one item' do
+    assert_equal [groups(:group_three)],
+                 Group.where(id: groups(:group_three).id).without_descendants
+  end
+
+  test '#without_descendants when collection has no related items' do
+    assert_equal [groups(:group_two), groups(:group_three)],
+                 Group.where(id: [groups(:group_two).id, groups(:group_three).id]).without_descendants
+  end
+
+  test '#without_descendants when collection has related items' do
+    assert_equal [groups(:group_one), groups(:group_three)],
+                 Group.where(id: [groups(:group_one).id,
+                                  groups(:group_three).id]).self_and_descendants.without_descendants
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Adds in `without_descendants` scope to be used on a collection of Namespaces to reduce the set to only the top-level ancestors.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Review tests in `test/models/namespace_test.rb` and try your own calls in the rails console.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
