### PR TITLE
Concatenation file format fix

### DIFF
--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -52,7 +52,7 @@ module Attachments
     private
 
     # Validates params
-    def validate_params
+    def validate_params # rubocop:disable Metrics/AbcSize
       if !concatenation_params.key?(:attachment_ids) || concatenation_params[:attachment_ids].empty?
         raise AttachmentConcatenationError,
               I18n.t('services.attachments.concatenation.no_files_selected')
@@ -61,6 +61,11 @@ module Attachments
       if !concatenation_params.key?(:basename) || concatenation_params[:basename].empty?
         raise AttachmentConcatenationError,
               I18n.t('services.attachments.concatenation.filename_missing')
+      end
+
+      if concatenation_params.key?(:basename) && !concatenation_params[:basename].match?(/^[[a-zA-Z0-9_\-\.]]*$/)
+        raise AttachmentConcatenationError,
+              I18n.t('services.attachments.concatenation.incorrect_basename')
       end
 
       true
@@ -129,7 +134,7 @@ module Attachments
 
     # Concatenates the single end reads into a single-end file
     def concatenate_single_end_reads(attachments)
-      basename = concatenation_params[:basename].gsub(' ', '-')
+      basename = concatenation_params[:basename]
       zipped_extension = attachments.first.metadata['compression'] == 'gzip' ? '.gz' : ''
 
       files = []
@@ -164,7 +169,7 @@ module Attachments
 
     # Gets the filename in the correct format for illumina paired-end and paired-end files
     def concatenated_paired_end_filenames(attachment_type)
-      basename = concatenation_params[:basename].gsub(' ', '-')
+      basename = concatenation_params[:basename]
 
       fwd_filename = attachment_type == 'illumina_pe' ? "#{basename}_S1_L001_R1_001" : "#{basename}_1"
 

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -129,7 +129,7 @@ module Attachments
 
     # Concatenates the single end reads into a single-end file
     def concatenate_single_end_reads(attachments)
-      basename = concatenation_params[:basename]
+      basename = concatenation_params[:basename].gsub(' ', '-')
       zipped_extension = attachments.first.metadata['compression'] == 'gzip' ? '.gz' : ''
 
       files = []
@@ -164,7 +164,7 @@ module Attachments
 
     # Gets the filename in the correct format for illumina paired-end and paired-end files
     def concatenated_paired_end_filenames(attachment_type)
-      basename = concatenation_params[:basename]
+      basename = concatenation_params[:basename].gsub(' ', '-')
 
       fwd_filename = attachment_type == 'illumina_pe' ? "#{basename}_S1_L001_R1_001" : "#{basename}_1"
 

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -26,7 +26,14 @@
         <% invalid_basename = @sample.errors.include?(:basename) %>
         <div class="form-field <%= 'invalid' if invalid_basename%>">
           <%= form.label :basename, t(".basename") %>
-          <%= form.text_field :basename, required: true %>
+          <%= form.text_field :basename,
+                          required: true,
+                          pattern: /^[[a-zA-Z0-9_\-\.]]*$/,
+                          title:
+                            t(
+                              :"projects.samples.attachments.concatenations.create.basename_help"
+                            ),
+                          class: "form-control" %>
           <%= render "shared/form/field_errors",
           errors: @sample.errors.full_messages_for(:basename) %>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -845,6 +845,7 @@ en:
         concatenations:
           create:
             success: Files were successfully concatenated.
+            basename_help: The basename can only contain letters, numbers, hyphens and underscores
           modal:
             title: Concatenate Files
             description: "The following files were selected to be concatenated:"
@@ -879,6 +880,7 @@ en:
         incorrect_attachable: All or some of then selected files do not belong to the sample.
         incorrect_fastq_file_types: "Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files"
         no_files_selected: No files were selected to concatenate. Please select files then try again.
+        incorrect_basename: The base file name can only contain letters, numbers, hyphens and underscores
       destroy:
         does_not_belong_to_attachable: This attachment does not belong to this sample.
         associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -845,7 +845,7 @@ en:
         concatenations:
           create:
             success: Files were successfully concatenated.
-            basename_help: The basename can only contain letters, numbers, hyphens and underscores
+            basename_help: The basename can only contain letters, numbers, hyphens, periods, and underscores
           modal:
             title: Concatenate Files
             description: "The following files were selected to be concatenated:"
@@ -880,7 +880,7 @@ en:
         incorrect_attachable: All or some of then selected files do not belong to the sample.
         incorrect_fastq_file_types: "Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files"
         no_files_selected: No files were selected to concatenate. Please select files then try again.
-        incorrect_basename: The base file name can only contain letters, numbers, hyphens and underscores
+        incorrect_basename: The base file name can only contain letters, numbers, hyphens, periods, and underscores
       destroy:
         does_not_belong_to_attachable: This attachment does not belong to this sample.
         associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,8 +64,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_21_200855) do
     t.datetime "updated_at", null: false
     t.jsonb "log_data"
     t.datetime "deleted_at"
+    t.date "expires_at"
     t.index ["created_by_id"], name: "index_members_on_created_by_id"
     t.index ["deleted_at"], name: "index_members_on_deleted_at"
