### PR TITLE
Metadata Summary Update by Transfers and Deletions

### DIFF
--- a/app/controllers/projects/samples/transfers_controller.rb
+++ b/app/controllers/projects/samples/transfers_controller.rb
@@ -37,11 +37,6 @@ module Projects
                  locals: { sample_ids: [], type: :alert,
                            message: @errors, errors: [] }
         end
-
-        return unless transferred_samples_ids.count.positive?
-
-        @project.namespace.update_metadata_summary_by_sample_transfer(transferred_samples_ids,
-                                                                      new_project_id)
       end
 
       private

--- a/app/controllers/projects/samples/transfers_controller.rb
+++ b/app/controllers/projects/samples/transfers_controller.rb
@@ -37,6 +37,11 @@ module Projects
                  locals: { sample_ids: [], type: :alert,
                            message: @errors, errors: [] }
         end
+
+        return unless transferred_samples_ids.count.positive?
+
+        @project.namespace.update_metadata_summary_by_sample_transfer(transferred_samples_ids,
+                                                                      new_project_id)
       end
 
       private

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -223,8 +223,13 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     metadata_to_update = transferred_namespace.metadata_summary
     return if metadata_to_update.empty?
 
-    subtract_metadata_from_old_namespaces(old_namespace, metadata_to_update) if old_namespace.type != 'User'
-    add_metadata_to_current_namespaces(metadata_to_update) if type != 'User'
+    if old_namespace.type != 'User'
+      subtract_from_metadata_summary(old_namespace.self_and_ancestors, metadata_to_update, false)
+    end
+
+    return unless type != 'User'
+
+    add_to_metadata_summary(self_and_ancestors, metadata_to_update, false)
   end
 
   def subtract_metadata_summary(metadata_field, value)

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -272,6 +272,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
         end
         namespace.save
       end
+      namespace.save
     end
   end
 
@@ -290,6 +291,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
         end
         namespace.save
       end
+      namespace.save
     end
   end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -223,7 +223,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     metadata_to_update = transferred_namespace.metadata_summary
     return if metadata_to_update.empty?
 
-    if old_namespace.type != 'User'
+    unless old_namespace.nil? || old_namespace.type == 'User'
       subtract_from_metadata_summary(old_namespace.self_and_ancestors, metadata_to_update, false)
     end
 

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -219,6 +219,22 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     errors.add(:parent_id, 'nesting level too deep')
   end
 
+  def update_metadata_summary_by_namespace_transfer(transferred_namespace, old_namespace)
+    metadata_to_update = transferred_namespace.metadata_summary
+    return if metadata_to_update.empty?
+
+    subtract_metadata_from_old_namespaces(old_namespace, metadata_to_update) if old_namespace.type != 'User'
+    add_metadata_to_current_namespaces(metadata_to_update) if type != 'User'
+  end
+
+  def subtract_metadata_summary(metadata_field, value)
+    return unless ancestors
+
+    ancestors.each do |ancestor|
+      ancestor.metadata_summary if ancestor.metadata_summary[metadata_field] == value
+    end
+  end
+
   private
 
   # Method to restore namespace routes when the namespace is restored

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -219,6 +219,8 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     errors.add(:parent_id, 'nesting level too deep')
   end
 
+  # self = namespace receiving transferred_namespace
+  # old_namespace = the old namespace transferred_namespace originated from
   def update_metadata_summary_by_namespace_transfer(transferred_namespace, old_namespace)
     metadata_to_update = transferred_namespace.metadata_summary
     return if metadata_to_update.empty?

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -276,8 +276,8 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
             namespace.metadata_summary[metadata_field] -= value
           end
         end
+        namespace.save
       end
-      namespace.save
     end
   end
 
@@ -294,8 +294,8 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
             namespace.metadata_summary[metadata_field] = value
           end
         end
+        namespace.save
       end
-      namespace.save
     end
   end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -232,6 +232,12 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     add_to_metadata_summary(self_and_ancestors, metadata_to_update, false)
   end
 
+  def update_metadata_summary_by_namespace_deletion
+    return if metadata_summary.empty?
+
+    subtract_from_metadata_summary(parent.self_and_ancestors, metadata_summary, false)
+  end
+
   private
 
   # Method to restore namespace routes when the namespace is restored

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -232,14 +232,6 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     add_to_metadata_summary(self_and_ancestors, metadata_to_update, false)
   end
 
-  def subtract_metadata_summary(metadata_field, value)
-    return unless ancestors
-
-    ancestors.each do |ancestor|
-      ancestor.metadata_summary if ancestor.metadata_summary[metadata_field] == value
-    end
-  end
-
   private
 
   # Method to restore namespace routes when the namespace is restored

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -223,19 +223,19 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     metadata_to_update = transferred_namespace.metadata_summary
     return if metadata_to_update.empty?
 
-    unless old_namespace.nil? || old_namespace.type == 'User'
-      subtract_from_metadata_summary(old_namespace.self_and_ancestors, metadata_to_update, false)
+    unless old_namespace.nil? || old_namespace.type == Namespaces::UserNamespace.sti_name
+      subtract_from_metadata_summary_count(old_namespace.self_and_ancestors, metadata_to_update, false)
     end
 
-    return unless type != 'User'
+    return unless type != Namespaces::UserNamespace.sti_name
 
-    add_to_metadata_summary(self_and_ancestors, metadata_to_update, false)
+    add_to_metadata_summary_count(self_and_ancestors, metadata_to_update, false)
   end
 
   def update_metadata_summary_by_namespace_deletion
     return if metadata_summary.empty?
 
-    subtract_from_metadata_summary(parent.self_and_ancestors, metadata_summary, false)
+    subtract_from_metadata_summary_count(parent.self_and_ancestors, metadata_summary, false)
   end
 
   private
@@ -276,7 +276,6 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
             namespace.metadata_summary[metadata_field] -= value
           end
         end
