### PR TITLE
Metadata update service

### DIFF
--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -9,11 +9,6 @@ module Projects
     def index
       authorize! @project, to: :sample_listing?
 
-      sample = Sample.find_by(name: 'sample 1')
-      project = Project.find(144)
-      params = { 'metadata' => { key1: 'value1' } }
-
-      ::Samples::Metadata::UpdateService.new(project, sample, current_user, params).execute
       @q = load_samples.ransack(params[:q])
       set_default_sort
       respond_to do |format|

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -9,6 +9,11 @@ module Projects
     def index
       authorize! @project, to: :sample_listing?
 
+      sample = Sample.find_by(name: 'sample 1')
+      project = Project.find(144)
+      params = { 'metadata' => { key1: 'value1' } }
+
+      ::Samples::Metadata::UpdateService.new(project, sample, current_user, params).execute
       @q = load_samples.ransack(params[:q])
       set_default_sort
       respond_to do |format|

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -8,6 +8,10 @@ module Projects
 
     def index
       authorize! @project, to: :sample_listing?
+      sample = Sample.find(1422)
+      project = Project.find(144)
+      params = { 'metadata' => { key3: 'value6', key5: 'value5' } }
+      ::Samples::Metadata::UpdateService.new(project, sample, current_user, params).execute
 
       @q = load_samples.ransack(params[:q])
       set_default_sort

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -8,10 +8,6 @@ module Projects
 
     def index
       authorize! @project, to: :sample_listing?
-      sample = Sample.find(1422)
-      project = Project.find(144)
-      params = { 'metadata' => { key3: 'value6', key5: 'value5' } }
-      ::Samples::Metadata::UpdateService.new(project, sample, current_user, params).execute
 
       @q = load_samples.ransack(params[:q])
       set_default_sort

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -56,20 +56,20 @@ module Samples
 
       private
 
-      def update_metadata_provenance(key) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/MethodLength
+      def update_metadata_provenance(key) # rubocop:disable Metrics/MethodLength
         if @sample['metadata_provenance'].key?(key)
           # We don't overwrite existing @sample['metadata_provenance'] or @sample['metadata']
           # that has a {source: 'analysis'} with a user
-          if @analysis_id
-            @sample['metadata_provenance'][key] = { source: 'analysis', id: @analysis_id }
-            true
-          elsif @analysis_id.nil?
+          if @analysis_id.nil?
             if @sample['metadata_provenance'][key]['source'] == 'user'
               @sample['metadata_provenance'][key] = { source: 'user', id: current_user.id }
               true
-            elsif @sample['metadata_provenance'][key]['source'] == 'analysis'
+            else
               false
             end
+          else
+            @sample['metadata_provenance'][key] = { source: 'analysis', id: @analysis_id }
+            true
           end
         else
           @sample['metadata_provenance'][key] =

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -24,7 +24,7 @@ module Samples
 
         transform_metadata_keys
 
-        metadata_fields_update_status = metadata_modification
+        metadata_fields_update_status = perform_metadata_update
 
         @sample.save
 
@@ -57,13 +57,13 @@ module Samples
         @metadata = @metadata.transform_keys(&:to_s)
       end
 
-      def metadata_modification
+      def perform_metadata_update
         update_status = { updated: [], not_updated: [] }
         @metadata.each do |key, value|
           if value.blank?
-            if @sample['metadata'].key?(key)
-              @sample['metadata'].delete(key)
-              @sample['metadata_provenance'].delete(key)
+            if @sample.metadata.key?(key)
+              @sample.metadata.delete(key)
+              @sample.metadata_provenance.delete(key)
               update_status[:updated].append(key)
             end
           else
@@ -75,15 +75,15 @@ module Samples
       end
 
       def assign_metadata_to_sample(key, value)
-        # We don't overwrite existing @sample['metadata_provenance'] or @sample['metadata']
+        # We don't overwrite existing @sample.metadata_provenance or @sample.metadata
         # that has a {source: 'analysis'} with a user
-        if @sample['metadata_provenance'].key?(key) && @analysis_id.nil? &&
-           @sample['metadata_provenance'][key]['source'] == 'analysis'
+        if @sample.metadata_provenance.key?(key) && @analysis_id.nil? &&
+           @sample.metadata_provenance[key]['source'] == 'analysis'
           false
         else
-          @sample['metadata_provenance'][key] =
+          @sample.metadata_provenance[key] =
             @analysis_id.nil? ? { source: 'user', id: current_user.id } : { source: 'analysis', id: @analysis_id }
