### PR TITLE
Project Sample Metadata: Metadata summary db representation

### DIFF
--- a/db/migrate/20231121200855_add_metadata_summary_to_namespaces.rb
+++ b/db/migrate/20231121200855_add_metadata_summary_to_namespaces.rb
@@ -4,5 +4,6 @@
 class AddMetadataSummaryToNamespaces < ActiveRecord::Migration[7.1]
   def change
     add_column :namespaces, :metadata_summary, :jsonb, default: {}
+    add_index :namespaces, :metadata_summary, using: :gin
   end
 end

--- a/db/migrate/20231121200855_add_metadata_summary_to_namespaces.rb
+++ b/db/migrate/20231121200855_add_metadata_summary_to_namespaces.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# migration to add metadata summary to namespaces table
+class AddMetadataSummaryToNamespaces < ActiveRecord::Migration[7.1]
+  def change
+    # frozen_string_literal: true
+    add_column :namespaces, :metadata_summary, :jsonb, default: {}
+  end
+end

--- a/db/migrate/20231121200855_add_metadata_summary_to_namespaces.rb
+++ b/db/migrate/20231121200855_add_metadata_summary_to_namespaces.rb
@@ -3,7 +3,6 @@
 # migration to add metadata summary to namespaces table
 class AddMetadataSummaryToNamespaces < ActiveRecord::Migration[7.1]
   def change
-    # frozen_string_literal: true
     add_column :namespaces, :metadata_summary, :jsonb, default: {}
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,6 +98,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_21_200855) do
     t.datetime "deleted_at"
     t.jsonb "metadata_summary", default: {}
     t.index ["deleted_at"], name: "index_namespaces_on_deleted_at"
+    t.index ["metadata_summary"], name: "index_namespaces_on_metadata_summary", using: :gin
     t.index ["owner_id"], name: "index_namespaces_on_owner_id"
     t.index ["parent_id"], name: "index_namespaces_on_parent_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_10_010313) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_21_200855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_10_010313) do
     t.datetime "updated_at", null: false
     t.jsonb "log_data"
     t.datetime "deleted_at"
+    t.jsonb "metadata_summary", default: {}
     t.index ["deleted_at"], name: "index_namespaces_on_deleted_at"
     t.index ["owner_id"], name: "index_namespaces_on_owner_id"
     t.index ["parent_id"], name: "index_namespaces_on_parent_id"

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -6,6 +6,7 @@ group_one:
   type: Group
   description: Group 1 description
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: { "metadatafield1": 633, "metadatafield2": 106 }
 
 subgroup1:
   name: Subgroup 1
@@ -13,6 +14,7 @@ subgroup1:
   type: Group
   description: Subgroup 1 description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
+  metadata_summary: {}
 
 <% (Namespace::MAX_ANCESTORS-1).times do |n| %>
 subgroup<%= (n+2) %>:
@@ -21,6 +23,7 @@ subgroup<%= (n+2) %>:
   type: Group
   description: <%= "Subgroup #{n+2} description" %>
   parent_id: <%= ActiveRecord::FixtureSet.identify("subgroup#{n+1}") %>
+  metadata_summary: {}
 <% end %>
 
 group_two:
@@ -28,12 +31,14 @@ group_two:
   path: group-2
   type: Group
   description: Group 2 description
+  metadata_summary: {}
 
 group_three:
   name: Group 3
   path: group-3
   type: Group
   description: Group 3 description
+  metadata_summary: {}
 
 subgroup_one_group_three:
   name: Subgroup 1 Group 3
@@ -41,18 +46,21 @@ subgroup_one_group_three:
   type: Group
   description: Subgroup 1 Group 3
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_three) %>
+  metadata_summary: {}
 
 david_doe_group_four:
   name: Group 4
   path: group-4
   type: Group
   description: David's first group
+  metadata_summary: {}
 
 group_five:
   name: Group 5
   path: group-5
   type: Group
   description: Group 5 description
+  metadata_summary: {}
 
 subgroup_one_group_five:
   name: Subgroup 1 Group 5
@@ -60,12 +68,14 @@ subgroup_one_group_five:
   type: Group
   description: Subgroup 1 Group 5
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
+  metadata_summary: {}
 
 group_six:
   name: Group 6
   path: group-6
   type: Group
   description: Group 6 description
+  metadata_summary: {}
 
 subgroup_one_group_six:
   name: Group 6
@@ -73,18 +83,21 @@ subgroup_one_group_six:
   type: Group
   description: Subgroup 1 description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_six) %>
+  metadata_summary: {}
 
 group_seven:
   name: Group 7
   path: group-7
   type: Group
   description: Group 7 description
