### PR TITLE
Metadata Summary Update by Metadata::UpdateService

### DIFF
--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -9,8 +9,8 @@ module Projects
         respond_to do |format|
           metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
                                                                    metadata_params).execute
-          changed_metadata_fields = metadata_fields[:added] + metadata_fields[:updated] + metadata_fields[:deleted]
-          if changed_metadata_fields.count.positive?
+          modified_metadata = metadata_fields[:added] + metadata_fields[:updated] + metadata_fields[:deleted]
+          if modified_metadata.count.positive?
             flash[:success] =
               t('.success', metadata_fields: metadata_fields[:updated].join(', '), sample_name: @sample.name)
           end

--- a/app/controllers/projects/samples/metadata_controller.rb
+++ b/app/controllers/projects/samples/metadata_controller.rb
@@ -9,7 +9,8 @@ module Projects
         respond_to do |format|
           metadata_fields = ::Samples::Metadata::UpdateService.new(@project, @sample, current_user,
                                                                    metadata_params).execute
-          if !metadata_fields.nil? && metadata_fields[:updated].count.positive?
+          changed_metadata_fields = metadata_fields[:added] + metadata_fields[:updated] + metadata_fields[:deleted]
+          if changed_metadata_fields.count.positive?
             flash[:success] =
               t('.success', metadata_fields: metadata_fields[:updated].join(', '), sample_name: @sample.name)
           end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -226,7 +226,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     Route.restore(Route.only_deleted.find_by(source_id: id).id, recursive: true)
   end
 
-  def subtract_from_metadata_summary(namespaces, metadata, update_by_one)
+  def subtract_from_metadata_summary_count(namespaces, metadata, update_by_one)
     namespaces.each do |namespace|
       metadata.each do |metadata_field, value|
         value = 1 if update_by_one
@@ -240,7 +240,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def add_to_metadata_summary(namespaces, metadata, update_by_one)
+  def add_to_metadata_summary_count(namespaces, metadata, update_by_one)
     namespaces.each do |namespace|
       metadata.each do |metadata_field, value|
         value = 1 if update_by_one

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -225,4 +225,32 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def restore_routes
     Route.restore(Route.only_deleted.find_by(source_id: id).id, recursive: true)
   end
+
+  def subtract_from_metadata_summary(namespaces, metadata, update_by_one)
+    namespaces.each do |namespace|
+      metadata.each do |metadata_field, value|
+        value = 1 if update_by_one
+        if namespace.metadata_summary[metadata_field] == value
+          namespace.metadata_summary.delete(metadata_field)
+        else
+          namespace.metadata_summary[metadata_field] -= value
+        end
+      end
+      namespace.save
+    end
+  end
+
+  def add_to_metadata_summary(namespaces, metadata, update_by_one)
+    namespaces.each do |namespace|
+      metadata.each do |metadata_field, value|
+        value = 1 if update_by_one
+        if namespace.metadata_summary.key?(metadata_field)
+          namespace.metadata_summary[metadata_field] += value
+        else
+          namespace.metadata_summary[metadata_field] = value
+        end
+      end
+      namespace.save
+    end
+  end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -248,15 +248,17 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # sample_transfer (original parents), sample_deletion, and update_service when metadata is deleted from a sample.
   def subtract_from_metadata_summary_count(namespaces, metadata, update_by_one)
     namespaces.each do |namespace|
-      metadata.each do |metadata_field, value|
-        value = 1 if update_by_one
-        if namespace.metadata_summary[metadata_field] == value
-          namespace.metadata_summary.delete(metadata_field)
-        else
-          namespace.metadata_summary[metadata_field] -= value
+      namespace.with_lock do
+        metadata.each do |metadata_field, value|
+          value = 1 if update_by_one
+          if namespace.metadata_summary[metadata_field] == value
+            namespace.metadata_summary.delete(metadata_field)
+          else
+            namespace.metadata_summary[metadata_field] -= value
+          end
         end
+        namespace.save
       end
-      namespace.save
     end
   end
 
@@ -264,15 +266,17 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # and update_service when metadata is added to a sample.
   def add_to_metadata_summary_count(namespaces, metadata, update_by_one)
     namespaces.each do |namespace|
-      metadata.each do |metadata_field, value|
-        value = 1 if update_by_one
-        if namespace.metadata_summary.key?(metadata_field)
-          namespace.metadata_summary[metadata_field] += value
-        else
-          namespace.metadata_summary[metadata_field] = value
+      namespace.with_lock do
+        metadata.each do |metadata_field, value|
+          value = 1 if update_by_one
+          if namespace.metadata_summary.key?(metadata_field)
+            namespace.metadata_summary[metadata_field] += value
+          else
+            namespace.metadata_summary[metadata_field] = value
+          end
         end
+        namespace.save
       end
-      namespace.save
     end
   end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -226,6 +226,26 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     Route.restore(Route.only_deleted.find_by(source_id: id).id, recursive: true)
   end
 
+  # The add and subtract_from_metadata_summary count functions are used by all update_metadata_summary functions
+  # (update_service, namespace_transfer, namespace_deletion, sample_transfer, sample_deletion)
+  # to update parental namespace metadata_summary attributes.
+  #
+  # When a sample is transferred, deleted, or updated, namespaces are the non-user parental namespaces, metadata is
+  # equal to sample.metadata, and update_by_one is assigned true. Because we are passing actual metadata values
+  # (ie: sample.metadata = {metadatafield1: metadatavalue1}), we assign true to update_by_one and value = 1 when
+  # calling these functions because we will update the samples' parents by a count of 1, regardless of what the actual
+  # metadata value is (ie: sample.metadata above with a value of metadatavalue1 will result in
+  # metadata_summary['metadatafield1'] += 1 for all parental namespaces).
+  #
+  # When namespaces are transferred or deleted, namespaces are the non-user parental namespaces, metadata is equal to
+  # the namespace.metadata_summary, and update_by_one is false. With namespaces, we will pass metadata_summary
+  # (ie: project.namespace.metadata_summary = {metadatafield1: 5, metadatafield2: 10}), and we can iterate over the
+  # summary and utilize the hash values to update all parental namespaces, so setting value = 1 is unnecessary and
+  # we assign false to update_by_one (ie: all parental namespaces will have their metadata_summary updated by
+  # 5 for metadatafield1 and 10 for metadatafield2).
+  #
+  # Subtract will be called for namespace_transfer (original parents), namespace_deletion,
+  # sample_transfer (original parents), sample_deletion, and update_service when metadata is deleted from a sample.
   def subtract_from_metadata_summary_count(namespaces, metadata, update_by_one)
     namespaces.each do |namespace|
       metadata.each do |metadata_field, value|
@@ -240,6 +260,8 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # Add will be called for namespace_transfer (new parents), sample_transfer (new parents),
+  # and update_service when metadata is added to a sample.
   def add_to_metadata_summary_count(namespaces, metadata, update_by_one)
     namespaces.each do |namespace|
       metadata.each do |metadata_field, value|

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -48,35 +48,5 @@ module Namespaces
       end
       add_to_metadata_summary(namespaces_to_update, metadata_to_add, true) unless metadata_to_add.empty?
     end