-          @sample['metadata'][key] = value
+          @sample.metadata[key] = value
           true
         end
       end

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -7,15 +7,22 @@ module Samples
       SampleMetadataUpdateError = Class.new(StandardError)
       attr_accessor :sample, :metadata, :metadata_key
 
-      def initialize(sample, user = nil, params = {}, metadata = nil, metadata_key = nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(project, sample, user = nil, params = {}, metadata = nil, metadata_key = nil) # rubocop:disable Metrics/ParameterLists
         super(user, params.except(:sample, :id))
+        @project = project
         @sample = sample
         @metadata = metadata
         @metadata_key = metadata_key
       end
 
-      def execute
+      def execute # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         authorize! sample.project, to: :update_sample?
+
+        if @project.id != @sample.project.id
+          raise SampleMetadataUpdateError,
+                I18n.t('services.samples.metadata.sample_does_not_belong_to_project', sample_name: @sample.name,
+                                                                                      project_name: @project.name)
+        end
 
         if @metadata
           @metadata = @metadata.transform_keys(&:to_s)

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -33,8 +33,7 @@ module Samples
                 @sample['metadata'].delete(key) && @sample['metadata_provenance'].delete(key)
               end
             else
-              @sample['metadata'][key] = value
-              update_sample_metadata_provenance(key, current_user)
+              update_sample_metadata(key, value, current_user)
             end
           end
         else
@@ -49,17 +48,21 @@ module Samples
 
       private
 
-      def update_sample_metadata_provenance(key, user)
+      def update_sample_metadata(key, value, user) # rubocop:disable Metrics/AbcSize
         if @sample['metadata_provenance'].key?(key)
-          # We don't overwrite existing @sample['metadata_provenance'] with {source: 'analysis'} with a user
+          # We don't overwrite existing @sample['metadata_provenance'] or @sample['metadata']
+          # that has a {source: 'analysis'} with a user
           if @analysis_id.nil? && @sample['metadata_provenance'][key]['source'] == 'user'
             @sample['metadata_provenance'][key] = { source: 'user', id: user.id }
+            @sample['metadata'][key] = value
           elsif @analysis_id
             @sample['metadata_provenance'][key] = { source: 'analysis', id: @analysis_id }
+            @sample['metadata'][key] = value
           end
         else
           @sample['metadata_provenance'][key] =
             @analysis_id.nil? ? { source: 'user', id: user.id } : { source: 'analysis', id: @analysis_id }
+          @sample['metadata'][key] = value
         end
       end
     end

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -4,20 +4,29 @@ module Samples
   module Metadata
     # Service used to Update Samples::Metadata
     class UpdateService < BaseService
-      attr_accessor :sample, :metadata, :key
+      SampleMetadataUpdateError = Class.new(StandardError)
+      attr_accessor :sample, :metadata, :metadata_key
 
-      def initialize(sample, user = nil, params = {}, metadata = {}, key = nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(sample, user = nil, params = {}, metadata = nil, metadata_key = nil) # rubocop:disable Metrics/ParameterLists
         super(user, params.except(:sample, :id))
         @sample = sample
         @metadata = metadata
-        @key = key
+        @metadata_key = metadata_key
       end
 
-      # def execute
-      #   authorize! sample.project, to: :update_sample?
+      def execute
+        authorize! sample.project, to: :update_sample?
 
-      #   sample.update(params)
-      # end
+        @sample.metadata.merge(@metadata) if @metadata
+
+        if @metadata_key
+          raise SampleMetadataUpdateError, I18n.t('key_does_not_exist') unless @sample.metadata.key?(@metadata_key)
+
+          @sample.metadata.delete(@metadata_key)
+        end
+      rescue Samples::Metadata::UpdateService::SampleMetadataUpdateError
+        @sample.errors.add(:base, e.message)
+      end
     end
   end
 end

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -35,6 +35,9 @@ module Samples
                 @analysis_id.nil? ? { source: 'user', id: current_user.id } : { source: 'analysis', id: @analysis_id }
             end
           end
+        else
+          raise SampleMetadataUpdateError,
+                I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)
         end
 
         @sample.update(id: @sample.id)

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -35,7 +35,11 @@ module Samples
               end
             else
               provenance_updated = update_metadata_provenance(key)
-              provenance_updated ? assign_metadata_value(key, value) : metadata_fields_not_updated.append(key)
+              if provenance_updated
+                assign_metadata_value(key, value)
+              else
+                metadata_fields_not_updated.append("#{key}: #{value}")
+              end
             end
           end
           @sample.update(id: @sample.id)

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -32,7 +32,7 @@ module Samples
         metadata_fields_update_status
       rescue Samples::Metadata::UpdateService::SampleMetadataUpdateError => e
         @sample.errors.add(:base, e.message)
-        metadata_fields_update_status || { updated: [], not_updated: [] }
+        metadata_fields_update_status || nil
       end
 
       private
@@ -89,12 +89,13 @@ module Samples
       end
 
       def fields_not_updated(metadata_fields_update_status)
-        return unless metadata_fields_update_status.count.positive?
+        metadata_fields_not_updated = metadata_fields_update_status[:not_updated]
+        return unless metadata_fields_not_updated.count.positive?
 
         raise SampleMetadataUpdateError,
               I18n.t('services.samples.metadata.user_cannot_update_metadata',
                      sample_name: @sample.name,
-                     metadata_fields: metadata_fields_update_status[:not_updated].join(', '))
+                     metadata_fields: metadata_fields_not_updated.join(', '))
       end
     end
   end

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Samples
+  module Metadata
+    # Service used to Update Samples::Metadata
+    class UpdateService < BaseService
+      attr_accessor :sample, :metadata, :key
+
+      def initialize(sample, user = nil, params = {}, metadata = {}, key = nil) # rubocop:disable Metrics/ParameterLists
+        super(user, params.except(:sample, :id))
+        @sample = sample
+        @metadata = metadata
+        @key = key
+      end
+
+      # def execute
+      #   authorize! sample.project, to: :update_sample?
+
+      #   sample.update(params)
+      # end
+    end
+  end
+end

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -33,7 +33,7 @@ module Samples
                 @sample['metadata'].delete(key) && @sample['metadata_provenance'].delete(key)
               end
             else
