### PR TITLE
Attachment destroy service

### DIFF
--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -38,23 +38,32 @@ module Projects
         end
       end
 
-      def destroy
+      def destroy # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         authorize! @project, to: :destroy_sample?
-        return destroy_error if @attachment.attachable_type != 'Sample' || @attachment.attachable_id != @sample.id
-
-        @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
-
-        return unless @destroyed_attachments
-
-        status = if @destroyed_attachments.count.positive?
-                   destroy_status(@attachment, @destroyed_attachments.length)
-                 else
-                   :unprocessable_entity
-                 end
-
         respond_to do |format|
-          format.turbo_stream do
-            render status:, locals: { destroyed_attachments: @destroyed_attachments }
+          if @attachment.attachable_type != 'Sample' || @attachment.attachable_id != @sample.id
+            format.turbo_stream do
+              render status: :bad_request,
+                     locals: { type: 'alert',
+                               message: t('.error',
+                                          filename: @attachment.file.filename,
+                                          errors: "Attachment does not belong to #{@sample.name}"),
+                               destroyed_attachments: nil }
+            end
+          else
+            @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
+
+            return unless @destroyed_attachments
+
+            status = if @destroyed_attachments.count.positive?
+                       destroy_status(@attachment, @destroyed_attachments.length)
+                     else
+                       :unprocessable_entity
+                     end
+
+            format.turbo_stream do
+              render status:, locals: { destroyed_attachments: @destroyed_attachments }
+            end
           end
         end
       end
@@ -79,19 +88,6 @@ module Projects
         return count == 2 ? :ok : :multi_status if attachment.associated_attachment
 
         count == 1 ? :ok : :unprocessable_entity
-      end
-
-      def destroy_error
-        respond_to do |format|
-          format.turbo_stream do
-            render status: :bad_request,
-                   locals: { type: 'alert',
-                             message: t('.error',
-                                        filename: @attachment.file.filename,
-                                        errors: "Attachment does not belong to #{@sample.name}"),
-                             destroyed_attachments: nil }
-          end
-        end
       end
     end
   end

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -41,7 +41,7 @@ module Projects
       def destroy
         authorize! @project, to: :destroy?
 
-        return unless @attachment.attachable_type == 'Sample' && @attachment.attachable_id == @attachable.id
+        return unless @attachment.attachable_type == 'Sample' && @attachment.attachable_id == @sample.id
 
         @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
 

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -42,7 +42,7 @@ module Projects
         authorize! @project, to: :update_sample?
 
         @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
-
+        puts @destroyed_attachments
         return unless @destroyed_attachments
 
         status = if @destroyed_attachments.count.positive?

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -40,12 +40,15 @@ module Projects
 
       def destroy
         authorize! @project, to: :destroy?
+
+        return unless @attachment.attachable_type == 'Sample' && @attachment.attachable_id == @attachable.id
+
         @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
 
         return unless @destroyed_attachments
 
         status = if @destroyed_attachments.count.positive?
-                   deleted_status(@attachment, @destroyed_attachments.length)
+                   destroy_status(@attachment, @destroyed_attachments.length)
                  else
                    :unprocessable_entity
                  end
@@ -73,7 +76,7 @@ module Projects
         @attachment = @sample.attachments.find_by(id: params[:id]) || not_found
       end
 
-      def deleted_status(attachment, count)
+      def destroy_status(attachment, count)
         return count == 2 ? :ok : :multi_status if attachment.associated_attachment
 
         count == 1 ? :ok : :unprocessable_entity

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -42,7 +42,7 @@ module Projects
         authorize! @project, to: :update_sample?
 
         @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
-        puts @destroyed_attachments
+
         return unless @destroyed_attachments
 
         status = if @destroyed_attachments.count.positive?

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -40,7 +40,6 @@ module Projects
 
       def destroy
         authorize! @project, to: :destroy?
-
         return unless @attachment.attachable_type == 'Sample' && @attachment.attachable_id == @sample.id
 
         @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -38,32 +38,21 @@ module Projects
         end
       end
 
