### PR TITLE
Fix for memberships on project transfer

### DIFF
--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -39,8 +39,9 @@ module Projects
         raise TransferError, I18n.t('services.projects.transfer.namespace_project_exists')
       end
 
-      project_ancestor_member_user_ids = Member.for_namespace_and_ancestors(project).map(&:user_id)
-      new_namespace_member_ids = Member.for_namespace_and_ancestors(@new_namespace).where(user_id: project_ancestor_member_user_ids).map(&:id) # rubocop:disable Layout/LineLength
+      project_ancestor_member_user_ids = Member.for_namespace_and_ancestors(project).select(:user_id)
+      new_namespace_member_ids = Member.for_namespace_and_ancestors(@new_namespace)
+                                       .where(user_id: project_ancestor_member_user_ids).select(&:id)
 
       project.namespace.update(parent_id: @new_namespace.id)
 

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -39,7 +39,12 @@ module Projects
         raise TransferError, I18n.t('services.projects.transfer.namespace_project_exists')
       end
 
+      project_ancestor_member_user_ids = Member.for_namespace_and_ancestors(project).map(&:user_id)
+      new_namespace_member_ids = Member.for_namespace_and_ancestors(@new_namespace).where(user_id: project_ancestor_member_user_ids).map(&:id) # rubocop:disable Layout/LineLength
+
       project.namespace.update(parent_id: @new_namespace.id)
+
+      UpdateMembershipsJob.perform_later(new_namespace_member_ids)
     end
   end
 end

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -39,7 +39,7 @@ module Projects
         raise TransferError, I18n.t('services.projects.transfer.namespace_project_exists')
       end
 
-      project_ancestor_member_user_ids = Member.for_namespace_and_ancestors(project).select(:user_id)
+      project_ancestor_member_user_ids = Member.for_namespace_and_ancestors(project.namespace).select(:user_id)
       new_namespace_member_ids = Member.for_namespace_and_ancestors(@new_namespace)
                                        .where(user_id: project_ancestor_member_user_ids).select(&:id)
 

--- a/test/jobs/update_memberships_job_test.rb
+++ b/test/jobs/update_memberships_job_test.rb
@@ -53,8 +53,25 @@ class UpdateMembershipsJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'project access level higher' do
+    @project_member.access_level = Member::AccessLevel::MAINTAINER
+    @project_member.save
+
+    assert_equal Member::AccessLevel::GUEST, @group_member.access_level
+    assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.access_level
+    assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.access_level
+
+    UpdateMembershipsJob.perform_now([@project_member.id])
+
+    assert_equal Member::AccessLevel::GUEST, @group_member.reload.access_level
+    assert_equal Member::AccessLevel::MAINTAINER, @project_member.reload.access_level
+    assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.reload.access_level
+    assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.reload.access_level
+  end
+
   test 'empty memberships' do
     assert_equal Member::AccessLevel::GUEST, @group_member.access_level
+    assert_equal Member::AccessLevel::GUEST, @project_member.access_level
     assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.access_level
     assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.access_level
 
@@ -68,6 +85,7 @@ class UpdateMembershipsJobTest < ActiveJob::TestCase
 
   test 'memberships do not exist' do
     assert_equal Member::AccessLevel::GUEST, @group_member.access_level
+    assert_equal Member::AccessLevel::GUEST, @project_member.access_level
     assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.access_level
     assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.access_level
 

--- a/test/jobs/update_memberships_job_test.rb
+++ b/test/jobs/update_memberships_job_test.rb
@@ -8,6 +8,7 @@ class UpdateMembershipsJobTest < ActiveJob::TestCase
     @group_member = members(:group_one_member_ryan_doe)
     @first_subgroup_member = members(:subgroup1_member_ryan_doe)
     @second_subgroup_member = members(:subgroup2_member_ryan_doe)
+    @project_member = members(:project_one_member_ryan_doe)
   end
 
   test 'parent group access level higher' do
@@ -60,6 +61,7 @@ class UpdateMembershipsJobTest < ActiveJob::TestCase
     UpdateMembershipsJob.perform_now([])
 
     assert_equal Member::AccessLevel::GUEST, @group_member.reload.access_level
+    assert_equal Member::AccessLevel::GUEST, @project_member.reload.access_level
     assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.reload.access_level
     assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.reload.access_level
   end
