### PR TITLE
Dashboard Groups pagination

### DIFF
--- a/app/components/namespace_tree/row/row_contents_component.html.erb
+++ b/app/components/namespace_tree/row/row_contents_component.html.erb
@@ -26,7 +26,7 @@
   <div class="flex flex-col namespace-text">
     <div class="namespace-text grow shrink">
       <div class="flex flex-wrap items-center mr-3 font-semibold title">
-        <%= link_to @namespace.name, group_path(@namespace) %>
+        <%= link_to @namespace.name, group_path(@namespace), data: { turbo: false } %>
       </div>
       <div class="description">
         <p><%= @namespace.description %></p>

--- a/app/controllers/dashboard/groups_controller.rb
+++ b/app/controllers/dashboard/groups_controller.rb
@@ -4,17 +4,42 @@ module Dashboard
   # Dashboard groups controller
   class GroupsController < ApplicationController
     def index
+      @q = Group.ransack(params[:q])
+      set_default_sort
       respond_to do |format|
-        format.html do
-          @groups = authorized_scope(Group, type: :relation).without_descendants.include_route.order(updated_at: :desc)
-        end
+        format.html
         format.turbo_stream do
-          @collapsed = params[:collapse] == 'true'
-          @group = Group.find(params[:parent_id])
-          @depth = params[:depth].to_i
-          @sub_groups = @group.children
+          if toggling_group?
+            toggle_group
+            render :group
+          else
+            @pagy, @groups = pagy(@q.result.where(id: load_groups.select(:id)).include_route)
+          end
         end
       end
+    end
+
+    private
+
+    def set_default_sort
+      @q.sorts = 'created_at desc' if @q.sorts.empty?
+    end
+
+    def toggling_group?
+      params.key? :parent_id
+    end
+
+    def toggle_group
+      @collapsed = params[:collapse] == 'true'
+      @group = Group.find(params[:parent_id])
+      @depth = params[:depth].to_i
+      return if @collapsed
+
+      @sub_groups = @group.children
+    end
+
+    def load_groups
+      @groups = authorized_scope(Group, type: :relation).without_descendants
     end
   end
 end

--- a/app/views/dashboard/groups/group.turbo_stream.erb
+++ b/app/views/dashboard/groups/group.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.replace dom_id(@group) do %>
+  <%= render NamespaceTree::Row::WithChildrenComponent.new(
+    namespace: @group,
+    children: @group.children,
+    collapsed: @collapsed,
+    path: "dashboard_groups_path",
+    type: [Group.sti_name] %>
+  <% end %>

--- a/app/views/dashboard/groups/group.turbo_stream.erb
+++ b/app/views/dashboard/groups/group.turbo_stream.erb
@@ -4,5 +4,6 @@
     children: @group.children,
     collapsed: @collapsed,
     path: "dashboard_groups_path",
-    type: [Group.sti_name] %>
-  <% end %>
+    type: [Group.sti_name]
+  ) %>
+<% end %>

--- a/app/views/dashboard/groups/index.html.erb
+++ b/app/views/dashboard/groups/index.html.erb
@@ -6,6 +6,35 @@
       "inline-flex items-center justify-center button button--state-primary button--size-default" %>
   <% end %>
 <% end %>
-<div class="bg-white dark:bg-gray-800">
-  <%= render NamespaceTreeContainerComponent.new(namespaces: @groups, path: "dashboard_groups_path") %>
+<div class="bg-white dark:bg-slate-800">
+  <div
+    class="
+      flex
+      text-sm
+      font-medium
+      text-center
+      border-b
+      text-slate-500
+      border-slate-200
+      dark:text-slate-400
+      dark:border-slate-700
+    "
+  >
+    <div class="flex flex-row items-center ml-auto space-x-2 font-normal py-1.5">
+      <%= sorting_dropdown(@q) do |dropdown| %>
+        <%= sorting_item(dropdown, @q, :updated_at, :desc) %>
+        <%= sorting_item(dropdown, @q, :created_at, :desc) %>
+        <%= sorting_item(dropdown, @q, :name, :asc) %>
+        <%= sorting_item(dropdown, @q, :name, :desc) %>
+        <%= sorting_item(dropdown, @q, :updated_at, :asc) %>
+        <%= sorting_item(dropdown, @q, :created_at, :asc) %>
+      <% end %>
+    </div>
+  </div>
+  <div class="flex flex-col" data-turbo-temporary>
+    <%= turbo_frame_tag "groups_tree",
+    src: dashboard_groups_url(format: :turbo_stream, **request.query_parameters),
+    loading: :lazy %>
+    <%= turbo_frame_tag "groups_pagination" %>
+  </div>
 </div>