-
-    private
-
-    def subtract_from_metadata_summary(namespaces, metadata, update_by_one)
-      namespaces.each do |namespace|
-        metadata.each do |metadata_field, value|
-          value = 1 if update_by_one
-          if namespace.metadata_summary[metadata_field] == value
-            namespace.metadata_summary.delete(metadata_field)
-          else
-            namespace.metadata_summary[metadata_field] -= value
-          end
-        end
-        namespace.save
-      end
-    end
-
-    def add_to_metadata_summary(namespaces, metadata, update_by_one)
-      namespaces.each do |namespace|
-        metadata.each do |metadata_field, value|
-          value = 1 if update_by_one
-          if namespace.metadata_summary.key?(metadata_field)
-            namespace.metadata_summary[metadata_field] += value
-          else
-            namespace.metadata_summary[metadata_field] = value
-          end
-        end
-        namespace.save
-      end
-    end
   end
 end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -54,7 +54,7 @@ module Namespaces
 
     def self_and_parents
       namespaces = [self]
-      namespaces += parent.self_and_ancestors unless parent.nil? || parent.type == 'User'
+      namespaces += parent.self_and_ancestors unless parent.type == 'User'
       namespaces
     end
 

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -35,18 +35,10 @@ module Namespaces
       'Project'
     end
 
-    def self_and_parents
-      namespaces = [self]
-      namespaces += parent.self_and_ancestors unless parent.type == 'User'
-      namespaces
-    end
-
-    def update_metadata_summary_by_update_service(metadata_to_subtract, metadata_to_add)
-      namespaces_to_update = self_and_parents
-      unless metadata_to_subtract.empty?
-        subtract_from_metadata_summary(namespaces_to_update, metadata_to_subtract, true)
-      end
-      add_to_metadata_summary(namespaces_to_update, metadata_to_add, true) unless metadata_to_add.empty?
+    def update_metadata_summary_by_update_service(deleted_metadata, added_metadata)
+      namespaces_to_update = [self] + parent.self_and_ancestors.where.not(type: Namespaces::UserNamespace.sti_name)
+      subtract_from_metadata_summary_count(namespaces_to_update, deleted_metadata, true) unless deleted_metadata.empty?
+      add_to_metadata_summary_count(namespaces_to_update, added_metadata, true) unless added_metadata.empty?
     end
   end
 end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -35,10 +35,20 @@ module Namespaces
       'Project'
     end
 
-    def update_metadata_summary(metadata_to_delete, metadata_to_add)
+    def update_metadata_summary_by_update_service(metadata_to_delete, metadata_to_add)
       namespaces_to_update = self_and_parents
-      delete_metadata(namespaces_to_update, metadata_to_delete) unless metadata_to_delete.empty?
-      add_metadata(namespaces_to_update, metadata_to_add) unless metadata_to_add.empty?
+
+      unless metadata_to_delete.empty?
+        namespaces_to_update.each do |namespace|
+          delete_metadata(namespace, metadata_to_delete)
+        end
+      end
+
+      unless metadata_to_add.empty?
+        namespaces_to_update.each do |namespace|
+          add_metadata(namespace, metadata_to_add)
+        end
+      end
       namespaces_to_update.each(&:save)
     end
 
@@ -48,26 +58,22 @@ module Namespaces
       namespaces
     end
 
-    def delete_metadata(namespaces_to_update, metadata_to_delete)
+    def delete_metadata(namespace, metadata_to_delete)
       metadata_to_delete.each do |metadata_field, _v|
-        namespaces_to_update.each do |namespace|
-          if namespace.metadata_summary[metadata_field] == 1
-            namespace.metadata_summary.delete(metadata_field)
-          else
-            namespace.metadata_summary[metadata_field] -= 1
-          end
+        if namespace.metadata_summary[metadata_field] == 1
+          namespace.metadata_summary.delete(metadata_field)
+        else
+          namespace.metadata_summary[metadata_field] -= 1
         end
       end
     end
 
-    def add_metadata(namespaces_to_update, metadata_to_add)
+    def add_metadata(namespace, metadata_to_add)
       metadata_to_add.each do |metadata_field, _v|
-        namespaces_to_update.each do |namespace|
-          if namespace.metadata_summary.key?(metadata_field)
-            namespace.metadata_summary[metadata_field] += 1
-          else
-            namespace.metadata_summary[metadata_field] = 1
-          end
+        if namespace.metadata_summary.key?(metadata_field)
+          namespace.metadata_summary[metadata_field] += 1
+        else
+          namespace.metadata_summary[metadata_field] = 1
         end
       end
     end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -43,9 +43,6 @@ module Namespaces
 
     def update_metadata_summary_by_update_service(metadata_to_subtract, metadata_to_add)
       namespaces_to_update = self_and_parents
-      puts 'in update metadata summary by update service'
-      puts metadata_to_subtract
-      puts metadata_to_add
       unless metadata_to_subtract.empty?
         subtract_from_metadata_summary(namespaces_to_update, metadata_to_subtract, true)
       end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -40,17 +40,19 @@ module Namespaces
 
       unless metadata_to_delete.empty?
         namespaces_to_update.each do |namespace|
-          delete_metadata(namespace, metadata_to_delete)
+          subtract_one_from_metadata_summary(namespace, metadata_to_delete)
         end
       end
 
       unless metadata_to_add.empty?
         namespaces_to_update.each do |namespace|
-          add_metadata(namespace, metadata_to_add)
+          add_one_to_metadata_summary(namespace, metadata_to_add)
         end
       end
       namespaces_to_update.each(&:save)
     end
+
+    private
 
     def self_and_parents
       namespaces = [self]
@@ -58,7 +60,7 @@ module Namespaces
       namespaces
     end
 
-    def delete_metadata(namespace, metadata_to_delete)
+    def subtract_one_from_metadata_summary(namespace, metadata_to_delete)
       metadata_to_delete.each do |metadata_field, _v|
         if namespace.metadata_summary[metadata_field] == 1
           namespace.metadata_summary.delete(metadata_field)
@@ -68,7 +70,7 @@ module Namespaces
       end
     end
 
-    def add_metadata(namespace, metadata_to_add)
+    def add_one_to_metadata_summary(namespace, metadata_to_add)
       metadata_to_add.each do |metadata_field, _v|
         if namespace.metadata_summary.key?(metadata_field)
           namespace.metadata_summary[metadata_field] += 1

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -43,6 +43,9 @@ module Namespaces
 
     def update_metadata_summary_by_update_service(metadata_to_subtract, metadata_to_add)
       namespaces_to_update = self_and_parents
+      puts 'in update metadata summary by update service'
+      puts metadata_to_subtract
+      puts metadata_to_add
       unless metadata_to_subtract.empty?
         subtract_from_metadata_summary(namespaces_to_update, metadata_to_subtract, true)
       end

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -31,7 +31,7 @@ module Samples
 
         update_metadata_summary
 
-        assign_errors_to_not_updated_fields
+        handle_not_updated_fields
         @metadata_changes
       rescue Samples::Metadata::UpdateService::SampleMetadataUpdateError => e
         @sample.errors.add(:base, e.message)
@@ -89,7 +89,10 @@ module Samples
         end
       end
 
-      def assign_errors_to_not_updated_fields
+      # Metadata fields that were not updated due to a user trying to overwrite metadata previously added by an
+      # analysis in assign_metadata_to_sample are handled here, where they are assigned to the @sample.error
+      # and will be used for a :error flash message in the UI.
+      def handle_not_updated_fields
         metadata_fields_not_updated = @metadata_changes[:not_updated]
         return unless metadata_fields_not_updated.count.positive?
 

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -113,7 +113,7 @@ module Samples
             old_metadata.delete(metadata_field) && new_metadata.delete(metadata_field)
           end
         end
