### PR TITLE
style: Fix checkbox colour for project samples

### DIFF
--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -18,7 +18,7 @@
         class="text-sm font-normal text-slate-500 dark:text-slate-400"
       >
         <% if allowed_to?(:transfer_sample?, project) %>
-          <td class="ps-4 w-10">
+          <td class="w-10 ps-4">
             <%= check_box_tag "sample_ids[]",
             sample.id,
             nil,
@@ -27,7 +27,9 @@
             data: {
               action: "input->selection#toggle",
               selection_target: "rowSelection"
-            } %>
+            },
+            class:
+              "w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
           </td>
         <% end %>
         <td class="p-4 whitespace-nowrap">


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Checkboxes on the project samples page are hard-coded to blue, they should be set to the primary colour.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Before**
![image](https://github.com/phac-nml/irida-next/assets/11295750/8a11e629-f4d2-4c27-a3ea-948999f76242)

**After**
![image](https://github.com/phac-nml/irida-next/assets/11295750/58bb4a5b-8d5d-4801-8dae-f91b8fac3a0c)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Go to any project that has samples and ensure the selected samples checkboxes are set to the appropriate colour.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
