### PR TITLE
Add assembly type to attachment metadata for fasta files

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -26,6 +26,10 @@ class Attachment < ApplicationRecord
     metadata['format'] == 'fastq'
   end
 
+  def fasta?
+    metadata[:format] == 'fasta'
+  end
+
   def associated_attachment
     attachable.attachments.find_by(id: metadata['associated_attachment_id'])
   end
@@ -37,6 +41,7 @@ class Attachment < ApplicationRecord
     # Assigns fasta to metadata format for following file types: .fasta, .fasta.gz, .fna, .fna.gz, .fa, .fa.gz
     when /^\S+\.fn?a(sta)?(\.gz)?$/
       metadata[:format] = 'fasta'
+      metadata[:type] = 'assembly'
     # Assigns fastq to metadata format for following file types: .fastq, .fastq.gz, .fq, .fq.gz
     when /^\S+\.f(ast)?q(\.gz)?$/
       metadata[:format] = 'fastq'

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -27,7 +27,7 @@ class Attachment < ApplicationRecord
   end
 
   def fasta?
-    metadata[:format] == 'fasta'
+    metadata['format'] == 'fasta'
   end
 
   def associated_attachment
@@ -41,14 +41,14 @@ class Attachment < ApplicationRecord
     # Assigns fasta to metadata format and assembly to type for following file types:
     # .fasta, .fasta.gz, .fna, .fna.gz, .fa, .fa.gz
     when /^\S+\.fn?a(sta)?(\.gz)?$/
-      metadata[:format] = 'fasta'
-      metadata[:type] = 'assembly'
+      metadata['format'] = 'fasta'
+      metadata['type'] = 'assembly'
     # Assigns fastq to metadata format for following file types: .fastq, .fastq.gz, .fq, .fq.gz
     when /^\S+\.f(ast)?q(\.gz)?$/
-      metadata[:format] = 'fastq'
+      metadata['format'] = 'fastq'
     # Else assigns unknown to metadata format
     else
-      metadata[:format] = 'unknown'
+      metadata['format'] = 'unknown'
     end
   end
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -38,7 +38,8 @@ class Attachment < ApplicationRecord
 
   def assign_metadata
     case filename.to_s
-    # Assigns fasta to metadata format for following file types: .fasta, .fasta.gz, .fna, .fna.gz, .fa, .fa.gz
+    # Assigns fasta to metadata format and assembly to type for following file types:
+    # .fasta, .fasta.gz, .fna, .fna.gz, .fa, .fa.gz
     when /^\S+\.fn?a(sta)?(\.gz)?$/
       metadata[:format] = 'fasta'
       metadata[:type] = 'assembly'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -556,20 +556,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_26_133927) do
   SQL
 
 
-  create_trigger :logidze_on_members, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_members BEFORE INSERT OR UPDATE ON public.members FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_users, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_namespaces, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_namespaces BEFORE INSERT OR UPDATE ON public.namespaces FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
-  create_trigger :logidze_on_personal_access_tokens, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_members, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_members BEFORE INSERT OR UPDATE ON public.members FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_samples, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_samples BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
-  create_trigger :logidze_on_users, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_personal_access_tokens, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_namespace_group_links, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_namespace_group_links BEFORE INSERT OR UPDATE ON public.namespace_group_links FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -59,6 +59,7 @@ class AttachmentTest < ActiveSupport::TestCase
     new_fasta_attachment_ext_fasta.save
     assert_equal new_fasta_attachment_ext_fasta.metadata['format'], 'fasta'
     assert_equal new_fasta_attachment_ext_fasta.metadata['type'], 'assembly'
+    assert_equal new_fasta_attachment_ext_fasta.fasta?, true
 
     new_fasta_attachment_ext_fasta_gz = @sample.attachments.build
     new_fasta_attachment_ext_fasta_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_6.fasta.gz').open,
@@ -66,6 +67,7 @@ class AttachmentTest < ActiveSupport::TestCase
     new_fasta_attachment_ext_fasta_gz.save
     assert_equal new_fasta_attachment_ext_fasta_gz.metadata['format'], 'fasta'
     assert_equal new_fasta_attachment_ext_fasta_gz.metadata['type'], 'assembly'