-        namespace.save
       end
       namespace.save
     end
@@ -295,7 +294,6 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
             namespace.metadata_summary[metadata_field] = value
           end
         end
-        namespace.save
       end
       namespace.save
     end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -48,13 +48,14 @@ module Namespaces
     end
 
     def update_metadata_summary_by_sample_transfer(transferred_samples_ids, new_project_id)
-      new_project = Project.find(new_project_id)
+      old_namespaces = self_and_parents
+      new_namespaces = Project.find(new_project_id).namespace.self_and_parents
       transferred_samples_ids.each do |sample_id|
         sample = Sample.find(sample_id)
-        unless sample.metadata.empty?
-          subtract_sample_from_old_metadata_summary(sample)
-          add_sample_to_new_metadata_summary(new_project, sample)
-        end
+        next if sample.metadata.empty?
+
+        subtract_from_metadata_summary(old_namespaces, sample.metadata, true)
+        add_to_metadata_summary(new_namespaces, sample.metadata, true)
       end
     end
 

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -47,22 +47,26 @@ module Namespaces
       add_to_metadata_summary_count(namespaces_to_update, added_metadata, true) unless added_metadata.empty?
     end
 
-    def update_metadata_summary_by_sample_transfer(transferred_samples_ids, new_project_id)
-      old_namespaces = self_and_parents
-      new_namespaces = Project.find(new_project_id).namespace.self_and_parents
+    def update_metadata_summary_by_sample_transfer(transferred_samples_ids, new_project_id) # rubocop:disable Metrics/AbcSize
+      old_namespaces = [self] + parent.self_and_ancestors.where.not(type: Namespaces::UserNamespace.sti_name)
+      new_project_namespace = Project.find(new_project_id).namespace
+      new_namespaces =
+        [new_project_namespace] +
+        new_project_namespace.parent.self_and_ancestors.where.not(type: Namespaces::UserNamespace.sti_name)
       transferred_samples_ids.each do |sample_id|
         sample = Sample.find(sample_id)
         next if sample.metadata.empty?
 
-        subtract_from_metadata_summary(old_namespaces, sample.metadata, true)
-        add_to_metadata_summary(new_namespaces, sample.metadata, true)
+        subtract_from_metadata_summary_count(old_namespaces, sample.metadata, true)
+        add_to_metadata_summary_count(new_namespaces, sample.metadata, true)
       end
     end
 
     def update_metadata_summary_by_sample_deletion(sample)
       return if sample.metadata.empty?
 
-      subtract_from_metadata_summary(self_and_parents, sample.metadata, true)
+      namespaces_to_update = [self] + parent.self_and_ancestors.where.not(type: Namespaces::UserNamespace.sti_name)
+      subtract_from_metadata_summary_count(namespaces_to_update, sample.metadata, true)
     end
   end
 end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -47,7 +47,20 @@ module Namespaces
       add_to_metadata_summary_count(namespaces_to_update, added_metadata, true) unless added_metadata.empty?
     end
 
-    def subtract_sample_from_metadata_summary(sample)
+    def update_metadata_summary_by_sample_transfer(transferred_samples_ids, new_project_id)
+      new_project = Project.find(new_project_id)
+      transferred_samples_ids.each do |sample_id|
+        sample = Sample.find(sample_id)
+        unless sample.metadata.empty?
+          subtract_sample_from_old_metadata_summary(sample)
+          add_sample_to_new_metadata_summary(new_project, sample)
+        end
+      end
+    end
+
+    private
+
+    def subtract_sample_from_old_metadata_summary(sample)
       namespaces_to_update = self_and_parents
       namespaces_to_update.each do |namespace|
         sample.metadata.each do |metadata_field, _v|

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -50,15 +50,19 @@ module Namespaces
     def subtract_sample_from_metadata_summary(sample)
       namespaces_to_update = self_and_parents
       namespaces_to_update.each do |namespace|
-        subtract_one_from_metadata_summary(namespace, sample.metadata)
+        sample.metadata.each do |metadata_field, _v|
+          subtract_from_metadata_summary(namespace, metadata_field, 1)
+        end
       end
       namespaces_to_update.each(&:save)
     end
 
-    def add_sample_to_metadata_summary(new_project, sample)
+    def add_sample_to_new_metadata_summary(new_project, sample)
       namespaces_to_update = new_project.namespace.self_and_parents
       namespaces_to_update.each do |namespace|
-        add_one_to_metadata_summary(namespace, sample.metadata)
+        sample.metadata.each do |metadata_field, _v|
+          add_to_metadata_summary(namespace, metadata_field, 1)
+        end
       end
       namespaces_to_update.each(&:save)
     end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -35,12 +35,6 @@ module Namespaces
       'Project'
     end
 
-    def self_and_parents
-      namespaces = [self]
-      namespaces += parent.self_and_ancestors unless parent.type == 'User'
-      namespaces
-    end
-
     def update_metadata_summary_by_update_service(deleted_metadata, added_metadata)
       namespaces_to_update = [self] + parent.self_and_ancestors.where.not(type: Namespaces::UserNamespace.sti_name)
       subtract_from_metadata_summary_count(namespaces_to_update, deleted_metadata, true) unless deleted_metadata.empty?

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -35,10 +35,32 @@ module Namespaces
       'Project'
     end
 
+    def self_and_parents
+      namespaces = [self]
+      namespaces += parent.self_and_ancestors unless parent.type == 'User'
+      namespaces
+    end
+
     def update_metadata_summary_by_update_service(deleted_metadata, added_metadata)
       namespaces_to_update = [self] + parent.self_and_ancestors.where.not(type: Namespaces::UserNamespace.sti_name)
       subtract_from_metadata_summary_count(namespaces_to_update, deleted_metadata, true) unless deleted_metadata.empty?
       add_to_metadata_summary_count(namespaces_to_update, added_metadata, true) unless added_metadata.empty?
