### PR TITLE
Workflow Executions: Status Service

### DIFF
--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    return unless !workflow_execution.completed? && !workflow_execution.cancelled? && !workflow_execution.error?
+    return unless !workflow_execution.completed? && !workflow_execution.canceled? && !workflow_execution.error?
 
     WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
   end

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    if workflow_execution.state != 'complete' && workflow_execution.state != 'canceled' &&
+    if workflow_execution.state != 'completed' && workflow_execution.state != 'canceled' &&
        workflow_execution.state != 'error'
       WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
     end

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,9 +8,8 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    if workflow_execution.state != 'completed' && workflow_execution.state != 'canceled' &&
-       workflow_execution.state != 'error'
-      WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
-    end
+    return unless !workflow_execution.completed? && !workflow_execution.canceled? && !workflow_execution.error?
+
+    WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
   end
 end

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Queues the workflow execution status job
+class WorkflowExecutionStatusJob < ApplicationJob
+  queue_as :default
+
+  def perform(workflow_execution)
+    wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
+    workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
+
+    if workflow_execution.state != 'complete' && workflow_execution.state != 'canceled' &&
+       workflow_execution.state != 'error'
+      WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
+    end
+  end
+end

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    return unless !workflow_execution.completed? && !workflow_execution.canceled? && !workflow_execution.error?
+    return unless !workflow_execution.completed? && !workflow_execution.cancelled? && !workflow_execution.error?
 
     WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
   end

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -6,6 +6,10 @@ class WorkflowExecutionSubmissionJob < ApplicationJob
 
   def perform(workflow_execution)
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
-    WorkflowExecutions::SubmissionService.new(workflow_execution, wes_connection).execute
+    workflow_execution = WorkflowExecutions::SubmissionService.new(workflow_execution, wes_connection).execute
+
+    return if workflow_execution.run_id.nil?
+
+    WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
   end
 end

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -23,6 +23,18 @@ class WorkflowExecution < ApplicationRecord
     state == 'prepared'
   end
 
