### PR TITLE
Member expiration backend

### DIFF
--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -8,7 +8,7 @@ module Groups
     before_action :current_page
 
     def member_params
-      params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id)
+      params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id, :expires_at)
     end
 
     private

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -8,7 +8,7 @@ module Projects
     before_action :current_page
 
     def member_params
-      params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id)
+      params.require(:member).permit(:user_id, :access_level, :type, :namespace_id, :created_by_id, :expires_at)
     end
 
     private

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -30,14 +30,6 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
                         where('expires_at IS NULL OR expires_at > ?', Time.zone.now)
                       }
 
-  def expires?
-    expires_at.present?
-  end
-
-  def expired?
-    expires? && expires_at <= Time.current
-  end
-
   class << self
     def access_levels(member)
       case member.access_level

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -26,6 +26,9 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :for_namespace_and_ancestors, lambda { |namespace = nil|
                                         where(namespace:).or(where(namespace: namespace.parent&.self_and_ancestors))
                                       }
+  scope :not_expired, lambda {
+                        where('expires_at IS NULL OR expires_at > ?', Time.zone.now)
+                      }
 
   class << self
     def access_levels(member)
@@ -42,7 +45,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
     def effective_access_level(namespace, user)
       return AccessLevel::OWNER if namespace.parent&.user_namespace? && namespace.parent.owner == user
 
-      access_level = Member.for_namespace_and_ancestors(namespace)
+      access_level = Member.for_namespace_and_ancestors(namespace).not_expired
                            .where(user:).order(:access_level).last&.access_level
 
       access_level = access_level_in_namespace_group_links(user, namespace) if access_level.nil?
@@ -114,7 +117,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
       if namespace_group_links.count.positive?
         maxlevel_namespace_group_link = namespace_group_links.order(:group_access_level).last
-        membership = Member.for_namespace_and_ancestors(maxlevel_namespace_group_link&.group)
+        membership = Member.for_namespace_and_ancestors(maxlevel_namespace_group_link&.group).not_expired
                      &.where(user:)&.order(:access_level)
 
         return [maxlevel_namespace_group_link.group_access_level, membership.last.access_level].min

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -109,7 +109,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
       effective_access_level(namespace, user) == Member::AccessLevel::MAINTAINER
     end
 
-    def access_level_in_namespace_group_links(user, namespace) # rubocop:disable Metrics/AbcSize
+    def access_level_in_namespace_group_links(user, namespace)
       namespace_group_links = NamespaceGroupLink.for_namespace_and_ancestors(namespace)
                                                 .where(group: user.groups.self_and_descendants).not_expired
 
@@ -119,8 +119,6 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
                      &.where(user:)&.order(:access_level)
 
         return [maxlevel_namespace_group_link.group_access_level, membership.last.access_level].min if membership.any?
-
-        return maxlevel_namespace_group_link.group_access_level
 
       end
       Member::AccessLevel::NO_ACCESS

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -26,9 +26,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :for_namespace_and_ancestors, lambda { |namespace = nil|
                                         where(namespace:).or(where(namespace: namespace.parent&.self_and_ancestors))
                                       }
-  scope :not_expired, lambda {
-                        where('expires_at IS NULL OR expires_at > ?', Time.zone.now)
-                      }
+  scope :not_expired, -> { where('expires_at IS NULL OR expires_at > ?', Time.zone.now) }
 
   class << self
     def access_levels(member)
@@ -117,7 +115,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
       if namespace_group_links.count.positive?
         maxlevel_namespace_group_link = namespace_group_links.order(:group_access_level).last
-        membership = Member.for_namespace_and_ancestors(maxlevel_namespace_group_link&.group).not_expired
+        membership = Member.for_namespace_and_ancestors(maxlevel_namespace_group_link&.group)
                      &.where(user:)&.order(:access_level)
 
         return [maxlevel_namespace_group_link.group_access_level, membership.last.access_level].min

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -30,6 +30,14 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
                         where('expires_at IS NULL OR expires_at > ?', Time.zone.now)
                       }
 
