### PR TITLE
Fix documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ Open `coverage/index.html`
 
 ## Documentation
 
-See [docs](/docs/README.md).
+See [docs](https://phac-nml.github.io/irida-next/).

--- a/docs-site/docs/development/development_processes/code_review.md
+++ b/docs-site/docs/development/development_processes/code_review.md
@@ -11,7 +11,7 @@ All merge requests for IRIDA Next, whether written by a IRIDA team member or a w
 ## Getting your pull request reviewed, approved, and merged
 
 Before you begin:
-* Familiarize yourself with the [contribution acceptance criteria](./pull_request_workflow/#contribution-acceptance-criteria)
+* Familiarize yourself with the [contribution acceptance criteria](./pull_request_workflow#contribution-acceptance-criteria)
 
 As soon as you have code to review, have the code **reviewed** by a reviewer. The reviewer can:
 * Give you a second opinion on the chosen solution and implementation.


### PR DESCRIPTION
## What does this PR do and why?
Fix broken links for docs

## Screenshots or screen recordings
N/A

## How to set up and validate locally
Using vscode you can open the markdown preview and click the link to move to the linked page
![image](https://github.com/phac-nml/irida-next/assets/16961365/07010903-d6c9-4d36-8d4c-2f29ea66624e)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
