### PR TITLE
Language Selection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,3 +128,6 @@ group :test do
   gem 'simplecov', require: false
   gem 'timecop'
 end
+
+# Extends Rails default locales beyond :en
+gem 'rails-i18n', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,6 +353,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.8)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.7.2)
       actionpack (= 7.0.7.2)
       activesupport (= 7.0.7.2)
@@ -512,6 +515,7 @@ DEPENDENCIES
   pg
   puma (~> 5.6)
   rails (~> 7.0.7, >= 7.0.7.2)
+  rails-i18n (~> 7.0.0)
   ransack (~> 3.2, >= 3.2.1)
   rubocop
   rubocop-graphql

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,12 @@ class ApplicationController < ActionController::Base
   include RouteHelper
 
   add_flash_types :success, :info, :warning, :danger
-  before_action :authenticate_user!
+  before_action :authenticate_user!, :use_locale
   around_action :use_logidze_responsible, only: %i[create destroy update] # rubocop:disable Rails/LexicallyScopedActionFilter
+
+  def use_locale
+    I18n.locale = current_user.locale.to_sym || I18n.default_locale
+  end
 
   def use_logidze_responsible(&)
     Logidze.with_responsible(current_user&.id, transactional: false, &)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,13 @@ class ApplicationController < ActionController::Base
   include RouteHelper
 
   add_flash_types :success, :info, :warning, :danger
-  before_action :authenticate_user!, :use_locale
+  before_action :authenticate_user!
   around_action :use_logidze_responsible, only: %i[create destroy update] # rubocop:disable Rails/LexicallyScopedActionFilter
+  around_action :switch_locale
 
-  def use_locale
-    I18n.locale = current_user.locale.to_sym || I18n.default_locale
+  def switch_locale(&)
+    locale = current_user.try(:locale) || I18n.default_locale
+    I18n.with_locale(locale, &)
   end
 
   def use_logidze_responsible(&)

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -14,13 +14,13 @@ module Profiles
 
     def update
       authorize! @user
-      # if update_params[:locale] == 'en'
-      #   flash[:success] = 'Language updated successfully'
-      # elsif update_params[:locale] == 'fr'
-      #   flash[:success] = 'Langue mise à jour avec succès'
-      # end
       respond_to do |format|
-        if @user.update(update_params)
+        # Locale is called now rather than from the around_action in app_controller because we need the locale
+        # change prior to the success flash so that the flash contains the correct translation
+        updated = @user.update(update_params)
+        locale = current_user.try(:locale) || I18n.default_locale
+        I18n.locale = locale
+        if updated
           flash[:success] = t('.success')
           format.html { redirect_to profile_preferences_path }
         else

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -23,8 +23,6 @@ module Profiles
           format.html { render :show, status: :unprocessable_entity, locals: { user: @user } }
         end
       end
-      locale = current_user.try(:locale) || I18n.default_locale
-      I18n.locale = locale
     end
 
     private

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -14,16 +14,14 @@ module Profiles
 
     def update
       authorize! @user
+      # if update_params[:locale] == 'en'
+      #   flash[:success] = 'Language updated successfully'
+      # elsif update_params[:locale] == 'fr'
+      #   flash[:success] = 'Langue mise à jour avec succès'
+      # end
       respond_to do |format|
         if @user.update(update_params)
-          # Success message is hardcoded here because using the translation still uses the old language
-          # ie going from en to fr will use the en text. Hardcoding here will also simplify things in case
-          # a 3rd language is added
-          if update_params[:locale] == 'en'
-            flash[:success] = 'Language updated successfully' # rubocop:disable Rails/I18nLocaleTexts
-          elsif update_params[:locale] == 'fr'
-            flash[:success] = 'Langue mise à jour avec succès' # rubocop:disable Rails/I18nLocaleTexts
-          end
+          flash[:success] = t('.success')
           format.html { redirect_to profile_preferences_path }
         else
           format.html { render :show, status: :unprocessable_entity, locals: { user: @user } }

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -11,5 +11,28 @@ module Profiles
     def current_page
       @current_page = 'preferences'
     end
+
+    def update
+      authorize! @user
+
+      respond_to do |format|
+        if @user.update(update_params)
+          flash[:success] = t('.success')
+          format.html { redirect_to profile_preferences_path }
+        else
+          format.html { render :show, status: :unprocessable_entity, locals: { user: @user } }
+        end
+      end
+      locale = current_user.try(:locale) || I18n.default_locale
+      I18n.locale = locale
+    end
+
+    private
+
+    def update_params
+      params.require(:user).permit(
+        :locale
+      )
+    end
   end
 end

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -14,10 +14,16 @@ module Profiles
 
     def update
       authorize! @user