+  def expires?
+    expires_at.present?
+  end
+
+  def expired?
+    expires? && expires_at <= Time.current
+  end
+
   class << self
     def access_levels(member)
       case member.access_level

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -123,10 +123,10 @@ class GroupPolicy < NamespacePolicy
 
   scope_for :relation do |relation|
     relation.with(
-      user_groups: relation.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids,
-      linked_groups: relation.where(id: NamespaceGroupLink.where(group:
-      Group.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendants)
-      .not_expired.select(:namespace_id)).select(:id)
+      user_groups: relation.where(id: user.members.joins(:namespace).where(namespace: { type: Group.sti_name })
+      .not_expired.select(:namespace_id)).self_and_descendant_ids,
+      linked_groups: NamespaceGroupLink.where(group: relation.where(id: user.members.joins(:namespace).where(namespace: { type: Group.sti_name })
+      .not_expired.select(:namespace_id)).self_and_descendant_ids).select(:namespace_id)
     ).where(
       Arel.sql(
         'namespaces.id in (select * from user_groups)

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -125,8 +125,8 @@ class GroupPolicy < NamespacePolicy
     relation.with(
       user_groups: relation.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids
       .where(type: Group.sti_name),
-      linked_groups: NamespaceGroupLink.where(group: relation.where(id: user.members.not_expired.select(:namespace_id))
-      .self_and_descendant_ids.where(type: Group.sti_name))
+      linked_groups: NamespaceGroupLink.where(group: relation.where(id: user.members.joins(:namespace)
+      .where(namespace: { type: Group.sti_name }).not_expired.select(:namespace_id)).self_and_descendant_ids)
       .select(:namespace_id)
     ).where(
       Arel.sql(

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -123,10 +123,11 @@ class GroupPolicy < NamespacePolicy
 
   scope_for :relation do |relation|
     relation.with(
-      user_groups: relation.where(id: user.members.joins(:namespace).where(namespace: { type: Group.sti_name })
-      .not_expired.select(:namespace_id)).self_and_descendant_ids,
-      linked_groups: NamespaceGroupLink.where(group: relation.where(id: user.members.joins(:namespace).where(namespace: { type: Group.sti_name })
-      .not_expired.select(:namespace_id)).self_and_descendant_ids).select(:namespace_id)
+      user_groups: relation.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids
+      .where(type: Group.sti_name),
+      linked_groups: NamespaceGroupLink.where(group: relation.where(id: user.members.not_expired.select(:namespace_id))
+      .self_and_descendant_ids.where(type: Group.sti_name))
+      .select(:namespace_id)
     ).where(
       Arel.sql(
         'namespaces.id in (select * from user_groups)

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -123,10 +123,9 @@ class GroupPolicy < NamespacePolicy
 
   scope_for :relation do |relation|
     relation.with(
-      user_groups: relation.where(id: user.members.where(namespace: user.groups.self_and_descendants).not_expired
-      .select(:namespace_id)).self_and_descendants.select(:id),
-      linked_groups: relation.where(id: NamespaceGroupLink
-      .where(group: user.groups.self_and_descendants)
+      user_groups: relation.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids,
+      linked_groups: relation.where(id: NamespaceGroupLink.where(group:
+      Group.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendants)
       .not_expired.select(:namespace_id)).select(:id)
     ).where(
       Arel.sql(

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -123,7 +123,8 @@ class GroupPolicy < NamespacePolicy
 
   scope_for :relation do |relation|
     relation.with(
-      user_groups: user.groups.self_and_descendant_ids,
+      user_groups: relation.where(id: user.members.where(namespace: user.groups.self_and_descendants).not_expired
+      .select(:namespace_id)).self_and_descendants.select(:id),
       linked_groups: relation.where(id: NamespaceGroupLink
       .where(group: user.groups.self_and_descendants)
       .not_expired.select(:namespace_id)).select(:id)

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -6,16 +6,16 @@ class NamespacePolicy < ApplicationPolicy
     relation.with(
       personal_namespaces: relation.where(id: user.namespace.id).select(:id),
       membership_in_namespaces: relation.where(type: Group.sti_name,
-                                               id: user.members.joins(:namespace).where(
+                                               id: user.members.not_expired.joins(:namespace).where(
                                                  access_level: Member::AccessLevel.manageable,
                                                  namespace: { type: Group.sti_name }
                                                ).select(:namespace_id)).self_and_descendants.where.not(
                                                  type: Namespaces::ProjectNamespace.sti_name
                                                ).select(:id),
       linked_namespaces: relation.where(id: NamespaceGroupLink.where(
-        group: user.groups.where(id: user.members.joins(:namespace).where(access_level: Member::AccessLevel.manageable,
-                                                                          namespace: { type: Group.sti_name })
-                                                        .select(:namespace_id)).self_and_descendants,
+        group: user.groups.where(id: user.members.not_expired.joins(:namespace)
+        .where(access_level: Member::AccessLevel.manageable, namespace: { type: Group.sti_name })
+        .select(:namespace_id)).self_and_descendants,
         group_access_level: Member::AccessLevel.manageable,
         namespace_type: Group.sti_name
       ).not_expired.select(:namespace_id)).self_and_descendants.where.not(type: Namespaces::ProjectNamespace.sti_name)

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -113,8 +113,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     false
   end
 
-  # self_and_descendant_ids returns all types
-  #
+  # Can we simplify this further?
 
   scope_for :relation do |relation|
     relation

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -143,20 +143,20 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     relation.with(
       personal_projects: relation.where(namespace: user.namespace.project_namespaces).select(:id),
       direct_projects: relation.where(
-        namespace: user.members.joins(:namespace).where(
+        namespace: user.members.not_expired.joins(:namespace).where(
           access_level: Member::AccessLevel.manageable,
           namespace: { type: Namespaces::ProjectNamespace.sti_name }
         ).select(:namespace_id)
       ).select(:id),
       group_projects: relation.joins(:namespace).where(namespace: { parent: Namespace.where(id:
-        user.members.joins(:namespace).where(
+        user.members.not_expired.joins(:namespace).where(
           namespace_id: user.groups.self_and_descendants,
           access_level: Member::AccessLevel.manageable,
           namespace: { type: Group.sti_name }
         ).select(:namespace_id), type: Group.sti_name).self_and_descendants.select(:id) }).select(:id),
       linked_projects: relation.joins(:namespace).where(namespace: { parent_id:
         Group.where(id: NamespaceGroupLink.where(
-          group: user.groups.where(id: user.members.joins(:namespace)
+          group: user.groups.where(id: user.members.not_expired.joins(:namespace)
           .where(access_level: Member::AccessLevel.manageable,
                  namespace: { type: Group.sti_name })
                                                           .select(:namespace_id)).self_and_descendants,

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -113,8 +113,6 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     false
   end
 
-  # Can we simplify this further?
-
   scope_for :relation do |relation|
     relation
       .with(
@@ -128,9 +126,9 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
         Namespace.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids
         .where(type: Group.sti_name) }).select(:id),
         linked_projects: relation.joins(:namespace).where(namespace: { parent_id:
-        Group.where(id: NamespaceGroupLink
-          .where(group: user.groups.self_and_descendants).not_expired.select(:namespace_id)).self_and_descendants })
-          .select(:id)
+        Group.where(id: NamespaceGroupLink.where(
+          group: Group.where(id: user.members.not_expired.joins(:namespace).select(:namespace_id)).self_and_descendants
+        ).not_expired.select(:namespace_id)).self_and_descendants }).select(:id)
       ).where(
         Arel.sql(
           'projects.id in (select * from personal_projects)

--- a/app/services/groups/transfer_service.rb
+++ b/app/services/groups/transfer_service.rb
@@ -19,8 +19,8 @@ module Groups
         raise TransferError, I18n.t('services.groups.transfer.namespace_group_exists')
       end
 
-      group_ancestor_member_user_ids = Member.for_namespace_and_ancestors(@group).select(:user_id)
-      new_namespace_member_ids = Member.for_namespace_and_ancestors(new_namespace)
+      group_ancestor_member_user_ids = Member.for_namespace_and_ancestors(@group).not_expired.select(:user_id)
+      new_namespace_member_ids = Member.for_namespace_and_ancestors(new_namespace).not_expired
                                        .where(user_id: group_ancestor_member_user_ids).select(&:id)
 
       @group.update(parent_id: new_namespace.id)

--- a/db/migrate/20231030151719_add_expires_at_to_members.rb
+++ b/db/migrate/20231030151719_add_expires_at_to_members.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# migration to add expires_at column to members
+class AddExpiresAtToMembers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :members, :expires_at, :date
+    add_index :members, :expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,8 +64,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_21_200855) do
     t.datetime "updated_at", null: false
     t.jsonb "log_data"
     t.datetime "deleted_at"
+    t.date "expires_at"
     t.index ["created_by_id"], name: "index_members_on_created_by_id"
     t.index ["deleted_at"], name: "index_members_on_deleted_at"
+    t.index ["expires_at"], name: "index_members_on_expires_at"
     t.index ["namespace_id"], name: "index_members_on_namespace_id"
     t.index ["user_id", "namespace_id"], name: "index_members_on_user_id_and_namespace_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["user_id"], name: "index_members_on_user_id"

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -20,6 +20,17 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should not show the group if member is expired' do
+    sign_in users(:john_doe)
+
+    group_member = members(:group_one_member_john_doe)
+    group_member.expires_at = 10.days.ago.to_date
+    group_member.save
+    group = groups(:group_one)
+    get group_path(group)
+    assert_response :unauthorized
+  end
+
   test 'should display create new group page' do
     sign_in users(:john_doe)
 

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -31,6 +31,17 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test 'should not show the group if member is expired in linked group' do
+    sign_in users(:david_doe)
+
+    group_member = members(:group_four_member_david_doe)
+    group_member.expires_at = 10.days.ago.to_date
+    group_member.save
+    group = groups(:david_doe_group_four)
+    get group_path(group)
+    assert_response :unauthorized
+  end
+
   test 'should display create new group page' do
     sign_in users(:john_doe)
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -22,6 +22,9 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test 'should not show the project if member is expired' do
     sign_in users(:john_doe)
 
+    group_member = members(:group_one_member_john_doe)
+    group_member.expires_at = 10.days.ago.to_date
+    group_member.save
     project_member = members(:project_one_member_john_doe)
     project_member.expires_at = 10.days.ago.to_date
     project_member.save

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -19,6 +19,16 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should not show the project if member is expired' do
+    sign_in users(:john_doe)
+
+    project_member = members(:project_one_member_john_doe)
+    project_member.expires_at = 10.days.ago.to_date
+    project_member.save
+    get project_path(projects(:project1))
+    assert_response :unauthorized
+  end
+
   test 'should not show the project' do
     sign_in users(:micha_doe)
 

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -130,7 +130,7 @@ class GroupMemberTest < ActiveSupport::TestCase
 
   test '#scope for_namespace_and_ancestors returns the correct collection' do
     namespace = groups(:subgroup1)
-    members = Member.for_namespace_and_ancestors(namespace)
+    members = Member.for_namespace_and_ancestors(namespace).not_expired
 
     group_and_ancestors = namespace.self_and_ancestors
     memberships = []

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -145,7 +145,7 @@ class GroupMemberTest < ActiveSupport::TestCase
     assert_same_unique_elements(members, memberships)
   end
 
-  test 'non expired group member' do
+  test '#scope not_expired for_namespace_and_ancestors returns the correct collection' do
     members = Member.for_namespace_and_ancestors(@group).not_expired
     assert_difference(-> { members.count } => -1) do
       @group_member.expires_at = 10.days.ago.to_date

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -146,13 +146,10 @@ class GroupMemberTest < ActiveSupport::TestCase
   end
 
   test 'non expired group member' do
-    assert_not @group_member.expires?
-    assert_not @group_member.expired?
-  end
-
-  test 'expired group member' do
-    @group_member.expires_at = 10.days.ago.to_date
-    assert @group_member.expires?
-    assert @group_member.expired?
+    members = Member.for_namespace_and_ancestors(@group).not_expired
+    assert_difference(-> { members.count } => -1) do
+      @group_member.expires_at = 10.days.ago.to_date
+      @group_member.save
+    end
   end
 end

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -130,7 +130,7 @@ class GroupMemberTest < ActiveSupport::TestCase
 
   test '#scope for_namespace_and_ancestors returns the correct collection' do
     namespace = groups(:subgroup1)
-    members = Member.for_namespace_and_ancestors(namespace).not_expired
+    members = Member.for_namespace_and_ancestors(namespace)
 
     group_and_ancestors = namespace.self_and_ancestors
     memberships = []
@@ -143,5 +143,16 @@ class GroupMemberTest < ActiveSupport::TestCase
 
     assert memberships.count == members.count
     assert_same_unique_elements(members, memberships)
+  end
+
+  test 'non expired group member' do
+    assert_not @group_member.expires?
+    assert_not @group_member.expired?
+  end
+
+  test 'expired group member' do
+    @group_member.expires_at = 10.days.ago.to_date
+    assert @group_member.expires?
+    assert @group_member.expired?
   end
 end

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -130,7 +130,7 @@ class ProjectMemberTest < ActiveSupport::TestCase
   test '#scope for_namespace_and_ancestors returns the correct collection' do
     project = projects(:project1)
 
-    members = Member.for_namespace_and_ancestors(project)
+    members = Member.for_namespace_and_ancestors(project).not_expired
 
     group_and_ancestors = project.namespace.parent&.self_and_ancestors
     memberships = []

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -145,7 +145,7 @@ class ProjectMemberTest < ActiveSupport::TestCase
     assert_same_unique_elements(members, memberships)
   end
 
-  test 'non expired project member' do
+  test '#scope not_expired for_namespace_and_ancestors returns the correct collection' do
     members = Member.for_namespace_and_ancestors(@project.namespace).not_expired
     assert_difference(-> { members.count } => -1) do
       @project_member.expires_at = 10.days.ago.to_date

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -146,13 +146,10 @@ class ProjectMemberTest < ActiveSupport::TestCase
   end
 
   test 'non expired project member' do
-    assert_not @project_member.expires?
-    assert_not @project_member.expired?
-  end
-
-  test 'expired project member' do
-    @project_member.expires_at = 10.days.ago.to_date
-    assert @project_member.expires?
-    assert @project_member.expired?
+    members = Member.for_namespace_and_ancestors(@project.namespace).not_expired
+    assert_difference(-> { members.count } => -1) do
+      @project_member.expires_at = 10.days.ago.to_date
+      @project_member.save
+    end
   end
 end

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -130,7 +130,7 @@ class ProjectMemberTest < ActiveSupport::TestCase
   test '#scope for_namespace_and_ancestors returns the correct collection' do
     project = projects(:project1)
 
-    members = Member.for_namespace_and_ancestors(project).not_expired
+    members = Member.for_namespace_and_ancestors(project)
 
     group_and_ancestors = project.namespace.parent&.self_and_ancestors
     memberships = []
@@ -143,5 +143,16 @@ class ProjectMemberTest < ActiveSupport::TestCase
 
     assert memberships.count == members.count
     assert_same_unique_elements(members, memberships)
+  end
+
+  test 'non expired project member' do
+    assert_not @project_member.expires?
+    assert_not @project_member.expired?
+  end
+
+  test 'expired project member' do
+    @project_member.expires_at = 10.days.ago.to_date
+    assert @project_member.expires?
+    assert @project_member.expired?
   end
 end

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -98,5 +98,21 @@ class GroupPolicyTest < ActiveSupport::TestCase
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
     assert_equal 19, scoped_groups.count
+    scoped_groups_names = scoped_groups.pluck(:name)
+    assert_not scoped_groups_names.include?(groups(:group_one).name)
+    assert_not scoped_groups_names.include?(groups(:subgroup3).name)
+    assert_not scoped_groups_names.include?(groups(:subgroup4).name)
+    assert_not scoped_groups_names.include?(groups(:subgroup5).name)
+    assert_not scoped_groups_names.include?(groups(:david_doe_group_four).name)
+
+    linked_group_member = members(:namespace_group_link8_member1)
+    linked_group_member.expires_at = 10.days.ago.to_date
+    linked_group_member.save
+
+    scoped_groups = @policy.apply_scope(Group, type: :relation)
+
+    assert_equal 18, scoped_groups.count
+    scoped_groups_names = scoped_groups.pluck(:name)
+    assert_not scoped_groups_names.include?(groups(:namespace_group_link_group_one).name)
   end
 end

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -89,4 +89,14 @@ class GroupPolicyTest < ActiveSupport::TestCase
     # David Doe has access to 2 groups
     assert_equal 2, scoped_groups.count
   end
+
+  test 'scope with expired group member' do
+    group_member = members(:group_one_member_john_doe)
+    group_member.expires_at = 10.days.ago.to_date
+    group_member.save
+
+    scoped_groups = @policy.apply_scope(Group, type: :relation)
+
+    assert_equal 19, scoped_groups.count
+  end
 end

--- a/test/policies/namespace_policy_test.rb
+++ b/test/policies/namespace_policy_test.rb
@@ -8,6 +8,21 @@ class NamespacePolicyTest < ActiveSupport::TestCase
     @policy = NamespacePolicy.new(user: @user)
   end
 
+  test 'named scope with expired memberships' do
+    # assuming personal projects cannot be expired
+
+    group_member = members(:group_four_member_david_doe)
+    group_member.expires_at = 10.days.ago.to_date
+    group_member.save
+
+    scoped_namespaces = @policy.apply_scope(Namespace, type: :relation, name: :manageable)
+
+    assert_equal 1, scoped_namespaces.count
+
+    scoped_namespaces_names = scoped_namespaces.pluck(:name)
+    assert_not scoped_namespaces_names.include?(groups(:david_doe_group_four).name)
+  end
+
   test 'named scope without modify access to namespace via namespace group link' do
     scoped_namespaces = @policy.apply_scope(Namespace, type: :relation, name: :manageable)
     user_namespace = namespaces_user_namespaces(:david_doe_namespace)

--- a/test/policies/namespace_policy_test.rb
+++ b/test/policies/namespace_policy_test.rb
@@ -9,8 +9,6 @@ class NamespacePolicyTest < ActiveSupport::TestCase
   end
 
   test 'named scope with expired memberships' do
-    # assuming personal projects cannot be expired
-
     group_member = members(:group_four_member_david_doe)
     group_member.expires_at = 10.days.ago.to_date
     group_member.save

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -84,6 +84,16 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     assert_equal 22, scoped_projects.count
   end
 
+  test 'scope expired project member' do
+    project_member = members(:group_one_member_john_doe)
+    project_member.expires_at = 10.days.ago.to_date
+    project_member.save
+
+    scoped_projects = @policy.apply_scope(Project, type: :relation)
+
+    assert_equal 11, scoped_projects.count
+  end
+
   test 'manageable scope' do
     scoped_projects = @policy.apply_scope(Project, type: :relation, name: :manageable)
 

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -85,7 +85,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   end
 
   test 'scope expired project member' do
-    # assuming personal project cannot be expired
+    # assuming personal projects cannot be expired
 
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
@@ -94,25 +94,25 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
     assert_equal 11, scoped_projects.count
-    scoped_projects_namespaces = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id))
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project5_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project6_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project7_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project8_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project9_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project10_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project11_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project12_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project13_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project14_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project15_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project16_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project17_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project18_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project19_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project20_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project21_namespace).name)
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project24_namespace).name)
+    scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project5_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project6_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project7_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project8_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project9_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project10_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project11_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project12_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project13_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project14_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project15_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project16_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project17_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project18_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project19_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project20_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project21_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project24_namespace).name)
 
     project_member = members(:project_one_member_john_doe)
     project_member.expires_at = 10.days.ago.to_date
@@ -121,8 +121,8 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
     assert_equal 10, scoped_projects.count
-    scoped_projects_namespaces = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id))
-    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project1_namespace).name)
+    scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project1_namespace).name)
 
     linked_group_member = members(:namespace_group_link8_member1)
     linked_group_member.expires_at = 10.days.ago.to_date
@@ -131,6 +131,8 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
     assert_equal 9, scoped_projects.count
+    scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project28_namespace).name)
   end
 
   test 'manageable scope' do

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -84,7 +84,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     assert_equal 22, scoped_projects.count
   end
 
-  test 'scope expired project member' do
+  test 'scope expired memberships' do
     # assuming personal projects cannot be expired
 
     group_member = members(:group_one_member_john_doe)
@@ -132,7 +132,9 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     assert_equal 9, scoped_projects.count
     scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
-    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project28_namespace).name)
+    assert_not scoped_projects_names.include?(
+      namespaces_project_namespaces(:namespace_group_link_group_one_project1_namespace).name
+    )
   end
 
   test 'manageable scope' do
