### PR TITLE
NamespaceGroupLink updating

### DIFF
--- a/app/controllers/concerns/share_actions.rb
+++ b/app/controllers/concerns/share_actions.rb
@@ -6,6 +6,8 @@ module ShareActions
 
   included do
     before_action proc { namespace }
+    # before_action proc { access_levels }
+    before_action proc { namespace_group_link }, only: %i[share_update]
   end
 
   def share # rubocop:disable Metrics/AbcSize
@@ -37,9 +39,43 @@ module ShareActions
     end
   end
 
+  def share_update
+    updated = Namespaces::GroupShareUpdateService.new(current_user, @namespace_group_link, params)
+
+    if updated
+      flash[:success] = t('success')
+      redirect_to namespace_path
+    else
+      flash[:error] = t('error')
+    end
+    #
+    # respond_to do |format|
+    #   if updated
+    #     format.turbo_stream do
+    #       render status: :ok, locals: { namespace_group_link: @namespace_group_link,
+    #                                     access_levels: @access_levels
+    #                                     type: 'success',
+    #                                     message: t('.success') }
+    #     end
+    #   else
+    #     format.turbo_stream do
+    #       render status: :bad_request,
+    #              locals: { namespace_group_link: @namespace_group_link, type: 'alert',
+    #                        message: t('.error') }
+    #     end
+    #   end
+    # end
+  end
+
   protected
 
   def namespace_path
     raise NotImplementedError
+  end
+
+  private
+
+  def namespace_group_link
+    @namespace_group_link ||= NamespaceGroupLink.find_by(id: params[:namespace_group_link_id])
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -109,6 +109,10 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
       can_modify?(user, object_namespace)
     end
 
