### PR TITLE
Fix: Dialog Component

### DIFF
--- a/app/components/viral/dialog_component.html.erb
+++ b/app/components/viral/dialog_component.html.erb
@@ -14,10 +14,10 @@
     <% if sections.present? %>
       <% sections.each_with_index do |section, index| %>
         <%= section %>
-        <% if sections.length() - 1 != index %>
-          <hr class="h-px my-4 bg-gray-200 border-0 dark:bg-gray-600" />
+        <% if sections.length - 1 != index %>
+          <hr class="h-px my-4 bg-gray-200 border-0 dark:bg-gray-600"/>
         <% end %>
-        <% end %>
+      <% end %>
     <% end %>
 
     <% if render_footer? %>
@@ -26,11 +26,11 @@
           <%= primary_action %>
         <% end %>
         <% if secondary_actions? %>
-        <% secondary_actions.each do |action| %>
-          <%= action %>
+          <% secondary_actions.each do |action| %>
+            <%= action %>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
     <% end %>
-    </div>
   </dialog>
 <% end %>

--- a/test/components/viral/alert_component_test.rb
+++ b/test/components/viral/alert_component_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'view_component_test_case'
 
 module Viral
-  class AlertComponentTest < ViewComponent::TestCase
+  class AlertComponentTest < ViewComponentTestCase
     test 'notice alert' do
       render_inline(Viral::AlertComponent.new(message: 'This is a notice alert', type: 'notice'))
       assert_text 'This is a notice alert'

--- a/test/components/viral/avatar_component_test.rb
+++ b/test/components/viral/avatar_component_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'view_component_test_case'
 
 module Viral
-  class AvatarComponentTest < ViewComponent::TestCase
+  class AvatarComponentTest < ViewComponentTestCase
     test 'default avatar' do
       render_inline(Viral::AvatarComponent.new(name: 'J'))
       assert_selector('div.avatar')

--- a/test/components/viral/breadcrumb_component_test.rb
+++ b/test/components/viral/breadcrumb_component_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'view_component_test_case'
 
 module Viral
-  class BreadcrumbComponentTest < ViewComponent::TestCase
+  class BreadcrumbComponentTest < ViewComponentTestCase
     test 'single path' do
       # Mock route
       mock_route = routes(:group_one_route)

--- a/test/components/viral/button_component_test.rb
+++ b/test/components/viral/button_component_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'view_component_test_case'
 
 module Viral
-  class ButtonComponentTest < ViewComponent::TestCase
+  class ButtonComponentTest < ViewComponentTestCase
     test 'basic button' do
       render_inline(Viral::ButtonComponent.new) do
         'Basic Button'

--- a/test/components/viral/card_component_test.rb
+++ b/test/components/viral/card_component_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'view_component_test_case'
 
 module Viral
-  class CardComponentTest < ViewComponent::TestCase
+  class CardComponentTest < ViewComponentTestCase
     test 'default card' do
       render_inline(Viral::CardComponent.new(title: 'Simple card with Title')) do
         'This is a card'

--- a/test/components/viral/dialog_component_test.rb
+++ b/test/components/viral/dialog_component_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'view_component_test_case'
+
+module Viral
+  class DialogComponentTest < ViewComponentTestCase
+    test 'confirmation dialog' do
+      render_preview(:confirmation)
+    end
+
+    test 'default dialog' do
+      render_preview(:default)
+    end
+
+    test 'small dialog' do
+      render_preview(:small)
+    end
+
+    test 'large dialog' do
+      render_preview(:large)
+    end
+
+    test 'extra_large dialog' do
+      render_preview(:extra_large)
+    end
+
+    test 'with_action_buttons dialog' do
+      render_preview(:with_action_buttons)
+    end
+
+    test 'with_trigger dialog' do
+      render_preview(:with_trigger)
+    end
+
+    test 'with_multiple_sections dialog' do
+      render_preview(:with_multiple_sections)
+    end
+  end
+end

--- a/test/components/viral/flash_component_test.rb
+++ b/test/components/viral/flash_component_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'view_component_system_test_case'
+require 'view_component_test_case'
 
 module Viral
-  class FlashComponentTest < ViewComponent::TestCase
+  class FlashComponentTest < ViewComponentTestCase
     test 'success message' do
       message = 'Successful Message!'
       render_inline(Viral::FlashComponent.new(type: 'success', data: message))

--- a/test/components/viral/icon_component_test.rb
+++ b/test/components/viral/icon_component_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'view_component_test_case'
 
 module Viral
-  class IconComponentTest < ViewComponent::TestCase
+  class IconComponentTest < ViewComponentTestCase
     test 'default' do
       render_inline(Viral::IconComponent.new(name: 'home'))
       assert_selector 'svg.Viral-Icon__Svg', count: 1

--- a/test/test_helpers/markup_validation_helpers.rb
+++ b/test/test_helpers/markup_validation_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module MarkupValidationHelpers
+  def format_nokogiri_errors(errors)
+    results = errors.map(&:to_s).join("\n    ")
+
+    %(
+    Found markup violations:
+    #{results}
+    )
+  end
+
+  def assert_valid_markup(markup)
+    result = Nokogiri::XML(markup)
+
+    assert result.errors.empty?, format_nokogiri_errors(result.errors)
+  end
+end

--- a/test/view_component_test_case.rb
+++ b/test/view_component_test_case.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'test_helpers/markup_validation_helpers'
+
+class ViewComponentTestCase < ViewComponent::TestCase
+  include MarkupValidationHelpers
+
+  def render_inline(component, **args, &)
+    super
+    assert_valid_markup(rendered_content)
+  end
+
+  def render_preview(name, params: {})
+    result = self.class.name.gsub('::', '').gsub('Test', 'Preview')
+    from = result.constantize
+    super(name, from:, params:)
+    # strip the head from the resulting html as link tags were causing issue with Nokogiri
+    markup = rendered_content.gsub(%r{<head>(.|\n)*</head>}, '')
+    assert_valid_markup(markup)
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Fixes the case of the Dialog component having a hanging closing div tag when no footer is present. This issue causes the dialog to break components that it is put into (e.g. having the dialog be contained within the card component).

This also adds in a `ViewComponentTestCase` class and `MarkupValidationHelpers` class. Whenever `render_inline` or `render_preview` is called in a class based on `ViewComponentTestCase` the resulting HTML is validated using Nokogiri. This will ensure that invalid markup is caught and reported.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