-        @project.namespace.update_metadata_summary(old_metadata, new_metadata)
+        @project.namespace.update_metadata_summary_by_update_service(old_metadata, new_metadata)
       end
     end
   end

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -72,7 +72,6 @@ module Samples
             assign_metadata_to_sample(key, value)
           end
         end
-        @update_status
       end
 
       def assign_metadata_to_sample(key, value) # rubocop:disable Metrics/AbcSize

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -189,6 +189,41 @@ group_eleven:
   description: Group 11 description
   metadata_summary: {}
 
+group_twelve:
+  name: Group 12
+  path: group-12
+  type: Group
+  description: Group 12 description
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: { "metadatafield1": 3, "metadatafield2": 3 }
+
+subgroup_twelve_a:
+  name: Subgroup 12 A
+  path: subgroup-12-a
+  type: Group
+  description: Subgroup 12 A description
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:group_twelve) %>
+  metadata_summary: { "metadatafield1": 2, "metadatafield2": 2 }
+
+subgroup_twelve_b:
+  name: Subgroup 12 B
+  path: subgroup-12-b
+  type: Group
+  description: Subgroup 12 B description
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:group_twelve) %>
+  metadata_summary: { "metadatafield1": 1, "metadatafield2": 1 }
+
+subgroup_twelve_a_a:
+  name: Subgroup 12 A A
+  path: subgroup-12-a-a
+  type: Group
+  description: Subgroup 12 A A description
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a) %>
+  metadata_summary: { "metadatafield1": 2, "metadatafield2": 2 }
+
 group_delta:
   name: Group Delta
   path: group-delta

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -222,7 +222,7 @@ subgroup_twelve_a_a:
   description: Subgroup 12 A A description
   owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a) %>
-  metadata_summary: { "metadatafield1": 2, "metadatafield2": 2 }
+  metadata_summary: { "metadatafield1": 1, "metadatafield2": 1 }
 
 group_delta:
   name: Group Delta

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -368,6 +368,48 @@ group_eleven_member_user_26:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_eleven) %>
   access_level: <%= Member::AccessLevel::OWNER %>
 
+group_twelve_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_twelve) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+subgroup_twelve_a_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+subgroup_twelve_b_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_b) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+subgroup_twelve_a_a_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a_a) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+project_twenty_nine_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project29_namespace) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+project_thirty_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project30_namespace) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+project_thirty_one_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project31_namespace) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
 group_delta_member_joan_doe:
   user_id: <%= ActiveRecord::FixtureSet.identify(:private_joan) %>
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:private_joan) %>

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -374,24 +374,6 @@ group_twelve_member_john_doe:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_twelve) %>
   access_level: <%= Member::AccessLevel::OWNER %>
 
-subgroup_twelve_a_member_john_doe:
-  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
-  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
-  namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a) %>
-  access_level: <%= Member::AccessLevel::OWNER %>
-
-subgroup_twelve_b_member_john_doe:
-  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
-  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
-  namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_b) %>
-  access_level: <%= Member::AccessLevel::OWNER %>
-
-subgroup_twelve_a_a_member_john_doe:
-  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
-  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
-  namespace_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a_a) %>
-  access_level: <%= Member::AccessLevel::OWNER %>
-
 project_twenty_nine_member_john_doe:
   user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -288,6 +288,33 @@ project28_namespace:
   owner_id: <%= ActiveRecord::FixtureSet.identify(:david_doe) %>
   metadata_summary: {}
 
+project29_namespace:
+  name: Project 29
+  path: project-29
+  description: Project 29 description
+  type: Project
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a) %>
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: { "metadatafield1": 1, "metadatafield2": 1}
+
+project30_namespace:
+  name: Project 30
+  path: project-30
+  description: Project 30 description
+  type: Project
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_b) %>
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: { "metadatafield1": 1, "metadatafield2": 1 }
+
+project31_namespace:
+  name: Project 31
+  path: project-31
+  description: Project 31 description
+  type: Project
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_twelve_a_a) %>
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  metadata_summary: { "metadatafield1": 1, "metadatafield2": 1 }
+
 projectAlpha_namespace:
   name: Project Alpha
   path: project-alpha

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -128,6 +128,18 @@ project28:
   creator_id: <%= ActiveRecord::FixtureSet.identify(:david_doe) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project28_namespace) %>
 
+project29:
+  creator_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project29_namespace) %>
+
+project30:
+  creator_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project30_namespace) %>
+
+project31:
+  creator_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project31_namespace) %>
+
 projectAlpha:
   creator_id: <%= ActiveRecord::FixtureSet.identify(:private_ryan) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectAlpha_namespace) %>

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -294,6 +294,41 @@ group_eleven_route:
   path: group-11
   source: group_eleven (Namespace)
 
+group_twelve_route:
+  name: Group 12
+  path: group-12
+  source: group_twelve (Namespace)
+
+subgroup12a_route:
+  name: Group 12 / Subgroup 12 A
+  path: group-12/subgroup-12-a
+  source: subgroup_twelve_a (Namespace)
+
+subgroup12b_route:
+  name: Group 12 / Subgroup 12 B
+  path: group-12/subgroup-12-b
+  source: subgroup_twelve_b (Namespace)
+
+subgroup12aa_route:
+  name: Group 12 / Subgroup 12 A / Subgroup 12 AA
+  path: group-12/subgroup-12-a/subgroup-12-a-a
+  source: subgroup_twelve_a_a (Namespace)
+
+project29_namespace_route:
+  name: Group 12 / Subgroup 12 A / Project 29
+  path: group-12/subgroup-12-a/project-29
+  source: project29_namespace (Namespace)
+
+project30_namespace_route:
+  name: Group 12 / Subgroup 12 B / Project 30
+  path: group-12/subgroup-12-b/project-30
+  source: project30_namespace (Namespace)
+
+project31_namespace_route:
+  name: Group 12 / Subgroup 12 A / Subgroup 12 A A / Project 31
+  path: group-12/subgroup-12-a/subgroup-12-a-a/project-31
+  source: project31_namespace (Namespace)
+
 group_delta_route:
   name: Group Delta
   path: group-delta

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -77,6 +77,32 @@ sample31:
   description: Sample 2 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:project26) %>
 
+sample32:
+  name: Sample 32
+  description: Sample 32 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:project29) %>
+  metadata: { 'metadatafield1': 'value1', 'metadatafield2': 'value2' }
+  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'user' }, 'metadatafield2': { 'id': 1, 'source': 'user' } }
+
+sample33:
+  name: Sample33
+  description: Sample 33 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:project30) %>
+  metadata: { 'metadatafield1': 'value1', 'metadatafield2': 'value2' }
+  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'user' }, 'metadatafield2': { 'id': 1, 'source': 'user' } }
+
+sample34:
+  name: Sample 34
+  description: Sample 34 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:project31) %>
+  metadata: { 'metadatafield1': 'value1', 'metadatafield2': 'value2' }
+  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'analysis' }, 'metadatafield2': { 'id': 1, 'source': 'analysis' } }
+
+sample35:
+  name: Sample 35
+  description: Sample 35 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:project31) %>
+
 sampleAlpha:
   name: Sample Alpha
   description: Sample Alpha description.

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -80,8 +80,8 @@ class GroupPolicyTest < ActiveSupport::TestCase
   test 'scope' do
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    # John Doe has access to 24 groups
-    assert_equal 24, scoped_groups.count
+    # John Doe has access to 28 groups
+    assert_equal 28, scoped_groups.count
 
     user = users(:david_doe)
     policy = GroupPolicy.new(user:)

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -97,7 +97,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    assert_equal 19, scoped_groups.count
+    assert_equal 23, scoped_groups.count
     scoped_groups_names = scoped_groups.pluck(:name)
     assert_not scoped_groups_names.include?(groups(:group_one).name)
     assert_not scoped_groups_names.include?(groups(:subgroup3).name)