-              update_sample_metadata(key, value, current_user)
+              update_metadata(key, value, current_user)
             end
           end
         else
@@ -48,22 +48,26 @@ module Samples
 
       private
 
-      def update_sample_metadata(key, value, user) # rubocop:disable Metrics/AbcSize
+      def update_metadata(key, value, user)
         if @sample['metadata_provenance'].key?(key)
           # We don't overwrite existing @sample['metadata_provenance'] or @sample['metadata']
           # that has a {source: 'analysis'} with a user
           if @analysis_id.nil? && @sample['metadata_provenance'][key]['source'] == 'user'
             @sample['metadata_provenance'][key] = { source: 'user', id: user.id }
-            @sample['metadata'][key] = value
+            assign_metadata_value(key, value)
           elsif @analysis_id
             @sample['metadata_provenance'][key] = { source: 'analysis', id: @analysis_id }
-            @sample['metadata'][key] = value
+            assign_metadata_value(key, value)
           end
         else
           @sample['metadata_provenance'][key] =
             @analysis_id.nil? ? { source: 'user', id: user.id } : { source: 'analysis', id: @analysis_id }
-          @sample['metadata'][key] = value
+          assign_metadata_value(key, value)
         end
+      end
+
+      def assign_metadata_value(key, value)
+        @sample['metadata'][key] = value
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -903,7 +903,8 @@ en:
         sample_exists: "Sample '%{sample_name}' already exists in the target project"
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
       metadata:
-        sample_does_not_belong_to_project: "Sample '%{sample_name} does not belong to project '${project_name}'"
+        sample_does_not_belong_to_project: "Sample '%{sample_name}'' does not belong to project '${project_name}'"
+        empty_metadata: "No metadata was received to update sample '%{sample_name}'"
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -903,7 +903,6 @@ en:
         sample_exists: "Sample '%{sample_name}' already exists in the target project"
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
       metadata:
-        key_does_not_exist: "Sample '%{sample_name}' does not contain '%{key}' in its metadata"
         sample_does_not_belong_to_project: "Sample '%{sample_name} does not belong to project '${project_name}'"
     projects:
       transfer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -902,6 +902,8 @@ en:
         same_project: The samples already exist in the project. Please select a different project.
         sample_exists: "Sample '%{sample_name}' already exists in the target project"
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+      metadata:
+        key_does_not_exist: "Sample '%{sample_name}' does not contain '%{key}' in its metadata"
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -905,6 +905,7 @@ en:
       metadata:
         sample_does_not_belong_to_project: "Sample '%{sample_name}'' does not belong to project '${project_name}'"
         empty_metadata: "No metadata was received to update sample '%{sample_name}'"
+        user_cannot_update_metadata: "Metadata fields '%{metadata_fields}' of sample '%{sample_name}' cannot be overwritten by a user as it was previously updated with an analysis. "
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -904,6 +904,7 @@ en:
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
       metadata:
         key_does_not_exist: "Sample '%{sample_name}' does not contain '%{key}' in its metadata"
