### PR TITLE
Refactor breadcrumbs

### DIFF
--- a/app/components/viral/breadcrumb_component.rb
+++ b/app/components/viral/breadcrumb_component.rb
@@ -6,7 +6,7 @@ module Viral
     attr_reader :links
 
     def initialize(context_crumbs: nil)
-      @links = validate_context_crumbs(context_crumbs) unless context_crumbs.nil?
+      @links = validate_context_crumbs(context_crumbs)
     end
 
     private

--- a/app/components/viral/breadcrumb_component.rb
+++ b/app/components/viral/breadcrumb_component.rb
@@ -6,45 +6,10 @@ module Viral
     attr_reader :links
 
     def initialize(context_crumbs: nil)
-      @links = context_crumbs.nil? ? nil : build_crumbs(context_crumbs)
+      @links = validate_context_crumbs(context_crumbs)
     end
-
-    def build_crumbs(context_crumbs)
-      crumbs = []
-      path = context_crumbs[0][:path].split('/')
-      path.each_with_index do |crumb, index|
-        next if index == 0 || index == path.length - 1 || crumb == '-'
-
-        crumbs << route_to_context_crumbs(path, crumb, index)
-      end
-      crumbs += context_crumbs if context_crumbs.present? && validate_context_crumbs(context_crumbs)
-      crumbs
-    end
-
-    # def build_crumbs(route, context_crumbs)
-    #   crumbs = []
-    #   route.path.split('/').each_with_index do |_part, index|
-    #     crumbs << crumb_for_route(route, index)
-    #   end
-    #   crumbs += context_crumbs if context_crumbs.present? && validate_context_crumbs(context_crumbs)
-    #   crumbs
-    # end
 
     private
-
-    def route_to_context_crumbs(path, crumb, index)
-      namespace = Namespace.all.find_by(path: crumb)
-      crumb = namespace.name if namespace
-
-      { name: crumb, path: path[0..index].join('/')[1..-1] }
-    end
-
-    def crumb_for_route(route, index)
-      {
-        name: route.name.split(' / ')[index],
-        path: route.path.split('/')[0..index].join('/')
-      }
-    end
 
     def validate_context_crumbs(context_crumbs)
       raise ArgumentError, 'Context crumbs must be an array' unless context_crumbs.is_a?(Array)

--- a/app/components/viral/breadcrumb_component.rb
+++ b/app/components/viral/breadcrumb_component.rb
@@ -6,7 +6,7 @@ module Viral
     attr_reader :links
 
     def initialize(context_crumbs: nil)
-      @links = validate_context_crumbs(context_crumbs)
+      @links = validate_context_crumbs(context_crumbs) unless context_crumbs.nil?
     end
 
     private

--- a/app/components/viral/breadcrumb_component.rb
+++ b/app/components/viral/breadcrumb_component.rb
@@ -5,20 +5,39 @@ module Viral
   class BreadcrumbComponent < Component
     attr_reader :links
 
-    def initialize(route:, context_crumbs: nil)
-      @links = build_crumbs(route, context_crumbs)
+    def initialize(context_crumbs: nil)
+      @links = context_crumbs.nil? ? nil : build_crumbs(context_crumbs)
     end
 
-    def build_crumbs(route, context_crumbs)
+    def build_crumbs(context_crumbs)
       crumbs = []
-      route.path.split('/').each_with_index do |_part, index|
-        crumbs << crumb_for_route(route, index)
+      path = context_crumbs[0][:path].split('/')
+      path.each_with_index do |crumb, index|
+        next if index == 0 || index == path.length - 1 || crumb == '-'
+
+        crumbs << route_to_context_crumbs(path, crumb, index)
       end
       crumbs += context_crumbs if context_crumbs.present? && validate_context_crumbs(context_crumbs)
       crumbs
     end
 