+    end
+
+    def subtract_sample_from_metadata_summary(sample)
+      namespaces_to_update = self_and_parents
+      namespaces_to_update.each do |namespace|
+        subtract_one_from_metadata_summary(namespace, sample.metadata)
+      end
+      namespaces_to_update.each(&:save)
+    end
+
+    def add_sample_to_metadata_summary(new_project, sample)
+      namespaces_to_update = new_project.namespace.self_and_parents
+      namespaces_to_update.each do |namespace|
+        add_one_to_metadata_summary(namespace, sample.metadata)
+      end
+      namespaces_to_update.each(&:save)
     end
   end
 end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -59,26 +59,10 @@ module Namespaces
       end
     end
 
-    private
+    def update_metadata_summary_by_sample_deletion(sample)
+      return if sample.metadata.empty?
 
-    def subtract_sample_from_old_metadata_summary(sample)
-      namespaces_to_update = self_and_parents
-      namespaces_to_update.each do |namespace|
-        sample.metadata.each do |metadata_field, _v|
-          subtract_from_metadata_summary(namespace, metadata_field, 1)
-        end
-      end
-      namespaces_to_update.each(&:save)
-    end
-
-    def add_sample_to_new_metadata_summary(new_project, sample)
-      namespaces_to_update = new_project.namespace.self_and_parents
-      namespaces_to_update.each do |namespace|
-        sample.metadata.each do |metadata_field, _v|
-          add_to_metadata_summary(namespace, metadata_field, 1)
-        end
-      end
-      namespaces_to_update.each(&:save)
+      subtract_from_metadata_summary(self_and_parents, sample.metadata, true)
     end
   end
 end

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -41,6 +41,9 @@ module Namespaces
       add_to_metadata_summary_count(namespaces_to_update, added_metadata, true) unless added_metadata.empty?
     end
 
+    # self = the original parent of the transferred samples
+    # new_project_id = the project ID receiving the new samples
+    # transferred_samples_ids contains the IDs of the transferred samples
     def update_metadata_summary_by_sample_transfer(transferred_samples_ids, new_project_id) # rubocop:disable Metrics/AbcSize
       old_namespaces = [self] + parent.self_and_ancestors.where.not(type: Namespaces::UserNamespace.sti_name)
       new_project_namespace = Project.find(new_project_id).namespace

--- a/app/services/groups/destroy_service.rb
+++ b/app/services/groups/destroy_service.rb
@@ -13,6 +13,10 @@ module Groups
     def execute
       authorize! @group, to: :destroy?
       group.destroy
+
+      return unless group.deleted? && !group.parent.nil?
+
+      group.update_metadata_summary_by_namespace_deletion
     end
   end
 end

--- a/app/services/projects/destroy_service.rb
+++ b/app/services/projects/destroy_service.rb
@@ -8,7 +8,7 @@ module Projects
 
       project.namespace.destroy!
 
-      return unless project.namespace.deleted? && project.namespace.parent.type != 'User'
+      return unless project.namespace.deleted? && project.namespace.where.not(type: Namespaces::UserNamespace.sti_name)
 
       project.namespace.update_metadata_summary_by_namespace_deletion
     end

--- a/app/services/projects/destroy_service.rb
+++ b/app/services/projects/destroy_service.rb
@@ -7,6 +7,10 @@ module Projects
       authorize! project, to: :destroy?
 
       project.namespace.destroy!
+
+      return unless project.namespace.deleted? && project.namespace.parent.type != 'User'
+
+      project.namespace.update_metadata_summary_by_namespace_deletion
     end
   end
 end

--- a/app/services/projects/destroy_service.rb
+++ b/app/services/projects/destroy_service.rb
@@ -8,7 +8,7 @@ module Projects
 
       project.namespace.destroy!
 
-      return unless project.namespace.deleted? && project.namespace.where.not(type: Namespaces::UserNamespace.sti_name)
+      return unless project.namespace.deleted? && project.namespace.type != Namespaces::UserNamespace.sti_name
 
       project.namespace.update_metadata_summary_by_namespace_deletion
     end

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -5,8 +5,9 @@ module Projects
   class TransferService < BaseProjectService
     TransferError = Class.new(StandardError)
 
-    def execute(new_namespace)
+    def execute(new_namespace) # rubocop:disable Metrics/AbcSize
       @new_namespace = new_namespace
+      old_namespace = @project.parent
 
       raise TransferError, I18n.t('services.projects.transfer.namespace_empty') if @new_namespace.blank?
 
@@ -22,6 +23,8 @@ module Projects
       authorize! @new_namespace, to: :transfer_into_namespace?
 
       transfer(project)
+
+      @new_namespace.update_metadata_summary_by_namespace_transfer(@project.namespace, old_namespace)
 
       true
     rescue Projects::TransferService::TransferError => e

--- a/app/services/samples/destroy_service.rb
+++ b/app/services/samples/destroy_service.rb
@@ -14,6 +14,8 @@ module Samples
       authorize! sample.project, to: :destroy_sample?
 
       sample.destroy
+
+      sample.project.namespace.update_metadata_summary_by_sample_deletion(sample) if sample.deleted?
     end
   end
 end

--- a/app/services/samples/transfer_service.rb
+++ b/app/services/samples/transfer_service.rb
@@ -47,7 +47,7 @@ module Samples
             I18n.t('services.samples.transfer.maintainer_transfer_not_allowed')
     end
 
-    def transfer(new_project_id, sample_ids) # rubocop:disable Metrics/MethodLength
+    def transfer(new_project_id, sample_ids) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       transferred_samples_ids = []
       not_found_sample_ids = []
       sample_ids.each do |sample_id|