@@ -111,7 +111,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    assert_equal 18, scoped_groups.count
+    assert_equal 22, scoped_groups.count
     scoped_groups_names = scoped_groups.pluck(:name)
     assert_not scoped_groups_names.include?(groups(:namespace_group_link_group_one).name)
   end

--- a/test/policies/namespace_policy_test.rb
+++ b/test/policies/namespace_policy_test.rb
@@ -70,9 +70,9 @@ class NamespacePolicyTest < ActiveSupport::TestCase
     policy = NamespacePolicy.new(user:)
     scoped_namespaces = policy.apply_scope(Namespace, type: :relation, name: :manageable)
 
-    # John Doe has manageable access to 24 namespaces
-    # (1 user namespace and 23 group namespaces)
-    assert_equal 24, scoped_namespaces.count
+    # John Doe has manageable access to 28 namespaces
+    # (1 user namespace and 27 group namespaces)
+    assert_equal 28, scoped_namespaces.count
 
     assert_not scoped_namespaces.include?(namespace_group_link.namespace)
 
@@ -84,10 +84,10 @@ class NamespacePolicyTest < ActiveSupport::TestCase
 
     scoped_namespaces = policy.apply_scope(Namespace, type: :relation, name: :manageable)
 
-    # John Doe has manageable access to 24 namespaces (1 user namespace,
-    # 23 group namespaces, and 1 group namespace via a namespace
+    # John Doe has manageable access to 28 namespaces (1 user namespace,
+    # 27 group namespaces, and 1 group namespace via a namespace
     # group link)
-    assert_equal 25, scoped_namespaces.count
+    assert_equal 29, scoped_namespaces.count
 
     assert scoped_namespaces.include?(namespace_group_link.namespace)
   end

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -68,11 +68,11 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
   test 'scope' do
     scoped_projects = @policy.apply_scope(Project, type: :relation)
-    # John Doe has access to 30 projects. 29 through his namespace
+    # John Doe has access to 33 projects. 32 through his namespace
     # and projects under groups in which he is a member plus a project
     # from David Doe's Group Four which is shared with subgroup 1 under
     # John Doe's group Group 1
-    assert_equal 30, scoped_projects.count
+    assert_equal 33, scoped_projects.count
 
     user = users(:david_doe)
     policy = ProjectPolicy.new(user:)
@@ -140,7 +140,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     # John Doe has manageable access to just projects under his namespace
     # and projects under groups in which he is a member
-    assert_equal 29, scoped_projects.count
+    assert_equal 32, scoped_projects.count
 
     user = users(:david_doe)
     policy = ProjectPolicy.new(user:)

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -91,7 +91,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
-    assert_equal 11, scoped_projects.count
+    assert_equal 14, scoped_projects.count
     scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
     assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project5_namespace).name)
     assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project6_namespace).name)
@@ -118,7 +118,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
-    assert_equal 10, scoped_projects.count
+    assert_equal 13, scoped_projects.count
     scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
     assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project1_namespace).name)
 
@@ -128,7 +128,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
-    assert_equal 9, scoped_projects.count
+    assert_equal 12, scoped_projects.count
     scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
     assert_not scoped_projects_names.include?(
       namespaces_project_namespaces(:namespace_group_link_group_one_project1_namespace).name
@@ -159,7 +159,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     scoped_projects = @policy.apply_scope(Project, type: :relation, name: :manageable)
 
-    assert_equal 11, scoped_projects.count
+    assert_equal 14, scoped_projects.count
     scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
     assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project5_namespace).name)
     assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project6_namespace).name)
@@ -187,7 +187,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     scoped_projects = @policy.apply_scope(Project, type: :relation, name: :manageable)
 
-    assert_equal 10, scoped_projects.count
+    assert_equal 13, scoped_projects.count
     scoped_projects_names = Namespaces::ProjectNamespace.where(id: scoped_projects.select(:namespace_id)).pluck(:name)
     assert_not scoped_projects_names.include?(namespaces_project_namespaces(:project1_namespace).name)
   end

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -7,159 +7,296 @@ module Samples
     class UpdateServiceTest < ActiveSupport::TestCase
       def setup
         @user = users(:john_doe)
-        @sample = samples(:sample1)
-        @project = projects(:project1)
+        @sample32 = samples(:sample32)
+        @sample33 = samples(:sample33)
+        @sample34 = samples(:sample34)
+        @sample35 = samples(:sample35)
+        @project29 = projects(:project29)
+        @project30 = projects(:project30)
+        @project31 = projects(:project31)
+        @group12 = groups(:group_twelve)
+        @subgroup12a = groups(:subgroup_twelve_a)
+        @subgroup12b = groups(:subgroup_twelve_b)
+        @subgroup12aa = groups(:subgroup_twelve_a_a)
       end
 
-      test 'update sample metadata with sample containing no existing metadata and user in metadata provenance' do
-        params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+      test 'update sample metadata with sample containing no existing metadata and user in metadata provenanc' do
+        params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project29, @sample32, @user,
+                                                                             params).execute
+        assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample32.metadata)
+        assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user' },
+                       'metadatafield2' => { 'id' => @user.id, 'source' => 'user' } },
+                     @sample32.metadata_provenance)
+        assert_equal({ updated: %w[metadatafield1 metadatafield2], not_updated: [] }, metadata_fields_update_status)
 
-        assert_equal({ 'key1' => 'value1', 'key2' => 'value2' }, @sample.metadata)
-        assert_equal({ 'key1' => { 'id' => @user.id, 'source' => 'user' },
-                       'key2' => { 'id' => @user.id, 'source' => 'user' } },
-                     @sample.metadata_provenance)
-        assert_equal({ updated: %w[key1 key2], not_updated: [] }, metadata_fields_update_status)
+        @project29.reload
+        @subgroup12a.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project29.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
       end
 
       test 'update sample metadata with sample containing no existing metadata and analysis in metadata provenance' do
-        params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' }, 'analysis_id' => 2 }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, 'analysis_id' => 2 }
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project31, @sample35, @user,
+                                                                             params).execute
 
-        assert_equal({ 'key1' => 'value1', 'key2' => 'value2' }, @sample.metadata)
-        assert_equal({ 'key1' => { 'id' => 2, 'source' => 'analysis' },
-                       'key2' => { 'id' => 2, 'source' => 'analysis' } },
-                     @sample.metadata_provenance)
-        assert_equal({ updated: %w[key1 key2], not_updated: [] }, metadata_fields_update_status)
+        assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample35.metadata)
+        assert_equal({ 'metadatafield1' => { 'id' => 2, 'source' => 'analysis' },
+                       'metadatafield2' => { 'id' => 2, 'source' => 'analysis' } },
+                     @sample35.metadata_provenance)
+        assert_equal({ updated: %w[metadatafield1 metadatafield2], not_updated: [] }, metadata_fields_update_status)
+
+        @project31.reload
+        @subgroup12aa.reload
+        @subgroup12a.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 4, 'metadatafield2' => 4 }, @group12.metadata_summary)
       end
 
       test 'update sample metadata merge with new metadata and analysis overwritting user' do