+        sample_does_not_belong_to_project: "Sample '%{sample_name} does not belong to project '${project_name}'"
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -888,6 +888,8 @@ fr:
         same_project: The samples already exist in the project. Please select a different project.
         sample_exists: "Sample '%{sample_name}' already exists in the target project"
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+      metadata:
+        key_does_not_exist: "Sample '%{sample_name}' does not contain '%{key}' in its metadata"
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -891,6 +891,7 @@ fr:
       metadata:
         sample_does_not_belong_to_project: "Sample '%{sample_name}' does not belong to project '${project_name}'"
         empty_metadata: "No metadata was received to update sample '%{sample_name}'"
+        user_cannot_update_metadata: "Metadata fields '%{metadata_fields}' of sample '%{sample_name}' cannot be overwritten by a user as it was previously updated with an analysis. "
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -890,6 +890,7 @@ fr:
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
       metadata:
         key_does_not_exist: "Sample '%{sample_name}' does not contain '%{key}' in its metadata"
+        sample_does_not_belong_to_project: "Sample '%{sample_name} does not belong to project '${project_name}'"
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -889,7 +889,8 @@ fr:
         sample_exists: "Sample '%{sample_name}' already exists in the target project"
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
       metadata:
-        sample_does_not_belong_to_project: "Sample '%{sample_name} does not belong to project '${project_name}'"
+        sample_does_not_belong_to_project: "Sample '%{sample_name}' does not belong to project '${project_name}'"
+        empty_metadata: "No metadata was received to update sample '%{sample_name}'"
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -889,7 +889,6 @@ fr:
         sample_exists: "Sample '%{sample_name}' already exists in the target project"
         samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
       metadata:
-        key_does_not_exist: "Sample '%{sample_name}' does not contain '%{key}' in its metadata"
         sample_does_not_belong_to_project: "Sample '%{sample_name} does not belong to project '${project_name}'"
     projects:
       transfer:

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -13,22 +13,22 @@ module Samples
 
       test 'update sample metadata with sample containing no existing metadata and user in metadata provenance' do
         params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
-        updated_metadata_fields = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value1', 'key2' => 'value2' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => @user.id, 'source' => 'user' },
                                                     'key2' => { 'id' => @user.id, 'source' => 'user' } })
-        assert_equal(updated_metadata_fields, %w[key1 key2])
+        assert_equal(metadata_fields_update_status, { updated: %w[key1 key2], not_updated: [] })
       end
 
       test 'update sample metadata with sample containing no existing metadata and analysis in metadata provenance' do
         params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' }, 'analysis_id' => 2 }
-        updated_metadata_fields = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value1', 'key2' => 'value2' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 2, 'source' => 'analysis' },
                                                     'key2' => { 'id' => 2, 'source' => 'analysis' } })
-        assert_equal(updated_metadata_fields, %w[key1 key2])
+        assert_equal(metadata_fields_update_status, { updated: %w[key1 key2], not_updated: [] })
       end
 
       test 'update sample metadata merge with new metadata and analysis overwritting user' do
@@ -36,13 +36,13 @@ module Samples
         @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'user' },
                                         'key2' => { 'id' => 1, 'source' => 'user' } }
         params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' }, 'analysis_id' => 10 }
-        updated_metadata_fields = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 10, 'source' => 'analysis' },
                                                     'key2' => { 'id' => 1, 'source' => 'user' },
                                                     'key3' => { 'id' => 10, 'source' => 'analysis' } })
-        assert_equal(updated_metadata_fields, %w[key1 key3])
+        assert_equal(metadata_fields_update_status, { updated: %w[key1 key3], not_updated: [] })
       end
 
       test 'update sample metadata merge with new metadata and user overwritting user' do
@@ -50,13 +50,13 @@ module Samples
         @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'user' },
                                         'key2' => { 'id' => 1, 'source' => 'user' } }
         params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' } }
-        updated_metadata_fields = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => @user.id, 'source' => 'user' },
                                                     'key2' => { 'id' => 1, 'source' => 'user' },
                                                     'key3' => { 'id' => @user.id, 'source' => 'user' } })
-        assert_equal(updated_metadata_fields, %w[key1 key3])
+        assert_equal(metadata_fields_update_status, { updated: %w[key1 key3], not_updated: [] })
       end
 
       test 'update sample metadata merge with new metadata and user unable to overwrite analysis' do
@@ -64,13 +64,13 @@ module Samples
         @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'analysis' },
                                         'key2' => { 'id' => 1, 'source' => 'analysis' } }
         params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' } }
-        updated_metadata_fields = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'analysis' },
                                                     'key2' => { 'id' => 1, 'source' => 'analysis' },
                                                     'key3' => { 'id' => @user.id, 'source' => 'user' } })