-
       respond_to do |format|
         if @user.update(update_params)
-          flash[:success] = t('.success')
+          # Success message is hardcoded here because using the translation still uses the old language
+          # ie going from en to fr will use the en text. Hardcoding here will also simplify things in case
+          # a 3rd language is added
+          if update_params[:locale] == 'en'
+            flash[:success] = 'Language updated successfully' # rubocop:disable Rails/I18nLocaleTexts
+          elsif update_params[:locale] == 'fr'
+            flash[:success] = 'Langue mise à jour avec succès' # rubocop:disable Rails/I18nLocaleTexts
+          end
           format.html { redirect_to profile_preferences_path }
         else
           format.html { render :show, status: :unprocessable_entity, locals: { user: @user } }

--- a/app/views/profiles/preferences/_locale_form.html.erb
+++ b/app/views/profiles/preferences/_locale_form.html.erb
@@ -1,5 +1,3 @@
-
-
 <%= form_with(model: @user, url: profile_preferences_path, method: :patch) do |f| %>
     <div class="grid grid-cols-1 gap-4">
         <div class="flex items-center">

--- a/app/views/profiles/preferences/_locale_form.html.erb
+++ b/app/views/profiles/preferences/_locale_form.html.erb
@@ -1,0 +1,25 @@
+<%= viral_card(title: t(:'.locale_title')) do %>
+    <%= form_with(model: @user, url: profile_preferences_path, method: :patch) do |f| %>
+        <div class="grid grid-cols-1 gap-4">
+            <div class="flex items-center">
+                <%= f.radio_button :locale, 'en', checked: (@user.locale == 'en'), class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'%>
+                <%= f.label t(:'.en'),
+                    class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+                %>
+            </div>
+            <div class="flex items-center">
+                <%= f.radio_button :locale,
+                    'fr',
+                    checked: (@user.locale == 'fr'),
+                    class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600' %></span>
+                <%= f.label t(:'.fr'),
+                    class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+                %>
+            </div>
+        </div>
+        <br/>
+        <div class="my-2">
+            <%= f.submit t(:'.submit_button'), class: "button button--state-primary button--size-default" %>
+        </div>
+    <% end %>
+<% end %>

--- a/app/views/profiles/preferences/_locale_form.html.erb
+++ b/app/views/profiles/preferences/_locale_form.html.erb
@@ -2,8 +2,12 @@
     <%= form_with(model: @user, url: profile_preferences_path, method: :patch) do |f| %>
         <div class="grid grid-cols-1 gap-4">
             <div class="flex items-center">
-                <%= f.radio_button :locale, 'en', checked: (@user.locale == 'en'), class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'%>
+                <%= f.radio_button :locale, 'en',
+                    checked: (@user.locale == 'en'),
+                    class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                %>
                 <%= f.label t(:'.en'),
+                    for: 'user_locale_en',
                     class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
                 %>
             </div>
@@ -11,8 +15,10 @@
                 <%= f.radio_button :locale,
                     'fr',
                     checked: (@user.locale == 'fr'),
-                    class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600' %></span>
+                    class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                    %>
                 <%= f.label t(:'.fr'),
+                    for: 'user_locale_fr',
                     class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
                 %>
             </div>

--- a/app/views/profiles/preferences/_locale_form.html.erb
+++ b/app/views/profiles/preferences/_locale_form.html.erb
@@ -1,29 +1,27 @@
+
+
 <%= form_with(model: @user, url: profile_preferences_path, method: :patch) do |f| %>
     <div class="grid grid-cols-1 gap-4">
         <div class="flex items-center">
             <%= f.radio_button :locale, 'en',
                 checked: (@user.locale == 'en'),
-                class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-            %>
+                class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600',
+                'data-action': "change->locale#toggleTheme",
+                onchange: "this.form.submit()" %>
             <%= f.label t(:'.en'),
                 for: 'user_locale_en',
-                class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
-            %>
+                class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300' %>
         </div>
         <div class="flex items-center">
             <%= f.radio_button :locale,
                 'fr',
                 checked: (@user.locale == 'fr'),
-                class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-                %>
+                class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600',
+                'data-action': "change->locale#toggleTheme",
+                onchange: "this.form.submit()" %>
             <%= f.label t(:'.fr'),
                 for: 'user_locale_fr',
-                class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
-            %>
+                class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300' %>
         </div>
