### PR TITLE
UpdatedComponent: translation and lookbook preview fix

### DIFF
--- a/app/components/updated_component.html.erb
+++ b/app/components/updated_component.html.erb
@@ -1,4 +1,3 @@
-<span class="text-sm">
-  <%= description %>
+<span class="text-sm text-gray-900 dark:text-white">
   <%= updated_at %>
 </span>

--- a/app/components/updated_component.rb
+++ b/app/components/updated_component.rb
@@ -2,10 +2,9 @@
 
 # A component for displaying when a record was updated.
 class UpdatedComponent < ViewComponent::Base
-  attr_reader :description, :updated_at
+  attr_reader :updated_at
 
-  def initialize(updated_at:, description: I18n.t(:'time.updated'))
-    @description = description
-    @updated_at = distance_of_time_in_words(Time.zone.now, updated_at)
+  def initialize(updated_at:)
+    @updated_at = distance_of_time_in_words(Time.zone.now, updated_at, scope: 'datetime.distance_in_words.updated')
   end
 end

--- a/app/components/viral/time_ago_component.html.erb
+++ b/app/components/viral/time_ago_component.html.erb
@@ -1,3 +1,3 @@
 <%= viral_tooltip(title: l(original_time, format: :long)) do %>
-    <span class='text-sm'><%= time_ago %></span>
+  <span class='text-sm text-gray-900 dark:text-white'><%= time_ago %></span>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,6 @@ en:
   time:
     formats:
       default: "%Y-%m-%d %H:%M:%S"
-    updated: Updated
   date:
     formats:
       iso: "YYYY-MM-DD"
@@ -203,6 +202,44 @@ en:
         direct: Direct shared
   datetime:
     distance_in_words:
+      updated:
+        about_x_hours:
+          one: Updated about %{count} hour ago
+          other: Updated about %{count} hours ago
+        about_x_months:
+          one: Updated about %{count} month ago
+          other: Updated about %{count} months ago
+        about_x_years:
+          one: Updated about %{count} year ago
+          other: Updated about %{count} years ago
+        almost_x_years:
+          one: Updated almost %{count} year ago
+          other: Updated almost %{count} years ago
+        half_a_minute: Updated half a minute ago
+        less_than_x_seconds:
+          one: Updated less than %{count} second ago
+          other: Updated less than %{count} seconds ago
+        less_than_x_minutes:
+          one: Updated less than a minute ago
+          other: Updated less than %{count} minutes ago
+        over_x_years:
+          one: Updated over %{count} year ago
+          other: Updated over %{count} years ago
+        x_seconds:
+          one: "Updated %{count} second ago"
+          other: "Updated %{count} seconds ago"
+        x_minutes:
+          one: "Updated %{count} minute ago"
+          other: "Updated %{count} minutes ago"
+        x_days:
+          one: "Updated %{count} day ago"
+          other: "Updated %{count} days ago"
+        x_months:
+          one: "Updated %{count} month ago"
+          other: "Updated %{count} months ago"
+        x_years:
+          one: "Updated %{count} year ago"
+          other: "Updated %{count} years ago"
       about_x_hours:
         one: about %{count} hour ago
         other: about %{count} hours ago

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -203,6 +203,44 @@ fr:
         direct: Direct shared
   datetime:
     distance_in_words:
+      updated:
+        about_x_hours:
+          one: Updated about %{count} hour ago
+          other: Updated about %{count} hours ago
+        about_x_months:
+          one: Updated about %{count} month ago
+          other: Updated about %{count} months ago
+        about_x_years:
+          one: Updated about %{count} year ago
+          other: Updated about %{count} years ago
+        almost_x_years:
+          one: Updated almost %{count} year ago
+          other: Updated almost %{count} years ago
+        half_a_minute: Updated half a minute ago
+        less_than_x_seconds:
+          one: Updated less than %{count} second ago
+          other: Updated less than %{count} seconds ago
+        less_than_x_minutes:
+          one: Updated less than a minute ago
+          other: Updated less than %{count} minutes ago
+        over_x_years:
+          one: Updated over %{count} year ago
+          other: Updated over %{count} years ago
+        x_seconds:
+          one: "Updated %{count} second ago"
+          other: "Updated %{count} seconds ago"
+        x_minutes:
+          one: "Updated %{count} minute ago"
+          other: "Updated %{count} minutes ago"
+        x_days:
+          one: "Updated %{count} day ago"
+          other: "Updated %{count} days ago"
+        x_months:
+          one: "Updated %{count} month ago"
+          other: "Updated %{count} months ago"
+        x_years:
+          one: "Updated %{count} year ago"
+          other: "Updated %{count} years ago"
       about_x_hours:
         one: about %{count} hour ago
         other: about %{count} hours ago

--- a/test/components/previews/updated_component_preview.rb
+++ b/test/components/previews/updated_component_preview.rb
@@ -2,6 +2,4 @@
 
 class UpdatedComponentPreview < ViewComponent::Preview
   def default; end
-
-  def with_custom_description; end
 end

--- a/test/components/previews/updated_component_preview/with_custom_description.html.erb
+++ b/test/components/previews/updated_component_preview/with_custom_description.html.erb
@@ -1,4 +1,0 @@
-<%= render UpdatedComponent.new(
-  description: "Record updated",
-  updated_at: Time.zone.now + 1
-) %>

--- a/test/components/updated_component_test.rb
+++ b/test/components/updated_component_test.rb
@@ -5,20 +5,6 @@ require 'test_helper'
 class UpdatedComponentTest < ViewComponent::TestCase
   include ActionView::Helpers::DateHelper
 
-  test 'renders custom description updated at time ago (less than a minute)' do
-    render_inline(UpdatedComponent.new(description: 'Record updated',
-                                       updated_at: Time.zone.now + 1))
-
-    assert_text 'Record updated less than a minute ago'
-  end
-
-  test 'renders custom description updated at time ago (greater than a minute)' do
-    render_inline(UpdatedComponent.new(description: 'Record updated',
-                                       updated_at: Time.zone.now + 1000))
-
-    assert_text 'Record updated 17 minutes ago'
-  end
-
   test 'renders default updated at time ago (less than a minute)' do
     render_inline(UpdatedComponent.new(
                     updated_at: Time.zone.now + 1


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the translation for `UpdatedComponent` to use scope for distance_in_words instead of having 2 translations joined. Fixed lookbook preview for `UpdatedComponent` and `TimeAgoComponent` so they display correctly in dark mode. Also, the custom description was removed for the `UpdatedComponent`

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/25466211/38230a72-c2e7-4a59-b15a-a5243898da81)

![image](https://github.com/phac-nml/irida-next/assets/25466211/00b861cc-1899-4c31-8632-8b47ee0dce46)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1) Ensure the translations display correctly in the lookbook previews
2) Ensure the translations display correctly for updated at in the members tables for groups and projects when the member is updated

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