+  metadata_summary: {}
 
 group_eight:
   name: Group 8
   path: group-8
   type: Group
   description: Group 8 description
+  metadata_summary: {}
 
 <% [*("a".."z")].each_with_index do |letter, index| %>
 group_<%= letter %>:
@@ -94,6 +107,7 @@ group_<%= letter %>:
   description: <%= "Group #{letter} description" %>
   created_at: <%= (index + 1).days.ago %>
   updated_at: <%= (index + 1).days.ago %>
+  metadata_summary: {}
 <% end %>
 
 namespace_group_link_group_one:
@@ -101,24 +115,28 @@ namespace_group_link_group_one:
   path: group-one
   type: Group
   description: Group One description
+  metadata_summary: {}
 
 namespace_group_link_group_two:
   name: Group Two
   path: group-two
   type: Group
   description: Group Two description
+  metadata_summary: {}
 
 namespace_group_link_group_three:
   name: Group Three
   path: group-three
   type: Group
   description: Group Three description
+  metadata_summary: {}
 
 group_nine:
   name: Group 9
   path: group-9
   type: Group
   description: Group 9 description
+  metadata_summary: {}
 
 subgroup_one_group_nine:
   name: Subgroup 1 Group 9
@@ -126,6 +144,7 @@ subgroup_one_group_nine:
   type: Group
   description: Subgroup 1 Group 9 description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_nine) %>
+  metadata_summary: {}
 
 group_ten:
   name: Group 10
@@ -133,27 +152,32 @@ group_ten:
   type: Group
   description: Group 10 description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_one_group_nine) %>
+  metadata_summary: {}
 
 group_alpha:
   name: Group Alpha
   path: group-alpha
   type: Group
   description: Group Alpha description
+  metadata_summary: {}
 
 group_bravo:
   name: Group Bravo
   path: group-bravo
   type: Group
   description: Group bravo description
+  metadata_summary: {}
 
 group_charlie:
   name: Group Charlie
   path: group-charlie
   type: Group
   description: Group Charlie description
+  metadata_summary: {}
 
 group_alpha_subgroup1:
   name: Subgroup 1
   path: group-alpha/subgroup-1
   type: Group
   description: Subgroup 1 description
+  metadata_summary: {}

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -7,6 +7,7 @@ project1_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: { "metadatafield1": 10, "metadatafield2": 35 }
 
 project2_namespace:
   name: Project 2
@@ -15,6 +16,7 @@ project2_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 john_doe_project2_namespace:
   name: Project 2
@@ -23,6 +25,7 @@ john_doe_project2_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:john_doe_namespace) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 john_doe_project3_namespace:
   name: Project 3
@@ -31,6 +34,7 @@ john_doe_project3_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:john_doe_namespace) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project4_namespace:
   name: Project 4
@@ -39,6 +43,7 @@ project4_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_one_group_three) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project5_namespace:
   name: Project 5
@@ -47,6 +52,7 @@ project5_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: { "metadatafield1": 623, "metadatafield2": 71 }
 
 project6_namespace:
   name: Project 6
@@ -55,6 +61,7 @@ project6_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project7_namespace:
   name: Project 7
@@ -63,6 +70,7 @@ project7_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project8_namespace:
   name: Project 8
@@ -71,6 +79,7 @@ project8_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project9_namespace:
   name: Project 9
@@ -79,6 +88,7 @@ project9_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project10_namespace:
   name: Project 10
@@ -87,6 +97,7 @@ project10_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project11_namespace:
   name: Project 11
@@ -95,6 +106,7 @@ project11_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project12_namespace:
   name: Project 12
@@ -103,6 +115,7 @@ project12_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project13_namespace:
   name: Project 13
@@ -111,6 +124,7 @@ project13_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project14_namespace:
   name: Project 14
@@ -119,6 +133,7 @@ project14_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project15_namespace:
   name: Project 15
@@ -127,6 +142,7 @@ project15_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project16_namespace:
   name: Project 16
@@ -135,6 +151,7 @@ project16_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project17_namespace:
   name: Project 17
@@ -143,6 +160,7 @@ project17_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project18_namespace:
   name: Project 18
@@ -151,6 +169,7 @@ project18_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project19_namespace:
   name: Project 19
@@ -159,6 +178,7 @@ project19_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project20_namespace:
   name: Project 20
@@ -167,6 +187,7 @@ project20_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project21_namespace:
   name: Project 21
@@ -175,6 +196,7 @@ project21_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project22_namespace:
   name: Project 22
@@ -183,6 +205,7 @@ project22_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_five) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project23_namespace:
   name: Project 23