@@ -68,6 +68,12 @@ module Samples
                            I18n.t('services.samples.transfer.samples_not_found',
                                   sample_ids: not_found_sample_ids.join(', ')))
       end
+
+      if transferred_samples_ids.count.positive?
+        @project.namespace.update_metadata_summary_by_sample_transfer(transferred_samples_ids,
+                                                                      new_project_id)
+      end
+
       transferred_samples_ids
     end
   end

--- a/test/services/groups/destroy_service_test.rb
+++ b/test/services/groups/destroy_service_test.rb
@@ -36,5 +36,27 @@ module Groups
         Groups::DestroyService.new(@group, @user).execute
       end
     end
+
+    test 'metadata summary updated after group deletion' do
+      # Reference group/projects descendants tree:
+      # group12 < subgroup12b (project30 > sample 33)
+      #    |
+      #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
+      @group12 = groups(:group_twelve)
+      @subgroup12a = groups(:subgroup_twelve_a)
+      @subgroup12b = groups(:subgroup_twelve_b)
+      @subgroup12aa = groups(:subgroup_twelve_a_a)
+
+      Groups::DestroyService.new(@subgroup12aa, @user).execute
+
+      @group12.reload
+      @subgroup12aa.reload
+      @subgroup12a.reload
+      @subgroup12b.reload
+
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.metadata_summary)
+    end
   end
 end

--- a/test/services/groups/destroy_service_test.rb
+++ b/test/services/groups/destroy_service_test.rb
@@ -47,16 +47,18 @@ module Groups
       @subgroup12b = groups(:subgroup_twelve_b)
       @subgroup12aa = groups(:subgroup_twelve_a_a)
 
-      Groups::DestroyService.new(@subgroup12aa, @user).execute
-
-      @group12.reload
-      @subgroup12aa.reload
-      @subgroup12a.reload
-      @subgroup12b.reload
-
-      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
       assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
-      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
+      assert_no_changes -> { @subgroup12b.reload.metadata_summary } do
+        Groups::DestroyService.new(@subgroup12aa, @user).execute
+      end
+
+      assert(@subgroup12aa.reload.deleted?)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.reload.metadata_summary)
     end
   end
 end

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -90,29 +90,30 @@ module Groups
       @subgroup12b = groups(:subgroup_twelve_b)
       @subgroup12aa = groups(:subgroup_twelve_a_a)
 
-      Groups::TransferService.new(@subgroup12aa, @john_doe).execute(@subgroup12b)
-
-      @group12.reload
-      @subgroup12aa.reload
-      @subgroup12a.reload
-      @subgroup12b.reload
-
       assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
-      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
-      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
       assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
 
-      Groups::TransferService.new(@subgroup12b, @john_doe).execute(@subgroup12a)
+      assert_no_changes -> { @group12.reload.metadata_summary } do
+        assert_no_changes -> { @subgroup12aa.reload.metadata_summary } do
+          Groups::TransferService.new(@subgroup12aa, @john_doe).execute(@subgroup12b)
+        end
+      end
 
-      @group12.reload
-      @subgroup12aa.reload
-      @subgroup12a.reload
-      @subgroup12b.reload
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.reload.metadata_summary)
 
-      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
-      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
-      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
-      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+      assert_no_changes -> { @group12.reload.metadata_summary } do
+        assert_no_changes -> { @subgroup12aa.reload.metadata_summary } do
+          assert_no_changes -> { @subgroup12b.reload.metadata_summary } do
+            Groups::TransferService.new(@subgroup12b, @john_doe).execute(@subgroup12a)
+          end
+        end
+      end
+
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.reload.metadata_summary)
     end
   end
 end

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -84,7 +84,7 @@ module Groups
       # Reference group/projects descendants tree:
       # group12 < subgroup12b (project30 > sample 33)
       #    |
-      #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)\
+      #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
       @group12 = groups(:group_twelve)
       @subgroup12a = groups(:subgroup_twelve_a)
       @subgroup12b = groups(:subgroup_twelve_b)

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -79,5 +79,40 @@ module Groups
       end
       assert_enqueued_with(job: UpdateMembershipsJob)
     end
+
+    test 'metadata summary updates after group transfer' do
+      # Reference group/projects descendants tree:
+      # group12 < subgroup12b (project30 > sample 33)
+      #    |
+      #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)\
+      @group12 = groups(:group_twelve)
+      @subgroup12a = groups(:subgroup_twelve_a)
+      @subgroup12b = groups(:subgroup_twelve_b)
+      @subgroup12aa = groups(:subgroup_twelve_a_a)
+
+      Groups::TransferService.new(@subgroup12aa, @john_doe).execute(@subgroup12b)
+
+      @group12.reload
+      @subgroup12aa.reload
+      @subgroup12a.reload
+      @subgroup12b.reload
+
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
+      Groups::TransferService.new(@subgroup12b, @john_doe).execute(@subgroup12a)
+
+      @group12.reload
+      @subgroup12aa.reload
+      @subgroup12a.reload
+      @subgroup12b.reload
+
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+    end
   end
 end

--- a/test/services/projects/destroy_service_test.rb
+++ b/test/services/projects/destroy_service_test.rb
@@ -51,17 +51,21 @@ module Projects
       @subgroup12aa = groups(:subgroup_twelve_a_a)
       @project31 = projects(:project31)
 
-      Projects::DestroyService.new(@project31, @user).execute
-
-      @group12.reload
-      @subgroup12aa.reload
-      @subgroup12a.reload
-      @subgroup12b.reload
-
-      assert_equal({}, @subgroup12aa.metadata_summary)
-      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
       assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
-      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
+      assert_no_changes -> { @subgroup12b.reload.metadata_summary } do
+        Projects::DestroyService.new(@project31, @user).execute
+      end
+
+      assert(@project31.namespace.reload.deleted?)
+      assert_equal({}, @subgroup12aa.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.reload.metadata_summary)
     end
   end
 end