-        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
-        @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'user' },
-                                        'key2' => { 'id' => 1, 'source' => 'user' } }
-        params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' }, 'analysis_id' => 10 }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' }, 'analysis_id' => 10 }
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
+                                                                             params).execute
 
-        assert_equal({ 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' }, @sample.metadata)
-        assert_equal({ 'key1' => { 'id' => 10, 'source' => 'analysis' },
-                       'key2' => { 'id' => 1, 'source' => 'user' },
-                       'key3' => { 'id' => 10, 'source' => 'analysis' } },
-                     @sample.metadata_provenance)
-        assert_equal({ updated: %w[key1 key3], not_updated: [] }, metadata_fields_update_status)
+        assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
+                     @sample33.metadata)
+        assert_equal({ 'metadatafield1' => { 'id' => 10, 'source' => 'analysis' },
+                       'metadatafield2' => { 'id' => 1, 'source' => 'user' },
+                       'metadatafield3' => { 'id' => 10, 'source' => 'analysis' } },
+                     @sample33.metadata_provenance)
+        assert_equal({ updated: %w[metadatafield1 metadatafield3], not_updated: [] }, metadata_fields_update_status)
+
+        @project30.reload
+        @subgroup12b.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
+                     @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
+                     @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield3' => 1 },
+                     @group12.metadata_summary)
       end
 
       test 'update sample metadata merge with new metadata and user overwritting user' do
-        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
-        @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'user' },
-                                        'key2' => { 'id' => 1, 'source' => 'user' } }
-        params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
+                                                                             params).execute
 
-        assert_equal({ 'key1' => 'value4', 'key2' => 'value2', 'key3' => 'value3' }, @sample.metadata)
-        assert_equal({ 'key1' => { 'id' => @user.id, 'source' => 'user' },
-                       'key2' => { 'id' => 1, 'source' => 'user' },
-                       'key3' => { 'id' => @user.id, 'source' => 'user' } },
-                     @sample.metadata_provenance)
-        assert_equal({ updated: %w[key1 key3], not_updated: [] }, metadata_fields_update_status)
+        assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
+                     @sample33.metadata)
+        assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user' },
+                       'metadatafield2' => { 'id' => 1, 'source' => 'user' },
+                       'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } },
+                     @sample33.metadata_provenance)
+        assert_equal({ updated: %w[metadatafield1 metadatafield3], not_updated: [] }, metadata_fields_update_status)
+
+        @project30.reload
+        @subgroup12b.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
+                     @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
+                     @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield3' => 1 },
+                     @group12.metadata_summary)
       end
 
       test 'update sample metadata merge with new metadata and user unable to overwrite analysis' do
-        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
-        @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'analysis' },
-                                        'key2' => { 'id' => 1, 'source' => 'analysis' } }
-        params = { 'metadata' => { 'key1' => 'value4', 'key3' => 'value3' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project31, @sample34, @user,
+                                                                             params).execute
 
-        assert_equal({ 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }, @sample.metadata)
-        assert_equal({ 'key1' => { 'id' => 1, 'source' => 'analysis' },
-                       'key2' => { 'id' => 1, 'source' => 'analysis' },
-                       'key3' => { 'id' => @user.id, 'source' => 'user' } },
-                     @sample.metadata_provenance)
-        assert_equal({ updated: %w[key3], not_updated: %w[key1] }, metadata_fields_update_status)
-        assert @sample.errors.full_messages.include?(
+        assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
+                     @sample34.metadata)
+        assert_equal({ 'metadatafield1' => { 'id' => 1, 'source' => 'analysis' },
+                       'metadatafield2' => { 'id' => 1, 'source' => 'analysis' },
+                       'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } },
+                     @sample34.metadata_provenance)
+        assert_equal({ updated: %w[metadatafield3], not_updated: %w[metadatafield1] }, metadata_fields_update_status)
+        assert @sample34.errors.full_messages.include?(
           I18n.t('services.samples.metadata.user_cannot_update_metadata',
-                 sample_name: @sample.name,
-                 metadata_fields: 'key1')
+                 sample_name: @sample34.name,
+                 metadata_fields: 'metadatafield1')
         )
+
+        @project31.reload
+        @subgroup12aa.reload
+        @subgroup12a.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
+                     @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield3' => 1 },
+                     @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield3' => 1 },
+                     @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield3' => 1 },
+                     @group12.metadata_summary)
       end
 
       test 'remove metadata key with user' do
-        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
-        @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'analysis' },
-                                        'key2' => { 'id' => 1, 'source' => 'analysis' } }
-        params = { 'metadata' => { 'key2' => '' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        params = { 'metadata' => { 'metadatafield2' => '' } }
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project31, @sample34, @user,
+                                                                             params).execute
 
-        assert_equal({ 'key1' => 'value1' }, @sample.metadata)
-        assert_equal({ 'key1' => { 'id' => 1, 'source' => 'analysis' } }, @sample.metadata_provenance)
-        assert_equal({ updated: %w[key2], not_updated: [] }, metadata_fields_update_status)
+        assert_equal({ 'metadatafield1' => 'value1' }, @sample34.metadata)
+        assert_equal({ 'metadatafield1' => { 'id' => 1, 'source' => 'analysis' } }, @sample34.metadata_provenance)
+        assert_equal({ updated: %w[metadatafield2], not_updated: [] }, metadata_fields_update_status)
+
+        @project31.reload
+        @subgroup12aa.reload
+        @subgroup12a.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 1 },
+                     @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1 },
+                     @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1 },
+                     @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 2 },
+                     @group12.metadata_summary)
       end
 
       test 'remove metadata key with analysis' do
-        @sample.metadata = { 'key1' => 'value1', 'key2' => 'value2' }
-        @sample.metadata_provenance = { 'key1' => { 'id' => 1, 'source' => 'user' },
-                                        'key2' => { 'id' => 1, 'source' => 'user' } }
-        params = { 'metadata' => { 'key2' => '' }, 'analysis_id' => 1 }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        params = { 'metadata' => { 'metadatafield1' => '' }, 'analysis_id' => 1 }
+        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
+                                                                             params).execute
 
-        assert_equal({ 'key1' => 'value1' }, @sample.metadata)
-        assert_equal({ 'key1' => { 'id' => 1, 'source' => 'user' } }, @sample.metadata_provenance)
-        assert_equal({ updated: %w[key2], not_updated: [] }, metadata_fields_update_status)
+        assert_equal({ 'metadatafield2' => 'value2' }, @sample33.metadata)
+        assert_equal({ 'metadatafield2' => { 'id' => 1, 'source' => 'user' } }, @sample33.metadata_provenance)
+        assert_equal({ updated: %w[metadatafield1], not_updated: [] }, metadata_fields_update_status)
+
+        @project30.reload
+        @subgroup12b.reload
+        @group12.reload
+        assert_equal({ 'metadatafield2' => 1 },
+                     @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield2' => 1 },
+                     @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 3 },
+                     @group12.metadata_summary)
       end
 
       test 'update sample metadata with valid permission' do
-        params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
+        params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
 