+    # def build_crumbs(route, context_crumbs)
+    #   crumbs = []
+    #   route.path.split('/').each_with_index do |_part, index|
+    #     crumbs << crumb_for_route(route, index)
+    #   end
+    #   crumbs += context_crumbs if context_crumbs.present? && validate_context_crumbs(context_crumbs)
+    #   crumbs
+    # end
+
     private
+
+    def route_to_context_crumbs(path, crumb, index)
+      namespace = Namespace.all.find_by(path: crumb)
+      crumb = namespace.name if namespace
+
+      { name: crumb, path: path[0..index].join('/')[1..-1] }
+    end
 
     def crumb_for_route(route, index)
       {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@
 class ApplicationController < ActionController::Base
   include Irida::Auth
   include Pagy::Backend
+  include RouteHelper
 
   add_flash_types :success, :info, :warning, :danger
   before_action :authenticate_user!

--- a/app/controllers/concerns/breadcrumb_navigation.rb
+++ b/app/controllers/concerns/breadcrumb_navigation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Executes context_crumbs in controllers after page action but before render, allowing crumbs to use updated vars
+module BreadcrumbNavigation
+  extend ActiveSupport::Concern
+
+  private
+
+  def render(*args)
+    context_crumbs
+    super
+  end
+end

--- a/app/controllers/groups/application_controller.rb
+++ b/app/controllers/groups/application_controller.rb
@@ -3,6 +3,13 @@
 module Groups
   # Base Controller for Groups
   class ApplicationController < ApplicationController
+    include BreadcrumbNavigation
     layout 'groups'
+
+    private
+
+    def context_crumbs
+      @context_crumbs = route_to_context_crumbs(@group.route)
+    end
   end
 end

--- a/app/controllers/groups/group_links_controller.rb
+++ b/app/controllers/groups/group_links_controller.rb
@@ -4,6 +4,7 @@ module Groups
   # Controller actions for Group Group Links
   class GroupLinksController < Groups::ApplicationController
     include ShareActions
+    include BreadcrumbNavigation
 
     def group_link_params
       params.require(:namespace_group_link).permit(:group_id, :group_access_level, :expires_at)

--- a/app/controllers/groups/group_links_controller.rb
+++ b/app/controllers/groups/group_links_controller.rb
@@ -26,13 +26,10 @@ module Groups
     end
 
     def context_crumbs
-      case action_name
-      when 'index'
-        @context_crumbs = [{
-          name: I18n.t('groups.members.index.title'),
-          path: group_links_path
-        }]
-      end
+      @context_crumbs = [{
+        name: I18n.t('groups.members.index.title'),
+        path: group_links_path
+      }]
     end
 
     def group_link_namespace

--- a/app/controllers/groups/group_links_controller.rb
+++ b/app/controllers/groups/group_links_controller.rb
@@ -26,10 +26,13 @@ module Groups
     end
 
     def context_crumbs
-      @context_crumbs = [{
-        name: I18n.t('groups.members.index.title'),
-        path: group_links_path
-      }]
+      case action_name
+      when 'index'
+        @context_crumbs = [{
+          name: I18n.t('groups.members.index.title'),
+          path: group_links_path
+        }]
+      end
     end
 
     def group_link_namespace

--- a/app/controllers/groups/group_links_controller.rb
+++ b/app/controllers/groups/group_links_controller.rb
@@ -26,9 +26,10 @@ module Groups
     end
 
     def context_crumbs
+      @context_crumbs = route_to_context_crumbs(@group.route)
       case action_name
       when 'index'
-        @context_crumbs = [{
+        @context_crumbs += [{
           name: I18n.t('groups.members.index.title'),
           path: group_links_path
         }]

--- a/app/controllers/groups/group_links_controller.rb
+++ b/app/controllers/groups/group_links_controller.rb
@@ -4,7 +4,6 @@ module Groups
   # Controller actions for Group Group Links
   class GroupLinksController < Groups::ApplicationController
     include ShareActions
-    include BreadcrumbNavigation
 
     def group_link_params
       params.require(:namespace_group_link).permit(:group_id, :group_access_level, :expires_at)
@@ -27,7 +26,7 @@ module Groups
     end
 
     def context_crumbs
-      @context_crumbs = route_to_context_crumbs(@group.route)
+      super
       case action_name
       when 'index'
         @context_crumbs += [{

--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -26,9 +26,10 @@ module Groups
     end
 
     def context_crumbs
+      @context_crumbs = route_to_context_crumbs(@group.route)
       case action_name
       when 'index', 'new'
-        @context_crumbs = [{
+        @context_crumbs += [{
           name: I18n.t('groups.members.index.title'),
           path: group_members_path
         }]

--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -4,6 +4,7 @@ module Groups
   # Controller actions for Members
   class MembersController < Groups::ApplicationController
     include MembershipActions
+    include BreadcrumbNavigation
 
     def member_params
       params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id)

--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -4,7 +4,6 @@ module Groups
   # Controller actions for Members
   class MembersController < Groups::ApplicationController
     include MembershipActions
-    include BreadcrumbNavigation
 
     def member_params
       params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id)
@@ -27,7 +26,7 @@ module Groups
     end
 
     def context_crumbs
-      @context_crumbs = route_to_context_crumbs(@group.route)
+      super
       case action_name
       when 'index', 'new'
         @context_crumbs += [{

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -4,8 +4,8 @@ module Groups
   # Controller actions for Samples within a Group
   class SamplesController < ApplicationController
     layout 'groups'
-    before_action :context_crumbs, only: %i[index]
     before_action :group, only: %i[index]
+    before_action :context_crumbs, only: %i[index]
 
     def index
       authorize! @group, to: :sample_listing?

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -26,10 +26,14 @@ module Groups
     end
 
     def context_crumbs
-      @context_crumbs = [{
-        name: I18n.t('groups.samples.index.title'),
-        path: group_samples_path
-      }]
+      @context_crumbs = route_to_context_crumbs(@group.route)
+      case action_name
+      when 'index'
+        @context_crumbs += [{
+          name: I18n.t('groups.samples.index.title'),
+          path: group_samples_path
+        }]
+      end
     end
   end
 end

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -3,11 +3,8 @@
 module Groups
   # Controller actions for Samples within a Group
   class SamplesController < ApplicationController
-    include BreadcrumbNavigation
-
     layout 'groups'
     before_action :group, only: %i[index]
-    before_action :context_crumbs, only: %i[index]
 
     def index
       authorize! @group, to: :sample_listing?
@@ -28,7 +25,7 @@ module Groups
     end
 
     def context_crumbs
-      @context_crumbs = route_to_context_crumbs(@group.route)
+      super
       case action_name
       when 'index'
         @context_crumbs += [{

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -3,6 +3,8 @@
 module Groups
   # Controller actions for Samples within a Group
   class SamplesController < ApplicationController
+    include BreadcrumbNavigation
+
     layout 'groups'
     before_action :group, only: %i[index]
     before_action :context_crumbs, only: %i[index]

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -148,7 +148,8 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   end
 
   def context_crumbs
-    @context_crumbs =
+    @context_crumbs = route_to_context_crumbs(@group.route)
+    @context_crumbs +=
       case action_name
       when 'show'
         [{

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -149,19 +149,13 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
 
   def context_crumbs
     @context_crumbs = route_to_context_crumbs(@group.route)
-    @context_crumbs +=
-      case action_name
-      when 'show'
-        [{
-          name: @group.name,
-          path: group_path
-        }]
-      else
-        [{
-          name: I18n.t('groups.edit.title'),
-          path: group_path
-        }]
-      end
+
+    return unless action_name != 'show'
+
+    @context_crumbs += [{
+      name: I18n.t('groups.edit.title'),
+      path: group_path
+    }]
   end
 
   protected

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,6 +2,7 @@
 
 # Controller actions for Groups
 class GroupsController < Groups::ApplicationController # rubocop:disable Metrics/ClassLength
+  include BreadcrumbNavigation
   layout :resolve_layout
   before_action :group, only: %i[edit show destroy update transfer]
   before_action :authorized_namespaces, except: %i[index show destroy]
@@ -31,7 +32,6 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
 
   def new
     @group = Group.find(params[:parent_id]) if params[:parent_id]
-    context_crumbs
     authorize! @group, to: :create_subgroup? if params[:parent_id]
 
     @new_group = Group.new(parent_id: @group&.id)
@@ -51,7 +51,6 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
       redirect_to group_path(@new_group.full_path)
     else
       @group = @new_group.parent
-      context_crumbs
       render_new status: :unprocessable_entity
     end
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,7 +2,6 @@
 
 # Controller actions for Groups
 class GroupsController < Groups::ApplicationController # rubocop:disable Metrics/ClassLength
-  include BreadcrumbNavigation
   layout :resolve_layout
   before_action :group, only: %i[edit show destroy update transfer]
   before_action :authorized_namespaces, except: %i[index show destroy]

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -148,13 +148,13 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   end
 
   def context_crumbs
-    @context_crumbs = route_to_context_crumbs(@group.route)
+    @context_crumbs = @group.nil? ? [] : route_to_context_crumbs(@group.route)
 
     return unless action_name != 'show'
 
     @context_crumbs += [{
       name: I18n.t('groups.edit.title'),
-      path: group_path
+      path: group_canonical_path
     }]
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,7 +5,6 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   layout :resolve_layout
   before_action :group, only: %i[edit show destroy update transfer]
   before_action :authorized_namespaces, except: %i[index show destroy]
-  before_action :context_crumbs, except: %i[index new create]
 
   def index
     redirect_to dashboard_groups_path

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,7 +4,7 @@
 class GroupsController < Groups::ApplicationController # rubocop:disable Metrics/ClassLength
   layout :resolve_layout
   before_action :group, only: %i[edit show destroy update transfer]
-  before_action :context_crumbs, except: %i[index new create show]
+  before_action :context_crumbs, except: %i[index new create]
   before_action :authorized_namespaces, except: %i[index show destroy]
 
   def index
@@ -148,10 +148,19 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   end
 
   def context_crumbs
-    @context_crumbs = [{
-      name: I18n.t('groups.edit.title'),
-      path: group_path
-    }]
+    @context_crumbs =
+      case action_name
+      when 'show'
+        [{
+          name: @group.name,
+          path: group_path
+        }]
+      else
+        [{
+          name: I18n.t('groups.edit.title'),
+          path: group_path
+        }]
+      end
   end
 
   protected

--- a/app/controllers/projects/application_controller.rb
+++ b/app/controllers/projects/application_controller.rb
@@ -3,6 +3,21 @@
 module Projects
   # Base Controller for Projects
   class ApplicationController < ApplicationController
+    include BreadcrumbNavigation
+
+    before_action :project
+
     layout 'projects'
+
+    private
+
+    def project
+      path = [params[:namespace_id], params[:project_id]].join('/')
+      @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
+    end
+
+    def context_crumbs
+      @context_crumbs = route_to_context_crumbs(@project.namespace.route)
+    end
   end
 end

--- a/app/controllers/projects/group_links_controller.rb
+++ b/app/controllers/projects/group_links_controller.rb
@@ -4,6 +4,7 @@ module Projects
   # Controller actions for Project Group Links
   class GroupLinksController < Projects::ApplicationController
     include ShareActions
+    include BreadcrumbNavigation
 
     def group_link_params
       params.require(:namespace_group_link).permit(:id, :group_id, :namespace_id, :group_access_level, :expires_at)

--- a/app/controllers/projects/group_links_controller.rb
+++ b/app/controllers/projects/group_links_controller.rb
@@ -27,9 +27,10 @@ module Projects
     end
 
     def context_crumbs
+      @context_crumbs = route_to_context_crumbs(@project.namespace.route)
       case action_name
       when 'index'
-        @context_crumbs = [{
+        @context_crumbs += [{
           name: I18n.t('projects.members.index.title'),
           path: group_links_path
         }]

--- a/app/controllers/projects/group_links_controller.rb
+++ b/app/controllers/projects/group_links_controller.rb
@@ -4,7 +4,6 @@ module Projects
   # Controller actions for Project Group Links
   class GroupLinksController < Projects::ApplicationController
     include ShareActions
-    include BreadcrumbNavigation
 
     def group_link_params
       params.require(:namespace_group_link).permit(:id, :group_id, :namespace_id, :group_access_level, :expires_at)
@@ -24,11 +23,11 @@ module Projects
     protected
 
     def group_links_path
-      group_group_links_path
+      namespace_project_group_links_path
     end
 
     def context_crumbs
-      @context_crumbs = route_to_context_crumbs(@project.namespace.route)
+      super
       case action_name
       when 'index'
         @context_crumbs += [{
@@ -39,8 +38,6 @@ module Projects
     end
 
     def group_link_namespace
-      path = [params[:namespace_id], params[:project_id]].join('/')
-      @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
       @project.namespace
     end
   end

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -4,6 +4,7 @@ module Projects
   # Controller actions for Members
   class MembersController < Projects::ApplicationController
     include MembershipActions
+    include BreadcrumbNavigation
 
     def member_params
       params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id)

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -26,9 +26,10 @@ module Projects
     end
 
     def context_crumbs
+      @context_crumbs = route_to_context_crumbs(@project.namespace.route)
       case action_name
       when 'index', 'new'
-        @context_crumbs = [{
+        @context_crumbs += [{
           name: I18n.t('projects.members.index.title'),
           path: namespace_project_members_path
         }]

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -4,7 +4,6 @@ module Projects
   # Controller actions for Members
   class MembersController < Projects::ApplicationController
     include MembershipActions
-    include BreadcrumbNavigation
 
     def member_params
       params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id)
@@ -27,7 +26,7 @@ module Projects
     end
 
     def context_crumbs
-      @context_crumbs = route_to_context_crumbs(@project.namespace.route)
+      super
       case action_name
       when 'index', 'new'
         @context_crumbs += [{
@@ -38,8 +37,6 @@ module Projects
     end
 
     def member_namespace
-      path = [params[:namespace_id], params[:project_id]].join('/')
-      @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
       @project.namespace
     end
   end

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -3,7 +3,7 @@
 module Projects
   module Samples
     # Controller actions for Project Samples Attachments
-    class AttachmentsController < ApplicationController
+    class AttachmentsController < Projects::ApplicationController
       before_action :sample
       before_action :attachment, only: %i[destroy download]
 

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -4,7 +4,6 @@ module Projects
   module Samples
     # Controller actions for Project Samples Attachments
     class AttachmentsController < ApplicationController
-      before_action :project
       before_action :sample
       before_action :attachment, only: %i[destroy download]
 
@@ -57,11 +56,6 @@ module Projects
 
       def sample
         @sample = @project.samples.find_by(id: params[:sample_id]) || not_found
-      end
-
-      def project
-        path = [params[:namespace_id], params[:project_id]].join('/')
-        @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
       end
     end
   end

--- a/app/controllers/projects/samples/transfers_controller.rb
+++ b/app/controllers/projects/samples/transfers_controller.rb
@@ -3,7 +3,7 @@
 module Projects
   module Samples
     # Controller actions for Project Samples Transfer
-    class TransfersController < ApplicationController
+    class TransfersController < Projects::ApplicationController
       before_action :projects
 
       def new

--- a/app/controllers/projects/samples/transfers_controller.rb
+++ b/app/controllers/projects/samples/transfers_controller.rb
@@ -4,7 +4,6 @@ module Projects
   module Samples
     # Controller actions for Project Samples Transfer
     class TransfersController < ApplicationController
-      before_action :project
       before_action :projects
 
       def new
@@ -51,11 +50,6 @@ module Projects
 
       def transfer_params
         params.permit(:new_project_id, sample_ids: [])
-      end
-
-      def project
-        path = [params[:namespace_id], params[:project_id]].join('/')
-        @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
       end
 
       def projects

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -3,11 +3,7 @@
 module Projects
   # Controller actions for Samples
   class SamplesController < Projects::ApplicationController
-    include BreadcrumbNavigation
-
     before_action :sample, only: %i[show edit update destroy]
-    before_action :project
-    before_action :context_crumbs
 
     def index
       authorize! @project, to: :sample_listing?
@@ -86,13 +82,8 @@ module Projects
       params.require(:sample).permit(:name, :description)
     end
 
-    def project
-      path = [params[:namespace_id], params[:project_id]].join('/')
-      @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
-    end
-
     def context_crumbs
-      @context_crumbs = route_to_context_crumbs(@project.namespace.route)
+      super
       @context_crumbs += [{
         name: I18n.t('projects.samples.index.title'),
         path: namespace_project_samples_path

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -3,6 +3,8 @@
 module Projects
   # Controller actions for Samples
   class SamplesController < Projects::ApplicationController
+    include BreadcrumbNavigation
+
     before_action :sample, only: %i[show edit update destroy]
     before_action :project
     before_action :context_crumbs

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -90,7 +90,8 @@ module Projects
     end
 
     def context_crumbs
-      @context_crumbs = [{
+      @context_crumbs = route_to_context_crumbs(@project.namespace.route)
+      @context_crumbs += [{
         name: I18n.t('projects.samples.index.title'),
         path: namespace_project_samples_path
       }]

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -140,18 +140,13 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   end
 
   def context_crumbs
-    @context_crumbs = []
+    @context_crumbs = route_to_context_crumbs(@project.namespace.route)
 
     case action_name
     when 'update', 'edit'
-      @context_crumbs = [{
+      @context_crumbs += [{
         name: I18n.t('projects.edit.title'),
         path: namespace_project_edit_path
-      }]
-    when 'show'
-      @context_crumbs = [{
-        name: @project.namespace.name,
-        path: namespace_project_path
       }]
     end
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -140,7 +140,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   end
 
   def context_crumbs
-    @context_crumbs = route_to_context_crumbs(@project.namespace.route)
+    @context_crumbs = @project.nil? ? [] : route_to_context_crumbs(@project.namespace.route)
 
     case action_name
     when 'update', 'edit'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,7 +5,6 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   include BreadcrumbNavigation
   layout :resolve_layout
   before_action :project, only: %i[show edit update activity transfer destroy]
-  before_action :context_crumbs, except: %i[new create update]
   before_action :authorized_namespaces, only: %i[edit new update create transfer]
 
   def index

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,6 +2,7 @@
 
 # Controller actions for Projects
 class ProjectsController < Projects::ApplicationController # rubocop:disable Metrics/ClassLength
+  include BreadcrumbNavigation
   layout :resolve_layout
   before_action :project, only: %i[show edit update activity transfer destroy]
   before_action :context_crumbs, except: %i[new create update]
@@ -56,7 +57,6 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
           render status: :unprocessable_entity
         end
       end
-      context_crumbs
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,7 @@
 class ProjectsController < Projects::ApplicationController # rubocop:disable Metrics/ClassLength
   layout :resolve_layout
   before_action :project, only: %i[show edit update activity transfer destroy]
-  before_action :context_crumbs, except: %i[new create]
+  before_action :context_crumbs, except: %i[new create update]
   before_action :authorized_namespaces, only: %i[edit new update create transfer]
 
   def index
@@ -56,6 +56,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
           render status: :unprocessable_entity
         end
       end
+      context_crumbs
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,7 @@
 class ProjectsController < Projects::ApplicationController # rubocop:disable Metrics/ClassLength
   layout :resolve_layout
   before_action :project, only: %i[show edit update activity transfer destroy]
-  before_action :context_crumbs, except: %i[new create show]
+  before_action :context_crumbs, except: %i[new create]
   before_action :authorized_namespaces, only: %i[edit new update create transfer]
 
   def index
@@ -147,6 +147,11 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
       @context_crumbs = [{
         name: I18n.t('projects.edit.title'),
         path: namespace_project_edit_path
+      }]
+    when 'show'
+      @context_crumbs = [{
+        name: @project.namespace.name,
+        path: namespace_project_path
       }]
     end
   end

--- a/app/helpers/route_helper.rb
+++ b/app/helpers/route_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Route helper that converts Route object into context_crumbs
+module RouteHelper
+  def route_to_context_crumbs(route)
+    crumbs = []
+    return crumbs unless route
+
+    route.path.split('/').each_with_index do |_part, index|
+      crumbs << crumb_for_route(route, index)
+    end
+    crumbs
+  end
+
+  private
+
+  def crumb_for_route(route, index)
+    {
+      name: route.name.split(' / ')[index],
+      path: route.path.split('/')[0..index].join('/')
+    }
+  end
+end

--- a/app/views/groups/update.turbo_stream.erb
+++ b/app/views/groups/update.turbo_stream.erb
@@ -10,10 +10,7 @@
   <% end %>
 
   <%= turbo_stream.update "breadcrumb" do %>
-    <%= render Viral::BreadcrumbComponent.new(
-      route: @group.route,
-      context_crumbs: @context_crumbs
-    ) %>
+    <%= render Viral::BreadcrumbComponent.new(context_crumbs: @context_crumbs) %>
   <% end %>
 <% end %>
 

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -28,7 +28,7 @@
             ) %>
           <% end %>
         <% end %>
-        <%= layout.with_breadcrumb(route: @group.route, context_crumbs: @context_crumbs) %>
+        <%= layout.with_breadcrumb(context_crumbs: @context_crumbs) %>
         <% layout.with_body do %>
           <%= yield %>
         <% end %>

--- a/app/views/layouts/projects.html.erb
+++ b/app/views/layouts/projects.html.erb
@@ -29,7 +29,6 @@
           <% end %>
         <% end %>
         <% layout.with_breadcrumb(
-          route: @project.namespace.route,
           context_crumbs: @context_crumbs
         ) %>
         <% layout.with_body do %>

--- a/app/views/projects/update.turbo_stream.erb
+++ b/app/views/projects/update.turbo_stream.erb
@@ -10,10 +10,7 @@
   <% end %>
 
   <%= turbo_stream.update "breadcrumb" do %>
-    <%= render Viral::BreadcrumbComponent.new(
-      route: @project.namespace.route,
-      context_crumbs: @context_crumbs
-    ) %>
+    <%= render Viral::BreadcrumbComponent.new(context_crumbs: @context_crumbs) %>
   <% end %>
 <% end %>
 

--- a/test/components/previews/viral_breadcrumb_component_preview/default.html.erb
+++ b/test/components/previews/viral_breadcrumb_component_preview/default.html.erb
@@ -1,1 +1,2 @@
-<%= viral_breadcrumb(route: Route.new(name: 'Group / Project', path: 'group/project')) %>
+<%= viral_breadcrumb(context_crumbs: route_to_context_crumbs(Route.new(name: 'Borrelia burgdorferi / Project Name', path: 'group/project'))) %>
+

--- a/test/components/previews/viral_breadcrumb_component_preview/with_crumbs.html.erb
+++ b/test/components/previews/viral_breadcrumb_component_preview/with_crumbs.html.erb
@@ -1,3 +1,3 @@
-<%= viral_breadcrumb(route: Route.new(name: 'Borrelia burgdorferi / Project Name', path: 'group/project'),
-                     context_crumbs: [{ name: 'A new group name',
-                                        path: '/groups' }]) %>
+
+<% context_crumbs_from_route = route_to_context_crumbs(Route.new(name: 'Borrelia burgdorferi / Project Name', path: 'group/project')) %>
+<%= viral_breadcrumb(context_crumbs: context_crumbs_from_route += [{ name: 'A new group name', path: '/groups' }]) %>

--- a/test/components/viral/breadcrumb_component_test.rb
+++ b/test/components/viral/breadcrumb_component_test.rb
@@ -4,14 +4,17 @@ require 'view_component_test_case'
 
 module Viral
   class BreadcrumbComponentTest < ViewComponentTestCase
+    include RouteHelper
     test 'single path' do
       # Mock route
       mock_route = routes(:group_one_route)
 
       # Mock context breadcrumb
-      context_crumbs = [{ name: I18n.t('groups.edit.title', raise: true), path: groups(:group_one).path }]
 
-      render_inline(Viral::BreadcrumbComponent.new(route: mock_route, context_crumbs:))
+      context_crumbs = route_to_context_crumbs(mock_route)
+      context_crumbs += [{ name: I18n.t('groups.edit.title', raise: true), path: groups(:group_one).path }]
+
+      render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
       assert_selector 'a', count: 2
       assert_selector 'svg', count: 1
@@ -22,24 +25,24 @@ module Viral
       mock_route = routes(:group_one_route)
 
       # Mock context breadcrumb
-      context_crumbs = [{ name: I18n.t('projects.edit.title', raise: true),
-                          path: "#{groups(:group_one).path}/-/edit`" }]
+      context_crumbs = route_to_context_crumbs(mock_route)
+      context_crumbs += [{ name: I18n.t('projects.edit.title', raise: true),
+                           path: "#{groups(:group_one).path}/-/edit`" }]
 
-      render_inline(Viral::BreadcrumbComponent.new(route: mock_route, context_crumbs:))
+      render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
       assert_text I18n.t('groups.edit.title', raise: true)
       assert_selector 'a', count: 2
       assert_selector 'svg', count: 1
     end
 
-    test 'without context crumbs' do
+    test 'route with no extra crumbs' do
       # Mock route
       mock_route = routes(:group_one_route)
 
-      # Mock context breadcrumb
-      context_crumbs = nil
+      context_crumbs = route_to_context_crumbs(mock_route)
 
-      render_inline(Viral::BreadcrumbComponent.new(route: mock_route, context_crumbs:))
+      render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
       assert_selector 'a', count: 1
     end
@@ -49,10 +52,11 @@ module Viral
       mock_route = routes(:group_one_route)
 
       # Mock context breadcrumb
-      context_crumbs = [{ name: I18n.t('projects.edit.title', raise: true),
-                          path: "#{groups(:group_one).path}/-/groups/new`" }]
+      context_crumbs = route_to_context_crumbs(mock_route)
+      context_crumbs += [{ name: I18n.t('projects.edit.title', raise: true),
+                           path: "#{groups(:group_one).path}/-/groups/new`" }]
 
-      render_inline(Viral::BreadcrumbComponent.new(route: mock_route, context_crumbs:))
+      render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
       assert_selector 'a', count: 2
       assert_selector 'svg', count: 1

--- a/test/helpers/route_helper_test.rb
+++ b/test/helpers/route_helper_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RouteHelperTest < ActionView::TestCase
+  include RouteHelper
+
+  test 'convert route to context crumbs' do
+    mock_route = routes(:group_one_route)
+
+    context_crumbs = route_to_context_crumbs(mock_route)
+    assert_equal(context_crumbs, [{ name: 'Group 1', path: 'group-1' }])
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
This PR refactors the breadcrumbs component so that the component no longer requires a ```Route``` object passed as an argument, only the ```context_crumbs```. A ```RouteHelper``` is now available to breakdown ```Routes``` into the ```context_crumbs``` format prior to being passed as the argument when initializing a ```Breadcrumb component```. All existing breadcrumbs should still have the same functionality as prior to this PR.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Pull down this branch
2. Clickthrough the groups and projects pages, ensuring breadcrumb names and links are accurate.
3. Compare with breadcrumb names and links on ```main```.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