-    </div>
-    <br/>
-    <div class="my-2">
-        <%= f.submit t(:'.submit_button'), class: "button button--state-primary button--size-default" %>
     </div>
 <% end %>

--- a/app/views/profiles/preferences/_locale_form.html.erb
+++ b/app/views/profiles/preferences/_locale_form.html.erb
@@ -1,31 +1,29 @@
-<%= viral_card(title: t(:'.locale_title')) do %>
-    <%= form_with(model: @user, url: profile_preferences_path, method: :patch) do |f| %>
-        <div class="grid grid-cols-1 gap-4">
-            <div class="flex items-center">
-                <%= f.radio_button :locale, 'en',
-                    checked: (@user.locale == 'en'),
-                    class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-                %>
-                <%= f.label t(:'.en'),
-                    for: 'user_locale_en',
-                    class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
-                %>
-            </div>
-            <div class="flex items-center">
-                <%= f.radio_button :locale,
-                    'fr',
-                    checked: (@user.locale == 'fr'),
-                    class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-                    %>
-                <%= f.label t(:'.fr'),
-                    for: 'user_locale_fr',
-                    class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
-                %>
-            </div>
+<%= form_with(model: @user, url: profile_preferences_path, method: :patch) do |f| %>
+    <div class="grid grid-cols-1 gap-4">
+        <div class="flex items-center">
+            <%= f.radio_button :locale, 'en',
+                checked: (@user.locale == 'en'),
+                class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+            %>
+            <%= f.label t(:'.en'),
+                for: 'user_locale_en',
+                class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+            %>
         </div>
-        <br/>
-        <div class="my-2">
-            <%= f.submit t(:'.submit_button'), class: "button button--state-primary button--size-default" %>
+        <div class="flex items-center">
+            <%= f.radio_button :locale,
+                'fr',
+                checked: (@user.locale == 'fr'),
+                class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+                %>
+            <%= f.label t(:'.fr'),
+                for: 'user_locale_fr',
+                class: 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
+            %>
         </div>
-    <% end %>
+    </div>
+    <br/>
+    <div class="my-2">
+        <%= f.submit t(:'.submit_button'), class: "button button--state-primary button--size-default" %>
+    </div>
 <% end %>

--- a/app/views/profiles/preferences/show.html.erb
+++ b/app/views/profiles/preferences/show.html.erb
@@ -26,3 +26,5 @@
     </div>
   </div>
 <% end %>
+
+<%= render 'locale_form', user: @user %>

--- a/app/views/profiles/preferences/show.html.erb
+++ b/app/views/profiles/preferences/show.html.erb
@@ -1,4 +1,5 @@
-<%= viral_card(title: t(:'.theme_title')) do %>
+<%= viral_card(title: t(:'.preferences')) do |card| %>
+  <% card.with_section(border_bottom: true, border_top: true, title: t(:'.theme_title')) do %>
   <div class="grid grid-cols-1 gap-4" data-controller="colour-mode">
     <div class="flex">
       <div class="flex items-center h-5"><input id="system-theme" type="radio" value="system" name="color-theme"
@@ -25,6 +26,8 @@
       <label for="light-theme" class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300"><%= t(:'.light_theme') %></label>
     </div>
   </div>
+  <% end %>
+  <% card.with_section(title: t(:'.locale_title')) do %>
+    <%= render 'locale_form', user: @user %>
+  <% end %>
 <% end %>
-
-<%= render 'locale_form', user: @user %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,5 +51,11 @@ module Irida
         end
       }
     end
+
+    # Only enables locale from rails_i18n. Other options include ordinals, pluralization, transliteration
+    # https://github.com/svenfuchs/rails-i18n
+    config.rails_i18n.enabled_modules = [:locale]
+    # Only enables en and fr locales, avoiding unnecessarily loading other locales
+    config.i18n.available_locales = %i[en fr]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,5 +57,7 @@ module Irida
     config.rails_i18n.enabled_modules = [:locale]
     # Only enables en and fr locales, avoiding unnecessarily loading other locales
     config.i18n.available_locales = %i[en fr]
+    # Set default locale
+    config.i18n.default_locale = :en
   end
 end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# config/initializers/locale.rb