--- a/app/views/dashboard/groups/index.turbo_stream.erb
+++ b/app/views/dashboard/groups/index.turbo_stream.erb
@@ -1,9 +1,28 @@
-<%= turbo_stream.replace dom_id(@group) do %>
-  <%= render NamespaceTree::Row::WithChildrenComponent.new(
-    namespace: @group,
-    children: @group.children,
-    collapsed: @collapsed,
-    path: "dashboard_groups_path",
-    type: [Group.sti_name]
+<%= turbo_stream.update("groups_tree") do %>
+  <%= render NamespaceTreeContainerComponent.new(
+    namespaces: @groups,
+    path: "dashboard_groups_path"
+  ) %>
+<% end %>
+
+<%= turbo_stream.update "groups_pagination" do %>
+  <%= render PaginationComponent.new(
+    info: nil,
+    prev_url:
+      (
+        if @pagy.prev
+          pagy_url_for(@pagy, @pagy.prev).gsub("groups.turbo_stream", "groups")
+        else
+          nil
+        end
+      ),
+    next_url:
+      (
+        if @pagy.next
+          pagy_url_for(@pagy, @pagy.next).gsub("groups.turbo_stream", "groups")
+        else
+          nil
+        end
+      )
   ) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,6 +314,14 @@ en:
         create_group_button: New group
         more_items: "%{count} more items"
         row_aria_label: "See %{name} subgroups"
+        subgroups: Subgroups
+        sorting:
+          updated_at_desc: Updated At
+          created_at_desc: Last created
+          name_asc: Name
+          name_desc: Name, descending
+          updated_at_asc: Oldest updated
+          created_at_asc: Oldest created
   profiles:
     sidebar:
       header: User Settings

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -13,7 +13,6 @@ subgroup1:
   type: Group
   description: Subgroup 1 description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
 <% (Namespace::MAX_ANCESTORS-1).times do |n| %>
 subgroup<%= (n+2) %>:
@@ -22,7 +21,6 @@ subgroup<%= (n+2) %>:
   type: Group
   description: <%= "Subgroup #{n+2} description" %>
   parent_id: <%= ActiveRecord::FixtureSet.identify("subgroup#{n+1}") %>
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 <% end %>
 
 group_two:
@@ -30,21 +28,18 @@ group_two:
   path: group-2
   type: Group
   description: Group 2 description
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
 group_three:
   name: Group 3
   path: group-3
   type: Group
   description: Group 3 description
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
 subgroup_one_group_three:
   name: Subgroup 1 Group 3
   path: subgroup-1-group-3
   type: Group
   description: Subgroup 1 Group 3
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_three) %>
 
 david_doe_group_four:
@@ -52,21 +47,18 @@ david_doe_group_four:
   path: group-4
   type: Group
   description: David's first group
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:david_doe) %>
 
 group_five:
   name: Group 5
   path: group-5
   type: Group
   description: Group 5 description
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
 subgroup_one_group_five:
   name: Subgroup 1 Group 5
   path: subgroup-1-group-5
   type: Group
   description: Subgroup 1 Group 5
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
 
 group_six:
@@ -74,7 +66,6 @@ group_six:
   path: group-6
   type: Group
   description: Group 6 description
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
 subgroup_one_group_six:
   name: Group 6
@@ -82,11 +73,17 @@ subgroup_one_group_six:
   type: Group
   description: Subgroup 1 description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_six) %>
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
 
 group_seven:
   name: Group 7
   path: group-7
   type: Group
   description: Group 7 description
