### PR TITLE
Datepicker View Component

### DIFF
--- a/app/components/viral/form/datepicker_component.html.erb
+++ b/app/components/viral/form/datepicker_component.html.erb
@@ -26,4 +26,9 @@
     </div>
     <%= render Viral::BaseComponent.new(**system_arguments) %>
   </div>
+  <% if help_text.present? %>
+    <%= viral_help_text do %>
+      <%= help_text %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/components/viral/form/datepicker_component.html.erb
+++ b/app/components/viral/form/datepicker_component.html.erb
@@ -1,0 +1,31 @@
+<div class="form-field datepicker" data-controller="datepicker">
+  <div class="relative max-w-sm">
+    <div
+      class="
+        absolute
+        inset-y-0
+        left-0
+        flex
+        items-center
+        pl-3
+        pointer-events-none
+      "
+    >
+      <%= render Viral::IconComponent.new(
+        name: "calendar_days",
+        classes: "w-5 h-5 text-gray-500 dark:text-gray-400"
+      ) %>
+    </div>
+    <%= form.text_field :expires_at,
+                    placeholder: I18n.t("date.formats.iso"),
+                    autocomplete: "off",
+                    value: namespace_group_link.expires_at,
+                    id: "invited-group-#{namespace_group_link.group.id}-expiration",
+                    "data-datepicker-target": "datePicker",
+                    "data-datepicker-autosubmit": "true",
+                    "aria-label":
+                      t(:"groups.group_links.index.aria_labels.expires_at") %>
+
+    <input type="hidden" name="format" value="turbo_stream"/>
+  </div>
+</div>

--- a/app/components/viral/form/datepicker_component.html.erb
+++ b/app/components/viral/form/datepicker_component.html.erb
@@ -1,4 +1,12 @@
-<div class="form-field datepicker" data-controller="datepicker">
+<div data-controller="datepicker">
+  <%- if label.present? %>
+    <label
+      for="<%= name %>"
+      class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
+    >
+      <%= label %>
+    </label>
+  <% end %>
   <div class="relative max-w-sm">
     <div
       class="
@@ -11,21 +19,11 @@
         pointer-events-none
       "
     >
