### PR TITLE
Sample metadata controller

### DIFF
--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -6,10 +6,7 @@ module Projects
     class MetadataController < Projects::Samples::ApplicationController
       def update # rubocop:disable Metrics/AbcSize
         authorize! @project, to: :update_sample?
-        puts params
-        puts 'HIHIHIHIHIHIHIAHGAEHEAIRNHINAERIHREIHEARH'
         respond_to do |format|
-          puts 'IT GOT HERER 1'
           metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
                                                                    metadata_params).execute
           if validate_updated_metadata(metadata_fields)

--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Projects
+  module Samples
+    # Controller actions for Project Samples Attachments
+    class MetadataController < Projects::Samples::ApplicationController
+      def update # rubocop:disable Metrics/AbcSize
+        authorize! @project, to: :update_sample?
+        respond_to do |format|
+          metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
+                                                                   metadata_params).execute
+          if validate_updated_metadata(metadata_fields)
+            flash[:success] =
+              t('.success', metadata_fields: metadata_fields[:updated].join(', '), sample_name: @sample.name)
+          end
+          flash[:error] = @sample.errors.full_messages.first if @sample.errors.any?
+          format.turbo_stream { redirect_to(project_path(@project)) }
+        end
+      end
+
+      private
+
+      def metadata_params
+        params.require(:metadata).permit(:analysis_id, metadata: {})
+      end
+
+      def validate_updated_metadata(metadata_fields)
+        !metadata_fields.nil? && metadata_fields[:updated].count.positive?
+      end
+    end
+  end
+end

--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -6,9 +6,10 @@ module Projects
     class MetadataController < Projects::Samples::ApplicationController
       def update # rubocop:disable Metrics/AbcSize
         authorize! @project, to: :update_sample?
+        params = { metadata: { metadata: { key1: 'value1' }, analysis_id: 1 } }
         respond_to do |format|
           metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
-                                                                   metadata_params).execute
+                                                                   params).execute
           if validate_updated_metadata(metadata_fields)
             flash[:success] =
               t('.success', metadata_fields: metadata_fields[:updated].join(', '), sample_name: @sample.name)

--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -9,7 +9,7 @@ module Projects
         respond_to do |format|
           metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
                                                                    metadata_params).execute
-          if validate_updated_metadata(metadata_fields)
+          if !metadata_fields.nil? && metadata_fields[:updated].count.positive?
             flash[:success] =
               t('.success', metadata_fields: metadata_fields[:updated].join(', '), sample_name: @sample.name)
           end
@@ -22,10 +22,6 @@ module Projects
 
       def metadata_params
         params.require(:metadata).permit(:analysis_id, metadata: {})
-      end
-
-      def validate_updated_metadata(metadata_fields)
-        !metadata_fields.nil? && metadata_fields[:updated].count.positive?
       end
     end
   end

--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -6,10 +6,10 @@ module Projects
     class MetadataController < Projects::Samples::ApplicationController
       def update # rubocop:disable Metrics/AbcSize
         authorize! @project, to: :update_sample?
-        params = { metadata: { metadata: { key1: 'value1' }, analysis_id: 1 } }
+
         respond_to do |format|
           metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
-                                                                   params).execute
+                                                                   metadata_params).execute
           if validate_updated_metadata(metadata_fields)
             flash[:success] =
               t('.success', metadata_fields: metadata_fields[:updated].join(', '), sample_name: @sample.name)

--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -6,8 +6,10 @@ module Projects
     class MetadataController < Projects::Samples::ApplicationController
       def update # rubocop:disable Metrics/AbcSize
         authorize! @project, to: :update_sample?
-
+        puts params
+        puts 'HIHIHIHIHIHIHIAHGAEHEAIRNHINAERIHREIHEARH'
         respond_to do |format|
+          puts 'IT GOT HERER 1'
           metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
                                                                    metadata_params).execute
           if validate_updated_metadata(metadata_fields)

--- a/app/views/projects/samples/edit.html.erb
+++ b/app/views/projects/samples/edit.html.erb
@@ -29,29 +29,10 @@
       >
         <%= t("projects.samples.edit.form.title") %>
       </h2>