-  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+
+<% [*("a".."z")].each do |letter| %>
+group_<%= letter %>:
+  name: <%= "Group #{letter.capitalize}" %>
+  path: <%= "group-#{letter}" %>
+  type: Group
+  description: <%= "Group #{letter} description" %>
+<% end %>

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -256,3 +256,11 @@ project_twenty_six_group_member25:
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project26_namespace) %>
   access_level: <%= Member::AccessLevel::OWNER %>
+
+<% [*("a".."z")].each do |letter| %>
+group_<%= letter %>_member_alpha_bet:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:alph_abet) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:alph_abet) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify("group_#{letter}".to_sym) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+<% end %>

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -146,3 +146,10 @@ project26_namespace_route:
   name: john.doe@localhost / Project 26
   path: john.doe_at_localhost/project-26
   source: project26_namespace (Namespace)
+
+<% [*("a".."z")].each do |letter| %>
+group_<%= letter %>_route:
+  name: <%= "Group #{letter.capitalize}" %>
+  path: <%= "group-#{letter}" %>
+  source: group<%= "_#{letter}" %> (Namespace)
+<% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -61,6 +61,12 @@ jeff_doe:
   provider: developer
   uid: jeff.doe@localhost
 
+alph_abet:
+  email: alph.abet@localhost
+  encrypted_password: <%= User.new.send :password_digest, "password1" %>
+  first_name: Alph
+  last_name: Abet
+
 <% 25.times do |n| %>
 user<%= (n) %>:
   email: <%= "user#{n}@localhost" %>

--- a/test/system/dashboard/groups_test.rb
+++ b/test/system/dashboard/groups_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 module Dashboard
   class GroupsTest < ApplicationSystemTestCase
     def setup
-      login_as users(:john_doe)
+      login_as users(:alph_abet)
     end
 
     test 'can see the list of groups' do
@@ -14,29 +14,41 @@ module Dashboard
       assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
 
       within 'ul.groups-list.namespace-list-tree' do