--- a/test/services/projects/destroy_service_test.rb
+++ b/test/services/projects/destroy_service_test.rb
@@ -39,5 +39,29 @@ module Projects
         ).execute
       end
     end
+
+    test 'metadata summary updated after project deletion' do
+      # Reference group/projects descendants tree:
+      # group12 < subgroup12b (project30 > sample 33)
+      #    |
+      #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
+      @group12 = groups(:group_twelve)
+      @subgroup12a = groups(:subgroup_twelve_a)
+      @subgroup12b = groups(:subgroup_twelve_b)
+      @subgroup12aa = groups(:subgroup_twelve_a_a)
+      @project31 = projects(:project31)
+
+      Projects::DestroyService.new(@project31, @user).execute
+
+      @group12.reload
+      @subgroup12aa.reload
+      @subgroup12a.reload
+      @subgroup12b.reload
+
+      assert_equal({}, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.metadata_summary)
+    end
   end
 end

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -155,17 +155,21 @@ module Projects
       @subgroup12b = groups(:subgroup_twelve_b)
       @subgroup12aa = groups(:subgroup_twelve_a_a)
 
-      Projects::TransferService.new(@project31, @john_doe).execute(@subgroup12b)
-
-      @group12.reload
-      @subgroup12aa.reload
-      @subgroup12a.reload
-      @subgroup12b.reload
-
-      assert_equal({}, @subgroup12aa.metadata_summary)
-      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
-      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
       assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
+      assert_no_changes -> { @group12.reload.metadata_summary } do
+        assert_no_changes -> { @project31.namespace.reload.metadata_summary } do
+          Projects::TransferService.new(@project31, @john_doe).execute(@subgroup12b)
+        end
+      end
+
+      assert_equal({}, @subgroup12aa.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.reload.metadata_summary)
     end
 
     test 'user namespace metadata summary does not update after project transfer' do

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -143,5 +143,40 @@ module Projects
 
       assert_enqueued_with(job: UpdateMembershipsJob)
     end
+
+    test 'metadata summary updates after project transfer' do
+      # Reference group/projects descendants tree:
+      # group12 < subgroup12b (project30 > sample 33)
+      #    |
+      #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
+      @project31 = projects(:project31)
+      @group12 = groups(:group_twelve)
+      @subgroup12a = groups(:subgroup_twelve_a)
+      @subgroup12b = groups(:subgroup_twelve_b)
+      @subgroup12aa = groups(:subgroup_twelve_a_a)
+
+      Projects::TransferService.new(@project31, @john_doe).execute(@subgroup12b)
+
+      @group12.reload
+      @subgroup12aa.reload
+      @subgroup12a.reload
+      @subgroup12b.reload
+
+      assert_equal({}, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+    end
+
+    test 'user namespace metadata summary does not update after project transfer' do
+      @project31 = projects(:project31)
+
+      new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+
+      Projects::TransferService.new(@project31, @john_doe).execute(new_namespace)
+
+      new_namespace.reload
+      assert_equal({}, new_namespace.metadata_summary)
+    end
   end
 end

--- a/test/services/samples/destroy_service_test.rb
+++ b/test/services/samples/destroy_service_test.rb
@@ -46,19 +46,24 @@ module Samples
       @subgroup12a = groups(:subgroup_twelve_a)
       @subgroup12b = groups(:subgroup_twelve_b)
       @subgroup12aa = groups(:subgroup_twelve_a_a)
+      @project31 = projects(:project31)
       @sample34 = samples(:sample34)
 
-      Samples::DestroyService.new(@sample34, @user).execute
-
-      @group12.reload
-      @subgroup12aa.reload
-      @subgroup12a.reload
-      @subgroup12b.reload
-
-      assert_equal({}, @subgroup12aa.metadata_summary)
-      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
       assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
-      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
+      assert_no_changes -> { @subgroup12b.reload.metadata_summary } do
+        Samples::DestroyService.new(@sample34, @user).execute
+      end
+
+      assert_equal({}, @project31.namespace.reload.metadata_summary)
+      assert_equal({}, @subgroup12aa.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.reload.metadata_summary)
     end
   end
 end

--- a/test/services/samples/destroy_service_test.rb
+++ b/test/services/samples/destroy_service_test.rb
@@ -36,5 +36,29 @@ module Samples
                                     @user).execute
       end
     end
+
+    test 'metadata summary updated after sample deletion' do
+      # Reference group/projects descendants tree:
+      # group12 < subgroup12b (project30 > sample 33)
+      #    |
+      #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
+      @group12 = groups(:group_twelve)
+      @subgroup12a = groups(:subgroup_twelve_a)
+      @subgroup12b = groups(:subgroup_twelve_b)
+      @subgroup12aa = groups(:subgroup_twelve_a_a)
+      @sample34 = samples(:sample34)
+
+      Samples::DestroyService.new(@sample34, @user).execute
+
+      @group12.reload
+      @subgroup12aa.reload
+      @subgroup12a.reload
+      @subgroup12b.reload
+
+      assert_equal({}, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @group12.metadata_summary)
+    end
   end
 end

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -306,15 +306,16 @@ module Samples
 
         params1 = { 'metadata' => { 'metadatafield4' => 'value4' } }
 
-        assert_no_changes @subgroup12b.metadata_summary do
-          Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params1).execute
-        end
+        Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params1).execute
 
+        @subgroup12b.reload
         @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
+
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
                      @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
                      @subgroup12aa.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
@@ -324,35 +325,38 @@ module Samples
 
         params2 = { 'metadata' => { 'metadatafield5' => 'value5' } }
 
-        assert_no_changes -> { @subgroup12a.metadata_summary } do
-          assert_no_changes -> { @subgroup12aa.metadata_summary } do
-            Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params2).execute
-          end
-        end
+        Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params2).execute
 
         @subgroup12b.reload
