### PR TITLE
Workflow Executions: Submission Service

### DIFF
--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -17,6 +17,10 @@ class WorkflowExecution < ApplicationRecord
 
   validates :metadata, presence: true, json: { message: ->(errors) { errors }, schema: METADATA_JSON_SCHEMA }
 
+  def prepared?
+    state == 'prepared'
+  end
+
   def as_wes_params
     {
       workflow_params:,

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -16,4 +16,16 @@ class WorkflowExecution < ApplicationRecord
   accepts_nested_attributes_for :samples_workflow_executions
 
   validates :metadata, presence: true, json: { message: ->(errors) { errors }, schema: METADATA_JSON_SCHEMA }
+
+  def as_wes_params
+    {
+      workflow_params:,
+      workflow_type:,
+      workflow_type_version:,
+      workflow_engine:,
+      workflow_engine_version:,
+      workflow_engine_parameters:,
+      workflow_url:
+    }.compact
+  end
 end

--- a/app/services/workflow_executions/submission_service.rb
+++ b/app/services/workflow_executions/submission_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WorkflowExecutions
+  # Service used to Prepare a WorkflowExecution
+  class SubmissionService < BaseService
+    def initialize(workflow_execution, wes_connection, user = nil, params = {})
+      super(user, params)
+      @workflow_execution = workflow_execution
+      @wes_client = Integrations::Ga4ghWesApi::V1::Client.new(conn: wes_connection)
+    end
+
+    def execute
+      run = @wes_client.run_workflow(**@workflow_execution.as_wes_params)
+
+      @workflow_execution.run_id = run[:run_id]
+
+      # mark workflow execution as submitted
+      @workflow_execution.state = 'submitted'
+
+      @workflow_execution.save
+    end
+  end
+end

--- a/app/services/workflow_executions/submission_service.rb
+++ b/app/services/workflow_executions/submission_service.rb
@@ -10,6 +10,8 @@ module WorkflowExecutions
     end
 
     def execute
+      return false unless @workflow_execution.prepared?
+
       run = @wes_client.run_workflow(**@workflow_execution.as_wes_params)
 
       @workflow_execution.run_id = run[:run_id]

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -32,3 +32,12 @@ sample1_irida_next_example:
     "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1)}" %>,
     "fastq_2": ""
   }
+
+sample1_irida_next_example_prepared:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_prepared) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1)}" %>,
+    "fastq_2": ""
+  }

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -57,3 +57,16 @@ irida_next_example:
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
   workflow_url: "https://github.com/phac-nml/iridanextexample"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+
+irida_next_example_prepared:
+  metadata: { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }
+  workflow_params: { "-r": "dev", "--input": '/blah/samplesheet.csv', "--outdir": '/blah/output' }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/iridanextexample"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  state: "prepared"

--- a/test/services/workflow_executions/submission_service_test.rb
+++ b/test/services/workflow_executions/submission_service_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WorkflowExecutions
+  class SubmissionServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:john_doe)
+      @workflow_execution = workflow_executions(:irida_next_example_prepared)
+    end
+
+    test 'submit workflow_execution with valid params' do
+      assert 'prepared', @workflow_execution.state
+
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.post('/runs') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_equal 'abc123', @workflow_execution.run_id
+
+      assert_equal 'submitted', @workflow_execution.state
+    end
+  end
+end

--- a/test/services/workflow_executions/submission_service_test.rb
+++ b/test/services/workflow_executions/submission_service_test.rb
@@ -9,7 +9,7 @@ module WorkflowExecutions
       @workflow_execution = workflow_executions(:irida_next_example_prepared)
     end
 
-    test 'submit workflow_execution with valid params' do
+    test 'submit prepared workflow_execution' do
       assert 'prepared', @workflow_execution.state
 
       stubs = Faraday::Adapter::Test::Stubs.new
@@ -25,11 +25,34 @@ module WorkflowExecutions
         builder.adapter :test, stubs
       end
 
-      WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
+      assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
 
       assert_equal 'abc123', @workflow_execution.run_id
 
       assert_equal 'submitted', @workflow_execution.state
+    end
+
+    test 'submit unprepared workflow_execution' do
+      @workflow_execution = workflow_executions(:irida_next_example)
+
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.post('/runs') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      assert_not WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_nil @workflow_execution.run_id
+
+      assert_not_equal 'submitted', @workflow_execution.state
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in the WorkflowExecutions::PreparationService as described in https://github.com/phac-nml/irida-next/issues/247

This first checks that the `WorkflowExecution` is in the `prepared` state, if not it returns false.

If `prepared` it continues on and submits to WES run_workflow endpoint, and stores the `run_id` and updates the state `submitted`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