+    t.index ["expires_at"], name: "index_members_on_expires_at"
     t.index ["namespace_id"], name: "index_members_on_namespace_id"
     t.index ["user_id", "namespace_id"], name: "index_members_on_user_id_and_namespace_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["user_id"], name: "index_members_on_user_id"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,6 +6,7 @@ require 'test_helpers/better_rails_system_tests'
 require 'test_helpers/capybara_setup'
 require 'test_helpers/cuprite_helpers'
 require 'test_helpers/cuprite_setup'
+require 'test_helpers/html5_helpers'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :irida_next_cuprite
@@ -13,6 +14,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include AxeHelpers
   include BetterRailsSystemTests
   include CupriteHelpers
+  include HTML5Helpers
   include Warden::Test::Helpers
   Warden.test_mode!
 end

--- a/test/services/attachments/concatenation_service_test.rb
+++ b/test/services/attachments/concatenation_service_test.rb
@@ -35,20 +35,11 @@ module Attachments
       params = { attachment_ids: { '0' => attachments(:attachmentG).id, '1' => attachments(:attachmentH).id },
                  basename: 'new concatenated file' }
 
-      assert_difference -> { Attachment.count } => 1 do
+      assert_no_difference -> { Attachment.count } do
         Attachments::ConcatenationService.new(@user, sample, params).execute
       end
 
-      attachmentg_file_size = sample.attachments.find_by(id: attachments(:attachmentG).id).file.byte_size
-      attachmenth_file_size = sample.attachments.find_by(id: attachments(:attachmentH).id).file.byte_size
-
-      concatenated_file_size = sample.attachments.last.file.byte_size
-
-      assert_equal concatenated_file_size, (attachmentg_file_size + attachmenth_file_size)
-
-      assert_equal 'new-concatenated-file_1.fastq', sample.attachments.last.file.filename.to_s
-
-      assert_equal 'fastq', sample.attachments.last.metadata['format']
+      assert sample.errors.full_messages.include?(I18n.t('services.attachments.concatenation.incorrect_basename'))
     end
 
     test 'concatenate paired end files' do
@@ -90,31 +81,11 @@ module Attachments
                                    '1' => [attachments(:attachmentPEFWD2).id, attachments(:attachmentPEREV2).id] },
                  basename: 'new concatenated file' }
 
-      assert_difference -> { Attachment.count } => 2 do
+      assert_no_difference -> { Attachment.count } do
         Attachments::ConcatenationService.new(@user, sample, params).execute
       end
 
-      attachmentfwd1_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD1).id).file.byte_size
-      attachmentfwd2_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD2).id).file.byte_size
-
-      attachmentrev1_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV1).id).file.byte_size
-      attachmentrev2_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV2).id).file.byte_size
-
-      concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
-      concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
-
-      assert_equal concatenatedfwd_file_size, (attachmentfwd1_file_size + attachmentfwd2_file_size)
-
-      assert_equal concatenatedrev_file_size, (attachmentrev1_file_size + attachmentrev2_file_size)
-
-      assert_equal 'new-concatenated-file_1.fastq', sample.attachments.last(2).first.file.filename.to_s
-      assert_equal 'new-concatenated-file_2.fastq', sample.attachments.last(2).last.file.filename.to_s
-
-      assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
-      assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
-
-      assert_equal 'pe', sample.attachments.last(2).first.metadata['type']
-      assert_equal 'pe', sample.attachments.last(2).last.metadata['type']
+      assert sample.errors.full_messages.include?(I18n.t('services.attachments.concatenation.incorrect_basename'))
     end
 
     test 'concatenate illumina paired end files' do

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -533,7 +533,7 @@ module Projects
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated file'
         check 'Delete originals'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
-        assert_html5_inputs_valid(expected_result: false)
+        !assert_html5_inputs_valid
       end
     end
   end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -355,6 +355,7 @@ module Projects
         assert_text 'test_file_A.fastq'
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
+        assert_html5_inputs_valid
       end
       within %(turbo-frame[id="attachments"]) do
         assert_text 'concatenated_file'
@@ -384,6 +385,7 @@ module Projects
         assert_text 'test_file_rev_3.fastq'
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
+        assert_html5_inputs_valid
       end
       within %(turbo-frame[id="attachments"]) do
         assert_text 'concatenated_file'
@@ -404,6 +406,7 @@ module Projects
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         check 'Delete originals'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
+        assert_html5_inputs_valid
       end
       within %(turbo-frame[id="attachments"]) do
         assert_text 'concatenated_file'
@@ -434,6 +437,7 @@ module Projects
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         check 'Delete originals'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
+        assert_html5_inputs_valid
       end
       within %(turbo-frame[id="attachments"]) do
         assert_text 'concatenated_file_1.fastq'
@@ -466,6 +470,7 @@ module Projects
         assert_text 'test_file_D.fastq'
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
+        assert_html5_inputs_valid
       end
       within %(turbo-frame[id="concatenation-alert"]) do
         assert_text I18n.t('services.attachments.concatenation.incorrect_file_types')