@@ -72,6 +74,7 @@ class UpdateMembershipsJobTest < ActiveJob::TestCase
     UpdateMembershipsJob.perform_now([0])
 
     assert_equal Member::AccessLevel::GUEST, @group_member.reload.access_level
+    assert_equal Member::AccessLevel::GUEST, @project_member.reload.access_level
     assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.reload.access_level
     assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.reload.access_level
   end

--- a/test/jobs/update_memberships_job_test.rb
+++ b/test/jobs/update_memberships_job_test.rb
@@ -60,18 +60,20 @@ class UpdateMembershipsJobTest < ActiveJob::TestCase
   end
 
   test 'project access level higher' do
-    assert_equal Member::AccessLevel::GUEST, @group_member.access_level
-    assert_equal Member::AccessLevel::GUEST, @project_member.access_level
-    assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.access_level
-    assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.access_level
+    perform_enqueued_jobs do
+      assert_equal Member::AccessLevel::GUEST, @group_member.access_level
+      assert_equal Member::AccessLevel::GUEST, @project_member.access_level
+      assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.access_level
+      assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.access_level
 
-    valid_params = { user: @project_member.user, access_level: Member::AccessLevel::MAINTAINER }
-    Members::UpdateService.new(@project_member, @group_member.namespace, @user, valid_params).execute
+      valid_params = { user: @project_member.user, access_level: Member::AccessLevel::MAINTAINER }
+      Members::UpdateService.new(@project_member, @group_member.namespace, @user, valid_params).execute
 
-    assert_equal Member::AccessLevel::GUEST, @group_member.reload.access_level
-    assert_equal Member::AccessLevel::MAINTAINER, @project_member.reload.access_level
-    assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.reload.access_level
-    assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.reload.access_level
+      assert_equal Member::AccessLevel::GUEST, @group_member.reload.access_level
+      assert_equal Member::AccessLevel::MAINTAINER, @project_member.reload.access_level
+      assert_equal Member::AccessLevel::GUEST, @first_subgroup_member.reload.access_level
+      assert_equal Member::AccessLevel::GUEST, @second_subgroup_member.reload.access_level
+    end
   end
 
   test 'empty memberships' do

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -80,7 +80,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
   test 'scope' do
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    # John Doe has access to 19 groups
+    # John Doe has access to 23 groups
     assert_equal scoped_groups.count, 23
 
     user = users(:david_doe)

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -14,7 +14,6 @@ module Groups
 
     test 'transfer group with permission' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
-
       assert_changes -> { @group.parent }, to: new_namespace do
         Groups::TransferService.new(@group, @john_doe).execute(new_namespace)
       end
@@ -41,11 +40,9 @@ module Groups
 
     test 'transfer group without group permission' do
       new_namespace = namespaces_user_namespaces(:jane_doe_namespace)
-
       exception = assert_raises(ActionPolicy::Unauthorized) do
         Groups::TransferService.new(@group, @jane_doe).execute(new_namespace)
       end
-
       assert_equal GroupPolicy, exception.policy
       assert_equal :transfer?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
@@ -57,7 +54,6 @@ module Groups
 
     test 'transfer group without target namespace permission' do
       new_namespace = namespaces_user_namespaces(:jane_doe_namespace)
-
       assert_raises(ActionPolicy::Unauthorized) do
         Groups::TransferService.new(@group, @john_doe).execute(new_namespace)
       end
@@ -66,7 +62,6 @@ module Groups
 
     test 'authorize allowed to transfer group with permission' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
-
       assert_authorized_to(:transfer?, @group,
                            with: GroupPolicy,
                            context: { user: @john_doe }) do
@@ -78,7 +73,6 @@ module Groups
 
     test 'authorize allowed to transfer group into namespace' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
-
       assert_authorized_to(:transfer_into_namespace?, new_namespace,
                            with: Namespaces::UserNamespacePolicy,
                            context: { user: @john_doe }) do

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -4,6 +4,8 @@ require 'test_helper'
 
 module Groups
   class TransferServiceTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
     def setup
       @john_doe = users(:john_doe)
       @jane_doe = users(:jane_doe)

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -4,8 +4,6 @@ require 'test_helper'
 
 module Groups
   class TransferServiceTest < ActiveSupport::TestCase