+        assert_selector 'li', count: 20
+        [*('z'..'g')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
+      end
+
+      click_on I18n.t(:'components.pagination.next')
+      assert_text I18n.t(:'components.pagination.previous')
+      within 'ul.groups-list.namespace-list-tree' do
         assert_selector 'li', count: 6
-        assert_text groups(:group_one).name
-        assert_text groups(:group_two).name
-        assert_text groups(:group_three).name
-        assert_text groups(:group_five).name
-        assert_text groups(:group_six).name
-        assert_text groups(:group_seven).name
+        [*('f'..'a')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
+      end
+
+      click_on I18n.t(:'components.pagination.previous')
+      assert_text I18n.t(:'components.pagination.next')
+      within 'ul.groups-list.namespace-list-tree' do
+        assert_selector 'li', count: 20
+        [*('z'..'g')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
       end
     end
 
-    test 'can sort the list of groups' do
+    test 'can sort the list of groups by name descending' do
       visit dashboard_groups_url
 
       assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
 
       within 'ul.groups-list.namespace-list-tree' do
-        assert_selector 'li', count: 6
-        assert_text groups(:group_one).name
-        assert_text groups(:group_two).name
-        assert_text groups(:group_three).name
-        assert_text groups(:group_five).name
-        assert_text groups(:group_six).name
-        assert_text groups(:group_seven).name
+        assert_selector 'li', count: 20
+        [*('z'..'g')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
       end
 
       click_on I18n.t(:'dashboard.projects.index.sorting.created_at_desc')
@@ -46,12 +58,109 @@ module Dashboard
 
       within 'ul.groups-list.namespace-list-tree' do
         within first('li') do
-          assert_text groups(:group_seven).name
+          assert_text groups(:group_z).name
+        end
+      end
+    end
+
+    test 'can sort the list of groups by name ascending' do
+      visit dashboard_groups_url
+
+      assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        assert_selector 'li', count: 20
+        [*('z'..'g')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
+      end
+
+      click_on I18n.t(:'dashboard.projects.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.projects.index.sorting.namespace_name_asc')
+      sleep 1
+      assert_text I18n.t(:'dashboard.projects.index.sorting.namespace_name_asc')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        within first('li') do
+          assert_text groups(:group_a).name
+        end
+      end
+    end
+
+    test 'can sort the list of groups by updated at desc' do
+      visit dashboard_groups_url
+
+      assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        assert_selector 'li', count: 20
+        [*('z'..'g')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
+      end
+
+      click_on I18n.t(:'dashboard.projects.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.projects.index.sorting.updated_at_desc')
+      sleep 1
+      assert_text I18n.t(:'dashboard.projects.index.sorting.updated_at_desc')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        within first('li') do
+          assert_text groups(:group_a).name
+        end
+      end
+    end
+
+    test 'can sort the list of groups by updated at asc' do
+      visit dashboard_groups_url
+
+      assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        assert_selector 'li', count: 20
+        [*('z'..'g')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
+      end
+
+      click_on I18n.t(:'dashboard.projects.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.projects.index.sorting.updated_at_asc')
+      sleep 1
+      assert_text I18n.t(:'dashboard.projects.index.sorting.updated_at_asc')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        within first('li') do
+          assert_text groups(:group_a).name
+        end
+      end
+    end
+
+    test 'can sort the list of groups by created_at asc' do
+      visit dashboard_groups_url
+
+      assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        assert_selector 'li', count: 20
+        [*('z'..'g')].each do |letter|
+          assert_text groups("group_#{letter}".to_sym).name
+        end
+      end
+
+      click_on I18n.t(:'dashboard.projects.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.projects.index.sorting.created_at_asc')
+      sleep 1
+      assert_text I18n.t(:'dashboard.projects.index.sorting.created_at_asc')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        within first('li') do
+          assert_text groups(:group_a).name
         end
       end
     end
 
     test 'can expand parent groups to see their children' do
+      login_as users(:john_doe)
       visit dashboard_groups_url
 
       within 'ul.groups-list.namespace-list-tree' do

--- a/test/system/dashboard/groups_test.rb
+++ b/test/system/dashboard/groups_test.rb
@@ -20,6 +20,34 @@ module Dashboard
         assert_text groups(:group_three).name
         assert_text groups(:group_five).name
         assert_text groups(:group_six).name
+        assert_text groups(:group_seven).name
+      end
+    end
+
+    test 'can sort the list of groups' do
+      visit dashboard_groups_url
+
+      assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        assert_selector 'li', count: 6
+        assert_text groups(:group_one).name
+        assert_text groups(:group_two).name
+        assert_text groups(:group_three).name
+        assert_text groups(:group_five).name
+        assert_text groups(:group_six).name
+        assert_text groups(:group_seven).name
+      end
+
+      click_on I18n.t(:'dashboard.projects.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.projects.index.sorting.namespace_name_desc')
+      sleep 1
+      assert_text I18n.t(:'dashboard.projects.index.sorting.namespace_name_desc')
+
+      within 'ul.groups-list.namespace-list-tree' do
+        within first('li') do
+          assert_text groups(:group_seven).name
+        end
       end
     end
 
@@ -27,7 +55,7 @@ module Dashboard
       visit dashboard_groups_url
 
       within 'ul.groups-list.namespace-list-tree' do
-        within first('li') do
+        within :xpath, "li[contains(@class, 'namespace-entry')][.//*/a[text()='#{groups(:group_one).name}']]" do
           assert_text groups(:group_one).name
           assert_no_selector 'ul.groups-list.namespace-list-tree'
           find('a.folder-toggle-wrap').click


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
This PR updates the Groups Dashboard to use pagination and also adds in sorting.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/492127/6271d234-967d-4b2e-9543-556d3a09123f)

![image](https://github.com/phac-nml/irida-next/assets/492127/e88a8085-1137-4e93-801d-9ba9f29f3b40)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. As a User create at least 21 groups (our default pagination is set to 20)
2. Navigate to Groups Dashboard
3. Observer that pagination buttons appear
4. Test out sorting and see that table is updated

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