-
-# Where the I18n library should search for translation files
-I18n.load_path += Dir[Rails.root.join('config/locales/*.{rb,yml}')]
-
-# Permitted locales available for the application
-I18n.available_locales = %i[en fr]

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# config/initializers/locale.rb
+
+# Where the I18n library should search for translation files
+I18n.load_path += Dir[Rails.root.join('config/locales/*.{rb,yml}')]
+
+# Permitted locales available for the application
+I18n.available_locales = %i[en fr]

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -1,0 +1,127 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+fr:
+  devise:
+    layout:
+      title: IRIDA Next
+    confirmations:
+      title: "Resend confirmation instructions"
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      submit_button: "Resend confirmation instructions"
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+        greeting: "Welcome %{email}!"
+        instructions: "You can confirm your account email through the link below:"
+        confirm_button: "Confirm my account"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+        greeting: "Hello %{email}!"
+        instructions: "Someone has requested a link to change your password. You can do this through the link below."
+        disclaimer_info: "If you didn't request this, please ignore this email."
+        link_info: "Your password won't change until you access the link above and create a new one."
+        reset_button: "Change my password"
+      unlock_instructions:
+        subject: "Unlock instructions"
+        greeting: "Hello %{email}!"
+        locked_info: "Your account has been locked due to an excessive number of unsuccessful sign in attempts."
+        instructions: "Click the link below to unlock your account:"
+        unlock_button: "Unlock my account"
+      email_changed:
+        subject: "Email Changed"
+        greeting: "Hello %{email}!"
+        confirmed_email_info: "We're contacting you to notify you that your email has been changed to %{email}."
+        unconfirmed_email_info: "We're contacting you to notify you that your email is being changed to %{email}."
+      password_change:
+        subject: "Password Changed"
+        greeting: "Hello %{email}!"
+        password_change_info: "We're contacting you to notify you that your password has been changed."
+    omniauth_callbacks:
+      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+      new:
+        submit_button: "Send me reset password instructions"
+      edit:
+        title: Change your password
+        password_label: "New password"
+        password_confirmation_label: "Confirm new password"
+        password_hint: "(%{minimum_password_length} characters minimum)"
+        submit_button: "Change my password"
+    registrations:
+      new:
+        password_hint: "(%{minimum_password_length} characters minimum)"
+        signed_up: "Already signed up?"
+        submit_button: "Sign up"
+      edit:
+        title: "Edit %{resource_name}"
+        cancel_title: "Cancel my account"
+        password_blank_hint: "(leave blank if you don't want to change it)"
+        password_length_hint: "(%{minimum_password_length} characters minimum)"
+        current_password_hint: "(we need your current password to confirm your changes)"
+        confirmation_message: "Currently waiting confirmation for: %{email}"
+        unhappy: Unhappy?
+        submit_button: "Update"
+        cancel_button: "Cancel my account"
+        cancel_confirmation: "Are you sure?"
+        back_link: "Back"
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+      new_with_providers:
+        local_button: "Sign in with Local Account"
+        return_button: "Return to sign in selection"
+        omniauth: "Sign in with %{provider}"
+    shared:
+      form:
+        sign_in: "Sign in"
+      links:
+        create_an_account: "Don't have an account?"
+        create_an_account_link: "Register now"
+        forgot_password_link: "Forgot your password?"
+        confirmation_link: "Didn't receive confirmation instructions?"
+        unlock_link: "Didn't receive unlock instructions?"
+        sign_in_link: "Sign in"
+    unlocks:
+      new:
+        title: "Resend unlock instructions"
+        submit_button: "Resend unlock instructions"
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,11 +364,12 @@ en:
         system_desc: The colour theme will update based on your operating system settings.
         light_theme: Light
         dark_theme: Dark
+        locale_title: Language
+        preferences: Preferences
       update:
         success: Language updated successfully
       success: Preferences updated successfully
       locale_form:
-        locale_title: Language
         en: English
         fr: French
         submit_button: Select Language

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -372,7 +372,6 @@ en:
       locale_form:
         en: English
         fr: French
-        submit_button: Select Language
     personal_access_tokens:
       access_token_section:
         label: Your new personal access token

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -29,7 +29,7 @@
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.
 
-en:
+fr:
   time:
     formats:
       default: "%Y-%m-%d %H:%M:%S"
@@ -368,10 +368,10 @@ en:
         success: Language updated successfully
       success: Preferences updated successfully
       locale_form:
-        locale_title: Language
-        en: English
-        fr: French
-        submit_button: Select Language
+        locale_title: Langue
+        en: Anglais
+        fr: Français
+        submit_button: Choisir la langue
     personal_access_tokens:
       access_token_section:
         label: Your new personal access token

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -367,7 +367,7 @@ fr:
         locale_title: Langue
         preferences: Preferences
       update:
-        success: Language updated successfully
+        success: Langue mise à jour avec succès
       success: Preferences updated successfully
       locale_form:
         en: Anglais

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -364,11 +364,12 @@ fr:
         system_desc: The colour theme will update based on your operating system settings.
         light_theme: Light
         dark_theme: Dark