-        assert_authorized_to(:update_sample?, @sample.project, with: ProjectPolicy,
-                                                               context: { user: @user }) do
-          Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+        assert_authorized_to(:update_sample?, @sample33.project, with: ProjectPolicy,
+                                                                 context: { user: @user }) do
+          Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
         end
       end
 
       test 'update sample metadata without permission to update sample' do
         user = users(:ryan_doe)
-        params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
+        params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
 
         exception = assert_raises(ActionPolicy::Unauthorized) do
-          assert_empty Samples::Metadata::UpdateService.new(@project, @sample, user, params).execute
+          assert_empty Samples::Metadata::UpdateService.new(@project30, @sample33, user, params).execute
         end
 
         assert_equal ProjectPolicy, exception.policy
         assert_equal :update_sample?, exception.rule
         assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-        assert_equal I18n.t(:'action_policy.policy.project.update_sample?', name: @sample.project.name),
+        assert_equal I18n.t(:'action_policy.policy.project.update_sample?', name: @sample33.project.name),
                      exception.result.message
       end
 
       test 'sample does not belong to project' do
-        params = { 'metadata' => { 'key1' => 'value1', 'key2' => 'value2' } }
+        params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
         project = projects(:projectA)
-        assert_no_changes -> { @sample } do
-          assert_nil Samples::Metadata::UpdateService.new(project, @sample, @user, params).execute
+        assert_no_changes -> { @sample33 } do
+          assert_nil Samples::Metadata::UpdateService.new(project, @sample33, @user, params).execute
         end
-        assert @sample.errors.full_messages.include?(
-          I18n.t('services.samples.metadata.sample_does_not_belong_to_project', sample_name: @sample.name,
+        assert @sample33.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.sample_does_not_belong_to_project', sample_name: @sample33.name,
                                                                                 project_name: project.name)
         )
       end
 
       test 'metadata is nil' do
         assert_no_changes -> { @sample } do
-          assert_nil Samples::Metadata::UpdateService.new(@project, @sample, @user, {}).execute
+          assert_nil Samples::Metadata::UpdateService.new(@project30, @sample33, @user, {}).execute
         end
-        assert @sample.errors.full_messages.include?(
-          I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)
+        assert @sample33.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample33.name)
         )
       end
 
       test 'metadata is empty hash' do
         params = { 'metadata' => {} }
         assert_no_changes -> { @sample } do
-          assert_nil Samples::Metadata::UpdateService.new(@project, @sample, @user, params).execute
+          assert_nil Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
         end
-        assert @sample.errors.full_messages.include?(
-          I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample.name)
+        assert @sample33.errors.full_messages.include?(
+          I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample33.name)
         )
+      end
+
+      test 'metadata summary updates parents but not projects/groups of same level on different branch' do
+        params1 = { 'metadata' => { 'metadatafield4' => 'value4' } }
+        assert_no_changes @subgroup12b.metadata_summary do
+          Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params1).execute
+        end
+
+        @project31.reload
+        @subgroup12b.reload
+        @subgroup12aa.reload
+        @subgroup12a.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
+                     @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
+                     @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
+                     @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield4' => 1 },
+                     @group12.metadata_summary)
+
+        params2 = { 'metadata' => { 'metadatafield5' => 'value5' } }
+
+        assert_no_changes -> { @subgroup12a.metadata_summary } do
+          assert_no_changes -> { @subgroup12aa.metadata_summary } do
+            Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params2).execute
+          end
+        end
+
+        @project31.reload
+        @subgroup12b.reload
+        @subgroup12aa.reload
+        @subgroup12a.reload
+        @group12.reload
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
+                     @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
+                     @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield4' => 1, 'metadatafield5' => 1 },
+                     @group12.metadata_summary)
+
+        params3 = { 'metadata' => { 'metadatafield2' => '' } }
+
+        assert_no_changes -> { @subgroup12b.metadata_summary } do
+          assert_no_changes -> { @subgroup12aa.metadata_summary } do
+            Samples::Metadata::UpdateService.new(@project29, @sample32, @user, params3).execute
+          end
+        end
+
+        @project31.reload
+        @subgroup12b.reload
+        @subgroup12aa.reload
+        @subgroup12a.reload
+        @group12.reload
+
+        assert_equal({ 'metadatafield1' => 1 },
+                     @project29.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1, 'metadatafield4' => 1 },
+                     @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 2, 'metadatafield4' => 1, 'metadatafield5' => 1 },
+                     @group12.metadata_summary)
       end
     end
   end

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -298,6 +298,21 @@ module Samples
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 2, 'metadatafield4' => 1, 'metadatafield5' => 1 },
                      @group12.metadata_summary)
       end
+
+      test 'user namespace metadata summary does not update' do
+        params = { 'metadata' => { 'metadatafield4' => 'value4' } }
+        project = projects(:john_doe_project2)
+        sample = samples(:sample24)
+        namespace = namespaces_user_namespaces(:john_doe_namespace)
+
+        assert_no_changes namespace.metadata_summary do
+          Samples::Metadata::UpdateService.new(project, sample, @user, params).execute
+        end
+
+        assert_equal({ 'metadatafield4' => 'value4' }, sample.metadata)
+        assert_equal({ 'metadatafield4' => { 'id' => @user.id, 'source' => 'user' } }, sample.metadata_provenance)
+        assert_equal({ 'metadatafield4' => 1 }, project.namespace.metadata_summary)
+      end
     end
   end
 end

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -20,37 +20,34 @@ module Samples
         @subgroup12aa = groups(:subgroup_twelve_a_a)
       end
 
-      test 'update sample metadata with sample containing no existing metadata and user in metadata provenanc' do
+      test 'add metadata to sample containing no existing metadata by user' do
         params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project29, @sample32, @user,
-                                                                             params).execute
-        assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample32.metadata)
+        metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample35, @user, params).execute
+        assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample35.metadata)
         assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user' },
                        'metadatafield2' => { 'id' => @user.id, 'source' => 'user' } },
-                     @sample32.metadata_provenance)
-        assert_equal(
-          { updated: %w[metadatafield1 metadatafield2], not_updated: [], metadata_was_added: true,
-            metadata_was_deleted: false }, metadata_fields_update_status
-        )
-
+                     @sample35.metadata_provenance)
+        assert_equal({ added: %w[metadatafield1 metadatafield2], updated: [], deleted: [],
+                       not_updated: [] }, metadata_changes)
+        @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
-        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project29.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
-        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 4, 'metadatafield2' => 4 }, @group12.metadata_summary)
       end
 
-      test 'update sample metadata with sample containing no existing metadata and analysis in metadata provenance' do
+      test 'add metadata to sample containing no existing metadata by analysis' do
         params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, 'analysis_id' => 2 }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project31, @sample35, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample35, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample35.metadata)
         assert_equal({ 'metadatafield1' => { 'id' => 2, 'source' => 'analysis' },
                        'metadatafield2' => { 'id' => 2, 'source' => 'analysis' } },
                      @sample35.metadata_provenance)
-        assert_equal({ updated: %w[metadatafield1 metadatafield2], not_updated: [], metadata_was_added: true,
-                       metadata_was_deleted: false }, metadata_fields_update_status)
+        assert_equal({ added: %w[metadatafield1 metadatafield2], updated: [], deleted: [],
+                       not_updated: [] }, metadata_changes)
 
         @subgroup12aa.reload
         @subgroup12a.reload