+  def completed?
+    state == 'completed'
+  end
+
+  def error?
+    state == 'error'
+  end
+
+  def canceled?
+    state == 'canceled'
+  end
+
   def as_wes_params
     {
       workflow_params:,

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -31,8 +31,8 @@ class WorkflowExecution < ApplicationRecord
     state == 'error'
   end
 
-  def canceled?
-    state == 'canceled'
+  def cancelled?
+    state == 'cancelled'
   end
 
   def as_wes_params

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -31,8 +31,8 @@ class WorkflowExecution < ApplicationRecord
     state == 'error'
   end
 
-  def cancelled?
-    state == 'cancelled'
+  def canceled?
+    state == 'canceled'
   end
 
   def as_wes_params

--- a/app/services/workflow_executions/status_service.rb
+++ b/app/services/workflow_executions/status_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module WorkflowExecutions
+  # Service used to update the status of a WorkflowExecution
+  class StatusService < BaseService
+    CANCELATION_STATES = %w[
+      CANCELED CANCELING PREEMPTED
+    ].freeze
+
+    ERROR_STATES = %w[
+      EXECUTOR_ERROR SYSTEM_ERROR
+    ].freeze
+
+    def initialize(workflow_execution, wes_connection, user = nil, params = {})
+      super(user, params)
+
+      @workflow_execution = workflow_execution
+      @wes_client = Integrations::Ga4ghWesApi::V1::Client.new(conn: wes_connection)
+    end
+
+    def execute
+      return if @workflow_execution.run_id.nil?
+
+      run_status = @wes_client.get_run_status(@workflow_execution.run_id)
+
+      state = run_status[:state]
+
+      @workflow_execution.state = 'complete' if state == 'COMPLETE'
+
+      @workflow_execution.state = 'canceled' if CANCELATION_STATES.include?(state)
+
+      @workflow_execution.state = 'error' if ERROR_STATES.include?(state)
+
+      @workflow_execution.save
+
+      @workflow_execution
+    end
+  end
+end

--- a/app/services/workflow_executions/status_service.rb
+++ b/app/services/workflow_executions/status_service.rb
@@ -20,7 +20,7 @@ module WorkflowExecutions
       @workflow_execution.state = 'completed' if state == 'COMPLETE'
 
       if Integrations::Ga4ghWesApi::V1::States::CANCELATION_STATES.include?(state)
-        @workflow_execution.state = 'cancelled'
+        @workflow_execution.state = 'canceled'
       end
 
       @workflow_execution.state = 'error' if Integrations::Ga4ghWesApi::V1::States::ERROR_STATES.include?(state)

--- a/app/services/workflow_executions/status_service.rb
+++ b/app/services/workflow_executions/status_service.rb
@@ -19,13 +19,13 @@ module WorkflowExecutions
     end
 
     def execute
-      return if @workflow_execution.run_id.nil?
+      return false if @workflow_execution.run_id.nil?
 
       run_status = @wes_client.get_run_status(@workflow_execution.run_id)
 
       state = run_status[:state]
 
-      @workflow_execution.state = 'complete' if state == 'COMPLETE'
+      @workflow_execution.state = 'completed' if state == 'COMPLETE'
 
       @workflow_execution.state = 'canceled' if CANCELATION_STATES.include?(state)
 

--- a/app/services/workflow_executions/submission_service.rb
+++ b/app/services/workflow_executions/submission_service.rb
@@ -20,6 +20,8 @@ module WorkflowExecutions
       @workflow_execution.state = 'submitted'
 
       @workflow_execution.save
+
+      @workflow_execution
     end
   end
 end

--- a/lib/integrations/ga4gh_wes_api/v1/states.rb
+++ b/lib/integrations/ga4gh_wes_api/v1/states.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Ga4ghWesApi
+    module V1
+      # GA4GH WES API States
+      class States
+        CANCELATION_STATES = %w[
+          CANCELED CANCELING PREEMPTED
+        ].freeze
+
+        ERROR_STATES = %w[
+          EXECUTOR_ERROR SYSTEM_ERROR
+        ].freeze
+      end
+    end
+  end
+end

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -145,7 +145,7 @@ module WorkflowExecutions
       assert_enqueued_jobs 0
     end
 
-    test 'test workflow execution canceled' do
+    test 'test workflow execution cancelled' do
       workflow_params = {
         metadata:
         { workflow_name: 'irida-next-example-new', workflow_version: '1.0dev' },
@@ -185,7 +185,7 @@ module WorkflowExecutions
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
       end
 
-      assert_equal 'canceled', @workflow_execution.reload.state
+      assert_equal 'cancelled', @workflow_execution.reload.state
     end
 
     test 'test workflow execution error' do

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -50,12 +50,12 @@ module WorkflowExecutions
         state: 'new'
       }
 
-      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "run123" }',
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_1" }',
                                                                                 headers: { content_type:
                                                                                            'application/json' })
 
-      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/run123/status')
-        .to_return(body: '{ "run_id": "run123", "state": "COMPLETE" }',
+      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/create_run_1/status')
+        .to_return(body: '{ "run_id": "create_run_1", "state": "COMPLETE" }',
                    headers: { content_type:
                             'application/json' })
 
@@ -74,12 +74,12 @@ module WorkflowExecutions
       assert_equal 'completed', @workflow_execution.reload.state
       assert_equal 'new', @workflow_execution2.reload.state
 
-      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "run234" }',
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_2" }',
                                                                                 headers: { content_type:
                  'application/json' })
 
-      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/run234/status')
-        .to_return(body: '{ "run_id": "run234", "state": "COMPLETE" }',
+      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/create_run_2/status')
+        .to_return(body: '{ "run_id": "create_run_2", "state": "COMPLETE" }',
                    headers: { content_type:
                             'application/json' })
 
@@ -145,7 +145,7 @@ module WorkflowExecutions
       assert_enqueued_jobs 0
     end
 
-    test 'test workflow execution cancelled' do
+    test 'test workflow execution canceled' do
       workflow_params = {
         metadata:
         { workflow_name: 'irida-next-example-new', workflow_version: '1.0dev' },
@@ -166,11 +166,11 @@ module WorkflowExecutions
         state: 'new'
       }
 
-      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "run123" }',
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_4" }',
                                                                                 headers: { content_type:
                                                                                            'application/json' })
 
-      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/run123/status')
+      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/create_run_4/status')
         .to_return(body: '{ "run_id": "run123", "state": "CANCELING" }',
                    headers: { content_type:
                             'application/json' })
@@ -185,7 +185,7 @@ module WorkflowExecutions
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
       end
 