-        assert_equal(updated_metadata_fields, %w[key3])
+        assert_equal(metadata_fields_update_status, { updated: %w[key3], not_updated: %w[key1] })
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.user_cannot_update_metadata',
                  sample_name: @sample.name,
@@ -83,11 +83,11 @@ module Samples
         @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'analysis' },
                                         'key2' => { 'id' => 1, 'source' => 'analysis' } }
         params = { 'metadata' => { 'key2' => '' } }
-        updated_metadata_fields = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value1' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'analysis' } })
-        assert_equal(updated_metadata_fields, %w[key2])
+        assert_equal(metadata_fields_update_status, { updated: %w[key2], not_updated: [] })
       end
 
       test 'remove metadata key with analysis' do
@@ -95,11 +95,11 @@ module Samples
         @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'user' },
                                         'key2' => { 'id' => 1, 'source' => 'user' } }
         params = { 'metadata' => { 'key2' => '' }, 'analysis_id' => 1 }
-        updated_metadata_fields = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value1' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'user' } })
-        assert_equal(updated_metadata_fields, %w[key2])
+        assert_equal(metadata_fields_update_status, { updated: %w[key2], not_updated: [] })
       end
 
       test 'update sample metadata with valid permission' do
@@ -130,7 +130,8 @@ module Samples
         params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
         project = projects(:projectA)
         assert_no_changes -> { @sample } do
-          assert_empty Samples::Metadata::UpdateService.new(project, @sample, @user, params).execute
+          assert_equal Samples::Metadata::UpdateService.new(project, @sample, @user, params).execute,
+                       { updated: [], not_updated: [] }
         end
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.sample_does_not_belong_to_project', sample_name: @sample.name,
@@ -140,7 +141,8 @@ module Samples
 
       test 'metadata is nil' do
         assert_no_changes -> { @sample } do
-          assert_empty Samples::Metadata::UpdateService.new(@project, @sample, @user, {}).execute
+          assert_equal Samples::Metadata::UpdateService.new(@project, @sample, @user, {}).execute,
+                       { updated: [], not_updated: [] }
         end
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)
@@ -150,7 +152,8 @@ module Samples
       test 'metadata is empty hash' do
         params = { 'metadata' => {} }
         assert_no_changes -> { @sample } do
-          assert_empty Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+          assert_equal Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute,
+                       { updated: [], not_updated: [] }
         end
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -131,9 +131,19 @@ module Samples
         )
       end
 
-      test 'no metadata' do
+      test 'metadata is nil' do
         assert_no_changes -> { @sample } do
           Samples::Metadata::UpdateService.new(@project, @sample, @user, {}).execute
+        end
+        assert @sample.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)
+        )
+      end
+
+      test 'metadata is empty hash' do
+        params = { 'metadata' => {} }
+        assert_no_changes -> { @sample } do
+          Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
         end
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -62,7 +62,7 @@ module Samples
         params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' } }
         Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' })
+        assert_equal(@sample.metadata, { 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' })
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'analysis' },
                                                     'key2' => { 'id' => 1, 'source' => 'analysis' },
                                                     'key3' => { 'id' => @user.id, 'source' => 'user' } })

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -15,20 +15,22 @@ module Samples
         params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
         metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value1', 'key2' => 'value2' })
-        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => @user.id, 'source' => 'user' },
-                                                    'key2' => { 'id' => @user.id, 'source' => 'user' } })
-        assert_equal(metadata_fields_update_status, { updated: %w[key1 key2], not_updated: [] })
+        assert_equal({ 'key1' => 'value1', 'key2' => 'value2' }, @sample.metadata)
+        assert_equal({ 'key1' => { 'id' => @user.id, 'source' => 'user' },
+                       'key2' => { 'id' => @user.id, 'source' => 'user' } },
+                     @sample.metadata_provenance)
+        assert_equal({ updated: %w[key1 key2], not_updated: [] }, metadata_fields_update_status)
       end
 
       test 'update sample metadata with sample containing no existing metadata and analysis in metadata provenance' do
         params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' }, 'analysis_id' => 2 }
         metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value1', 'key2' => 'value2' })
-        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 2, 'source' => 'analysis' },
-                                                    'key2' => { 'id' => 2, 'source' => 'analysis' } })
-        assert_equal(metadata_fields_update_status, { updated: %w[key1 key2], not_updated: [] })
+        assert_equal({ 'key1' => 'value1', 'key2' => 'value2' }, @sample.metadata)
+        assert_equal({ 'key1' => { 'id' => 2, 'source' => 'analysis' },
+                       'key2' => { 'id' => 2, 'source' => 'analysis' } },
+                     @sample.metadata_provenance)
+        assert_equal({ updated: %w[key1 key2], not_updated: [] }, metadata_fields_update_status)
       end
 
       test 'update sample metadata merge with new metadata and analysis overwritting user' do
