### PR TITLE
Remove unnecessary lines from language selection

### DIFF
--- a/app/views/profiles/preferences/_locale_form.html.erb
+++ b/app/views/profiles/preferences/_locale_form.html.erb
@@ -4,7 +4,6 @@
             <%= f.radio_button :locale, 'en',
                 checked: (@user.locale == 'en'),
                 class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600',
-                'data-action': "change->locale#toggleTheme",
                 onchange: "this.form.submit()" %>
             <%= f.label t(:'.en'),
                 for: 'user_locale_en',
@@ -15,7 +14,6 @@
                 'fr',
                 checked: (@user.locale == 'fr'),
                 class: 'w-4 h-4 text-primary-600 bg-gray-100 border-gray-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600',
-                'data-action': "change->locale#toggleTheme",
                 onchange: "this.form.submit()" %>
             <%= f.label t(:'.fr'),
                 for: 'user_locale_fr',


### PR DESCRIPTION
## What does this PR do and why?
Removes a couple lines that were left behind when attempting to add a stimulus controller for language selection. They are now unneeded as the language selection is handled by submitting the language form onchange

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
Select languages to ensure it still works as expected.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