+        @subgroup12aa.reload
+        @subgroup12a.reload
         @group12.reload
 
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
                      @project30.namespace.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
                      @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
+                     @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
+                     @subgroup12a.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield4' => 1, 'metadatafield5' => 1 },
                      @group12.metadata_summary)
 
         params3 = { 'metadata' => { 'metadatafield2' => '' } }
 
-        assert_no_changes -> { @subgroup12b.metadata_summary } do
-          assert_no_changes -> { @subgroup12aa.metadata_summary } do
-            Samples::Metadata::UpdateService.new(@project29, @sample32, @user, params3).execute
-          end
-        end
+        Samples::Metadata::UpdateService.new(@project29, @sample32, @user, params3).execute
 
+        @subgroup12b.reload
+        @subgroup12aa.reload
         @subgroup12a.reload
         @group12.reload
 
-        assert_equal({ 'metadatafield1' => 1 },
-                     @project29.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1 }, @project29.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
+                     @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
+                     @subgroup12aa.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1, 'metadatafield4' => 1 },
                      @subgroup12a.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 2, 'metadatafield4' => 1, 'metadatafield5' => 1 },
@@ -366,10 +370,10 @@ module Samples
         sample = samples(:sample24)
         namespace = namespaces_user_namespaces(:john_doe_namespace)
 
-        assert_no_changes namespace.metadata_summary do
-          Samples::Metadata::UpdateService.new(project, sample, @user, params).execute
-        end
+        Samples::Metadata::UpdateService.new(project, sample, @user, params).execute
 
+        namespace.reload
+        assert_equal({}, namespace.metadata_summary)
         assert_equal({ 'metadatafield4' => 'value4' }, sample.metadata)
         assert_equal({ 'metadatafield4' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current } },
                      sample.metadata_provenance)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -23,6 +23,12 @@ module Samples
       test 'add metadata to sample containing no existing metadata by user' do
         freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample35, @user, params).execute
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample35.metadata)
         assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current },
@@ -30,18 +36,22 @@ module Samples
                      @sample35.metadata_provenance)
         assert_equal({ added: %w[metadatafield1 metadatafield2], updated: [], deleted: [],
                        not_updated: [] }, metadata_changes)
-        @subgroup12aa.reload
-        @subgroup12a.reload
-        @group12.reload
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12aa.metadata_summary)
-        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
-        assert_equal({ 'metadatafield1' => 4, 'metadatafield2' => 4 }, @group12.metadata_summary)
+
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @project31.namespace.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12aa.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 4, 'metadatafield2' => 4 }, @group12.reload.metadata_summary)
       end
 
       test 'add metadata to sample containing no existing metadata by analysis' do
         freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, 'analysis_id' => 2 }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample35, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample35.metadata)
@@ -51,18 +61,23 @@ module Samples
         assert_equal({ added: %w[metadatafield1 metadatafield2], updated: [], deleted: [],
                        not_updated: [] }, metadata_changes)
 
-        @subgroup12aa.reload
-        @subgroup12a.reload
-        @group12.reload
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12aa.metadata_summary)
-        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
-        assert_equal({ 'metadatafield1' => 4, 'metadatafield2' => 4 }, @group12.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @project31.namespace.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12aa.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 4, 'metadatafield2' => 4 }, @group12.reload.metadata_summary)
       end
 
       test 'update sample metadata merge with new metadata and analysis overwritting user' do
         freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' }, 'analysis_id' => 10 }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 },
+                     @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 },
+                     @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 },
+                     @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
@@ -75,19 +90,22 @@ module Samples
         assert_equal({ added: %w[metadatafield3], updated: %w[metadatafield1], deleted: [],
                        not_updated: [] }, metadata_changes)
 
-        @subgroup12b.reload
-        @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @project30.namespace.metadata_summary)
+                     @project30.namespace.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @subgroup12b.metadata_summary)
+                     @subgroup12b.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield3' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
       end
 
       test 'update sample metadata merge with new metadata and user overwritting user' do
         freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
@@ -100,19 +118,23 @@ module Samples
         assert_equal({ added: %w[metadatafield3], updated: %w[metadatafield1], deleted: [],
                        not_updated: [] }, metadata_changes)
 
-        @subgroup12b.reload
-        @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @project30.namespace.metadata_summary)
+                     @project30.namespace.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @subgroup12b.metadata_summary)
+                     @subgroup12b.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield3' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
       end
 
       test 'update sample metadata merge with new metadata and user unable to overwrite analysis' do
         freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
@@ -131,21 +153,24 @@ module Samples
                  metadata_fields: 'metadatafield1')
         )
 
-        @subgroup12aa.reload
-        @subgroup12a.reload
-        @group12.reload
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @project31.namespace.metadata_summary)
+                     @project31.namespace.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @subgroup12aa.metadata_summary)
+                     @subgroup12aa.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield3' => 1 },
-                     @subgroup12a.metadata_summary)
+                     @subgroup12a.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield3' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
       end
 
       test 'remove metadata key with user' do
         params = { 'metadata' => { 'metadatafield2' => '' } }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1' }, @sample34.metadata)
@@ -155,21 +180,19 @@ module Samples
         )
         assert_equal({ added: [], updated: [], deleted: %w[metadatafield2], not_updated: [] }, metadata_changes)
 
-        @subgroup12aa.reload
-        @subgroup12a.reload
-        @group12.reload
-        assert_equal({ 'metadatafield1' => 1 },
-                     @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 1 },
-                     @subgroup12aa.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1 },
-                     @subgroup12a.metadata_summary)
-        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 2 },
-                     @group12.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1 }, @project31.namespace.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1 }, @subgroup12aa.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1 }, @subgroup12a.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 2 }, @group12.reload.metadata_summary)
       end
 
       test 'remove metadata key with analysis' do
         params = { 'metadata' => { 'metadatafield1' => '' }, 'analysis_id' => 1 }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'value2' }, @sample33.metadata)
