### PR TITLE
Updating sample transfer modal to use turbo_stream

### DIFF
--- a/app/controllers/projects/samples/transfers_controller.rb
+++ b/app/controllers/projects/samples/transfers_controller.rb
@@ -9,6 +9,12 @@ module Projects
 
       def new
         authorize! @project, to: :transfer_sample?
+
+        respond_to do |format|
+          format.turbo_stream do
+            render status: :ok
+          end
+        end
       end
 
       def create # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -9,7 +9,8 @@
         <%= link_to t("projects.samples.index.transfer_button"),
         new_namespace_project_samples_transfer_path,
         data: {
-          turbo_frame: "transfer_modal"
+          turbo_frame: "transfer_modal",
+          turbo_stream: true
         },
         class: "button button--size-default button--state-default mr-1" %>
       <% end %>

--- a/app/views/projects/samples/transfers/new.html.erb
+++ b/app/views/projects/samples/transfers/new.html.erb
@@ -1,3 +1,0 @@
-<%= turbo_frame_tag "transfer_modal" do %>
-  <%= render partial: "transfer_modal", locals: { open: true } %>
-<% end %>

--- a/app/views/projects/samples/transfers/new.turbo_stream.erb
+++ b/app/views/projects/samples/transfers/new.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "transfer_modal",
+                    partial: "transfer_modal",
+                    locals: {
+                      open: true
+                    } %>

--- a/test/controllers/projects/samples/transfers_controller_test.rb
+++ b/test/controllers/projects/samples/transfers_controller_test.rb
@@ -15,7 +15,7 @@ module Projects
       end
 
       test 'should get new if owner' do
-        get new_namespace_project_samples_transfer_path(@namespace, @project1)
+        get new_namespace_project_samples_transfer_path(@namespace, @project1, format: :turbo_stream)
         assert_response :success
       end
 


### PR DESCRIPTION
## What does this PR do and why?
Updating the sample transfer modal to use turbo_stream.
Pulled from https://github.com/phac-nml/irida-next/pull/135.

## Screenshots or screen recordings
![Screenshot from 2023-09-14 11-29-26](https://github.com/phac-nml/irida-next/assets/325703/3bcbe910-75a1-4ddc-85bc-d7ee9504defb)

## How to set up and validate locally
1. Navigate to a project that is owned by the logged-in user.
2. Hit `Samples` on the left side menu.
3. Check the samples you wish to transfer.
4. Click the `Transfer samples` button.
5. A dialog should appear. Verify the modal was rendered via turbo_stream.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