-      assert_equal 'cancelled', @workflow_execution.reload.state
+      assert_equal 'canceled', @workflow_execution.reload.state
     end
 
     test 'test workflow execution error' do
@@ -209,12 +209,12 @@ module WorkflowExecutions
         state: 'new'
       }
 
-      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "run123" }',
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_5" }',
                                                                                 headers: { content_type:
                                                                                            'application/json' })
 
-      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/run123/status')
-        .to_return(body: '{ "run_id": "run123", "state": "EXECUTOR_ERROR" }',
+      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/create_run_5/status')
+        .to_return(body: '{ "run_id": "create_run_5", "state": "EXECUTOR_ERROR" }',
                    headers: { content_type:
                             'application/json' })
 

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -71,7 +71,7 @@ module WorkflowExecutions
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
       end
 
-      assert_equal 'complete', @workflow_execution.reload.state
+      assert_equal 'completed', @workflow_execution.reload.state
       assert_equal 'new', @workflow_execution2.reload.state
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "run234" }',
@@ -87,7 +87,7 @@ module WorkflowExecutions
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution2)
       end
 
-      assert_equal 'complete', @workflow_execution2.reload.state
+      assert_equal 'completed', @workflow_execution2.reload.state
     end
 
     test 'test create new workflow execution with missing required workflow name' do
@@ -143,6 +143,92 @@ module WorkflowExecutions
       assert @workflow_execution.errors.full_messages
                                 .include?('Metadata root is missing required keys: workflow_version')
       assert_enqueued_jobs 0
+    end
+
+    test 'test workflow execution canceled' do
+      workflow_params = {
+        metadata:
+        { workflow_name: 'irida-next-example-new', workflow_version: '1.0dev' },
+        workflow_params:
+        {
+          '-r': 'dev',
+          '--input': '/blah/samplesheet.csv',
+          '--outdir': '/blah/output'
+        },
+        workflow_type: 'DSL2',
+        workflow_type_version: '22.10.7',
+        tags: [],
+        workflow_engine: 'nextflow',
+        workflow_engine_version: '',
+        workflow_engine_parameters: { engine: 'nextflow', execute_loc: 'azure' },
+        workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
+        submitter_id: @user.id,
+        state: 'new'
+      }
+
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "run123" }',
+                                                                                headers: { content_type:
+                                                                                           'application/json' })
+
+      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/run123/status')
+        .to_return(body: '{ "run_id": "run123", "state": "CANCELING" }',
+                   headers: { content_type:
+                            'application/json' })
+
+      @workflow_execution = WorkflowExecutions::CreateService.new(
+        @user, workflow_params
+      ).execute
+
+      assert_equal 'new', @workflow_execution.state
+
+      perform_enqueued_jobs do
+        WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
+      end
+
+      assert_equal 'canceled', @workflow_execution.reload.state
+    end
+
+    test 'test workflow execution error' do
+      workflow_params = {
+        metadata:
+        { workflow_name: 'irida-next-example-new', workflow_version: '1.0dev' },
+        workflow_params:
+        {
+          '-r': 'dev',
+          '--input': '/blah/samplesheet.csv',
+          '--outdir': '/blah/output'
+        },
+        workflow_type: 'DSL2',
+        workflow_type_version: '22.10.7',
+        tags: [],
+        workflow_engine: 'nextflow',
+        workflow_engine_version: '',
+        workflow_engine_parameters: { engine: 'nextflow', execute_loc: 'azure' },
+        workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
+        submitter_id: @user.id,
+        state: 'new'
+      }
+
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "run123" }',
+                                                                                headers: { content_type:
+                                                                                           'application/json' })
+
+      stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/run123/status')
+        .to_return(body: '{ "run_id": "run123", "state": "EXECUTOR_ERROR" }',
+                   headers: { content_type:
+                            'application/json' })
+
+      @workflow_execution = WorkflowExecutions::CreateService.new(
+        @user, workflow_params
+      ).execute
+
+      assert_equal 'new', @workflow_execution.state
+
+      perform_enqueued_jobs do
+        WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
+      end
+
+      assert_equal 'error', @workflow_execution.reload.state
     end
   end
 end