-      def destroy # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-        authorize! @project, to: :destroy_sample?
+      def destroy
+        authorize! @project, to: :update_sample?
         respond_to do |format|
-          if @attachment.attachable_type != 'Sample' || @attachment.attachable_id != @sample.id
-            format.turbo_stream do
-              render status: :bad_request,
-                     locals: { type: 'alert',
-                               message: t('.error',
-                                          filename: @attachment.file.filename,
-                                          errors: "Attachment does not belong to #{@sample.name}"),
-                               destroyed_attachments: nil }
-            end
-          else
-            @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
+          @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
 
-            return unless @destroyed_attachments
+          return unless @destroyed_attachments
 
-            status = if @destroyed_attachments.count.positive?
-                       destroy_status(@attachment, @destroyed_attachments.length)
-                     else
-                       :unprocessable_entity
-                     end
+          status = if @destroyed_attachments.count.positive?
+                     destroy_status(@attachment, @destroyed_attachments.length)
+                   else
+                     :unprocessable_entity
+                   end
 
-            format.turbo_stream do
-              render status:, locals: { destroyed_attachments: @destroyed_attachments }
-            end
+          format.turbo_stream do
+            render status:, locals: { destroyed_attachments: @destroyed_attachments }
           end
         end
       end

--- a/app/services/attachments/destroy_service.rb
+++ b/app/services/attachments/destroy_service.rb
@@ -12,13 +12,12 @@ module Attachments
 
     def execute # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       authorize! @attachable.project, to: :destroy?
-
-      if @attachment.attachable_id != @attachable.id || !@attachable.is_a?(@attachment.attachable_type.constantize)
+      destroyed_attachments = []
+      if @attachment.attachable_id != @attachable.id
         raise AttachmentsDestroyError, I18n.t('services.attachments.destroy.does_not_belong_to_attachable')
       end
 
-      destroyed_attachments = []
-      if @attachable.instance_of?(Sample) && @attachment.associated_attachment
+      if @attachment.associated_attachment
         if @attachment.associated_attachment.attachable_id != @attachable.id
           raise AttachmentsDestroyError,
                 I18n.t('services.attachments.destroy.associated_att_does_not_belong_to_attachable')
@@ -31,6 +30,9 @@ module Attachments
 
       @attachment.destroy
       destroyed_attachments.append(@attachment)
+      destroyed_attachments
+    rescue Attachments::DestroyService::AttachmentsDestroyError => e
+      @attachment.errors.add(:base, e.message)
       destroyed_attachments
     end
   end

--- a/app/services/attachments/destroy_service.rb
+++ b/app/services/attachments/destroy_service.rb
@@ -12,16 +12,16 @@ module Attachments
     def execute
       authorize! @attachable.project, to: :destroy?
 
-      attachments = []
+      destroyed_attachments = []
       if @attachable.instance_of?(Sample) && @attachment.associated_attachment
         associated_attachment = @attachment.associated_attachment
         associated_attachment.destroy
-        attachments.append(associated_attachment)
+        destroyed_attachments.append(associated_attachment)
       end
 
       @attachment.destroy
-      attachments.append(@attachment)
-      attachments
+      destroyed_attachments.append(@attachment)
+      destroyed_attachments
     end
   end
 end

--- a/app/services/attachments/destroy_service.rb
+++ b/app/services/attachments/destroy_service.rb
@@ -11,12 +11,9 @@ module Attachments
 
     def execute
       authorize! @attachable.project, to: :destroy?
-      return unless @attachable.instance_of?(Sample)
 
       attachments = []
-      return unless @attachment.attachable_type == 'Sample' && @attachment.attachable_id == @attachable.id
-
-      if @attachment.associated_attachment
+      if @attachable.instance_of?(Sample) && @attachment.associated_attachment
         associated_attachment = @attachment.associated_attachment
         associated_attachment.destroy
         attachments.append(associated_attachment)

--- a/app/services/attachments/destroy_service.rb
+++ b/app/services/attachments/destroy_service.rb
@@ -3,6 +3,7 @@
 module Attachments
   # Service used to Delete Projects
   class DestroyService < BaseService
