### PR TITLE
Attachments listing update

### DIFF
--- a/app/controllers/projects/samples/attachments/deletions_controller.rb
+++ b/app/controllers/projects/samples/attachments/deletions_controller.rb
@@ -8,7 +8,7 @@ module Projects
         respond_to :turbo_stream
 
         def new
-          authorize! @project, to: :update_sample?
+          authorize! @sample, to: :destroy_attachment?
           render turbo_stream: turbo_stream.update('sample_files_modal',
                                                    partial: 'modal',
                                                    locals: {
@@ -17,7 +17,7 @@ module Projects
         end
 
         def destroy # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-          authorize! @project, to: :update_sample?
+          authorize! @sample, to: :destroy_attachment?
 
           attachments_to_delete = get_attachments(deletion_params['attachment_ids'])
           attachments_to_delete_count = attachments_to_delete.count

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -39,7 +39,7 @@ module Projects
       end
 
       def destroy # rubocop:disable Metrics/MethodLength
-        authorize! @project, to: :update_sample?
+        authorize! @sample, to: :destroy_attachment?
 
         @destroyed_attachments = ::Attachments::DestroyService.new(@sample, @attachment, current_user).execute
         respond_to do |format|

--- a/app/policies/sample_policy.rb
+++ b/app/policies/sample_policy.rb
@@ -2,6 +2,15 @@
 
 # Policy samples authorization
 class SamplePolicy < ApplicationPolicy
+  def destroy_attachment?
+    project = Project.find(record.project_id)
+    return true if project.namespace.parent.user_namespace? && project.namespace.parent.owner == user
+    return true if Member.namespace_owners_include_user?(user, project.namespace) == true
+
+    details[:name] = record.name
+    false
+  end
+
   scope_for :relation, :group_samples do |relation, options|
     group = options[:group]
 

--- a/app/policies/sample_policy.rb
+++ b/app/policies/sample_policy.rb
@@ -2,10 +2,9 @@
 
 # Policy samples authorization
 class SamplePolicy < ApplicationPolicy
-  def destroy_attachment?
-    project = Project.find(record.project_id)
-    return true if project.namespace.parent.user_namespace? && project.namespace.parent.owner == user
-    return true if Member.namespace_owners_include_user?(user, project.namespace) == true
+  def destroy_attachment? # rubocop:disable Metrics/AbcSize
+    return true if record.project.namespace.parent.user_namespace? && record.project.namespace.parent.owner == user
+    return true if Member.namespace_owners_include_user?(user, record.project.namespace) == true
 
     details[:name] = record.name
     false

--- a/app/services/attachments/destroy_service.rb
+++ b/app/services/attachments/destroy_service.rb
@@ -11,7 +11,7 @@ module Attachments
     end
 
     def execute # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-      authorize! @attachable.project, to: :destroy?
+      authorize! @attachable.project, to: :destroy_sample?
       destroyed_attachments = []
       if @attachment.attachable_id != @attachable.id
         raise AttachmentsDestroyError, I18n.t('services.attachments.destroy.does_not_belong_to_attachable')

--- a/app/services/attachments/destroy_service.rb
+++ b/app/services/attachments/destroy_service.rb
@@ -11,7 +11,7 @@ module Attachments
     end
 
     def execute # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-      authorize! @attachable.project, to: :destroy_sample?
+      authorize! @attachable, to: :destroy_attachment?
       destroyed_attachments = []
       if @attachment.attachable_id != @attachable.id
         raise AttachmentsDestroyError, I18n.t('services.attachments.destroy.does_not_belong_to_attachable')

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -69,6 +69,7 @@
                     turbo: false
                   }
                 ) %>
+                <% if allowed_to?(:destroy_sample?, @project) %>
                   <%= dropdown.with_item(
                     label: t(:"projects.samples.index.remove_button"),
                     url: namespace_project_sample_path(id: sample.id),
@@ -77,6 +78,7 @@
                       turbo_confirm: t(:"projects.samples.index.remove_button_confirmation")
                     }
                   ) %>
+                <% end %>
               <% end %>
             </div>
           </td>

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -69,7 +69,6 @@
                     turbo: false
                   }
                 ) %>
-                <% if allowed_to?(:destroy_sample?, @project) %>
                   <%= dropdown.with_item(
                     label: t(:"projects.samples.index.remove_button"),
                     url: namespace_project_sample_path(id: sample.id),
@@ -78,7 +77,6 @@
                       turbo_confirm: t(:"projects.samples.index.remove_button_confirmation")
                     }
                   ) %>