-    include ActiveJob::TestHelper
-
     def setup
       @john_doe = users(:john_doe)
       @jane_doe = users(:jane_doe)

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -10,23 +10,11 @@ module Groups
       @group = groups(:group_one)
     end
 
-    test 'transfer group with permission & maximum ancestors' do
-      new_namespace = groups(:group_eight)
-      user = users(:ryan_doe)
+    test 'transfer group with permission' do
+      new_namespace = namespaces_user_namespaces(:john_doe_namespace)
 
-      assert_nil @group.parent
-      assert_equal Member::AccessLevel::GUEST,
-                   @group.group_members.where(user_id: user.id).first.access_level
-
-      Groups::TransferService.new(@group, @john_doe).execute(new_namespace)
-
-      assert_equal @group.parent, new_namespace
-      assert_equal Member::AccessLevel::MAINTAINER,
-                   @group.group_members.where(user_id: user.id).first.access_level
-
-      (Namespace::MAX_ANCESTORS - 1).times do |n|
-        assert_equal Member::AccessLevel::MAINTAINER,
-                     groups("subgroup#{n + 1}").group_members.where(user_id: user.id).first.access_level
+      assert_changes -> { @group.parent }, to: new_namespace do
+        Groups::TransferService.new(@group, @john_doe).execute(new_namespace)
       end
 
       assert_enqueued_with(job: UpdateMembershipsJob)

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -10,11 +10,23 @@ module Groups
       @group = groups(:group_one)
     end
 
-    test 'transfer group with permission' do
-      new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+    test 'transfer group with permission & maximum ancestors' do
+      new_namespace = groups(:group_eight)
+      user = users(:ryan_doe)
 
-      assert_changes -> { @group.parent }, to: new_namespace do
-        Groups::TransferService.new(@group, @john_doe).execute(new_namespace)
+      assert_nil @group.parent
+      assert_equal Member::AccessLevel::GUEST,
+                   @group.group_members.where(user_id: user.id).first.access_level
+
+      Groups::TransferService.new(@group, @john_doe).execute(new_namespace)
+
+      assert_equal @group.parent, new_namespace
+      assert_equal Member::AccessLevel::MAINTAINER,
+                   @group.group_members.where(user_id: user.id).first.access_level
+
+      (Namespace::MAX_ANCESTORS - 1).times do |n|
+        assert_equal Member::AccessLevel::MAINTAINER,
+                     groups("subgroup#{n + 1}").group_members.where(user_id: user.id).first.access_level
       end
 
       assert_enqueued_with(job: UpdateMembershipsJob)

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -4,8 +4,6 @@ require 'test_helper'
 
 module Projects
   class TransferServiceTest < ActiveSupport::TestCase
-    include ActiveJob::TestHelper
-
     def setup
       @john_doe = users(:john_doe)
       @jane_doe = users(:jane_doe)

--- a/test/services/samples/update_service_test.rb
+++ b/test/services/samples/update_service_test.rb
@@ -4,8 +4,6 @@ require 'test_helper'
 
 module Samples
   class UpdateServiceTest < ActiveSupport::TestCase
-    include ActionPolicy::TestHelper
-
     def setup
       @user = users(:john_doe)
       @sample = samples(:sample23)


### PR DESCRIPTION
## What does this PR do and why?
Fixes the memberships after a project transfer, so that the access level is ascending through its descendants.
Fixes part of #226.

## Screenshots or screen recordings
![Screenshot from 2023-10-26 08-50-09](https://github.com/phac-nml/irida-next/assets/325703/6e7c29c0-e465-4bde-9f07-33b3c829b6a6)
![Screenshot from 2023-10-26 08-51-03](https://github.com/phac-nml/irida-next/assets/325703/83d462b2-b138-4483-9ec4-cf373b6ddc90)
![Screenshot from 2023-11-15 15-18-16](https://github.com/phac-nml/irida-next/assets/325703/62bd891b-aa17-4b99-bbed-53af391c1b7b)

## How to set up and validate locally
1. Create a new group called `Group A`.
2. Add user `user1@email.com` with `Maintainer` access to `Group A`.
3. Create a new group called `Group B`.
4. Create a new project within `Group B` called `Project B`.
5. Add user `user1@email.com` with `Guest` access to `Project B`.
6. Transfer `Project B` to parent group `Group A`.
7. Verify that `user1@email.com` has changed to `Maintainer` in `Project B`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
