### PR TITLE
Disable table action links if no samples are seleceted

### DIFF
--- a/app/javascript/controllers/action_link_controller.js
+++ b/app/javascript/controllers/action_link_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  #classes = [
+    "pointer-events-none",
+    "cursor-not-allowed",
+    "bg-slate-200",
+    "text-slate-400",
+  ];
+
+  setDisabled(disabled = true) {
+    if (disabled) {
+      this.element.classList.add(...this.#classes);
+    } else {
+      this.element.classList.remove(...this.#classes);
+    }
+  }
+}

--- a/app/javascript/controllers/action_link_controller.js
+++ b/app/javascript/controllers/action_link_controller.js
@@ -5,18 +5,27 @@ export default class extends Controller {
 
   // # indicated private attribute or method
   // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties
-  #classes = [
-    "pointer-events-none",
-    "cursor-not-allowed",
-    "bg-slate-200",
-    "text-slate-400",
-  ];
+  #event_classes = ["pointer-events-none", "cursor-not-allowed"];
+
+  #default_colours = ["bg-slate-200", "text-slate-400"];
+
+  #primary_colours = ["bg-primary-200", "text-slate-400", "border-primary-200"];
 
   setDisabled(count = 0) {
     if (this.requiredValue > count) {
-      this.element.classList.add(...this.#classes);
+      this.element.classList.add(...this.#event_classes);
+      if (this.element.classList.contains("button--state-primary")) {
+        this.element.classList.add(...this.#primary_colours);
+      } else {
+        this.element.classList.add(...this.#default_colours);
+      }
     } else {
-      this.element.classList.remove(...this.#classes);
+      this.element.classList.remove(...this.#event_classes);
+      if (this.element.classList.contains("button--state-primary")) {
+        this.element.classList.remove(...this.#primary_colours);
+      } else {
+        this.element.classList.remove(...this.#default_colours);
+      }
     }
   }
 }

--- a/app/javascript/controllers/action_link_controller.js
+++ b/app/javascript/controllers/action_link_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static values = { required: { type: Number, default: 0 } };
 
-  // # indicated private attribute or method
+  // # indicates private attribute or method
   // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties
   #event_classes = ["pointer-events-none", "cursor-not-allowed"];
 

--- a/app/javascript/controllers/action_link_controller.js
+++ b/app/javascript/controllers/action_link_controller.js
@@ -10,10 +10,6 @@ export default class extends Controller {
     "text-slate-400",
   ];
 
-  connect() {
-    console.log(this.requiredValue);
-  }
-
   setDisabled(count = 0) {
     if (this.requiredValue > count) {
       this.element.classList.add(...this.#classes);

--- a/app/javascript/controllers/action_link_controller.js
+++ b/app/javascript/controllers/action_link_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
+  static values = { required: { type: Number, default: 0 } };
+
   #classes = [
     "pointer-events-none",
     "cursor-not-allowed",
@@ -8,8 +10,12 @@ export default class extends Controller {
     "text-slate-400",
   ];
 
-  setDisabled(disabled = true) {
-    if (disabled) {
+  connect() {
+    console.log(this.requiredValue);
+  }
+
+  setDisabled(count = 0) {
+    if (this.requiredValue > count) {
       this.element.classList.add(...this.#classes);
     } else {
       this.element.classList.remove(...this.#classes);

--- a/app/javascript/controllers/action_link_controller.js
+++ b/app/javascript/controllers/action_link_controller.js
@@ -3,6 +3,8 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static values = { required: { type: Number, default: 0 } };
 
+  // # indicated private attribute or method
+  // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties
   #classes = [
     "pointer-events-none",
     "cursor-not-allowed",

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
     const storageValue = JSON.parse(
       sessionStorage.getItem(this.storageKeyValue)
     );
-    outlet.setDisabled(storageValue?.length === 0);
+    outlet.setDisabled(storageValue.length);
   }
 
   toggle(event) {
@@ -50,7 +50,7 @@ export default class extends Controller {
     }
     this.save(newStorageValue);
 
-    this.#updateActinLinks(newStorageValue.length === 0);
+    this.#updateActinLinks(newStorageValue.length);
   }
 
   save(storageValue) {
@@ -60,9 +60,9 @@ export default class extends Controller {
     );
   }
 
-  #updateActinLinks(disabled = false) {
+  #updateActinLinks(count) {
     this.actionLinkOutlets.forEach((outlet) => {
-      outlet.setDisabled(disabled);
+      outlet.setDisabled(count);
     });
   }
 }

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -1,6 +1,9 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
+  // # indicated private attribute or method
+  // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties
+
   static targets = ["rowSelection"];
   static values = {
     storageKey: {

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
     const storageValue = JSON.parse(
       sessionStorage.getItem(this.storageKeyValue)
     );
-    outlet.setDisabled(storageValue === undefined || storageValue.length === 0);
+    outlet.setDisabled(storageValue?.length === 0);
   }
 
   toggle(event) {

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -50,7 +50,7 @@ export default class extends Controller {
     }
     this.save(newStorageValue);
 
-    this.#updateActinLinks(newStorageValue.length);
+    this.#updateActionLinks(newStorageValue.length);
   }
 
   save(storageValue) {
@@ -60,7 +60,7 @@ export default class extends Controller {
     );
   }
 
-  #updateActinLinks(count) {
+  #updateActionLinks(count) {
     this.actionLinkOutlets.forEach((outlet) => {
       outlet.setDisabled(count);
     });

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  // # indicated private attribute or method
+  // # indicates private attribute or method
   // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties
 
   static targets = ["rowSelection"];

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
       default: location.protocol + "//" + location.host + location.pathname,
     },
   };
+  static outlets = ["action-link"];
 
   connect() {
     this.element.setAttribute("data-controller-connected", "true");
@@ -27,6 +28,13 @@ export default class extends Controller {
     }
   }
 
+  actionLinkOutletConnected(outlet) {
+    const storageValue = JSON.parse(
+      sessionStorage.getItem(this.storageKeyValue)
+    );
+    outlet.setDisabled(storageValue === undefined || storageValue.length === 0);
+  }
+
   toggle(event) {
     const newStorageValue = JSON.parse(
       sessionStorage.getItem(this.storageKeyValue)
@@ -41,6 +49,8 @@ export default class extends Controller {
       }
     }
     this.save(newStorageValue);
+
+    this.#updateActinLinks(newStorageValue.length === 0);
   }
 
   save(storageValue) {
@@ -48,5 +58,11 @@ export default class extends Controller {
       this.storageKeyValue,
       JSON.stringify([...storageValue])
     );
+  }
+
+  #updateActinLinks(disabled = false) {
+    this.actionLinkOutlets.forEach((outlet) => {
+      outlet.setDisabled(disabled);
+    });
   }
 }

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   static values = {
     storageKey: {
       type: String,
-      default: location.protocol + "//" + location.host + location.pathname,
+      default: `${location.protocol}//${location.host}${location.pathname}`,
     },
   };
   static outlets = ["action-link"];
@@ -16,9 +16,7 @@ export default class extends Controller {
   connect() {
     this.element.setAttribute("data-controller-connected", "true");
 
-    const storageValue = JSON.parse(
-      sessionStorage.getItem(this.storageKeyValue)
-    );
+    const storageValue = this.#getStoredSamples();
 
     if (storageValue) {
       this.rowSelectionTargets.map((row) => {
@@ -32,16 +30,12 @@ export default class extends Controller {
   }
 
   actionLinkOutletConnected(outlet) {
-    const storageValue = JSON.parse(
-      sessionStorage.getItem(this.storageKeyValue)
-    );
+    const storageValue = this.#getStoredSamples();
     outlet.setDisabled(storageValue.length);
   }
 
   toggle(event) {
-    const newStorageValue = JSON.parse(
-      sessionStorage.getItem(this.storageKeyValue)
-    );
+    const newStorageValue = this.#getStoredSamples();
 
     if (event.target.checked) {
       newStorageValue.push(event.target.value);
@@ -61,6 +55,10 @@ export default class extends Controller {
       this.storageKeyValue,
       JSON.stringify([...storageValue])
     );
+  }
+
+  #getStoredSamples() {
+    return JSON.parse(sessionStorage.getItem(this.storageKeyValue)) || [];
   }
 
   #updateActionLinks(count) {

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -2,7 +2,7 @@
   id="samples-table"
   class="min-w-full table-fixed dark:divide-slate-600"
   data-controller="selection"
-  data-selection-action-link-outlet=".link"
+  data-selection-action-link-outlet=".action-link"
 >
   <tbody
     class="

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -2,6 +2,7 @@
   id="samples-table"
   class="min-w-full table-fixed dark:divide-slate-600"
   data-controller="selection"
+  data-selection-action-link-outlet=".link"
 >
   <tbody
     class="

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -6,7 +6,7 @@
   <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
     <div class="flex items-center space-x-2">
-      <%= link_to pipeline_selection_workflow_executions_submissions_path, data: { turbo_frame: "workflow_modal", turbo_stream: true, controller: "action-link" },
+      <%= link_to pipeline_selection_workflow_executions_submissions_path, data: { turbo_frame: "workflow_modal", turbo_stream: true, controller: "action-link", action_link_required_value: 1 },
         class: "button button--size-default button--state-default link" do %>
         <%= viral_icon(name: :rocket_launch, classes: "w-4 h-4 inline-block") %>
         <span class="sr-only"><%= t(:".workflows.button_sr") %></span>
@@ -17,7 +17,8 @@
         data: {
           turbo_frame: "transfer_modal",
           turbo_stream: true,
-          controller: "action-link"
+          controller: "action-link",
+          action_link_required_value: 1
         },
         class: "button button--size-default button--state-default link" %>
       <% end %>

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -6,8 +6,8 @@
   <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
     <div class="flex items-center space-x-2">
-      <%= link_to pipeline_selection_workflow_executions_submissions_path, data: { turbo_frame: "workflow_modal", turbo_stream: true },
-        class: "button button--size-default button--state-default" do %>
+      <%= link_to pipeline_selection_workflow_executions_submissions_path, data: { turbo_frame: "workflow_modal", turbo_stream: true, controller: "action-link" },
+        class: "button button--size-default button--state-default link" do %>
         <%= viral_icon(name: :rocket_launch, classes: "w-4 h-4 inline-block") %>
         <span class="sr-only"><%= t(:".workflows.button_sr") %></span>
       <% end %>
@@ -16,9 +16,10 @@
         new_namespace_project_samples_transfer_path,
         data: {
           turbo_frame: "transfer_modal",
-          turbo_stream: true
+          turbo_stream: true,
+          controller: "action-link"
         },
-        class: "button button--size-default button--state-default" %>
+        class: "button button--size-default button--state-default link" %>
       <% end %>
       <% if allowed_to?(:create_sample?, @project) %>
         <%= link_to t("projects.samples.index.new_button"),

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -7,7 +7,7 @@
   <%= component.with_buttons do %>
     <div class="flex items-center space-x-2">
       <%= link_to pipeline_selection_workflow_executions_submissions_path, data: { turbo_frame: "workflow_modal", turbo_stream: true, controller: "action-link", action_link_required_value: 1 },
-        class: "button button--size-default button--state-default link" do %>
+        class: "button button--size-default button--state-default action-link" do %>
         <%= viral_icon(name: :rocket_launch, classes: "w-4 h-4 inline-block") %>
         <span class="sr-only"><%= t(:".workflows.button_sr") %></span>
       <% end %>
@@ -20,7 +20,7 @@
           controller: "action-link",
           action_link_required_value: 1
         },
-        class: "button button--size-default button--state-default link" %>
+        class: "button button--size-default button--state-default action-link" %>
       <% end %>
       <% if allowed_to?(:create_sample?, @project) %>
         <%= link_to t("projects.samples.index.new_button"),


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Currently, on the project samples page, the workflow execution and transfer samples links function without any samples being selected.  This PR add a check when the buttons are connected to the dom to see if there are any samples selected for that project, and when the selections are updated the buttons will update.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**No samples selected**
![image](https://github.com/phac-nml/irida-next/assets/11295750/95b63041-0a02-4f48-95ea-c2c9b90c2e73)

**Samples selected**
![image](https://github.com/phac-nml/irida-next/assets/11295750/84f4fb68-6698-4467-ba2e-6f01daf18fb6)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

**EDIT**
This also works for buttons and both default and primary CSS button classes)
![image](https://github.com/phac-nml/irida-next/assets/11295750/7897f298-12ef-46c6-8cba-bd857b7a3fbe)


Go to any project samples page (that has samples).  

- If no samples are previously selected on the initial load, the two buttons should be disabled.  
- Select a sample and the buttons should become enabled.
- De-select the sample and again the buttons should be disabled. (try clicking to make sure nothing happens).
- Select samples and refresh the page, the buttons should be enabled.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