@@ -63,8 +60,7 @@ module Samples
 
       test 'update sample metadata merge with new metadata and analysis overwritting user' do
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' }, 'analysis_id' => 10 }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
                      @sample33.metadata)
@@ -72,8 +68,8 @@ module Samples
                        'metadatafield2' => { 'id' => 1, 'source' => 'user' },
                        'metadatafield3' => { 'id' => 10, 'source' => 'analysis' } },
                      @sample33.metadata_provenance)
-        assert_equal({ updated: %w[metadatafield1 metadatafield3], not_updated: [], metadata_was_added: true,
-                       metadata_was_deleted: false }, metadata_fields_update_status)
+        assert_equal({ added: %w[metadatafield3], updated: %w[metadatafield1], deleted: [],
+                       not_updated: [] }, metadata_changes)
 
         @subgroup12b.reload
         @group12.reload
@@ -87,8 +83,7 @@ module Samples
 
       test 'update sample metadata merge with new metadata and user overwritting user' do
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
                      @sample33.metadata)
@@ -96,8 +91,8 @@ module Samples
                        'metadatafield2' => { 'id' => 1, 'source' => 'user' },
                        'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } },
                      @sample33.metadata_provenance)
-        assert_equal({ updated: %w[metadatafield1 metadatafield3], not_updated: [], metadata_was_added: true,
-                       metadata_was_deleted: false }, metadata_fields_update_status)
+        assert_equal({ added: %w[metadatafield3], updated: %w[metadatafield1], deleted: [],
+                       not_updated: [] }, metadata_changes)
 
         @subgroup12b.reload
         @group12.reload
@@ -111,8 +106,7 @@ module Samples
 
       test 'update sample metadata merge with new metadata and user unable to overwrite analysis' do
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project31, @sample34, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
                      @sample34.metadata)
@@ -120,8 +114,8 @@ module Samples
                        'metadatafield2' => { 'id' => 1, 'source' => 'analysis' },
                        'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } },
                      @sample34.metadata_provenance)
-        assert_equal({ updated: %w[metadatafield3], not_updated: %w[metadatafield1], metadata_was_added: true,
-                       metadata_was_deleted: false }, metadata_fields_update_status)
+        assert_equal({ added: %w[metadatafield3], updated: [], deleted: [],
+                       not_updated: %w[metadatafield1] }, metadata_changes)
         assert @sample34.errors.full_messages.include?(
           I18n.t('services.samples.metadata.user_cannot_update_metadata',
                  sample_name: @sample34.name,
@@ -143,13 +137,11 @@ module Samples
 
       test 'remove metadata key with user' do
         params = { 'metadata' => { 'metadatafield2' => '' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project31, @sample34, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1' }, @sample34.metadata)
         assert_equal({ 'metadatafield1' => { 'id' => 1, 'source' => 'analysis' } }, @sample34.metadata_provenance)
-        assert_equal({ updated: %w[metadatafield2], not_updated: [], metadata_was_added: false,
-                       metadata_was_deleted: true }, metadata_fields_update_status)
+        assert_equal({ added: [], updated: [], deleted: %w[metadatafield2], not_updated: [] }, metadata_changes)
 
         @subgroup12aa.reload
         @subgroup12a.reload
@@ -166,13 +158,11 @@ module Samples
 
       test 'remove metadata key with analysis' do
         params = { 'metadata' => { 'metadatafield1' => '' }, 'analysis_id' => 1 }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'value2' }, @sample33.metadata)
         assert_equal({ 'metadatafield2' => { 'id' => 1, 'source' => 'user' } }, @sample33.metadata_provenance)
-        assert_equal({ updated: %w[metadatafield1], not_updated: [], metadata_was_added: false,
-                       metadata_was_deleted: true }, metadata_fields_update_status)
+        assert_equal({ added: [], updated: [], deleted: %w[metadatafield1], not_updated: [] }, metadata_changes)
 
         @subgroup12b.reload
         @group12.reload
@@ -187,16 +177,17 @@ module Samples
       test 'add, update, and remove metadata in same request to mimic batch update request with analysis' do
         params = { 'metadata' => { 'metadatafield1' => '', 'metadatafield2' => 'newvalue2',
                                    'metadatafield3' => 'value3' }, 'analysis_id' => 1 }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'newvalue2', 'metadatafield3' => 'value3' }, @sample33.metadata)
         assert_equal(
           { 'metadatafield2' => { 'id' => 1, 'source' => 'analysis' },
             'metadatafield3' => { 'id' => 1, 'source' => 'analysis' } }, @sample33.metadata_provenance
         )
-        assert_equal({ updated: %w[metadatafield1 metadatafield2 metadatafield3], not_updated: [],
-                       metadata_was_added: true, metadata_was_deleted: true }, metadata_fields_update_status)
+        assert_equal(
+          { added: %w[metadatafield3], updated: %w[metadatafield2], deleted: %w[metadatafield1],
+            not_updated: [] }, metadata_changes
+        )
 
         @subgroup12b.reload
         @group12.reload
@@ -211,16 +202,17 @@ module Samples
       test 'add, update, and remove metadata in same request to mimic batch update with user' do
         params = { 'metadata' => { 'metadatafield1' => '', 'metadatafield2' => 'newvalue2',
                                    'metadatafield3' => 'value3' } }
-        metadata_fields_update_status = Samples::Metadata::UpdateService.new(@project30, @sample33, @user,
-                                                                             params).execute
+        metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'newvalue2', 'metadatafield3' => 'value3' }, @sample33.metadata)
         assert_equal(
           { 'metadatafield2' => { 'id' => @user.id, 'source' => 'user' },
             'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } }, @sample33.metadata_provenance
         )
-        assert_equal({ updated: %w[metadatafield1 metadatafield2 metadatafield3], not_updated: [],
-                       metadata_was_added: true, metadata_was_deleted: true }, metadata_fields_update_status)
+        assert_equal(
+          { added: %w[metadatafield3], updated: %w[metadatafield2], deleted: %w[metadatafield1],
+            not_updated: [] }, metadata_changes
+        )
 
         @subgroup12b.reload
         @group12.reload
@@ -259,9 +251,9 @@ module Samples
       test 'sample does not belong to project' do
         params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
         project = projects(:projectA)
-        assert_no_changes -> { @sample33 } do
-          assert_nil Samples::Metadata::UpdateService.new(project, @sample33, @user, params).execute
-        end
+        metadata_changes = Samples::Metadata::UpdateService.new(project, @sample33, @user, params).execute
+
+        assert_equal({ added: [], updated: [], deleted: [], not_updated: [] }, metadata_changes)
         assert @sample33.errors.full_messages.include?(
           I18n.t('services.samples.metadata.sample_does_not_belong_to_project', sample_name: @sample33.name,
                                                                                 project_name: project.name)
@@ -269,9 +261,9 @@ module Samples
       end
 
       test 'metadata is nil' do
-        assert_no_changes -> { @sample } do
-          assert_nil Samples::Metadata::UpdateService.new(@project30, @sample33, @user, {}).execute
-        end
+        metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, {}).execute
+
+        assert_equal({ added: [], updated: [], deleted: [], not_updated: [] }, metadata_changes)
         assert @sample33.errors.full_messages.include?(
           I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample33.name)
         )
@@ -279,9 +271,9 @@ module Samples
 
       test 'metadata is empty hash' do
         params = { 'metadata' => {} }