+    AttachmentsDestroyError = Class.new(StandardError)
     def initialize(attachable, attachment, user = nil)
       super(user)
       @attachable = attachable
@@ -11,7 +12,9 @@ module Attachments
 
     def execute
       authorize! @attachable.project, to: :destroy?
+      unless @attachment.attachable_id != @attachable.id || !@attachable.is_a?(@attachment.attachable_type.constantize)
 
+      end
       destroyed_attachments = []
       if @attachable.instance_of?(Sample) && @attachment.associated_attachment
         associated_attachment = @attachment.associated_attachment

--- a/app/services/attachments/destroy_service.rb
+++ b/app/services/attachments/destroy_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Attachments
+  # Service used to Delete Projects
+  class DestroyService < BaseService
+    def initialize(attachable, attachment, user = nil)
+      super(user)
+      @attachable = attachable
+      @attachment = attachment
+    end
+
+    def execute
+      authorize! @attachable.project, to: :destroy?
+      return unless @attachable.instance_of?(Sample)
+
+      attachments = []
+      return unless @attachment.attachable_type == 'Sample' && @attachment.attachable_id == @attachable.id
+
+      if @attachment.associated_attachment
+        associated_attachment = @attachment.associated_attachment
+        associated_attachment.destroy
+        attachments.append(associated_attachment)
+      end
+
+      @attachment.destroy
+      attachments.append(@attachment)
+      attachments
+    end
+  end
+end

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -53,14 +53,22 @@
       </div>
     </td>
   <% else %>
-    <td class="px-6 py-4"><%= link_to attachment.file.filename,
-      download_namespace_project_sample_attachment_path(
-        sample_id: @sample.id,
-        id: attachment.id
-      ),
-      data: {
-        turbo: false
-      } %>
+    <td class="px-6 py-4">
+    <div>
+        <div class="flex items-center">
+          <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+          <span>
+            <%= link_to attachment.file.filename,
+              download_namespace_project_sample_attachment_path(
+                sample_id: @sample.id,
+                id: attachment.id
+              ),
+              data: {
+                turbo: false
+              } %>
+          </span>
+        </div>
+      </div>
     </td>
   <% end %>
 

--- a/app/views/projects/samples/attachments/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/destroy.turbo_stream.erb
@@ -1,10 +1,16 @@
-<% destroyed_attachments.each do |attachment| %>
-  <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(
-      type: :success,
-      data: t(".success", filename: attachment.file.filename)
-    ) %>
-  <% end %>
+<% if destroyed_attachments %>
+  <% destroyed_attachments.each do |attachment| %>
+    <%= turbo_stream.append "flashes" do %>
+      <%= viral_flash(
+        type: :success,
+        data: t(".success", filename: attachment.file.filename)
+      ) %>
+    <% end %>
 
-  <%= turbo_stream.remove dom_id(attachment) %>
+    <%= turbo_stream.remove dom_id(attachment) %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.append "flashes" do %>
+    <%= viral_flash(type: :error, data: message) %>
+  <% end %>
 <% end %>

--- a/app/views/projects/samples/attachments/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/destroy.turbo_stream.erb
@@ -1,16 +1,10 @@
-<% if destroyed_attachments %>
-  <% destroyed_attachments.each do |attachment| %>
-    <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
-        type: :success,
-        data: t(".success", filename: attachment.file.filename)
-      ) %>
-    <% end %>
-
-    <%= turbo_stream.remove dom_id(attachment) %>
-  <% end %>
-<% else %>
+<% destroyed_attachments.each do |attachment| %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= viral_flash(
+      type: :success,
+      data: t(".success", filename: attachment.file.filename)
+    ) %>
   <% end %>
+
+  <%= turbo_stream.remove dom_id(attachment) %>
 <% end %>

--- a/app/views/projects/samples/attachments/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/destroy.turbo_stream.erb
@@ -1,10 +1,16 @@
-<% destroyed_attachments.each do |attachment| %>
-  <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(
-      type: :success,
-      data: t(".success", filename: attachment.file.filename)
-    ) %>
-  <% end %>
+<% if destroyed_attachments %>
+  <% destroyed_attachments.each do |attachment| %>
+    <%= turbo_stream.append "flashes" do %>
+      <%= viral_flash(
+        type: :success,
+        data: t(".success", filename: attachment.file.filename)
+      ) %>
+    <% end %>
 