@@ -179,20 +202,20 @@ module Samples
         )
         assert_equal({ added: [], updated: [], deleted: %w[metadatafield1], not_updated: [] }, metadata_changes)
 
-        @subgroup12b.reload
-        @group12.reload
-        assert_equal({ 'metadatafield2' => 1 },
-                     @project30.namespace.metadata_summary)
-        assert_equal({ 'metadatafield2' => 1 },
-                     @subgroup12b.metadata_summary)
-        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 3 },
-                     @group12.metadata_summary)
+        assert_equal({ 'metadatafield2' => 1 }, @project30.namespace.reload.metadata_summary)
+        assert_equal({ 'metadatafield2' => 1 }, @subgroup12b.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 3 }, @group12.reload.metadata_summary)
       end
 
       test 'add, update, and remove metadata in same request to mimic batch update request with analysis' do
         freeze_time
         params = { 'metadata' => { 'metadatafield1' => '', 'metadatafield2' => 'newvalue2',
                                    'metadatafield3' => 'value3' }, 'analysis_id' => 1 }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'newvalue2', 'metadatafield3' => 'value3' }, @sample33.metadata)
@@ -206,20 +229,21 @@ module Samples
             not_updated: [] }, metadata_changes
         )
 
-        @subgroup12b.reload
-        @group12.reload
-        assert_equal({ 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @project30.namespace.metadata_summary)
-        assert_equal({ 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield2' => 1, 'metadatafield3' => 1 }, @project30.namespace.reload.metadata_summary)
+        assert_equal({ 'metadatafield2' => 1, 'metadatafield3' => 1 }, @subgroup12b.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 3, 'metadatafield3' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
       end
 
       test 'add, update, and remove metadata in same request to mimic batch update with user' do
         freeze_time
         params = { 'metadata' => { 'metadatafield1' => '', 'metadatafield2' => 'newvalue2',
                                    'metadatafield3' => 'value3' } }
+
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project30.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'newvalue2', 'metadatafield3' => 'value3' }, @sample33.metadata)
@@ -233,14 +257,12 @@ module Samples
             not_updated: [] }, metadata_changes
         )
 
-        @subgroup12b.reload
-        @group12.reload
         assert_equal({ 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @project30.namespace.metadata_summary)
+                     @project30.namespace.reload.metadata_summary)
         assert_equal({ 'metadatafield2' => 1, 'metadatafield3' => 1 },
-                     @subgroup12b.metadata_summary)
+                     @subgroup12b.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 3, 'metadatafield3' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
       end
 
       test 'update sample metadata with valid permission' do
@@ -306,61 +328,52 @@ module Samples
 
         params1 = { 'metadata' => { 'metadatafield4' => 'value4' } }
 
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
         Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params1).execute
 
-        @subgroup12b.reload
-        @subgroup12aa.reload
-        @subgroup12a.reload
-        @group12.reload
-
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
-                     @project31.namespace.metadata_summary)
-        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
+                     @project31.namespace.reload.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
-                     @subgroup12aa.metadata_summary)
+                     @subgroup12aa.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
-                     @subgroup12a.metadata_summary)
+                     @subgroup12a.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield4' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
 
         params2 = { 'metadata' => { 'metadatafield5' => 'value5' } }
 
         Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params2).execute
 
-        @subgroup12b.reload
-        @subgroup12aa.reload
-        @subgroup12a.reload
-        @group12.reload
-
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
-                     @project30.namespace.metadata_summary)
+                     @project30.namespace.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
-                     @subgroup12b.metadata_summary)
+                     @subgroup12b.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
-                     @subgroup12aa.metadata_summary)
+                     @subgroup12aa.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2, 'metadatafield4' => 1 },
-                     @subgroup12a.metadata_summary)
+                     @subgroup12a.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3, 'metadatafield4' => 1, 'metadatafield5' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
 
         params3 = { 'metadata' => { 'metadatafield2' => '' } }
 
         Samples::Metadata::UpdateService.new(@project29, @sample32, @user, params3).execute
 
-        @subgroup12b.reload
-        @subgroup12aa.reload
-        @subgroup12a.reload
-        @group12.reload
-
-        assert_equal({ 'metadatafield1' => 1 }, @project29.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 1 }, @project29.namespace.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield5' => 1 },
-                     @subgroup12b.metadata_summary)
+                     @subgroup12b.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1, 'metadatafield4' => 1 },
-                     @subgroup12aa.metadata_summary)
+                     @subgroup12aa.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 1, 'metadatafield4' => 1 },
-                     @subgroup12a.metadata_summary)
+                     @subgroup12a.reload.metadata_summary)
         assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 2, 'metadatafield4' => 1, 'metadatafield5' => 1 },
-                     @group12.metadata_summary)
+                     @group12.reload.metadata_summary)
       end
 
       test 'user namespace metadata summary does not update' do
@@ -372,12 +385,11 @@ module Samples
 
         Samples::Metadata::UpdateService.new(project, sample, @user, params).execute
 
-        namespace.reload
-        assert_equal({}, namespace.metadata_summary)
+        assert_equal({}, namespace.reload.metadata_summary)
         assert_equal({ 'metadatafield4' => 'value4' }, sample.metadata)
         assert_equal({ 'metadatafield4' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current } },
                      sample.metadata_provenance)
-        assert_equal({ 'metadatafield4' => 1 }, project.namespace.metadata_summary)
+        assert_equal({ 'metadatafield4' => 1 }, project.namespace.reload.metadata_summary)
       end
     end
   end

--- a/test/services/samples/transfer_service_test.rb
+++ b/test/services/samples/transfer_service_test.rb
@@ -109,7 +109,6 @@ module Samples
       # group12 < subgroup12b (project30 > sample 33)
       #    |
       #    ---- < subgroup12a (project29 > sample 32) < subgroup12aa (project31 > sample34 + 35)