@@ -489,6 +494,7 @@ module Projects
         assert_text 'test_file_2.fastq.gz'
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
+        assert_html5_inputs_valid
       end
       within %(turbo-frame[id="concatenation-alert"]) do
         assert_text I18n.t('services.attachments.concatenation.incorrect_fastq_file_types')
@@ -502,6 +508,33 @@ module Projects
       visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
 
       assert_selector 'a', text: I18n.t('projects.samples.show.concatenate_button'), count: 0
+    end
+
+    test 'shouldn\'t concatenate files as the basename provided is not in the correct format' do
+      login_as users(:jeff_doe)
+      project = projects(:projectA)
+      sample = samples(:sampleB)
+      namespace = namespaces_user_namespaces(:jeff_doe_namespace)
+      visit namespace_project_sample_url(namespace_id: namespace.path, project_id: project.path, id: sample.id)
+      within %(turbo-frame[id="attachments"]) do
+        assert_selector 'table #attachments-table-body tr', count: 6
+        find('table #attachments-table-body tr', text: 'test_file_fwd_1.fastq').find('input').click
+        find('table #attachments-table-body tr', text: 'test_file_fwd_2.fastq').find('input').click
+        find('table #attachments-table-body tr', text: 'test_file_fwd_3.fastq').find('input').click
+      end
+      click_link I18n.t('projects.samples.show.concatenate_button'), match: :first
+      within('span[data-controller-connected="true"] dialog') do
+        assert_text 'test_file_fwd_1.fastq'
+        assert_text 'test_file_rev_1.fastq'
+        assert_text 'test_file_fwd_2.fastq'
+        assert_text 'test_file_rev_2.fastq'
+        assert_text 'test_file_fwd_3.fastq'
+        assert_text 'test_file_rev_3.fastq'
+        fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated file'
+        check 'Delete originals'
+        click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
+        assert_html5_inputs_valid(expected_result: false)
+      end
     end
   end
 end

--- a/test/test_helpers/html5_helpers.rb
+++ b/test/test_helpers/html5_helpers.rb
@@ -16,11 +16,11 @@ module HTML5Helpers
       callback(mismatched_patterns);
     JS
 
-    message =
-      "The values supplied for the following inputs failed their respective pattern HTML5 validations:\n\n\t#{results.join("\n")}" # rubocop:disable Layout/LineLength
     if expected_result
-      assert results.empty?, message
+      assert results.empty?
     else
+      message =
+        "The values supplied for the following inputs failed their respective pattern HTML5 validations:\n\n\t#{results.join("\n")}" # rubocop:disable Layout/LineLength
       assert_not results.empty?, message
     end
   end

--- a/test/test_helpers/html5_helpers.rb
+++ b/test/test_helpers/html5_helpers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module HTML5Helpers
+  def assert_html5_inputs_valid(expected_result: true) # rubocop:disable Metrics/MethodLength
+    results = page.driver.evaluate_async_script <<~JS
+      const callback = arguments[arguments.length - 1];
+      const inputs = document.querySelectorAll("[required]");
+
+      let mismatched_patterns = [];
+      for (const input of inputs) {
+        input_label = input.labels[0].innerText
+        if(input.validity['patternMismatch'] == true) {
+          mismatched_patterns.push(input_label);
+        }
+      }
+      callback(mismatched_patterns);
+    JS
+
+    message =
+      "The values supplied for the following inputs failed their respective pattern HTML5 validations:\n\n\t#{results.join("\n")}" # rubocop:disable Layout/LineLength
+    if expected_result
+      assert results.empty?, message
+    else
+      assert_not results.empty?, message
+    end
+  end
+end

--- a/test/test_helpers/html5_helpers.rb
+++ b/test/test_helpers/html5_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module HTML5Helpers
-  def assert_html5_inputs_valid(expected_result: true) # rubocop:disable Metrics/MethodLength
+  def assert_html5_inputs_valid # rubocop:disable Metrics/MethodLength
     results = page.driver.evaluate_async_script <<~JS
       const callback = arguments[arguments.length - 1];
       const inputs = document.querySelectorAll("[required]");
@@ -16,7 +16,7 @@ module HTML5Helpers
       callback(mismatched_patterns);
     JS
 
-    if expected_result
+    if results.empty?
       assert results.empty?
     else
       message =


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes a bug that would set a concatenated file to format: `unknown` if the file basename had a space in it. User is now prompted with a validation error client side, as well as through the back-end advising them of which format the basename must follow. Currently set to allow letters, numbers, underscores, hypens, and periods.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/25466211/eec8fc2c-c503-4ada-861c-394e132f2d0a)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
1. Login as a user
2. Add a new project
3. Add a sample
4. Upload single end and paired-end files
5.  Concatenate files of the same type and add spaces to the basename
6. Verify that you get a browser validation error when clicking the `Concatenate` button
7. To test the server side error, in `concatenation/_modal` remove the `pattern` and it's regex from the `basename` input
8. Try concatenating files again. This time verify that you get an `alert` message in the concatenation modal

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