@@ -38,11 +40,12 @@ module Samples
         params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' }, 'analysis_id' => 10 }
         metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' })
-        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 10, 'source' => 'analysis' },
-                                                    'key2' => { 'id' => 1, 'source' => 'user' },
-                                                    'key3' => { 'id' => 10, 'source' => 'analysis' } })
-        assert_equal(metadata_fields_update_status, { updated: %w[key1 key3], not_updated: [] })
+        assert_equal({ 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' }, @sample.metadata)
+        assert_equal({ 'key1' => { 'id' => 10, 'source' => 'analysis' },
+                       'key2' => { 'id' => 1, 'source' => 'user' },
+                       'key3' => { 'id' => 10, 'source' => 'analysis' } },
+                     @sample.metadata_provenance)
+        assert_equal({ updated: %w[key1 key3], not_updated: [] }, metadata_fields_update_status)
       end
 
       test 'update sample metadata merge with new metadata and user overwritting user' do
@@ -52,11 +55,12 @@ module Samples
         params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' } }
         metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' })
-        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => @user.id, 'source' => 'user' },
-                                                    'key2' => { 'id' => 1, 'source' => 'user' },
-                                                    'key3' => { 'id' => @user.id, 'source' => 'user' } })
-        assert_equal(metadata_fields_update_status, { updated: %w[key1 key3], not_updated: [] })
+        assert_equal({ 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' }, @sample.metadata)
+        assert_equal({ 'key1' => { 'id' => @user.id, 'source' => 'user' },
+                       'key2' => { 'id' => 1, 'source' => 'user' },
+                       'key3' => { 'id' => @user.id, 'source' => 'user' } },
+                     @sample.metadata_provenance)
+        assert_equal({ updated: %w[key1 key3], not_updated: [] }, metadata_fields_update_status)
       end
 
       test 'update sample metadata merge with new metadata and user unable to overwrite analysis' do
@@ -66,11 +70,12 @@ module Samples
         params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' } }
         metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' })
-        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'analysis' },
-                                                    'key2' => { 'id' => 1, 'source' => 'analysis' },
-                                                    'key3' => { 'id' => @user.id, 'source' => 'user' } })
-        assert_equal(metadata_fields_update_status, { updated: %w[key3], not_updated: %w[key1] })
+        assert_equal({ 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }, @sample.metadata)
+        assert_equal({ 'key1' => { 'id' => 1, 'source' => 'analysis' },
+                       'key2' => { 'id' => 1, 'source' => 'analysis' },
+                       'key3' => { 'id' => @user.id, 'source' => 'user' } },
+                     @sample.metadata_provenance)
+        assert_equal({ updated: %w[key3], not_updated: %w[key1] }, metadata_fields_update_status)
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.user_cannot_update_metadata',
                  sample_name: @sample.name,
@@ -85,9 +90,9 @@ module Samples
         params = { 'metadata' => { 'key2' => '' } }
         metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value1' })
-        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'analysis' } })
-        assert_equal(metadata_fields_update_status, { updated: %w[key2], not_updated: [] })
+        assert_equal({ 'key1' => 'value1' }, @sample.metadata)
+        assert_equal({ 'key1' => { 'id' => 1, 'source' => 'analysis' } }, @sample.metadata_provenance)
+        assert_equal({ updated: %w[key2], not_updated: [] }, metadata_fields_update_status)
       end
 
       test 'remove metadata key with analysis' do
@@ -97,9 +102,9 @@ module Samples
         params = { 'metadata' => { 'key2' => '' }, 'analysis_id' => 1 }
         metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
-        assert_equal(@sample.metadata, { 'key1' => 'value1' })
-        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'user' } })
-        assert_equal(metadata_fields_update_status, { updated: %w[key2], not_updated: [] })
+        assert_equal({ 'key1' => 'value1' }, @sample.metadata)
+        assert_equal({ 'key1' => { 'id' => 1, 'source' => 'user' } }, @sample.metadata_provenance)
+        assert_equal({ updated: %w[key2], not_updated: [] }, metadata_fields_update_status)
       end
 
       test 'update sample metadata with valid permission' do

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -130,8 +130,7 @@ module Samples
         params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
         project = projects(:projectA)
         assert_no_changes -> { @sample } do