-       <%= form_for(:metadata, url: namespace_project_sample_metadata_path(sample_id: @sample.id), method: :patch) do |form| %>
-        <%
-=begin%>
- <%= form.fields_for :metadata do |metadata| %>
+      <%= form_with(model: @sample, url: namespace_project_sample_path(id: @sample.id), method: :patch) do |form| %>
         <div class="grid gap-4">
-<div class="form-field ">
-  <%= metadata.label :key1 %>
-  <%= metadata.text_field :key1, minlength: 3, maxlength: 255 %>
-</div>
-
-<div class="form-field ">
-  <%= metadata.label :key2 %>
-  <%= metadata.text_area :key2, rows: 4 %>
-</div>
-<div class="form-field ">
-  <%= metadata.label :key3 %>
-  <%= metadata.text_area :key3, rows: 4 %>
-</div>
-
-<%end%>
-<%
-=end%>
-<div>
+          <%= render partial: "form_fields", locals: { form: form, sample: @sample } %>
+          <div>
             <%= form.submit t("projects.samples.edit.submit_button"),
                             class: "button button--state-primary button--size-default mr-1" %>
             <%= link_to t("projects.samples.edit.cancel_button"),

--- a/app/views/projects/samples/edit.html.erb
+++ b/app/views/projects/samples/edit.html.erb
@@ -29,10 +29,29 @@
       >
         <%= t("projects.samples.edit.form.title") %>
       </h2>
-      <%= form_with(model: @sample, url: namespace_project_sample_path(id: @sample.id), method: :patch) do |form| %>
+       <%= form_for(:metadata, url: namespace_project_sample_metadata_path(sample_id: @sample.id), method: :patch) do |form| %>
+        <%
+=begin%>
+ <%= form.fields_for :metadata do |metadata| %>
         <div class="grid gap-4">