+        locale_title: Langue
+        preferences: Preferences
       update:
         success: Language updated successfully
       success: Preferences updated successfully
       locale_form:
-        locale_title: Langue
         en: Anglais
         fr: Français
         submit_button: Choisir la langue

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -372,7 +372,6 @@ fr:
       locale_form:
         en: Anglais
         fr: Français
-        submit_button: Choisir la langue
     personal_access_tokens:
       access_token_section:
         label: Your new personal access token

--- a/config/routes/profile.rb
+++ b/config/routes/profile.rb
@@ -4,7 +4,7 @@ resource :profile, only: %i[show update] do
   scope module: :profiles do
     resource :password, only: %i[edit update]
     resource :account, only: %i[show destroy]
-    resource :preferences, only: %i[show]
+    resource :preferences, only: %i[show update]
     resources :personal_access_tokens, only: %i[index create] do
       member do
         delete :revoke

--- a/db/migrate/20231025155037_add_locale_to_user.rb
+++ b/db/migrate/20231025155037_add_locale_to_user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Migration to add locale to users table
+class AddLocaleToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :locale, :string, default: 'en'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_29_194603) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_25_155037) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -174,6 +174,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_194603) do
     t.datetime "deleted_at"
     t.string "first_name"
     t.string "last_name"
+    t.string "locale", default: "en"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(deleted_at IS NULL)"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, where: "(deleted_at IS NULL)"

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -115,10 +115,11 @@ class ProfileTest < ApplicationSystemTestCase
 
     find('input[id=user_locale_fr]').click
 
-    assert_text 'Anglais'
-
-    within %(div[data-controller='viral--flash']) do
-      assert_text 'Langue mise à jour avec succès'
+    I18n.with_locale(:fr) do
+      assert_text I18n.t(:'profiles.preferences.locale_form.en')
+      within %(div[data-controller='viral--flash']) do
+        assert_text I18n.t(:'profiles.preferences.update.success')
+      end
     end
   end
 end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -103,4 +103,19 @@ class ProfileTest < ApplicationSystemTestCase
     assert_text I18n.t(:'profiles.personal_access_tokens.index.active_personal_access_tokens',
                        count: @active_token_count - 1)
   end
+
+  test 'can view language selection' do
+    visit profile_preferences_path
+
+    assert_text I18n.t(:'profiles.preferences.locale_form.locale_title')
+  end
+  test 'can update language to french' do
+    visit profile_preferences_path
+
+    find('input[id=user_locale_fr]').click
+
+    click_button I18n.t(:'profiles.preferences.locale_form.submit_button')
+
+    assert_text I18n.t(:'profiles.preferences.locale_form.locale_title')
+  end
 end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -109,11 +109,16 @@ class ProfileTest < ApplicationSystemTestCase
 
     assert_text I18n.t(:'profiles.preferences.locale_form.en')
   end
+
   test 'can update language to french' do
     visit profile_preferences_path
 
     find('input[id=user_locale_fr]').click
 
     assert_text 'Anglais'
+
+    within %(div[data-controller='viral--flash']) do
+      assert_text 'Langue mise à jour avec succès'
+    end
   end
 end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -107,15 +107,13 @@ class ProfileTest < ApplicationSystemTestCase
   test 'can view language selection' do
     visit profile_preferences_path
 
-    assert_text I18n.t(:'profiles.preferences.locale_form.locale_title')
+    assert_text I18n.t(:'profiles.preferences.locale_form.en')
   end
   test 'can update language to french' do
     visit profile_preferences_path
 
     find('input[id=user_locale_fr]').click
 
-    click_button I18n.t(:'profiles.preferences.locale_form.submit_button')
-
-    assert_text I18n.t(:'profiles.preferences.locale_form.locale_title')
+    assert_text 'Anglais'
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
In this PR, locale selection has been implemented under the user's profile preferences settings. This will allow users to select between English and French language translations for the website.

## Screenshots or screen recordings
![image](https://github.com/phac-nml/irida-next/assets/82407232/9912517b-9335-4188-a7d9-2c0890b95f60)
![image](https://github.com/phac-nml/irida-next/assets/82407232/2dada32d-15d2-4e84-a4a6-57202bf6a8a5)


## How to set up and validate locally
1. Navigate to profile preferences.
2. Under language, select either English or French and submit.
- Only the language card contains translations currently. Therefore, the language card's wording should be translated based on the language selected.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