-          assert_equal Samples::Metadata::UpdateService.new(project, @sample, @user, params).execute,
-                       { updated: [], not_updated: [] }
+          assert_nil Samples::Metadata::UpdateService.new(project, @sample, @user, params).execute
         end
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.sample_does_not_belong_to_project', sample_name: @sample.name,
@@ -141,8 +140,7 @@ module Samples
 
       test 'metadata is nil' do
         assert_no_changes -> { @sample } do
-          assert_equal Samples::Metadata::UpdateService.new(@project, @sample, @user, {}).execute,
-                       { updated: [], not_updated: [] }
+          assert_nil Samples::Metadata::UpdateService.new(@project, @sample, @user, {}).execute
         end
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)
@@ -152,8 +150,7 @@ module Samples
       test 'metadata is empty hash' do
         params = { 'metadata' => {} }
         assert_no_changes -> { @sample } do
-          assert_equal Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute,
-                       { updated: [], not_updated: [] }
+          assert_nil Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
         end
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -66,6 +66,11 @@ module Samples
         assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'analysis' },
                                                     'key2' => { 'id' => 1, 'source' => 'analysis' },
                                                     'key3' => { 'id' => @user.id, 'source' => 'user' } })
+        assert @sample.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.user_cannot_update_metadata',
+                 sample_name: @sample.name,
+                 metadata_fields: 'key1')
+        )
       end
 
       test 'remove metadata key with user' do

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -76,6 +76,15 @@ module Samples
                                                                                 project_name: project.name)
         )
       end
+
+      test 'no metadata' do
+        assert_no_changes -> { @sample } do
+          Samples::Metadata::UpdateService.new(@project, @sample, @user, {}, nil, nil).execute
+        end
+        assert @sample.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)
+        )
+      end
     end
   end
 end

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -70,18 +70,24 @@ module Samples
 
       test 'remove metadata key with user' do
         @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+        @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'analysis' },
+                                        'key2' => { 'id' => 1, 'source' => 'analysis' } }
         params = { 'metadata' => { 'key2' => '' } }
         Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value1' })
+        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'analysis' } })
       end
 
       test 'remove metadata key with analysis' do
         @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+        @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'user' },
+                                        'key2' => { 'id' => 1, 'source' => 'user' } }
         params = { 'metadata' => { 'key2' => '' }, 'analysis_id' => 1 }
         Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
 
         assert_equal(@sample.metadata, { 'key1' => 'value1' })
+        assert_equal(@sample.metadata_provenance, { 'key1' => { 'id' => 1, 'source' => 'user' } })
       end
 
       test 'update sample metadata with valid permission' do

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -69,7 +69,7 @@ module Samples
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.user_cannot_update_metadata',
                  sample_name: @sample.name,
-                 metadata_fields: 'key1: value4')
+                 metadata_fields: 'key1')
         )
       end
 

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Samples
+  module Metadata
+    class UpdateServiceTest < ActiveSupport::TestCase
+      def setup
+        @user = users(:john_doe)
+        @sample = samples(:sample1)
+      end
+
+      test 'update sample metadata with sample containing no existing metadata' do
+        metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+
+        assert_changes -> { @sample.metadata }, to: { 'key1' => 'value1', 'key2' => 'value2' } do
+          Samples::Metadata::UpdateService.new(@sample, @user, {}, metadata, nil).execute
+        end
+      end
+
+      test 'update sample existing metadata with new metadata including key merge' do
+        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+        metadata = { 'key1' => 'value4', 'key3' => 'value3' }
+
+        assert_changes lambda {
+                         @sample.metadata
+                       }, to: { 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' } do
+          Samples::Metadata::UpdateService.new(@sample, @user, {}, metadata, nil).execute
+        end
+      end
+
+      test 'remove metadata key' do
+        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+
+        Samples::Metadata::UpdateService.new(@sample, @user, {}, nil, 'key2').execute
+
+        assert_equal(@sample.metadata, { 'key1' => 'value1' })
+      end
+
+      test 'remove metadata key that does not exist' do
+        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+
+        assert_no_changes -> { @sample } do
+          Samples::Metadata::UpdateService.new(@sample, @user, {}, nil, 'key3').execute
+        end
+        assert @sample.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.key_does_not_exist', sample_name: @sample.name, key: 'key3')
+        )
+      end
+
+      test 'update sample metadata and remove key in single service execution' do
+        metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+
+        assert_changes -> { @sample.metadata }, to: { 'key1' => 'value1' } do
+          Samples::Metadata::UpdateService.new(@sample, @user, {}, metadata, 'key2').execute
+        end
+      end
+
+      test 'update sample metadata and try to remove metadata key that does not exist' do
+        metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+
+        assert_changes -> { @sample.metadata }, to: { 'key1' => 'value1', 'key2' => 'value2' } do
+          Samples::Metadata::UpdateService.new(@sample, @user, {}, metadata, 'key3').execute
+        end
+        assert @sample.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.key_does_not_exist', sample_name: @sample.name, key: 'key3')
+        )
+      end
+      test 'update sample metadata without permission to update sample' do
+        user = users(:ryan_doe)
+        metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+
+        exception = assert_raises(ActionPolicy::Unauthorized) do
+          Samples::Metadata::UpdateService.new(@sample, user, {}, metadata, nil).execute
+        end
+
+        assert_equal ProjectPolicy, exception.policy
+        assert_equal :update_sample?, exception.rule
+        assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+        assert_equal I18n.t(:'action_policy.policy.project.update_sample?', name: @sample.project.name),
+                     exception.result.message
+      end
+
+      test 'update sample metadata with valid permission' do
+        metadata = { 'key1' => 'value1', 'key2' => 'value2' }
+
+        assert_authorized_to(:update_sample?, @sample.project, with: ProjectPolicy,
+                                                               context: { user: @user }) do
+          Samples::Metadata::UpdateService.new(@sample, @user, {}, metadata, nil).execute
+        end
+      end
+    end
+  end
+end

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -69,7 +69,7 @@ module Samples
         assert @sample.errors.full_messages.include?(
           I18n.t('services.samples.metadata.user_cannot_update_metadata',
                  sample_name: @sample.name,
-                 metadata_fields: 'key1')
+                 metadata_fields: 'key1: value4')
         )
       end
 