-  <%= turbo_stream.remove dom_id(attachment) %>
+    <%= turbo_stream.remove dom_id(attachment) %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.append "flashes" do %>
+    <%= viral_flash(type:, data: message) %>
+  <% end %>
 <% end %>

--- a/app/views/projects/samples/attachments/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/destroy.turbo_stream.erb
@@ -1,8 +1,10 @@
-<%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(
-    type: :success,
-    data: t(".success", filename: @attachment.file.filename)
-  ) %>
-<% end %>
+<% destroyed_attachments.each do |attachment| %>
+  <%= turbo_stream.append "flashes" do %>
+    <%= viral_flash(
+      type: :success,
+      data: t(".success", filename: attachment.file.filename)
+    ) %>
+  <% end %>
 
-<%= turbo_stream.remove dom_id(@attachment) %>
+  <%= turbo_stream.remove dom_id(attachment) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -848,7 +848,7 @@ en:
           failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         destroy:
           success: File %{filename} was successfully removed.
-          error: 'File %{filename} was not removed due to the following errors: %{errors}.'
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
         error: File %{filename} was not removed.
   services:
     attachments:
@@ -860,7 +860,7 @@ en:
         incorrect_fastq_file_types: "Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files"
         no_files_selected: No files were selected to concatenate. Please select files then try again.
       destroy:
-        does_not_belong_to_attachable: This attachment does not belong to this attachable.
+        does_not_belong_to_attachable: This attachment does not belong to this sample.
         associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.
     groups:
       transfer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -848,6 +848,8 @@ en:
           failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         destroy:
           success: File %{filename} was successfully removed.
+          error: 'File %{filename} was not be removed due to the following errors: %{errors}.'
+        error: File %{filename} was not be removed.
   services:
     attachments:
       concatenation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -848,8 +848,8 @@ en:
           failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         destroy:
           success: File %{filename} was successfully removed.
-          error: 'File %{filename} was not be removed due to the following errors: %{errors}.'
-        error: File %{filename} was not be removed.
+          error: 'File %{filename} was not removed due to the following errors: %{errors}.'
+        error: File %{filename} was not removed.
   services:
     attachments:
       concatenation:
@@ -859,6 +859,9 @@ en:
         incorrect_attachable: All or some of then selected files do not belong to the sample.
         incorrect_fastq_file_types: "Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files"
         no_files_selected: No files were selected to concatenate. Please select files then try again.
+      destroy:
+        does_not_belong_to_attachable: This attachment does not belong to this attachable.
+        associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.
     groups:
       transfer:
         namespace_empty: The new namespace is empty.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -839,7 +839,7 @@ fr:
           failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         destroy:
           success: File %{filename} was successfully removed.
-          error: 'File %{filename} was not removed due to the following errors: %{errors}.'
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
         error: File %{filename} was not removed.
   services:
     attachments:
@@ -851,8 +851,8 @@ fr:
         incorrect_fastq_file_types: "Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files"
         no_files_selected: No files were selected to concatenate. Please select files then try again.
       destroy:
-        does_not_belong_to_attachable: This attachment does not belong to this attachable.
-        associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the attachable.
+        does_not_belong_to_attachable: This attachment does not belong to this sample.
+        associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.
     groups:
       transfer:
         namespace_empty: The new namespace is empty.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -839,9 +839,20 @@ fr:
           failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         destroy:
           success: File %{filename} was successfully removed.
-          error: 'File %{filename} was not be removed due to the following errors: %{errors}.'
-        error: File %{filename} was not be removed.
+          error: 'File %{filename} was not removed due to the following errors: %{errors}.'
+        error: File %{filename} was not removed.
   services:
+    attachments:
+      concatenation:
+        filename_missing: Base file name not provided. Please provide a base name for the concatenated file.
+        incorrect_file_pairs: Incorrect file pairing. Forward and reverse read file counts do not match.
+        incorrect_file_types: 'Files are not of the same type. Paired-end files can only be concatenated with other paired-end files, and single-end files can only be concatenated with other single-end files.'
+        incorrect_attachable: All or some of then selected files do not belong to the sample.
+        incorrect_fastq_file_types: "Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files"
+        no_files_selected: No files were selected to concatenate. Please select files then try again.
+      destroy:
+        does_not_belong_to_attachable: This attachment does not belong to this attachable.
+        associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the attachable.
     groups:
       transfer:
         namespace_empty: The new namespace is empty.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -839,6 +839,8 @@ fr:
           failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         destroy:
           success: File %{filename} was successfully removed.
+          error: 'File %{filename} was not be removed due to the following errors: %{errors}.'
+        error: File %{filename} was not be removed.
   services:
     groups:
       transfer:

--- a/test/services/attachments/destroy_service_test.rb
+++ b/test/services/attachments/destroy_service_test.rb
@@ -9,6 +9,7 @@ module Attachments
       @sample = samples(:sample1)
       @attachment1 = attachments(:attachment1)
       @attachment2 = attachments(:attachment2)
+      @attachment3 = attachments(:attachmentA)
     end
 
     test 'delete attachment with correct permissions' do
@@ -36,6 +37,16 @@ module Attachments
       assert_difference -> { Attachment.count } => -2 do
         Attachments::DestroyService.new(@sample, @attachment2, @user).execute
       end
+    end
+
+    test 'delete attachment that does not belong to sample' do
+      assert_no_difference ['Attachment.count'] do
+        Attachments::DestroyService.new(@sample, @attachment3, @user).execute
+      end
+
+      assert @attachment3.errors.full_messages.include?(
+        I18n.t('services.attachments.destroy.does_not_belong_to_attachable')
+      )
     end
   end
 end

--- a/test/services/attachments/destroy_service_test.rb
+++ b/test/services/attachments/destroy_service_test.rb
@@ -9,8 +9,6 @@ module Attachments
       @sample = samples(:sample1)
       @attachment1 = attachments(:attachment1)
       @attachment2 = attachments(:attachment2)
-      @testsample_illumina_pe_fwd_blob = active_storage_blobs(:testsample_illumina_pe_forward_blob)
-      @testsample_illumina_pe_rev_blob = active_storage_blobs(:testsample_illumina_pe_reverse_blob)
     end
 
     test 'delete attachment with correct permissions' do

--- a/test/services/attachments/destroy_service_test.rb
+++ b/test/services/attachments/destroy_service_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Attachments
+  class DestroyServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:john_doe)
+      @sample = samples(:sample1)
+      @attachment1 = attachments(:attachment1)
+      @attachment2 = attachments(:attachment2)
+      @testsample_illumina_pe_fwd_blob = active_storage_blobs(:testsample_illumina_pe_forward_blob)
+      @testsample_illumina_pe_rev_blob = active_storage_blobs(:testsample_illumina_pe_reverse_blob)
+    end
+
+    test 'delete attachment with correct permissions' do
+      assert_difference -> { Attachment.count } => -1 do
+        Attachments::DestroyService.new(@sample, @attachment1, @user).execute
+      end
+    end
+
+    test 'delete attachment with incorrect permissions' do
+      user = users(:joan_doe)
+
+      exception = assert_raises(ActionPolicy::Unauthorized) do
+        Attachments::DestroyService.new(@sample, @attachment1, user).execute
+      end
+
+      assert_equal ProjectPolicy, exception.policy
+      assert_equal :destroy?, exception.rule
+      assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+      assert_equal I18n.t(:'action_policy.policy.project.destroy?', name: @sample.project.name),
+                   exception.result.message
+    end
+
+    test 'delete attachment with associated attachment' do
+      @attachment2.metadata['associated_attachment_id'] = @attachment1.id
+      assert_difference -> { Attachment.count } => -2 do
+        Attachments::DestroyService.new(@sample, @attachment2, @user).execute
+      end
+    end
+  end
+end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -112,6 +112,7 @@ module Projects
 
     test 'user with role >= Maintainer should be able to attach, view, and destroy paired files to a Sample' do
       visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample2.id)
