### PR TITLE
Re-use faraday net_http connections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'omniauth-saml'
 
 # API Integrations
 gem 'faraday'
-gem 'faraday-net_http'
+gem 'faraday-net_http_persistent', '~> 2.0'
 
 # Use Sass to process CSS
 # gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -539,7 +539,7 @@ DEPENDENCIES
   devise (~> 4.9.2)
   erb-formatter (~> 0.4.3)
   faraday
-  faraday-net_http
+  faraday-net_http_persistent (~> 2.0)
   fx
   good_job (~> 3.21)
   google-cloud-storage (~> 1.11)

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Faraday.default_adapter = :net_http
+Faraday.default_adapter = :net_http_persistent

--- a/lib/integrations/ga4gh_wes_api/v1/api_connection.rb
+++ b/lib/integrations/ga4gh_wes_api/v1/api_connection.rb
@@ -27,7 +27,7 @@ module Integrations
                           end
         end
 
-        def conn
+        def conn # rubocop:disable Metrics/MethodLength
           headers = { 'Content-Type': 'application/json' }
           extra_headers = Rails.application.credentials.dig(:ga4gh_wes, :headers)
           headers = headers.merge(extra_headers) unless extra_headers.nil?
@@ -43,7 +43,10 @@ module Integrations
             f.response :logger # logs request and responses
             f.response :json # decode response bodies as JSON
             f.response :raise_error, include_request: true
-            f.adapter :net_http # Use the Net::HTTP adapter
+            f.adapter :net_http_persistent, pool_size: 5 do |http|
+              # yields Net::HTTP::Persistent
+              http.idle_timeout = 100
+            end
           end
         end
       end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Fixes #326 

Add gem `faraday-net_http_persistent`
Remove gem `faraday-net_http` as it is now a dependency with version number specified by `faraday-net_http_persistent`

Setup basic persistence with default values provided by gem README
* `pool_size: 5`
* `http.idle_timeout = 100`

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
1. run `bundle` in some way to get the new gems
e.g. `./scripts/clean_dev.sh`
2. Ensure you have ga4gh_wes credentials in your credentials file
`EDITOR="vim --nofork " bin/rails credentials:edit`
3. run a rake task from `:ga4gh_wes`
`rake debug ga4gh_wes:service_info`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