-      @sample32 = samples(:sample32)
       @sample33 = samples(:sample33)
       @sample34 = samples(:sample34)
       @sample35 = samples(:sample35)

--- a/test/services/samples/transfer_service_test.rb
+++ b/test/services/samples/transfer_service_test.rb
@@ -123,28 +123,25 @@ module Samples
       @sample_transfer_params1 = { new_project_id: @project30.id,
                                    sample_ids: [@sample34.id, @sample35.id] }
 
-      assert_no_changes -> { @group12.metadata_summary } do
-        Samples::TransferService.new(@project31, @john_doe).execute(@sample_transfer_params1[:new_project_id],
-                                                                    @sample_transfer_params1[:sample_ids])
-      end
+      Samples::TransferService.new(@project31, @john_doe).execute(@sample_transfer_params1[:new_project_id],
+                                                                  @sample_transfer_params1[:sample_ids])
 
-      @subgroup12aa.reload
       @subgroup12a.reload
+      @subgroup12aa.reload
       @subgroup12b.reload
 
       assert_equal({}, @project31.namespace.metadata_summary)
       assert_equal({}, @subgroup12aa.metadata_summary)
       assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
       assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 },
+                   @group12.metadata_summary)
 
       @sample_transfer_params2 = { new_project_id: @project29.id,
                                    sample_ids: [@sample33.id, @sample34.id, @sample35.id] }
-      assert_no_changes -> { @group12.metadata_summary } do
-        assert_no_changes -> { @subgroup12aa.metadata_summary } do
-          Samples::TransferService.new(@project30, @john_doe).execute(@sample_transfer_params2[:new_project_id],
-                                                                      @sample_transfer_params2[:sample_ids])
-        end
-      end
+
+      Samples::TransferService.new(@project30, @john_doe).execute(@sample_transfer_params2[:new_project_id],
+                                                                  @sample_transfer_params2[:sample_ids])
 
       @subgroup12aa.reload
       @subgroup12a.reload

--- a/test/services/samples/transfer_service_test.rb
+++ b/test/services/samples/transfer_service_test.rb
@@ -123,35 +123,36 @@ module Samples
       @sample_transfer_params1 = { new_project_id: @project30.id,
                                    sample_ids: [@sample34.id, @sample35.id] }
 
-      Samples::TransferService.new(@project31, @john_doe).execute(@sample_transfer_params1[:new_project_id],
-                                                                  @sample_transfer_params1[:sample_ids])
-
-      @subgroup12a.reload
-      @subgroup12aa.reload
-      @subgroup12b.reload
-
-      assert_equal({}, @project31.namespace.metadata_summary)
-      assert_equal({}, @subgroup12aa.metadata_summary)
-      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.metadata_summary)
-      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project31.namespace.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12aa.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12b.metadata_summary)
       assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 },
                    @group12.metadata_summary)
+
+      assert_no_changes -> { @group12.reload.metadata_summary } do
+        Samples::TransferService.new(@project31, @john_doe).execute(@sample_transfer_params1[:new_project_id],
+                                                                    @sample_transfer_params1[:sample_ids])
+      end
+
+      assert_equal({}, @project31.namespace.reload.metadata_summary)
+      assert_equal({}, @subgroup12aa.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @subgroup12a.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12b.reload.metadata_summary)
 
       @sample_transfer_params2 = { new_project_id: @project29.id,
                                    sample_ids: [@sample33.id, @sample34.id, @sample35.id] }
 
-      Samples::TransferService.new(@project30, @john_doe).execute(@sample_transfer_params2[:new_project_id],
-                                                                  @sample_transfer_params2[:sample_ids])
+      assert_no_changes -> { @group12.reload.metadata_summary } do
+        Samples::TransferService.new(@project30, @john_doe).execute(@sample_transfer_params2[:new_project_id],
+                                                                    @sample_transfer_params2[:sample_ids])
+      end
 
-      @subgroup12aa.reload
-      @subgroup12a.reload
-      @subgroup12b.reload
-
-      assert_equal({}, @project30.namespace.metadata_summary)
-      assert_equal({}, @project31.namespace.metadata_summary)
-      assert_equal({}, @subgroup12b.metadata_summary)
-      assert_equal({}, @subgroup12aa.metadata_summary)
-      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.metadata_summary)
+      assert_equal({}, @project30.namespace.reload.metadata_summary)
+      assert_equal({}, @project31.namespace.reload.metadata_summary)
+      assert_equal({}, @subgroup12b.reload.metadata_summary)
+      assert_equal({}, @subgroup12aa.reload.metadata_summary)
+      assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @subgroup12a.reload.metadata_summary)
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
Note: Dependent and branched off of [PR 339](https://github.com/phac-nml/irida-next/pull/339)

This PR is the secondary part of the `metadata_summary` update and includes updating based on group/project/sample `transfers` and `deletion`.

When transferred or deleted, all namespaces  will be updated accordingly.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
In the Rails console, set up your metadata as described in [PR 339](https://github.com/phac-nml/irida-next/pull/339)

Using the website UI, transfer groups, projects, and samples and subsequently check in the console that both old and new parents/ancestors are updated accordingly. Ie: if a sample with `metadata = {'metadatafield1' => 'value1'}` is transferred, ensure its old parents have `metadata_summary['metadatafield1'] -= 1` and the new parents have `metadata_summary['metadatafield1'] += 1` 

Using the website UI, delete groups, projects, and samples and subsequently check in the console that itsparents/ancestors are updated accordingly. Ie: if a sample with `metadata = {'metadatafield1' => 'value1'}` is deleted, ensure its parents have `metadata_summary['metadatafield1'] -= 1` 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