-          <%= render partial: "form_fields", locals: { form: form, sample: @sample } %>
-          <div>
+<div class="form-field ">
+  <%= metadata.label :key1 %>
+  <%= metadata.text_field :key1, minlength: 3, maxlength: 255 %>
+</div>
+
+<div class="form-field ">
+  <%= metadata.label :key2 %>
+  <%= metadata.text_area :key2, rows: 4 %>
+</div>
+<div class="form-field ">
+  <%= metadata.label :key3 %>
+  <%= metadata.text_area :key3, rows: 4 %>
+</div>
+
+<%end%>
+<%
+=end%>
+<div>
             <%= form.submit t("projects.samples.edit.submit_button"),
                             class: "button button--state-primary button--size-default mr-1" %>
             <%= link_to t("projects.samples.edit.cancel_button"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -869,6 +869,9 @@ en:
         created_at: Created
         updated_at: Last Updated
         action: Action
+      metadata:
+        update:
+          success: "Metadata fields '%{metadata_fields}' for sample '%{sample_name}' were updated"
   workflow_executions:
     submissions:
         pipeline_selection:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -858,6 +858,9 @@ fr:
         created_at: Created
         updated_at: Last Updated
         action: Action
+      metadata:
+        update:
+          success: 'Metadata fields %{metadata_fields} for sample %{sample_name} were updated'
   workflow_executions:
     submissions:
       pipeline_selection:

--- a/config/routes/project.rb
+++ b/config/routes/project.rb
@@ -35,6 +35,7 @@ constraints(::Constraints::ProjectUrlConstrainer.new) do
             end
           end
         end
+        resource :metadata, module: :samples, only: %i[update]
       end
     end
   end

--- a/test/controllers/projects/samples/metadata_controller_test.rb
+++ b/test/controllers/projects/samples/metadata_controller_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Projects
+  module Samples
+    class MetadataControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        sign_in users(:john_doe)
+        @sample1 = samples(:sample1)
+        @sample2 = samples(:sample2)
+        @project1 = projects(:project1)
+        @project2 = projects(:project2)
+        @namespace = groups(:group_one)
+      end
+
+      test 'update metadata params' do
+        patch namespace_project_sample_metadata_path(@namespace, @project1, @sample1),
+              params: { metadata: { metadata: { key1: 'value1' } }, format: :turbo_stream }
+        assert_redirected_to namespace_project_path(@namespace, @project1)
+      end
+    end
+  end
+end

--- a/test/controllers/projects/samples/metadata_controller_test.rb
+++ b/test/controllers/projects/samples/metadata_controller_test.rb
@@ -8,16 +8,44 @@ module Projects
       setup do
         sign_in users(:john_doe)
         @sample1 = samples(:sample1)
-        @sample2 = samples(:sample2)
+        @sample23 = samples(:sample23)
         @project1 = projects(:project1)
         @project2 = projects(:project2)
         @namespace = groups(:group_one)
       end
 
-      test 'updating metadata' do
+      test 'updating metadata with no analysis_id' do
         patch namespace_project_sample_metadata_path(@namespace, @project1, @sample1),
               params: { metadata: { metadata: { key1: 'value1' } }, format: :turbo_stream }
         assert_redirected_to namespace_project_path(@namespace, @project1)
+      end
+      test 'updating metadata with analysis_id' do
+        patch namespace_project_sample_metadata_path(@namespace, @project1, @sample1),
+              params: { metadata: { metadata: { key1: 'value1' }, analysis_id: 1 }, format: :turbo_stream }
+        assert_redirected_to namespace_project_path(@namespace, @project1)
+      end
+
+      test 'updating metadata to delete field value from sample' do
+        patch namespace_project_sample_metadata_path(@namespace, @project1, @sample1),
+              params: { metadata: { metadata: { key1: '' } }, format: :turbo_stream }
+        assert_redirected_to namespace_project_path(@namespace, @project1)
+      end
+
+      test 'cannot update sample, if it does not belong to the project' do
+        patch namespace_project_sample_metadata_path(@namespace, @project1, @sample23),
+              params: { metadata: { metadata: { key1: 'value1' } }, format: :turbo_stream }
+        assert_response :not_found
+      end
+
+      test 'cannot update sample if not a member with access to the project' do
+        sign_in users(:david_doe)
+        namespace = namespaces_user_namespaces(:john_doe_namespace)
+        project = projects(:john_doe_project2)
+        sample = samples(:sample24)
+
+        patch namespace_project_sample_metadata_path(namespace, project, sample),
+              params: { metadata: { metadata: { key1: 'value1' } }, format: :turbo_stream }
+        assert_response :unauthorized
       end
     end
   end

--- a/test/controllers/projects/samples/metadata_controller_test.rb
+++ b/test/controllers/projects/samples/metadata_controller_test.rb
@@ -14,7 +14,7 @@ module Projects
         @namespace = groups(:group_one)
       end
 
-      test 'update metadata params' do
+      test 'updating metadata' do
         patch namespace_project_sample_metadata_path(@namespace, @project1, @sample1),
               params: { metadata: { metadata: { key1: 'value1' } }, format: :turbo_stream }
         assert_redirected_to namespace_project_path(@namespace, @project1)


### PR DESCRIPTION
## What does this PR do and why?
This PR starts the `samples_metadata` controller. The controller currently only has the `update` action, and this action utilizes the `Samples::Metadata::UpdateService` to create, update, and delete sample metadata fields. There is currently no front-end/ui to interact with the controller on the website.

Notes: 
Because there's no `update` template, I'm unable to implement status' and their respective tests. These will be updated once the UI is tied in. 
This includes:
- `:ok` status if there are no errors and `metadata_fields[:updated].count.positive?`
- `:multi_status` status if there are both errors and `metadata_fields[:updated].count.positive?`. This captures the likely scenario that a user tried to update metafields including those they are unable to.
- `:unprocessable_entity` status if metadata was `nil?` to begin with, or `!metadata_fields[:updated].count.positive?` and errors exist, again likely due to the user updating fields they are unable to and no fields were able to be updated.

After `status` implementation, the `redirect` will likely be replaced with a `turbo_stream` `render status`. The current `redirect` path was chosen as metadata field updating is likely to sit at the `project` level.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
Ensure tests pass locally.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