-      <%= render Viral::IconComponent.new(
+      <%= viral_icon(
         name: "calendar_days",
         classes: "w-5 h-5 text-gray-500 dark:text-gray-400"
       ) %>
     </div>
-    <%= form.text_field :expires_at,
-                    placeholder: I18n.t("date.formats.iso"),
-                    autocomplete: "off",
-                    value: namespace_group_link.expires_at,
-                    id: "invited-group-#{namespace_group_link.group.id}-expiration",
-                    "data-datepicker-target": "datePicker",
-                    "data-datepicker-autosubmit": "true",
-                    "aria-label":
-                      t(:"groups.group_links.index.aria_labels.expires_at") %>
-
-    <input type="hidden" name="format" value="turbo_stream"/>
+    <%= render Viral::BaseComponent.new(**system_arguments) %>
   </div>
 </div>

--- a/app/components/viral/form/datepicker_component.rb
+++ b/app/components/viral/form/datepicker_component.rb
@@ -4,13 +4,14 @@ module Viral
   module Form
     # Form control for datepicker
     class DatepickerComponent < Viral::Component
-      attr_reader :name, :label
+      attr_reader :name, :label, :help_text
 
-      def initialize(id:, name:, label: nil, value: nil, **options)
+      def initialize(id:, name:, label: nil, value: nil, help_text: nil, **options) # rubocop:disable Metrics/ParameterLists
         @id = id
         @name = name
         @label = label
         @value = value
+        @help_text = help_text
         @options = options
       end
 

--- a/app/components/viral/form/datepicker_component.rb
+++ b/app/components/viral/form/datepicker_component.rb
@@ -1,5 +1,36 @@
 # frozen_string_literal: true
 
-class Viral::Form::DatepickerComponent < ViewComponent::Base
+module Viral
+  module Form
+    # Form control for datepicker
+    class DatepickerComponent < Viral::Component
+      attr_reader :name, :label
 
+      def initialize(id:, name:, label: nil, value: nil, **options)
+        @id = id
+        @name = name
+        @label = label
+        @value = value
+        @options = options
+      end
+
+      def system_arguments
+        @options.tap do |opts|
+          opts[:tag] = 'input'
+          opts[:type] = 'text'
+          opts[:name] = @name
+          opts[:id] = @id
+          opts[:value] = @value
+          opts[:classes] = class_names(
+            'border border-slate-300 text-slate-900 sm:text-sm rounded-md focus:ring-primary-700',
+            'focus:border-primary-700 block w-full pl-10 p-2.5 dark:bg-slate-800 dark:border-slate-600',
+            'dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500'
+          )
+          opts[:data] = {
+            datepicker_target: 'datePicker'
+          }
+        end
+      end
+    end
+  end
 end

--- a/app/components/viral/form/datepicker_component.rb
+++ b/app/components/viral/form/datepicker_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Viral::Form::DatepickerComponent < ViewComponent::Base
+
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -9,6 +9,7 @@ module ViewHelper
     button: 'Viral::ButtonComponent',
     card: 'Viral::CardComponent',
     checkbox: 'Viral::Form::CheckboxComponent',
+    datepicker: 'Viral::Form::DatepickerComponent',
     dialog: 'Viral::DialogComponent',
     dropdown: 'Viral::DropdownComponent',
     flash: 'Viral::FlashComponent',

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -3,18 +3,19 @@ import { Datepicker } from "flowbite-datepicker";
 
 export default class extends Controller {
   static targets = ["datePicker"];
+  static values = { format: { type: String, default: "yyyy-mm-dd" } };
 
   connect() {
     if (this.datePickerTarget.dataset.datepickerDialog) {
       new Datepicker(this.datePickerTarget, {
         container: "#dialog",
-        format: "yyyy-mm-dd",
+        format: this.formatValue,
         orientation: "bottom left",
         autohide: true,
       });
     } else {
       new Datepicker(this.datePickerTarget, {
-        format: "yyyy-mm-dd",
+        format: this.formatValue,
         orientation: "bottom left",
         autohide: true,
       });

--- a/test/components/previews/viral_form_datepicker_component_preview.rb
+++ b/test/components/previews/viral_form_datepicker_component_preview.rb
@@ -4,4 +4,5 @@ class ViralFormDatepickerComponentPreview < ViewComponent::Preview
   def default; end
   def with_label; end
   def with_help_text; end
+  def with_placeholder; end
 end

--- a/test/components/previews/viral_form_datepicker_component_preview.rb
+++ b/test/components/previews/viral_form_datepicker_component_preview.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ViralFormDatepickerComponentPreview < ViewComponent::Preview
+  def default; end
+end

--- a/test/components/previews/viral_form_datepicker_component_preview.rb
+++ b/test/components/previews/viral_form_datepicker_component_preview.rb
@@ -2,4 +2,6 @@
 
 class ViralFormDatepickerComponentPreview < ViewComponent::Preview
   def default; end
+  def with_label; end
+  def with_help_text; end
 end

--- a/test/components/previews/viral_form_datepicker_component_preview/default.html.erb
+++ b/test/components/previews/viral_form_datepicker_component_preview/default.html.erb
@@ -1,6 +1,1 @@
-<%= viral_datepicker(
-  id: "datepicker-id",
-  name: "datepicker-name",
-  label: "Pick a date",
-  value: Time.now
-) %>
+<%= viral_datepicker(id: "datepicker-id", name: "datepicker-name", value: Time.now) %>

--- a/test/components/previews/viral_form_datepicker_component_preview/default.html.erb
+++ b/test/components/previews/viral_form_datepicker_component_preview/default.html.erb
@@ -1,0 +1,6 @@
+<%= viral_datepicker(
+  id: "datepicker-id",
+  name: "datepicker-name",
+  label: "Pick a date",
+  value: Time.now
+) %>

--- a/test/components/previews/viral_form_datepicker_component_preview/with_help_text.html.erb
+++ b/test/components/previews/viral_form_datepicker_component_preview/with_help_text.html.erb
@@ -1,0 +1,1 @@
+<%= viral_datepicker(id: "datepicker-id", name: "datepicker-name", value: Time.now, help_text: "Select a date in the future") %>

--- a/test/components/previews/viral_form_datepicker_component_preview/with_label.html.erb
+++ b/test/components/previews/viral_form_datepicker_component_preview/with_label.html.erb
@@ -1,0 +1,6 @@
+<%= viral_datepicker(
+  id: "datepicker-id",
+  name: "datepicker-name",
+  value: Time.now,
+  label: "Pick a date"
+) %>

--- a/test/components/previews/viral_form_datepicker_component_preview/with_placeholder.html.erb
+++ b/test/components/previews/viral_form_datepicker_component_preview/with_placeholder.html.erb
@@ -1,0 +1,5 @@
+<%= viral_datepicker(
+  id: "datepicker-id",
+  name: "datepicker-name",
+  placeholder: "Pick a date"
+) %>

--- a/test/components/viral/form/datepicker_component_test.rb
+++ b/test/components/viral/form/datepicker_component_test.rb
@@ -1,12 +1,30 @@
 # frozen_string_literal: true
 
-require "test_helper"
+require 'view_component_test_case'
 
-class Viral::Form::DatepickerComponentTest < ViewComponent::TestCase
-  def test_component_renders_something_useful
-    # assert_equal(
-    #   %(<span>Hello, components!</span>),
-    #   render_inline(Viral::Form::DatepickerComponent.new(message: "Hello, components!")).css("span").to_html
-    # )
+module Viral
+  module Form
+    class DatepickerComponentTest < ViewComponentTestCase
+      test 'default' do
+        render_preview(:default)
+        assert_no_selector 'label'
+        assert_selector 'input[type="text"]', count: 1
+        assert_selector '.Viral-Icon', count: 1
+      end
+
+      test 'with label' do
+        render_preview(:with_label)
+        assert_selector 'label', text: 'Pick a date'
+        assert_selector 'input[type="text"]', count: 1
+        assert_selector '.Viral-Icon', count: 1
+      end
+
+      test 'with help text' do
+        render_preview(:with_help_text)
+        assert_no_selector 'label'
+        assert_selector 'input[type="text"]', count: 1
+        assert_selector 'p.text-sm', text: 'Select a date in the future'
+      end
+    end
   end
 end

--- a/test/components/viral/form/datepicker_component_test.rb
+++ b/test/components/viral/form/datepicker_component_test.rb
@@ -25,6 +25,12 @@ module Viral
         assert_selector 'input[type="text"]', count: 1
         assert_selector 'p.text-sm', text: 'Select a date in the future'
       end
+
+      test 'with placeholder' do
+        render_preview(:with_placeholder)
+        assert_no_selector 'label'
+        assert_selector 'input[type="text"][placeholder:"Pick a date"]', count: 1
+      end
     end
   end
 end

--- a/test/components/viral/form/datepicker_component_test.rb
+++ b/test/components/viral/form/datepicker_component_test.rb
@@ -29,7 +29,7 @@ module Viral
       test 'with placeholder' do
         render_preview(:with_placeholder)
         assert_no_selector 'label'
-        assert_selector 'input[type="text"][placeholder:"Pick a date"]', count: 1
+        assert_selector 'input[type="text"][placeholder="Pick a date"]', count: 1
       end
     end
   end

--- a/test/components/viral/form/datepicker_component_test.rb
+++ b/test/components/viral/form/datepicker_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Viral::Form::DatepickerComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Viral::Form::DatepickerComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Custom datepicker components:

- Accomodates with and without a label
- Can add any attributes to the input (e.g. data args)

Fixes #199 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Default**
![image](https://github.com/phac-nml/irida-next/assets/11295750/e14a18fa-f909-42ff-a517-ebfac821888b)

**With label**
![image](https://github.com/phac-nml/irida-next/assets/11295750/684e22c3-6663-4710-b29e-f32656cca6a5)

**With help text**
![image](https://github.com/phac-nml/irida-next/assets/11295750/4f4df170-43b8-4c04-8578-04b85fe42d48)

**With placeholder**
![image](https://github.com/phac-nml/irida-next/assets/11295750/a9656f1a-22f2-4e0a-82a1-8a83d8bfbbbd)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Lookbook Previews:

1. [Default](http://localhost:3000/rails/lookbook/inspect/viral_form_datepicker/default)
2. [With label](http://localhost:3000/rails/lookbook/inspect/viral_form_datepicker/with_label)
3. [With help text](http://localhost:3000/rails/lookbook/inspect/viral_form_datepicker/with_help_text)
4. [With placeholder](http://localhost:3000/rails/lookbook/inspect/viral_form_datepicker/with_placeholder)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