@@ -191,6 +214,7 @@ project23_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_six) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project24_namespace:
   name: Project 24
@@ -199,6 +223,7 @@ project24_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 john_doe_project4_namespace:
   name: Project 4
@@ -207,6 +232,7 @@ john_doe_project4_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:john_doe_namespace) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project25_namespace:
   name: Project 25
@@ -215,6 +241,7 @@ project25_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup1) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 project26_namespace:
   name: Project 26
@@ -223,6 +250,7 @@ project26_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:john_doe_namespace) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: {}
 
 projectA_namespace:
   name: Project A
@@ -231,6 +259,7 @@ projectA_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe_namespace) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe) %>
+  metadata_summary: {}
 
 namespace_group_link_group_one_project1_namespace:
   name: Group One Project 1
@@ -239,6 +268,7 @@ namespace_group_link_group_one_project1_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:namespace_group_link_group_one) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:user24) %>
+  metadata_summary: {}
 
 namespace_group_link_group_three_project1_namespace:
   name: Group Three Project 1
@@ -247,6 +277,7 @@ namespace_group_link_group_three_project1_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:namespace_group_link_group_three) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:user24) %>
+  metadata_summary: {}
 
 project28_namespace:
   name: Project 28
@@ -255,6 +286,7 @@ project28_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:david_doe_group_four) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:david_doe) %>
+  metadata_summary: {}
 
 projectAlpha_namespace:
   name: Project Alpha
@@ -262,6 +294,7 @@ projectAlpha_namespace:
   description: Project Alpha description
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_alpha) %>
+  metadata_summary: {}
 
 projectBravo_namespace:
   name: Project Bravo
@@ -269,6 +302,7 @@ projectBravo_namespace:
   description: Project Bravo description
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_bravo) %>
+  metadata_summary: {}
 
 projectCharlie_namespace:
   name: Project Charlie
@@ -276,6 +310,7 @@ projectCharlie_namespace:
   description: Project Charlie description
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_charlie) %>
+  metadata_summary: {}
 
 projectAlpha1_namespace:
   name: Project Alpha 1
@@ -284,3 +319,4 @@ projectAlpha1_namespace:
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_alpha_subgroup1) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:private_ryan) %>
+  metadata_summary: {}

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class GroupTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
+class GroupTest < ActiveSupport::TestCase
   def setup
     @group = groups(:group_one)
     @subgroup_one = groups(:subgroup1)
@@ -163,5 +163,17 @@ class GroupTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
     assert group_group_links.include?(group_group_link2)
     assert group_group_links.include?(group_group_link3)
     assert group_group_links.include?(namespace_group_links(:namespace_group_link2))
+  end
+
+  test 'group should have metadata summary with metadata fields and their counts from projects within' do
+    expected_metadata_summary = @group.metadata_summary
+    actual_metadata_summary = {}
+
+    group_project_namespaces = @group.project_namespaces
+    group_project_namespaces.each do |gpn|
+      actual_metadata_summary.merge!(gpn.metadata_summary) { |_key, old_value, new_value| old_value + new_value }
+    end
+
+    assert_equal expected_metadata_summary, actual_metadata_summary
   end
 end

--- a/test/models/namespaces/project_namespace_test.rb
+++ b/test/models/namespaces/project_namespace_test.rb
@@ -123,4 +123,12 @@ class ProjectNamespaceTest < ActiveSupport::TestCase
     assert namespace_group_links.include?(namespace_group_link1)
     assert namespace_group_links.include?(namespace_group_link2)
   end
+
+  test 'project namespace should have metadata summary with metadata fields and their counts' do
+    assert_equal 2, @project_namespace.metadata_summary.count
+    assert @project_namespace.metadata_summary.key?('metadatafield1')
+    assert @project_namespace.metadata_summary.key?('metadatafield2')
+    assert_equal 10, @project_namespace.metadata_summary['metadatafield1']
+    assert_equal 35, @project_namespace.metadata_summary['metadatafield2']
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in the db representation for `metadata_summary` in the `namespaces` table. A `jsonb` column was added with the default value of `{}`. 

**Note** validation will be added later most likely in the update logic to ensure that a user namespace does not get assigned a summary of the metadata

Fixes #267 
Fixes #268 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Using the rails console create a new project and verify that the metadata_summary field contains an empty hash
2. Merge in `{"field1": 10, "field2": 15} to the project metadata summary from the above step
3. Verify that the project metadata summary now has these fields and values in it's metadata_summary hash
4. Repeat the above steps for a group
5. Run tests locally to make sure they pass

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