+    def can_update_namespace_with_group_share?(user, object_namespace)
+      can_modify?(user, object_namespace)
+    end
+
     def namespace_owners_include_user?(user, namespace)
       if namespace.project_namespace?
         Member.exists?(

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -114,6 +114,13 @@ class GroupPolicy < NamespacePolicy
     false
   end
 
+  def update_namespace_with_group_share?
+    return true if Member.can_update_namespace_with_group_share?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
   scope_for :relation do |_relation|
     user.groups.self_and_descendants.include_route
   end

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -56,5 +56,12 @@ module Namespaces
       details[:name] = record.name
       false
     end
+
+    def update_namespace_with_group_share?
+      return true if Member.can_update_namespace_with_group_share?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
   end
 end

--- a/app/services/namespaces/group_share_update_service.rb
+++ b/app/services/namespaces/group_share_update_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Namespaces
+  # Service used to update NamespaceGroupLinks
+  class GroupShareUpdateService < BaseService
+    attr_accessor :namespace_group_link
+
+    def initialize(user, namespace_group_link, params)
+      super(user, params)
+      @namespace_group_link = namespace_group_link
+    end
+
+    def execute
+      authorize! @namespace_group_link.namespace, to: :update_namespace_with_group_share?
+
+      @namespace_group_link.update(params)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
         sample_listing?: You are not authorized to view samples for group %{name} on this server.
         share_namespace_with_group?: You are not authorized to share group %{name} with other groups on this server.
         unshare_namespace_with_group?: You are not authorized to unshare group %{name} with other groups on this server.
+        update_namespace_with_group_share?: You are not authorized to update group %{name} share on this server.
       project:
         activity?: You are not authorized to view the activity for project %{name} on this server.
         destroy?: You are not authorized to remove project %{name} from this server.
@@ -85,6 +86,7 @@ en:
         update_member?: You are not authorized to update members for the project namespace %{name} on this server.
         share_namespace_with_group?: You are not authorized to share project %{name} with other groups on this server.
         unshare_namespace_with_group?: You are not authorized to unshare project %{name} with other groups on this server.
+        update_namespace_with_group_share?: You are not authorized to update project %{name} share on this server.
       namespaces/user_namespace:
         create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace
@@ -416,6 +418,9 @@ en:
       error: There was an error sharing group with group
     unshare:
       success: Successfully unshared group
+    share_update:
+      success: Successfully updated namespace group link
+      error: There was an error updating the namespace group link
     members:
       create:
         error: "Error adding member"
@@ -524,6 +529,9 @@ en:
       error: There was an error sharing project with group
     unshare:
       success: Successfully unshared project with group
+    share_update:
+      success: Successfully updated namespace group link
+      error: There was an error updating the namespace group link
     members:
       create:
         error: "Error adding member"

--- a/config/routes/group.rb
+++ b/config/routes/group.rb
@@ -8,6 +8,7 @@ constraints(::Constraints::GroupUrlConstrainer.new) do
       get :edit, as: :edit_group
       post :share, as: :group_share
       post :unshare, as: :group_unshare
+      patch :share_update, as: :group_share_update
     end
 
     get '/', action: :show, as: :group_canonical

--- a/config/routes/project.rb
+++ b/config/routes/project.rb
@@ -27,6 +27,7 @@ constraints(::Constraints::ProjectUrlConstrainer.new) do
       end
       post :share
       post :unshare
+      patch :share_update
     end
   end
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -259,4 +259,17 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable M
 
     assert_response :unauthorized
   end
+
+  test 'should update namespace group share' do
+    sign_in users(:john_doe)
+
+    namespace_group_link = namespace_group_links(:namespace_group_link2)
+
+    patch group_share_update_path(namespace_group_link.namespace), params: {
+      namespace_group_link_id: namespace_group_link.id,
+      group_access_level: Member::AccessLevel::GUEST
+    }
+
+    assert_redirected_to group_path(namespace_group_link.namespace)
+  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -337,4 +337,21 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable
 
     assert_response :unprocessable_entity
   end
+
+  test 'should update namespace group share' do
+    sign_in users(:john_doe)
+
+    namespace_group_link = namespace_group_links(:namespace_group_link1)
+
+    project_namespace = namespace_group_link.namespace
+
+    patch namespace_project_share_update_path(project_namespace.parent,
+                                              project_namespace.project, params: {
+                                                namespace_group_link_id: namespace_group_link.id,
+                                                group_access_level: Member::AccessLevel::GUEST
+                                              })
+
+    assert_redirected_to namespace_project_path(project_namespace.parent,
+                                                project_namespace.project)
+  end
 end

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -73,6 +73,10 @@ class GroupPolicyTest < ActiveSupport::TestCase
     assert @policy.unshare_namespace_with_group?
   end
 
+  test '#update_namespace_with_group_share?' do
+    assert @policy.update_namespace_with_group_share?
+  end
+
   test 'scope' do
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 

--- a/test/policies/namespaces/project_namespace_policy_test.rb
+++ b/test/policies/namespaces/project_namespace_policy_test.rb
@@ -37,5 +37,9 @@ module Namespaces
     test '#unshare_namespace_with_group?' do
       assert @policy.unshare_namespace_with_group?
     end
+
+    test '#update_namespace_with_group_share?' do
+      assert @policy.update_namespace_with_group_share?
+    end
   end
 end

--- a/test/services/namespaces/group_share_update_service_test.rb
+++ b/test/services/namespaces/group_share_update_service_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Namespaces
+  class GroupShareUpdateServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
+    def setup
+      @user = users(:john_doe)
+    end
+
+    test 'update group to group share access level' do
+      namespace_group_link = namespace_group_links(:namespace_group_link2)
+
+      assert_changes -> { namespace_group_link.group_access_level }, to: Member::AccessLevel::GUEST do
+        Namespaces::GroupShareUpdateService.new(@user, namespace_group_link,
+                                                { group_access_level: Member::AccessLevel::GUEST }).execute
+      end
+    end
+
+    test 'update project to group share access level' do
+      namespace_group_link = namespace_group_links(:namespace_group_link1)
+
+      assert_changes -> { namespace_group_link.group_access_level }, to: Member::AccessLevel::GUEST do
+        Namespaces::GroupShareUpdateService.new(@user, namespace_group_link,
+                                                { group_access_level: Member::AccessLevel::GUEST }).execute
+      end
+    end
+
+    test 'update group to group share expiration' do
+      expiration_date = Date.strptime('2023-08-16', '%Y-%m-%d')
+      namespace_group_link = namespace_group_links(:namespace_group_link2)
+
+      assert_changes -> { namespace_group_link.expires_at }, to: expiration_date do
+        Namespaces::GroupShareUpdateService.new(@user, namespace_group_link,
+                                                { expires_at: expiration_date }).execute
+      end
+    end
+
+    test 'update project to group share expiration' do
+      expiration_date = Date.strptime('2023-08-16', '%Y-%m-%d')
+      namespace_group_link = namespace_group_links(:namespace_group_link1)
+
+      assert_changes -> { namespace_group_link.expires_at }, to: expiration_date do
+        Namespaces::GroupShareUpdateService.new(@user, namespace_group_link,
+                                                { expires_at: expiration_date }).execute
+      end
+    end
+
+    test 'update group with group share with incorrect permissions' do
+      user = users(:david_doe)
+      namespace_group_link = namespace_group_links(:namespace_group_link2)
+
+      exception = assert_raises(ActionPolicy::Unauthorized) do
+        Namespaces::GroupShareUpdateService.new(user, namespace_group_link,
+                                                { group_access_level: Member::AccessLevel::GUEST }).execute
+      end
+
+      assert_equal GroupPolicy, exception.policy
+      assert_equal :update_namespace_with_group_share?, exception.rule
+      assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.group.update_namespace_with_group_share?',
+                          name: namespace_group_link.namespace.name),
+                   exception.result.message
+    end
+
+    test 'update project with group share with incorrect permissions' do
+      user = users(:david_doe)
+      namespace_group_link = namespace_group_links(:namespace_group_link1)
+
+      exception = assert_raises(ActionPolicy::Unauthorized) do
+        Namespaces::GroupShareUpdateService.new(user, namespace_group_link,
+                                                { group_access_level: Member::AccessLevel::GUEST }).execute
+      end
+
+      assert_equal ProjectNamespacePolicy, exception.policy
+      assert_equal :update_namespace_with_group_share?, exception.rule
+      assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.update_namespace_with_group_share?',
+                          name: namespace_group_link.namespace.name),
+                   exception.result.message
+    end
+
+    test 'valid authorization to update group to group share' do
+      namespace_group_link = namespace_group_links(:namespace_group_link2)
+
+      assert_authorized_to(:update_namespace_with_group_share?, namespace_group_link.namespace,
+                           with: GroupPolicy,
+                           context: { user: @user }) do
+        Namespaces::GroupShareUpdateService.new(@user, namespace_group_link,
+                                                { group_access_level: Member::AccessLevel::GUEST }).execute
+      end
+    end
+
+    test 'valid authorization to update project to group share' do
+      namespace_group_link = namespace_group_links(:namespace_group_link1)
+
+      assert_authorized_to(:update_namespace_with_group_share?, namespace_group_link.namespace,
+                           with: ProjectNamespacePolicy,
+                           context: { user: @user }) do
+        Namespaces::GroupShareUpdateService.new(@user, namespace_group_link,
+                                                { group_access_level: Member::AccessLevel::GUEST }).execute
+      end
+    end
+
+    test 'group to group share is logged using logidze' do
+      group_group_link = namespace_group_links(:namespace_group_link2)
+      group_group_link.create_logidze_snapshot!
+      Namespaces::GroupShareUpdateService.new(@user, group_group_link,
+                                              { group_access_level: Member::AccessLevel::GUEST }).execute
+      group_group_link.create_logidze_snapshot!
+
+      assert_equal 2, group_group_link.log_data.version
+      assert_equal 2, group_group_link.log_data.size
+
+      assert_equal Member::AccessLevel::ANALYST, group_group_link.at(version: 1).group_access_level
+      assert_equal Member::AccessLevel::GUEST, group_group_link.at(version: 2).group_access_level
+    end
+
+    test 'project to group share is logged using logidze' do
+      project_group_link = namespace_group_links(:namespace_group_link1)
+      project_group_link.create_logidze_snapshot!
+      Namespaces::GroupShareUpdateService.new(@user, project_group_link,
+                                              { group_access_level: Member::AccessLevel::GUEST }).execute
+      project_group_link.create_logidze_snapshot!
+
+      assert_equal 2, project_group_link.log_data.version
+      assert_equal 2, project_group_link.log_data.size
+
+      assert_equal Member::AccessLevel::MAINTAINER, project_group_link.at(version: 1).group_access_level
+      assert_equal Member::AccessLevel::GUEST, project_group_link.at(version: 2).group_access_level
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in functionality to update NamespaceGroupLinks (group access level and expiration date). 
The following changes were made:

Controller action added to `share_actions` concern to update namespace_group_link
Routes added for project and group for `share_update`
Service added to do the actual updating of the namespace_group_link
Policy methods added to `ProjectNamespacePolicy` and `GroupPolicy` to handle authorization
Testing added for controller, service and policies

**Note**: The commented out code in `share_actions.rb` will be used in the UI branch which is ongoing.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

No screenshots as this only adds in back-end code

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Verify that the tests pass and that there is good test coverage

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated
  the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