+    assert_equal new_fasta_attachment_ext_fasta_gz.fasta?, true
 
     new_fasta_attachment_ext_fa = @sample.attachments.build
     new_fasta_attachment_ext_fa.file.attach(io: Rails.root.join('test/fixtures/files/test_file_7.fa').open,
@@ -73,6 +75,7 @@ class AttachmentTest < ActiveSupport::TestCase
     new_fasta_attachment_ext_fa.save
     assert_equal new_fasta_attachment_ext_fa.metadata['format'], 'fasta'
     assert_equal new_fasta_attachment_ext_fa.metadata['type'], 'assembly'
+    assert_equal new_fasta_attachment_ext_fa.fasta?, true
 
     new_fasta_attachment_ext_fa_gz = @sample.attachments.build
     new_fasta_attachment_ext_fa_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_8.fa.gz').open,
@@ -80,6 +83,7 @@ class AttachmentTest < ActiveSupport::TestCase
     new_fasta_attachment_ext_fa_gz.save
     assert_equal new_fasta_attachment_ext_fa_gz.metadata['format'], 'fasta'
     assert_equal new_fasta_attachment_ext_fa_gz.metadata['type'], 'assembly'
+    assert_equal new_fasta_attachment_ext_fa_gz.fasta?, true
 
     new_fasta_attachment_ext_fna = @sample.attachments.build
     new_fasta_attachment_ext_fna.file.attach(io: Rails.root.join('test/fixtures/files/test_file_9.fna').open,
@@ -87,6 +91,7 @@ class AttachmentTest < ActiveSupport::TestCase
     new_fasta_attachment_ext_fna.save
     assert_equal new_fasta_attachment_ext_fna.metadata['format'], 'fasta'
     assert_equal new_fasta_attachment_ext_fna.metadata['type'], 'assembly'
+    assert_equal new_fasta_attachment_ext_fna.fasta?, true
 
     new_fasta_attachment_ext_fna_gz = @sample.attachments.build
     new_fasta_attachment_ext_fna_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_10.fna.gz').open,
@@ -94,6 +99,7 @@ class AttachmentTest < ActiveSupport::TestCase
     new_fasta_attachment_ext_fna_gz.save
     assert_equal new_fasta_attachment_ext_fna_gz.metadata['format'], 'fasta'
     assert_equal new_fasta_attachment_ext_fna_gz.metadata['type'], 'assembly'
+    assert_equal new_fasta_attachment_ext_fna_gz.fasta?, true
   end
 
   test 'metadata unknown file types' do

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -26,7 +26,7 @@ class AttachmentTest < ActiveSupport::TestCase
     assert new_attachment.errors.added?(:file, :checksum_uniqueness)
   end
 
-  test 'metadata format fastq file types' do
+  test 'metadata fastq file types' do
     new_fastq_attachment_ext_fastq = @sample.attachments.build
     new_fastq_attachment_ext_fastq.file.attach(io: Rails.root.join('test/fixtures/files/test_file_1.fastq').open,
                                                filename: 'test_file_1.fastq')
@@ -52,45 +52,51 @@ class AttachmentTest < ActiveSupport::TestCase
     assert_equal new_fastq_attachment_ext_fq_gz.metadata['format'], 'fastq'
   end
 
-  test 'metadata format fasta file types' do
+  test 'metadata fasta file types' do
     new_fasta_attachment_ext_fasta = @sample.attachments.build
     new_fasta_attachment_ext_fasta.file.attach(io: Rails.root.join('test/fixtures/files/test_file_5.fasta').open,
                                                filename: 'test_file_5.fasta')
     new_fasta_attachment_ext_fasta.save
     assert_equal new_fasta_attachment_ext_fasta.metadata['format'], 'fasta'
+    assert_equal new_fasta_attachment_ext_fasta.metadata['type'], 'assembly'
 
     new_fasta_attachment_ext_fasta_gz = @sample.attachments.build
     new_fasta_attachment_ext_fasta_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_6.fasta.gz').open,
                                                   filename: 'test_file_6.fasta.gz')
     new_fasta_attachment_ext_fasta_gz.save
     assert_equal new_fasta_attachment_ext_fasta_gz.metadata['format'], 'fasta'
+    assert_equal new_fasta_attachment_ext_fasta_gz.metadata['type'], 'assembly'
 
     new_fasta_attachment_ext_fa = @sample.attachments.build
     new_fasta_attachment_ext_fa.file.attach(io: Rails.root.join('test/fixtures/files/test_file_7.fa').open,
                                             filename: 'test_file_7.fa')
     new_fasta_attachment_ext_fa.save
     assert_equal new_fasta_attachment_ext_fa.metadata['format'], 'fasta'
+    assert_equal new_fasta_attachment_ext_fa.metadata['type'], 'assembly'
 
     new_fasta_attachment_ext_fa_gz = @sample.attachments.build
     new_fasta_attachment_ext_fa_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_8.fa.gz').open,
                                                filename: 'test_file_8.fa.gz')
     new_fasta_attachment_ext_fa_gz.save
     assert_equal new_fasta_attachment_ext_fa_gz.metadata['format'], 'fasta'
+    assert_equal new_fasta_attachment_ext_fa_gz.metadata['type'], 'assembly'
 
     new_fasta_attachment_ext_fna = @sample.attachments.build
     new_fasta_attachment_ext_fna.file.attach(io: Rails.root.join('test/fixtures/files/test_file_9.fna').open,
                                              filename: 'test_file_9.fna')
     new_fasta_attachment_ext_fna.save
     assert_equal new_fasta_attachment_ext_fna.metadata['format'], 'fasta'
+    assert_equal new_fasta_attachment_ext_fna.metadata['type'], 'assembly'
 
     new_fasta_attachment_ext_fna_gz = @sample.attachments.build
     new_fasta_attachment_ext_fna_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_10.fna.gz').open,
                                                 filename: 'test_file_10.fna.gz')
     new_fasta_attachment_ext_fna_gz.save
     assert_equal new_fasta_attachment_ext_fna_gz.metadata['format'], 'fasta'
+    assert_equal new_fasta_attachment_ext_fna_gz.metadata['type'], 'assembly'
   end
 
-  test 'metadata format unknown file types' do
+  test 'metadata unknown file types' do
     new_unknown_attachment_ext_docx = @sample.attachments.build
     new_unknown_attachment_ext_docx.file.attach(io: Rails.root.join('test/fixtures/files/test_file_11.docx').open,
                                                 filename: 'test_file_11.docx')


### PR DESCRIPTION
## What does this PR do and why?
This PR adds the ```type: assembly``` to an ```Attachment```'s metadata for ```fasta``` files. In addition, ```Attachments``` now has a ```fasta?``` method that will return ```true``` if the ```Attachment``` ```metadata``` ```format``` is ```fasta```.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
Add attachments with a ```fasta``` format to samples, and check that the new database entries contain both ```type: assembly``` and ```format: fasta``` under metadata.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