### PR DESCRIPTION
## What does this PR do and why?
This PR creates the new project sample metadata update service. 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Open the rails console with `rails c`
2. Either create or assign a Sample (preferably that contains an empty metadata field) and assign it to variable `sample`.
3. Assign the sample's associated project to `project`.
4. Assign a user that is authorized to update the sample to `user`

**Keep the console values for each testing phase**

5. Test adding a new metadata hash to the sample and metadata_provenance with user:
a) Assign a new variable `params_1` with a new hash `metadata` (such as `params_1 = {'metadata' => {'key1': 'value1', 'key2': 'value2'}}`)
b) Execute the update service with `Samples::Metadata::UpdateService.new(project, sample, user, params_1).execute`
c) Check the metadata field of the `sample` to ensure it equals your `metadata` value, and `sample.metadata_provenance` equals `id: user.id` and `source: user` for each key.

6. Test merging a new metadata hash to a sample containing metadata, using an analysis for metadata_provenance:
a) Create and assign a new `params_2` hash which includes both `metadata` and `analysis_id`. Ensure it has an overlapping metadata key with a different value that exists in `sample.metadata`. For example, for the above sample, you could use `params_2 = {'metadata' => {'key3': 'value3', 'key1': 'value4'}, 'analysis_id' => 1}`.
b) Execute the update service with `Samples::Metadata::UpdateService.new(project, sample, user, params_2).execute`.
c) Check that the overlapping key of `sample.metadata` now has the value from `params_2['metadata']` and not from `params_1['metadata']` and any new key value pairs you may have assigned. Ensure any overwritten and new metadata fields have the accompanying `metadata_provenance` fields with `id: 1` and `source: analysis`.

7. Test merging a new metadata hash to a sample containing metadata, using an user for metadata_provenance:
Note: A user should not be able to overwrite any metadata added by an `analysis`
a) Create and assign a new `params_3` hash which includes `metadata`. Ensure it has an overlapping metadata key with a different value that exists in `sample.metadata`, and that metadata key exists in `sample.metadata_provenance` and was added by an analysis. For example, for the above sample, you could use `params_3 = {'metadata' => {'key3': 'value6', 'key5': 'value5'}}`.
b) Execute the update service with `Samples::Metadata::UpdateService.new(project, sample, user, params_3).execute`.
c) Check that the overlapping key of `sample.metadata` does NOT have the new value from `params_3['metadata']`, but any new key value pairs should now be assigned. Ensure new metadata fields have the corresponding `user` source in `metadata_provenance` and any fields that were not overwritten do not have changes to `metadata_provenance`.

8. Test removal of a key value pair from `sample.metadata`:
a) Assign a params hash containing a metadata key that exists in `sample.metadata` but with an empty string value, like `params_4 = {'metadata' => {'key3': ''}}`
b) Execute the update service with  `Samples::Metadata::UpdateService.new(project, sample, user, params_4).execute`.
c) Ensure the `key` passed to the service was removed from `sample.metadata` and `sample.metadata_provenance`. Ensure to test both `user` and `analysis` source can delete both a `user` and `analysis` added metadata field.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