-                <% end %>
               <% end %>
             </div>
           </td>

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -2,7 +2,7 @@
   id="<%= dom_id(attachment) %>"
   class="bg-white border-b dark:bg-slate-800 dark:border-slate-700"
 >
-  <% if allowed_to?(:update?, @project) %>
+  <% if allowed_to?(:update_sample?, @project) %>
     <td class="px-6 py-4">
       <%= check_box_tag "attachment_ids[]",
       (

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -99,7 +99,7 @@
   </td>
 
   <td class="px-6 py-4">
-    <% if allowed_to?(:destroy_sample?, @project) %>
+    <% if allowed_to?(:destroy_attachment?, @sample) %>
       <%= button_to(
         t(".delete"),
         namespace_project_sample_attachment_path(

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -99,7 +99,7 @@
   </td>
 
   <td class="px-6 py-4">
-    <% if allowed_to?(:update_sample?, @project) %>
+    <% if allowed_to?(:destroy_sample?, @project) %>
       <%= button_to(
         t(".delete"),
         namespace_project_sample_attachment_path(

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -2,25 +2,27 @@
   id="<%= dom_id(attachment) %>"
   class="bg-white border-b dark:bg-slate-800 dark:border-slate-700"
 >
-  <td class="px-6 py-4">
-    <%= check_box_tag "attachment_ids[]",
-    (
-      if attachment.associated_attachment
-        [attachment.id, attachment.associated_attachment.id].to_s
-      else
-        attachment.id
-      end
-    ),
-    nil,
-    id: dom_id(attachment.file, :file),
-    "aria-label": attachment.file.filename,
-    data: {
-      selection_target: "rowSelection",
-      action: "input->selection#toggle"
-    },
-    class:
-      "w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
-  </td>
+  <% if allowed_to?(:update?, @project) %>
+    <td class="px-6 py-4">
+      <%= check_box_tag "attachment_ids[]",
+      (
+        if attachment.associated_attachment
+          [attachment.id, attachment.associated_attachment.id].to_s
+        else
+          attachment.id
+        end
+      ),
+      nil,
+      id: dom_id(attachment.file, :file),
+      "aria-label": attachment.file.filename,
+      data: {
+        selection_target: "rowSelection",
+        action: "input->selection#toggle"
+      },
+      class:
+        "w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
+    </td>
+  <% end %>
   <% if attachment.associated_attachment && attachment.metadata['direction'] == 'forward' %>
     <td class="px-6 py-4">
       <div>

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -6,7 +6,7 @@
   >
     <thead class="text-slate-700 bg-slate-50 dark:bg-slate-900 dark:text-slate-400">
       <tr>
-        <% if allowed_to?(:update?, @project) %>
+        <% if allowed_to?(:update_sample?, @project) %>
           <th aria-hidden="true" class="px-6 py-3"></th>
         <% end %>
         <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.filename") %></th>

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -6,7 +6,9 @@
   >
     <thead class="text-slate-700 bg-slate-50 dark:bg-slate-900 dark:text-slate-400">
       <tr>
-        <th aria-hidden="true" class="px-6 py-3"></th>
+        <% if allowed_to?(:update?, @project) %>
+          <th aria-hidden="true" class="px-6 py-3"></th>
+        <% end %>
         <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.filename") %></th>
         <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.format") %></th>
         <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.type") %></th>

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -61,24 +61,11 @@
             turbo_frame: "sample_files_modal",
             turbo_stream: false,
             controller: "action-link",
-            action_link_required_value: 2
+            action_link_required_value: 1
           },
-          class: "button button--size-default button--state-default action-link" %>
+          class: "button button--size-default button--state-destructive action-link" %>
         <% end %>
       <%end%>
-      <% header.with_action do %>
-        <%= link_to t(".delete_files_button"),
-        new_namespace_project_sample_attachments_deletion_path(
-          sample_id: @sample.id
-        ),
-        data: {
-          turbo_frame: "sample_files_modal",
-          turbo_stream: false,
-          controller: "action-link",
-          action_link_required_value: 1
-        },
-        class: "button button--size-default button--state-destructive action-link" %>
-      <% end %>
     <% end %>
   <% else %>
     <% card.with_header(title: t("projects.samples.show.files")) %>

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -27,7 +27,7 @@
 <% end %>
 
 <%= viral_card do |card| %>
-  <% if allowed_to?(:update?, @project) %>
+  <% if allowed_to?(:update_sample?, @project) %>
     <% card.with_header(title: t("projects.samples.show.files")) do |header| %>
       <% header.with_action do %>
         <%= link_to t(".new_attachment_button"),

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -51,6 +51,21 @@
         },
         class: "button button--size-default button--state-default action-link" %>
       <% end %>
+      <% if allowed_to?(:destroy_attachment?, @sample) %>
+        <% header.with_action do %>
+          <%= link_to t(".delete_files_button"),
+          new_namespace_project_sample_attachments_deletion_path(
+            sample_id: @sample.id
+          ),
+          data: {
+            turbo_frame: "sample_files_modal",
+            turbo_stream: false,
+            controller: "action-link",
+            action_link_required_value: 2
+          },
+          class: "button button--size-default button--state-default action-link" %>
+        <% end %>
+      <%end%>
       <% header.with_action do %>
         <%= link_to t(".delete_files_button"),
         new_namespace_project_sample_attachments_deletion_path(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,7 +94,7 @@ en:
         create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace
       sample:
-        destroy_attachment?: You are not authorized to destroy attachments belonging to sample %{name}.
+        destroy_attachment?: You are not authorized to delete attachments belonging to sample %{name}.
       user:
         create?: You are not authorized to create a user on this server.
         destroy?: You are not authorized to remove user %{name} from this server.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,8 @@ en:
       namespaces/user_namespace:
         create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace
+      sample:
+        destroy_attachment?: You are not authorized to destroy attachments belonging to sample %{name}.
       user:
         create?: You are not authorized to create a user on this server.
         destroy?: You are not authorized to remove user %{name} from this server.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -94,6 +94,8 @@ fr:
       namespaces/user_namespace:
         create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace
+      sample:
+        destroy_attachment?: You are not authorized to destroy attachments belonging to sample %{name}.
       user:
         create?: You are not authorized to create a user on this server.
         destroy?: You are not authorized to remove user %{name} from this server.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -95,7 +95,7 @@ fr:
         create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace
       sample:
-        destroy_attachment?: You are not authorized to destroy attachments belonging to sample %{name}.
+        destroy_attachment?: You are not authorized to delete attachments belonging to sample %{name}.
       user:
         create?: You are not authorized to create a user on this server.
         destroy?: You are not authorized to remove user %{name} from this server.

--- a/test/controllers/projects/samples/attachments/deletions_controller_test.rb
+++ b/test/controllers/projects/samples/attachments/deletions_controller_test.rb
@@ -35,7 +35,7 @@ module Projects
           assert_response :unauthorized
         end
 
-        test 'should delete attachments for a member with role >= maintainer' do
+        test 'should delete attachments for a member with role == owner' do
           delete namespace_project_sample_attachments_deletion_path(@namespace, @project1, @sample1,
                                                                     format: :turbo_stream),
                  params: {
@@ -85,7 +85,7 @@ module Projects
           assert_response :unprocessable_entity
         end
 
-        test 'should not delete attachments for a non member' do
+        test 'should not delete attachments with role <= owner' do
           user = users(:micha_doe)
           login_as user
 

--- a/test/policies/sample_policy_test.rb
+++ b/test/policies/sample_policy_test.rb
@@ -14,12 +14,13 @@ class SamplePolicyTest < ActiveSupport::TestCase
   end
 
   test 'scope' do
-    policy = SamplePolicy.new(groups(:group_one), user: @user)
+    group_one = groups(:group_one)
+    policy = SamplePolicy.new(group_one, user: @user)
     scoped_samples = policy.apply_scope(Sample, type: :relation, name: :group_samples,
-                                                scope_options: { group: @group })
+                                                scope_options: { group: group_one })
 
     projects_samples_count = 0
-    group_self_and_descendants = @group.self_and_descendants
+    group_self_and_descendants = group_one.self_and_descendants
 
     # Sample counts from projects belonging to group and it's descendants
     group_self_and_descendants.each do |group|

--- a/test/policies/sample_policy_test.rb
+++ b/test/policies/sample_policy_test.rb
@@ -5,13 +5,18 @@ require 'test_helper'
 class SamplePolicyTest < ActiveSupport::TestCase
   def setup
     @user = users(:john_doe)
-    @group = groups(:group_one)
-    @policy = SamplePolicy.new(@group, user: @user)
+    @sample = samples(:sample1)
+    @policy = SamplePolicy.new(@sample, user: @user)
+  end
+
+  test '#destroy_attachment?' do
+    assert @policy.destroy_attachment?
   end
 
   test 'scope' do
-    scoped_samples = @policy.apply_scope(Sample, type: :relation, name: :group_samples,
-                                                 scope_options: { group: @group })
+    policy = SamplePolicy.new(groups(:group_one), user: @user)
+    scoped_samples = policy.apply_scope(Sample, type: :relation, name: :group_samples,
+                                                scope_options: { group: @group })
 
     projects_samples_count = 0
     group_self_and_descendants = @group.self_and_descendants

--- a/test/services/attachments/destroy_service_test.rb
+++ b/test/services/attachments/destroy_service_test.rb
@@ -26,9 +26,9 @@ module Attachments
       end
 
       assert_equal ProjectPolicy, exception.policy
-      assert_equal :destroy?, exception.rule
+      assert_equal :destroy_sample?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.project.destroy?', name: @sample.project.name),
+      assert_equal I18n.t(:'action_policy.policy.project.destroy_sample?', name: @sample.project.name),
                    exception.result.message
     end
 

--- a/test/services/attachments/destroy_service_test.rb
+++ b/test/services/attachments/destroy_service_test.rb
@@ -25,10 +25,10 @@ module Attachments
         Attachments::DestroyService.new(@sample, @attachment1, user).execute
       end
 
-      assert_equal ProjectPolicy, exception.policy
-      assert_equal :destroy_sample?, exception.rule
+      assert_equal SamplePolicy, exception.policy
+      assert_equal :destroy_attachment?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.project.destroy_sample?', name: @sample.project.name),
+      assert_equal I18n.t(:'action_policy.policy.sample.destroy_attachment?', name: @sample.name),
                    exception.result.message
     end
 

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -704,5 +704,21 @@ module Projects
       end
       assert_text I18n.t('projects.samples.attachments.deletions.destroy.success')
     end
+
+    test 'user should not see sample attachment delete buttons if they are non-owner' do
+      visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
+      assert_text I18n.t('projects.samples.show.delete_files_button'), count: 1
+      within %(turbo-frame[id="attachments"]) do
+        assert_selector 'table #attachments-table-body tr', count: 2
+        assert_text I18n.t('projects.samples.attachments.attachment.delete'), count: 2
+      end
+      login_as users(:ryan_doe)
+      visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
+      assert_text I18n.t('projects.samples.show.delete_files_button'), count: 0
+      within %(turbo-frame[id="attachments"]) do
+        assert_selector 'table #attachments-table-body tr', count: 2
+        assert_text I18n.t('projects.samples.attachments.attachment.delete'), count: 0
+      end
+    end
   end
 end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -723,5 +723,20 @@ module Projects
         assert_text I18n.t('projects.samples.attachments.attachment.delete'), count: 0
       end
     end
+
+    test 'user with role >= Maintainer can see attachment checkboxes' do
+      visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
+      within %(turbo-frame[id="attachments"]) do
+        assert_selector 'table #attachments-table-body input[type=checkbox]', count: 2
+      end
+    end
+
+    test 'user with role < Maintainer should not see checkboxes' do
+      login_as users(:ryan_doe)
+      visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
+      within %(turbo-frame[id="attachments"]) do
+        assert_selector 'table #attachments-table-body input[type=checkbox]', count: 0
+      end
+    end
   end
 end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -705,13 +705,16 @@ module Projects
       assert_text I18n.t('projects.samples.attachments.deletions.destroy.success')
     end
 
-    test 'user should not see sample attachment delete buttons if they are non-owner' do
+    test 'user can see delete buttons as owner' do
       visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
       assert_text I18n.t('projects.samples.show.delete_files_button'), count: 1
       within %(turbo-frame[id="attachments"]) do
         assert_selector 'table #attachments-table-body tr', count: 2
         assert_text I18n.t('projects.samples.attachments.attachment.delete'), count: 2
       end
+    end
+
+    test 'user should not see sample attachment delete buttons if they are non-owner' do
       login_as users(:ryan_doe)
       visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
       assert_text I18n.t('projects.samples.show.delete_files_button'), count: 0


### PR DESCRIPTION
## What does this PR do and why?
This PR prevents non-owners of samples to delete attachments by hiding the `Delete` button in the row under the `Action` header, as well as the `Delete Files` button alongside the `Upload/Concatenate Files` buttons, which is used to delete multiple attachments.

The buttons are hidden under the `sample destroy_attachment?` policy. The `Attachments::DestroyService` and `attachments deletions_controller` have been updated with the same policy.

## Screenshots or screen recordings
Non-Owner:
![image](https://github.com/phac-nml/irida-next/assets/82407232/b53d23d3-0c64-499f-a8fa-451d518d5597)

Owner:
![image](https://github.com/phac-nml/irida-next/assets/82407232/99dadc4f-901d-4ed9-9a1e-c91bfc5e96aa)


## How to set up and validate locally
Login as both an owner and non-owner of a sample with attachments, navigate to the attachments page and you can either see or not see the Delete buttons based on the access level.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