@@ -150,6 +152,48 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     # none through namespace group links as manageable access has not
     # been set for any of the links
     assert_equal 1, scoped_projects.count
+  end
+
+  test 'manageable scope expired memberships' do
+    # assuming personal projects cannot be expired
+
+    group_member = members(:group_one_member_john_doe)
+    group_member.expires_at = 10.days.ago.to_date
+    group_member.save
+
+    scoped_projects = @policy.apply_scope(Project, type: :relation, name: :manageable)
+
+    assert_equal 10, scoped_projects.count
+    scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project5_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project6_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project7_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project8_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project9_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project10_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project11_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project12_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project13_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project14_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project15_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project16_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project17_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project18_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project19_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project20_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project21_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project24_namespace).name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project25_namespace).name)
+
+    project_member = members(:project_one_member_john_doe)
+    project_member.expires_at = 10.days.ago.to_date
+    project_member.save
+
+    scoped_projects = @policy.apply_scope(Project, type: :relation, name: :manageable)
+
+    assert_equal 9, scoped_projects.count
+    scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
+    assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project1_namespace).name)
   end
 
   test 'named scope with modify access to namespace via a namespace group link ' do

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -85,13 +85,52 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   end
 
   test 'scope expired project member' do
-    project_member = members(:group_one_member_john_doe)
+    # assuming personal project cannot be expired
+
+    group_member = members(:group_one_member_john_doe)
+    group_member.expires_at = 10.days.ago.to_date
+    group_member.save
+
+    scoped_projects = @policy.apply_scope(Project, type: :relation)
+
+    assert_equal 11, scoped_projects.count
+    scoped_projects_namespaces = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id))
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project5_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project6_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project7_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project8_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project9_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project10_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project11_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project12_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project13_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project14_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project15_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project16_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project17_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project18_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project19_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project20_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project21_namespace).name)
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project24_namespace).name)
+
+    project_member = members(:project_one_member_john_doe)
     project_member.expires_at = 10.days.ago.to_date
     project_member.save
 
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
-    assert_equal 11, scoped_projects.count
+    assert_equal 10, scoped_projects.count
+    scoped_projects_namespaces = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id))
+    assert_not scoped_projects_namespaces.include?(namespaces_project_namespaces(:project1_namespace).name)
+
+    linked_group_member = members(:namespace_group_link8_member1)
+    linked_group_member.expires_at = 10.days.ago.to_date
+    linked_group_member.save
+
+    scoped_projects = @policy.apply_scope(Project, type: :relation)
+
+    assert_equal 9, scoped_projects.count
   end
 
   test 'manageable scope' do

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -85,8 +85,6 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   end
 
   test 'scope expired memberships' do
-    # assuming personal projects cannot be expired
-
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
     group_member.save
@@ -155,8 +153,6 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   end
 
   test 'manageable scope expired memberships' do
-    # assuming personal projects cannot be expired
-
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
     group_member.save


### PR DESCRIPTION
## What does this PR do and why?
Fixes #230.
- Added a new `expires_at` column in the members table.
- Created a new scope `not_expired` for members.
- Updated policies to only retrieve non-expired members.

## Screenshots or screen recordings
N/A

## How to set up and validate locally
There are a couple ways to test:
1. Call the new scope via console
`Member.for_namespace_and_ancestors(@group).not_expired` or `Member.for_namespace_and_ancestors(@project.namespace).not_expired` and verify the members.
2. Even though this is not the fronted PR, you can log in as the user with an expired membership to make sure groups and projects are not displayed. Some areas to check are:
    - the groups/projects dashboards
    - transferring groups/projects drop-down list

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