-        assert_no_changes -> { @sample } do
-          assert_nil Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
-        end
+        metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
+
+        assert_equal({ added: [], updated: [], deleted: [], not_updated: [] }, metadata_changes)
         assert @sample33.errors.full_messages.include?(
           I18n.t('services.samples.metadata.empty_metadata', sample_name: @sample33.name)
         )

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -238,13 +238,16 @@ module Samples
       end
 
       test 'metadata summary updates parents but not projects/groups of same level on different branch' do
+        # Reference group/projects descendants tree:
+        # group12 < subgroup12b (project30 > sample 33)
+        #    |
+        #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
         params1 = { 'metadata' => { 'metadatafield4' => 'value4' } }
+
         assert_no_changes @subgroup12b.metadata_summary do
           Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params1).execute
         end
 
-        @project31.reload
-        @subgroup12b.reload
         @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
@@ -265,11 +268,9 @@ module Samples
           end
         end
 
-        @project31.reload
         @subgroup12b.reload
-        @subgroup12aa.reload
-        @subgroup12a.reload
         @group12.reload
+
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
                      @project30.namespace.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
@@ -285,9 +286,6 @@ module Samples
           end
         end
 
-        @project31.reload
-        @subgroup12b.reload
-        @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
 

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -52,7 +52,7 @@ module Samples
         @subgroup12a.reload
         @group12.reload
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12aa.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
         assert_equal({ 'metadatafield1' => 4, 'metadatafield2' => 4 }, @group12.metadata_summary)
       end
@@ -126,7 +126,7 @@ module Samples
         @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
                      @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield3' => 1 },
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
                      @subgroup12aa.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield3' => 1 },
                      @subgroup12a.metadata_summary)
@@ -148,7 +148,7 @@ module Samples
         @group12.reload
         assert_equal({ 'metadatafield1' => 1 },
                      @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1 },
+        assert_equal({ 'metadatafield1' => 1 },
                      @subgroup12aa.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1 },
                      @subgroup12a.metadata_summary)
@@ -235,6 +235,7 @@ module Samples
         # group12 < subgroup12b (project30 > sample 33)
         #    |
         #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
+
         params1 = { 'metadata' => { 'metadatafield4' => 'value4' } }
 
         assert_no_changes @subgroup12b.metadata_summary do
@@ -246,7 +247,7 @@ module Samples
         @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
                      @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
                      @subgroup12aa.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
                      @subgroup12a.metadata_summary)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -30,7 +30,6 @@ module Samples
                      @sample32.metadata_provenance)
         assert_equal({ updated: %w[metadatafield1 metadatafield2], not_updated: [] }, metadata_fields_update_status)
 
-        @project29.reload
         @subgroup12a.reload
         @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project29.namespace.metadata_summary)
@@ -49,7 +48,6 @@ module Samples
                      @sample35.metadata_provenance)
         assert_equal({ updated: %w[metadatafield1 metadatafield2], not_updated: [] }, metadata_fields_update_status)
 
-        @project31.reload
         @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
@@ -72,7 +70,6 @@ module Samples
                      @sample33.metadata_provenance)
         assert_equal({ updated: %w[metadatafield1 metadatafield3], not_updated: [] }, metadata_fields_update_status)
 
-        @project30.reload
         @subgroup12b.reload
         @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
@@ -96,7 +93,6 @@ module Samples
                      @sample33.metadata_provenance)
         assert_equal({ updated: %w[metadatafield1 metadatafield3], not_updated: [] }, metadata_fields_update_status)
 
-        @project30.reload
         @subgroup12b.reload
         @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
@@ -125,7 +121,6 @@ module Samples
                  metadata_fields: 'metadatafield1')
         )
 
-        @project31.reload
         @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
@@ -148,7 +143,6 @@ module Samples
         assert_equal({ 'metadatafield1' => { 'id' => 1, 'source' => 'analysis' } }, @sample34.metadata_provenance)
         assert_equal({ updated: %w[metadatafield2], not_updated: [] }, metadata_fields_update_status)
 
-        @project31.reload
         @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
@@ -171,7 +165,6 @@ module Samples
         assert_equal({ 'metadatafield2' => { 'id' => 1, 'source' => 'user' } }, @sample33.metadata_provenance)
         assert_equal({ updated: %w[metadatafield1], not_updated: [] }, metadata_fields_update_status)
 
-        @project30.reload
         @subgroup12b.reload
         @group12.reload
         assert_equal({ 'metadatafield2' => 1 },

--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -18,7 +18,7 @@ module Dashboard
       assert_no_selector 'a', text: I18n.t(:'components.pagination.previous')
 
       click_on I18n.t(:'components.pagination.next')
-      assert_selector 'tr', count: 10
+      assert_selector 'tr', count: 13
       click_on I18n.t(:'components.pagination.previous')
       assert_selector 'tr', count: 20
 


### PR DESCRIPTION
## What does this PR do and why?
As part of [issue 334](https://github.com/phac-nml/irida-next/issues/334), this PR implements `group` and `project` `metadata_summary` updating when metadata for a sample is changed via the `Samples::Metadata::UpdateServce`. 

When `sample_metadata` is updated by the `UpdateService`, the `project.namespace` and any `group` parents will have a count updated to track how many samples contain each metadata_field in their respective `update_summary`.

Note: updating `metadata_summary` by `project/group/sample` `transfer` will be implemented in a separate PR.
Note: Although not too clear in this PR, `subtract_from_metadata_summary` and `add_to_metadata_summary` were refactored to include the `update_by_one` argument in order for these functions to be usable by all `metadata_summary` updating (ie: transfers and deletions). See [PR 350](https://github.com/phac-nml/irida-next/pull/350/files) for context.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
Either create or utilize `groups/projects/samples` within `db:seed` with empty `metadata_summary` that would have a 'master' group, with separate descendent groups and/or projects.

I will use the following:
Bacillus 
     V
Bacillus cereus > Outbreak 2021 (var: `project1`) > Sample 10 (var: `sample1`)
             |
              ---------------- > Outbreak 2022 (var: `project2`) > Sample 10 (var: `sample2`)

1. In the rails console, assign the above variables `sample1`, `sample2`, `project1`, `project2`.
2. Assign a `user`  with permission to edit the above.
3. Test adding metadata
a) Assign `params1 = {'metadata' => {'metadatafield1' => 'value1'}}`
b) Run `Samples::Metadata::UpdateService.new(project1, sample1, user, params1).execute`
c) Check that Outbreak 2021, Bacillus cereus, and Bacillus now have an `metadata_summary = {'metadatafield1': 1}`. Outbreak 2022 `metadata_summary` should still be empty.
d) Run `Samples::Metadata::UpdateService.new(project2, sample2, user, params1).execute`
e) Check Bacillus cereus and Bacillus now have an `metadata_summary = {'metadatafield1': 2}`, and Outbreak 2021 and Outbreak 2022 `metadata_summary = {'metadatafield1': 1}` ` .

4. Test adding and deleting metadata
a) Assign `params2 = {'metadata' => {'metadatafield1' => '', 'metadatafield2' => 'value2'}}`
b) Run `Samples::Metadata::UpdateService.new(project1, sample1, user, params2).execute`
c) Check that Bacillus cereus, and Bacillus now have an `metadata_summary = {'metadatafield1': 1, 'metadatafield2': 1}`, Outbreak 2021 `metadata_summary = {'metadatafield2': 1}` and Outbreak 2022 `metadata_summary = {'metadatafield1': 1}`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