--- a/test/services/workflow_executions/status_service_test.rb
+++ b/test/services/workflow_executions/status_service_test.rb
@@ -10,12 +10,13 @@ module WorkflowExecutions
     end
 
     test 'get status of workflow execution which has completed' do
+      run_id = 'status_test_1'
       stubs = Faraday::Adapter::Test::Stubs.new
       stubs.post('/runs') do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'status_test_1' }
+          { run_id: }
         ]
       end
 
@@ -25,16 +26,16 @@ module WorkflowExecutions
 
       assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'status_test_1', @workflow_execution.run_id
+      assert_equal run_id, @workflow_execution.run_id
 
       assert_equal 'submitted', @workflow_execution.state
 
       stubs = Faraday::Adapter::Test::Stubs.new
-      stubs.get('/runs/status_test_1/status') do
+      stubs.get("/runs/#{run_id}/status") do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'status_test_1', state: 'COMPLETE' }
+          { run_id:, state: 'COMPLETE' }
         ]
       end
 
@@ -48,12 +49,13 @@ module WorkflowExecutions
     end
 
     test 'get status of workflow execution which has been canceled' do
+      run_id = 'status_test_2'
       stubs = Faraday::Adapter::Test::Stubs.new
       stubs.post('/runs') do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'status_test_2' }
+          { run_id: }
         ]
       end
 
@@ -63,16 +65,16 @@ module WorkflowExecutions
 
       assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'status_test_2', @workflow_execution.run_id
+      assert_equal run_id, @workflow_execution.run_id
 
       assert_equal 'submitted', @workflow_execution.state
 
       stubs = Faraday::Adapter::Test::Stubs.new
-      stubs.get('/runs/status_test_2/status') do
+      stubs.get("/runs/#{run_id}/status") do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'status_test_2', state: 'CANCELED' }
+          { run_id:, state: 'CANCELED' }
         ]
       end
 
@@ -86,12 +88,13 @@ module WorkflowExecutions
     end
 
     test 'get status of workflow execution which has errored' do
+      run_id = 'status_test_3'
       stubs = Faraday::Adapter::Test::Stubs.new
       stubs.post('/runs') do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'status_test_3' }
+          { run_id: }
         ]
       end
 
@@ -101,16 +104,16 @@ module WorkflowExecutions
 
       assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'status_test_3', @workflow_execution.run_id
+      assert_equal run_id, @workflow_execution.run_id
 
       assert_equal 'submitted', @workflow_execution.state
 
       stubs = Faraday::Adapter::Test::Stubs.new
-      stubs.get('/runs/status_test_3/status') do
+      stubs.get("/runs/#{run_id}/status") do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'status_test_3', state: 'SYSTEM_ERROR' }
+          { run_id:, state: 'SYSTEM_ERROR' }
         ]
       end
 

--- a/test/services/workflow_executions/status_service_test.rb
+++ b/test/services/workflow_executions/status_service_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WorkflowExecutions
+  class CreateServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:john_doe)
+      @workflow_execution = workflow_executions(:irida_next_example_prepared)
+    end
+
+    test 'get status of workflow execution which has completed' do
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.post('/runs') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_equal 'abc123', @workflow_execution.run_id
+
+      assert_equal 'submitted', @workflow_execution.state
+
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.get('/runs/abc123/status') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123', state: 'COMPLETE' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      @workflow_execution = WorkflowExecutions::StatusService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_equal 'completed', @workflow_execution.state
+    end
+
+    test 'get status of workflow execution which has been canceled' do
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.post('/runs') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_equal 'abc123', @workflow_execution.run_id
+
+      assert_equal 'submitted', @workflow_execution.state
+
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.get('/runs/abc123/status') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123', state: 'CANCELED' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      @workflow_execution = WorkflowExecutions::StatusService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_equal 'canceled', @workflow_execution.state
+    end
+
+    test 'get status of workflow execution which has errored' do
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.post('/runs') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_equal 'abc123', @workflow_execution.run_id
+
+      assert_equal 'submitted', @workflow_execution.state
+
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.get('/runs/abc123/status') do
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: 'abc123', state: 'SYSTEM_ERROR' }
+        ]
+      end
+
+      conn = Faraday.new do |builder|
+        builder.adapter :test, stubs
+      end
+
+      @workflow_execution = WorkflowExecutions::StatusService.new(@workflow_execution, conn, @user, {}).execute
+
+      assert_equal 'error', @workflow_execution.state
+    end
+  end
+end

