### PR TITLE
Remove not_expired scope from for_namespace_and_ancestors scope

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -117,7 +117,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     def access_level_in_namespace_group_links(user, namespace)
       namespace_group_links = NamespaceGroupLink.for_namespace_and_ancestors(namespace)
-                                                .where(group: user.groups.self_and_descendants)
+                                                .where(group: user.groups.self_and_descendants).not_expired
 
       if namespace_group_links.count.positive?
         maxlevel_namespace_group_link = namespace_group_links.order(:group_access_level).last

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -23,7 +23,6 @@ class NamespaceGroupLink < ApplicationRecord
   scope :not_expired, -> { where('expires_at IS NULL OR expires_at > ?', Time.zone.now) }
   scope :for_namespace_and_ancestors, lambda { |namespace = nil|
                                         where(namespace:).or(where(namespace: namespace.parent&.self_and_ancestors))
-                                                         .not_expired
                                       }
 
   private

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -129,8 +129,19 @@ class GroupMemberTest < ActiveSupport::TestCase
   end
 
   test '#scope for_namespace_and_ancestors returns the correct collection' do
-    group = groups(:subgroup1)
-    members = Member.for_namespace_and_ancestors(group)
-    assert members.include?(@group_member)
+    namespace = groups(:subgroup1)
+    members = Member.for_namespace_and_ancestors(namespace)
+
+    group_and_ancestors = namespace.self_and_ancestors
+    memberships = []
+
+    group_and_ancestors.each do |group|
+      memberships << group.group_members
+    end
+
+    memberships = memberships.flatten
+
+    assert memberships.count == members.count
+    assert_same_unique_elements(members, memberships)
   end
 end

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -127,4 +127,10 @@ class GroupMemberTest < ActiveSupport::TestCase
       Member.restore(@group_member.id, recursive: true)
     end
   end
+
+  test '#scope for_namespace_and_ancestors returns the correct collection' do
+    group = groups(:subgroup1)
+    members = Member.for_namespace_and_ancestors(group)
+    assert members.include?(@group_member)
+  end
 end

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -129,8 +129,19 @@ class ProjectMemberTest < ActiveSupport::TestCase
 
   test '#scope for_namespace_and_ancestors returns the correct collection' do
     project = projects(:project1)
-    @project_parent_member = members(:group_one_member_james_doe)
+
     members = Member.for_namespace_and_ancestors(project)
-    assert members.include?(@project_parent_member)
+
+    group_and_ancestors = project.namespace.parent&.self_and_ancestors
+    memberships = []
+
+    group_and_ancestors.each do |group|
+      memberships << group.group_members
+    end
+
+    memberships = memberships.flatten
+
+    assert memberships.count == members.count
+    assert_same_unique_elements(members, memberships)
   end
 end

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -126,4 +126,11 @@ class ProjectMemberTest < ActiveSupport::TestCase
       Member.restore(@project_member.id, recursive: true)
     end
   end
+
+  test '#scope for_namespace_and_ancestors returns the correct collection' do
+    project = projects(:project1)
+    @project_parent_member = members(:group_one_member_james_doe)
+    members = Member.for_namespace_and_ancestors(project)
+    assert members.include?(@project_parent_member)
+  end
 end

--- a/test/models/namespace_group_link_test.rb
+++ b/test/models/namespace_group_link_test.rb
@@ -69,13 +69,20 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
   test '#scope for_namespace_and_ancestors returns the correct collection' do
     group_group_link = namespace_group_links(:namespace_group_link2)
 
-    group = group_group_link.namespace
+    namespace = group_group_link.namespace
 
-    shared_with_group_links = group.shared_with_group_links
-    namespace_group_links = NamespaceGroupLink.for_namespace_and_ancestors(group)
+    namespace_group_links = NamespaceGroupLink.for_namespace_and_ancestors(namespace)
 
-    shared_with_group_links.each do |shared_with_group_link|
-      assert namespace_group_links.include?(shared_with_group_link)
+    group_and_ancestors = namespace.self_and_ancestors
+    shared_with_group_links = []
+
+    group_and_ancestors.each do |group|
+      shared_with_group_links << group.shared_with_group_links
     end
+
+    shared_with_group_links = shared_with_group_links.flatten
+
+    assert shared_with_group_links.count == namespace_group_links.count
+    assert_same_unique_elements(namespace_group_links, shared_with_group_links)
   end
 end

--- a/test/models/namespace_group_link_test.rb
+++ b/test/models/namespace_group_link_test.rb
@@ -65,4 +65,17 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
       I18n.t('activerecord.errors.models.namespace_group_link.attributes.namespace_type.inclusion')
     )
   end
+
+  test '#scope for_namespace_and_ancestors returns the correct collection' do
+    group_group_link = namespace_group_links(:namespace_group_link2)
+
+    group = group_group_link.namespace
+
+    shared_with_group_links = group.shared_with_group_links
+    namespace_group_links = NamespaceGroupLink.for_namespace_and_ancestors(group)
+
+    shared_with_group_links.each do |shared_with_group_link|
+      assert namespace_group_links.include?(shared_with_group_link)
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 require 'action_policy/test_helper'
+require 'test_helpers/array_helpers'
 
 module ActiveSupport
   class TestCase
@@ -38,5 +39,6 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
     include Devise::Test::IntegrationHelpers
     include ActionPolicy::TestHelper
+    include ArrayHelpers
   end
 end

--- a/test/test_helpers/array_helpers.rb
+++ b/test/test_helpers/array_helpers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ArrayHelpers
+  def assert_same_unique_elements(array1 = [], array2 = [])
+    (array1 & array2) == array1
+  end
+end

--- a/test/test_helpers/array_helpers.rb
+++ b/test/test_helpers/array_helpers.rb
@@ -2,6 +2,6 @@
 
 module ArrayHelpers
   def assert_same_unique_elements(array1 = [], array2 = [])
-    (array1 & array2) == array1
+    assert (array1 & array2) == array1
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR removes `not_expired scope` from `for_namespace_and_ancestors` scope and instead applies it to the collection of for_namespace_and_ancestors when getting the user's access level through group links. The reasoning for this is we will need the scope to be able to display the expired and non expired group links on the Members -> Groups tab

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Login as a `user1@email.com`
2. Create 2 groups `Group A` and `Group B`
3. Create a namespace group link between 2 groups `Group A` and `Group B` where `Group B` is invited to `Group A`
4. Update the group link to a date in the past
5. Add `user2@email.com` to `Group B`
6. Login as `user2@email.com`
7. Visit the URL for `Group A` and you should get an Access Denied page as the group link has expired

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
