### PR TITLE
Fix: Use turbo stream when project transfer fails

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -72,7 +72,9 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
       end
     else
       @error = @project.errors.messages.values.flatten.first
-      render :edit, status: :unprocessable_entity
+      respond_to do |format|
+        format.turbo_stream
+      end
     end
   end
 

--- a/app/views/projects/transfer.turbo_stream.erb
+++ b/app/views/projects/transfer.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace("edit_advanced_transfer") do %>
-  <%= render "projects/transfer/transfer_form" %>
+  <%= render "projects/transfer_form" %>
 <% end %>

--- a/test/system/projects/transfer_test.rb
+++ b/test/system/projects/transfer_test.rb
@@ -5,13 +5,14 @@ require 'application_system_test_case'
 module Projects
   class TransferTest < ApplicationSystemTestCase
     setup do
+      @unauthorized_namespace = namespaces_user_namespaces(:jane_doe_namespace)
+    end
+
+    test 'should transfer project' do
       @user = users(:john_doe)
       login_as @user
       @project = projects(:project1)
       @namespace = namespaces_user_namespaces(:john_doe_namespace)
-    end
-
-    test 'should transfer project' do
       visit project_edit_path(@project)
       assert_selector "input[value='#{I18n.t(:'projects.edit.advanced.transfer.submit')}']:disabled", count: 1
       find('#new_namespace_id').find("option[value='#{@namespace.id}']").select_option
@@ -25,6 +26,27 @@ module Projects
       end
 
       assert_text I18n.t(:'projects.transfer.success', project_name: @project.name)
+    end
+
+    test 'should display error message when user attempts to transfer to namespace with same project name' do
+      @user = users(:john_doe)
+      login_as @user
+      @project = projects(:project2)
+      @namespace = namespaces_user_namespaces(:john_doe_namespace)
+
+      visit project_edit_path(@project)
+      assert_selector "input[value='#{I18n.t(:'projects.edit.advanced.transfer.submit')}']:disabled", count: 1
+      find('#new_namespace_id').find("option[value='#{@namespace.id}']").select_option
+      assert_selector "input[value='#{I18n.t(:'projects.edit.advanced.transfer.submit')}']", count: 1
+      click_on I18n.t(:'projects.edit.advanced.transfer.submit')
+
+      within('#turbo-confirm') do
+        assert_text I18n.t(:'components.confirmation.title')
+        find('input[type=text]').fill_in with: @project.name
+        click_on I18n.t(:'components.confirmation.confirm')
+      end
+
+      assert_text I18n.t(:'services.projects.transfer.namespace_project_exists', project_name: @project.name)
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Currently when a project transfer fails, the whole page refreshes because the response was not set to be a turbo stream.  This updates the response type and fixes the path to the transfer form template.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Here you can see that the response is only a turbo stream with the updated form:
![image](https://github.com/phac-nml/irida-next/assets/11295750/a3c6f02f-5e4d-43dd-b96a-23c1ab8c4836)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

With the default database seed:
1. Login with user1
2. Go to http://localhost:3000/streptococcus/streptococcus-pyogenes/outbreak-2022/-/edit
3. Open the network tab on chrome/firefox developer tools
4. Select `Neisseria / Neisseria meningitidis` from the new namespace select
5. Follow the instructions in the confirmation modal and confirm the transfer
6. An error should be displayed below the select
7. In the network panel, click on the transfer request.  You should only see the partial stream response.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated
  the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