--- a/test/services/workflow_executions/status_service_test.rb
+++ b/test/services/workflow_executions/status_service_test.rb
@@ -15,7 +15,7 @@ module WorkflowExecutions
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'abc123' }
+          { run_id: 'status_test_1' }
         ]
       end
 
@@ -25,16 +25,16 @@ module WorkflowExecutions
 
       assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'abc123', @workflow_execution.run_id
+      assert_equal 'status_test_1', @workflow_execution.run_id
 
       assert_equal 'submitted', @workflow_execution.state
 
       stubs = Faraday::Adapter::Test::Stubs.new
-      stubs.get('/runs/abc123/status') do
+      stubs.get('/runs/status_test_1/status') do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'abc123', state: 'COMPLETE' }
+          { run_id: 'status_test_1', state: 'COMPLETE' }
         ]
       end
 
@@ -53,7 +53,7 @@ module WorkflowExecutions
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'abc123' }
+          { run_id: 'status_test_2' }
         ]
       end
 
@@ -63,16 +63,16 @@ module WorkflowExecutions
 
       assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'abc123', @workflow_execution.run_id
+      assert_equal 'status_test_2', @workflow_execution.run_id
 
       assert_equal 'submitted', @workflow_execution.state
 
       stubs = Faraday::Adapter::Test::Stubs.new
-      stubs.get('/runs/abc123/status') do
+      stubs.get('/runs/status_test_2/status') do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'abc123', state: 'CANCELED' }
+          { run_id: 'status_test_2', state: 'CANCELED' }
         ]
       end
 
@@ -91,7 +91,7 @@ module WorkflowExecutions
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'abc123' }
+          { run_id: 'status_test_3' }
         ]
       end
 
@@ -101,16 +101,16 @@ module WorkflowExecutions
 
       assert WorkflowExecutions::SubmissionService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'abc123', @workflow_execution.run_id
+      assert_equal 'status_test_3', @workflow_execution.run_id
 
       assert_equal 'submitted', @workflow_execution.state
 
       stubs = Faraday::Adapter::Test::Stubs.new
-      stubs.get('/runs/abc123/status') do
+      stubs.get('/runs/status_test_3/status') do
         [
           200,
           { 'Content-Type': 'application/json' },
-          { run_id: 'abc123', state: 'SYSTEM_ERROR' }
+          { run_id: 'status_test_3', state: 'SYSTEM_ERROR' }
         ]
       end
 

--- a/test/services/workflow_executions/status_service_test.rb
+++ b/test/services/workflow_executions/status_service_test.rb
@@ -48,7 +48,7 @@ module WorkflowExecutions
       assert_equal 'completed', @workflow_execution.state
     end
 
-    test 'get status of workflow execution which has been canceled' do
+    test 'get status of workflow execution which has been cancelled' do
       run_id = 'status_test_2'
       stubs = Faraday::Adapter::Test::Stubs.new
       stubs.post('/runs') do
@@ -84,7 +84,7 @@ module WorkflowExecutions
 
       @workflow_execution = WorkflowExecutions::StatusService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'canceled', @workflow_execution.state
+      assert_equal 'cancelled', @workflow_execution.state
     end
 
     test 'get status of workflow execution which has errored' do

--- a/test/services/workflow_executions/status_service_test.rb
+++ b/test/services/workflow_executions/status_service_test.rb
@@ -48,7 +48,7 @@ module WorkflowExecutions
       assert_equal 'completed', @workflow_execution.state
     end
 
-    test 'get status of workflow execution which has been cancelled' do
+    test 'get status of workflow execution which has been canceled' do
       run_id = 'status_test_2'
       stubs = Faraday::Adapter::Test::Stubs.new
       stubs.post('/runs') do
@@ -84,7 +84,7 @@ module WorkflowExecutions
 
       @workflow_execution = WorkflowExecutions::StatusService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'cancelled', @workflow_execution.state
+      assert_equal 'canceled', @workflow_execution.state
     end
 
     test 'get status of workflow execution which has errored' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in the `status` service which checks the status of a workflow execution every 30 seconds and when in a final state updates the workflow state to this final state. This service is called via a status job which the submission job queues up once a run_id is returned from the submission service

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
1) Ensure that the tests pass locally

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
