### PR TITLE
Workflow Executions: Update WES Params

### DIFF
--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -36,7 +36,6 @@
       <%= workflow.hidden_field :workflow_url, value: @workflow.url %>
 
       <%= workflow.fields_for "workflow_engine_parameters" do |engine| %>
-        <%= engine.hidden_field :engine, value: @workflow.engine %>
         <%= engine.hidden_field :execute_loc, value: @workflow.execute_loc %>
       <% end %>
 

--- a/app/controllers/workflow_executions/submissions_controller.rb
+++ b/app/controllers/workflow_executions/submissions_controller.rb
@@ -24,7 +24,7 @@ module WorkflowExecutions
                             :engine_version, :url, :execute_loc)
       metadata = { workflow_name: 'irida-next-example', workflow_version: '1.0dev' }
       @workflow = workflow.new('phac-nml/iridanextexample', 1, 'IRIDA Next Example Pipeline', '1.0.1', metadata,
-                               'DSL2', '22.10.7', 'nextflow', '',
+                               'NFL', 'DSL2', 'nextflow', '23.10.0',
                                'https://github.com/phac-nml/iridanextexample', 'azure')
     end
 

--- a/app/services/workflow_executions/preparation_service.rb
+++ b/app/services/workflow_executions/preparation_service.rb
@@ -30,8 +30,7 @@ module WorkflowExecutions
       @workflow_execution.workflow_params = @workflow_execution.workflow_params.merge(
         {
           '--input': blob_key_to_service_path(samplesheet_key),
-          '--outdir': blob_key_to_service_path(generate_input_key('output')),
-          '--validate-params': 'false' # This is real bad and only present due to this issue https://github.com/nextflow-io/nf-validation/issues/130
+          '--outdir': blob_key_to_service_path(generate_input_key('output'))
         }
       )
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Remove `--validate-params` which is no longer required in nextflow 23.10.0
Remove `workflow_engine_params -> engine` as `workflow_engine` is now being used
Update `workflow_type`, `workflow_type_version`, and `workflow_engine_version` to match our WES implementation

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