+      sleep 1
       # Initial View
       assert_selector 'button', text: I18n.t('projects.samples.show.upload_files'), count: 1
       within('#attachments') do

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -112,9 +112,8 @@ module Projects
 
     test 'user with role >= Maintainer should be able to attach, view, and destroy paired files to a Sample' do
       visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample2.id)
-      sleep 1
       # Initial View
-      assert_selector 'button', text: I18n.t('projects.samples.show.upload_files'), count: 1
+      assert_selector 'a', text: I18n.t('projects.samples.show.new_attachment_button'), count: 1
       within('#attachments') do
         assert_text I18n.t('projects.samples.show.no_files')
         assert_text I18n.t('projects.samples.show.no_associated_files')

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -110,6 +110,52 @@ module Projects
       end
     end
 
+    test 'user with role >= Maintainer should be able to attach, view, and destroy paired files to a Sample' do
+      visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample2.id)
+      # Initial View
+      assert_selector 'button', text: I18n.t('projects.samples.show.upload_files'), count: 1
+      within('#attachments') do
+        assert_text I18n.t('projects.samples.show.no_files')
+        assert_text I18n.t('projects.samples.show.no_associated_files')
+        assert_selector 'button', text: I18n.t('projects.samples.attachments.attachment.delete'), count: 0
+      end
+      click_on I18n.t('projects.samples.show.upload_files')
+
+      # Attach paired files
+      within('dialog') do
+        attach_file 'attachment[files][]',
+                    [Rails.root.join('test/fixtures/files/TestSample_S1_L001_R1_001.fastq'),
+                     Rails.root.join('test/fixtures/files/TestSample_S1_L001_R2_001.fastq')]
+        click_on I18n.t('projects.samples.show.upload')
+      end
+
+      assert_text I18n.t('projects.samples.attachments.create.success', filename: 'TestSample_S1_L001_R1_001.fastq')
+      assert_text I18n.t('projects.samples.attachments.create.success', filename: 'TestSample_S1_L001_R2_001.fastq')
+
+      # View paired files
+      within('#attachments') do
+        assert_text 'TestSample_S1_L001_R1_001.fastq'
+        assert_text 'TestSample_S1_L001_R2_001.fastq'
+        assert_selector 'button', text: I18n.t('projects.samples.attachments.attachment.delete'), count: 1
+      end
+
+      # Destroy paired files
+      click_on I18n.t('projects.samples.attachments.attachment.delete'), match: :first
+
+      within('#turbo-confirm[open]') do
+        click_button I18n.t(:'components.confirmation.confirm')
+      end
+
+      assert_text I18n.t('projects.samples.attachments.destroy.success', filename: 'TestSample_S1_L001_R1_001.fastq')
+      assert_text I18n.t('projects.samples.attachments.destroy.success', filename: 'TestSample_S1_L001_R2_001.fastq')
+      within('#attachments') do
+        assert_no_text 'TestSample_S1_L001_R1_001.fastq'
+        assert_no_text 'TestSample_S1_L001_R2_001.fastq'
+        assert_text I18n.t('projects.samples.show.no_files')
+        assert_text I18n.t('projects.samples.show.no_associated_files')
+      end
+    end
+
     test 'should destroy Sample' do
       visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
       assert_selector 'a', text: I18n.t('projects.samples.index.remove_button'), count: 1


### PR DESCRIPTION
## What does this PR do and why?
This PR creates the destroy service for attachments, moving the destroy functionality away from the attachments controller. In addition to the destroy service, deletion of paired sample attachments is now also fixed whereby the shared delete button on the samples attachment page for paired attachments will now delete both associated attachments. 

## Screenshots or screen recordings
[Screencast from 2023-11-03 09:23:46 AM.webm](https://github.com/phac-nml/irida-next/assets/82407232/49204e67-e806-486f-921c-007aa0773132)

## How to set up and validate locally
Upload both single and paired attachments to a sample and delete, ensuring delete functionality is handled as expected.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
