### PR TITLE
Add updated_at field to metadata_provenance

### DIFF
--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -25,9 +25,10 @@ module Samples
 
         transform_metadata_keys
 
-        perform_metadata_update
-
-        @sample.save
+        @sample.with_lock do
+          perform_metadata_update
+          @sample.save
+        end
 
         update_metadata_summary
 

--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -83,7 +83,11 @@ module Samples
         else
           @sample.metadata.key?(key) ? @metadata_changes[:updated] << key : @metadata_changes[:added] << key
           @sample.metadata_provenance[key] =
-            @analysis_id.nil? ? { source: 'user', id: current_user.id } : { source: 'analysis', id: @analysis_id }
+            if @analysis_id.nil?
+              { source: 'user', id: current_user.id, updated_at: Time.current }
+            else
+              { source: 'analysis', id: @analysis_id, updated_at: Time.current }
+            end
           @sample.metadata[key] = value
         end
       end

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -82,21 +82,25 @@ sample32:
   description: Sample 32 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:project29) %>
   metadata: { 'metadatafield1': 'value1', 'metadatafield2': 'value2' }
-  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'user' }, 'metadatafield2': { 'id': 1, 'source': 'user' } }
+  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+  'metadatafield2': { 'id': 1, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
 
 sample33:
   name: Sample33
   description: Sample 33 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:project30) %>
   metadata: { 'metadatafield1': 'value1', 'metadatafield2': 'value2' }
-  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'user' }, 'metadatafield2': { 'id': 1, 'source': 'user' } }
+  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+  'metadatafield2': { 'id': 1, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
 
 sample34:
   name: Sample 34
   description: Sample 34 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:project31) %>
   metadata: { 'metadatafield1': 'value1', 'metadatafield2': 'value2' }
-  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'analysis' }, 'metadatafield2': { 'id': 1, 'source': 'analysis' } }
+  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'analysis',
+  'updated_at': <%= DateTime.new(2000,1,1) %> },
+  'metadatafield2': { 'id': 1, 'source': 'analysis', 'updated_at': <%= DateTime.new(2000,1,1) %> }}
 
 sample35:
   name: Sample 35

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -21,11 +21,12 @@ module Samples
       end
 
       test 'add metadata to sample containing no existing metadata by user' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' } }
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample35, @user, params).execute
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample35.metadata)
-        assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user' },
-                       'metadatafield2' => { 'id' => @user.id, 'source' => 'user' } },
+        assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current },
+                       'metadatafield2' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current } },
                      @sample35.metadata_provenance)
         assert_equal({ added: %w[metadatafield1 metadatafield2], updated: [], deleted: [],
                        not_updated: [] }, metadata_changes)
@@ -39,12 +40,13 @@ module Samples
       end
 
       test 'add metadata to sample containing no existing metadata by analysis' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, 'analysis_id' => 2 }
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample35, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample35.metadata)
-        assert_equal({ 'metadatafield1' => { 'id' => 2, 'source' => 'analysis' },
-                       'metadatafield2' => { 'id' => 2, 'source' => 'analysis' } },
+        assert_equal({ 'metadatafield1' => { 'id' => 2, 'source' => 'analysis', 'updated_at' => Time.current },
+                       'metadatafield2' => { 'id' => 2, 'source' => 'analysis', 'updated_at' => Time.current } },
                      @sample35.metadata_provenance)
         assert_equal({ added: %w[metadatafield1 metadatafield2], updated: [], deleted: [],
                        not_updated: [] }, metadata_changes)
@@ -59,14 +61,16 @@ module Samples
       end
 
       test 'update sample metadata merge with new metadata and analysis overwritting user' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' }, 'analysis_id' => 10 }
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
                      @sample33.metadata)
-        assert_equal({ 'metadatafield1' => { 'id' => 10, 'source' => 'analysis' },
-                       'metadatafield2' => { 'id' => 1, 'source' => 'user' },
-                       'metadatafield3' => { 'id' => 10, 'source' => 'analysis' } },
+        assert_equal({ 'metadatafield1' => { 'id' => 10, 'source' => 'analysis', 'updated_at' => Time.current },
+                       'metadatafield2' => { 'id' => 1, 'source' => 'user',
+                                             'updated_at' => '2000-01-01T00:00:00.000+00:00' },
+                       'metadatafield3' => { 'id' => 10, 'source' => 'analysis', 'updated_at' => Time.current } },
                      @sample33.metadata_provenance)
         assert_equal({ added: %w[metadatafield3], updated: %w[metadatafield1], deleted: [],
                        not_updated: [] }, metadata_changes)
@@ -82,14 +86,16 @@ module Samples
       end
 
       test 'update sample metadata merge with new metadata and user overwritting user' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value4', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
                      @sample33.metadata)
-        assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user' },
-                       'metadatafield2' => { 'id' => 1, 'source' => 'user' },
-                       'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } },
+        assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current },
+                       'metadatafield2' => { 'id' => 1, 'source' => 'user',
+                                             'updated_at' => '2000-01-01T00:00:00.000+00:00' },
+                       'metadatafield3' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current } },
                      @sample33.metadata_provenance)
         assert_equal({ added: %w[metadatafield3], updated: %w[metadatafield1], deleted: [],
                        not_updated: [] }, metadata_changes)
@@ -105,14 +111,17 @@ module Samples
       end
 
       test 'update sample metadata merge with new metadata and user unable to overwrite analysis' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value4', 'metadatafield3' => 'value3' } }
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2', 'metadatafield3' => 'value3' },
                      @sample34.metadata)
-        assert_equal({ 'metadatafield1' => { 'id' => 1, 'source' => 'analysis' },
-                       'metadatafield2' => { 'id' => 1, 'source' => 'analysis' },
-                       'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } },
+        assert_equal({ 'metadatafield1' => { 'id' => 1, 'source' => 'analysis',
+                                             'updated_at' => '2000-01-01T00:00:00.000+00:00' },
+                       'metadatafield2' => { 'id' => 1, 'source' => 'analysis',
+                                             'updated_at' => '2000-01-01T00:00:00.000+00:00' },
+                       'metadatafield3' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current } },
                      @sample34.metadata_provenance)
         assert_equal({ added: %w[metadatafield3], updated: [], deleted: [],
                        not_updated: %w[metadatafield1] }, metadata_changes)
@@ -140,7 +149,10 @@ module Samples
         metadata_changes = Samples::Metadata::UpdateService.new(@project31, @sample34, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1' }, @sample34.metadata)
-        assert_equal({ 'metadatafield1' => { 'id' => 1, 'source' => 'analysis' } }, @sample34.metadata_provenance)
+        assert_equal(
+          { 'metadatafield1' => { 'id' => 1, 'source' => 'analysis',
+                                  'updated_at' => '2000-01-01T00:00:00.000+00:00' } }, @sample34.metadata_provenance
+        )
         assert_equal({ added: [], updated: [], deleted: %w[metadatafield2], not_updated: [] }, metadata_changes)
 
         @subgroup12aa.reload
@@ -161,7 +173,10 @@ module Samples
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'value2' }, @sample33.metadata)
-        assert_equal({ 'metadatafield2' => { 'id' => 1, 'source' => 'user' } }, @sample33.metadata_provenance)
+        assert_equal(
+          { 'metadatafield2' => { 'id' => 1, 'source' => 'user',
+                                  'updated_at' => '2000-01-01T00:00:00.000+00:00' } }, @sample33.metadata_provenance
+        )
         assert_equal({ added: [], updated: [], deleted: %w[metadatafield1], not_updated: [] }, metadata_changes)
 
         @subgroup12b.reload
@@ -175,14 +190,16 @@ module Samples
       end
 
       test 'add, update, and remove metadata in same request to mimic batch update request with analysis' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield1' => '', 'metadatafield2' => 'newvalue2',
                                    'metadatafield3' => 'value3' }, 'analysis_id' => 1 }
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'newvalue2', 'metadatafield3' => 'value3' }, @sample33.metadata)
         assert_equal(
-          { 'metadatafield2' => { 'id' => 1, 'source' => 'analysis' },
-            'metadatafield3' => { 'id' => 1, 'source' => 'analysis' } }, @sample33.metadata_provenance
+          { 'metadatafield2' => { 'id' => 1, 'source' => 'analysis', 'updated_at' => Time.current },
+            'metadatafield3' => { 'id' => 1, 'source' => 'analysis',
+                                  'updated_at' => Time.current } }, @sample33.metadata_provenance
         )
         assert_equal(
           { added: %w[metadatafield3], updated: %w[metadatafield2], deleted: %w[metadatafield1],
@@ -200,14 +217,16 @@ module Samples
       end
 
       test 'add, update, and remove metadata in same request to mimic batch update with user' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield1' => '', 'metadatafield2' => 'newvalue2',
                                    'metadatafield3' => 'value3' } }
         metadata_changes = Samples::Metadata::UpdateService.new(@project30, @sample33, @user, params).execute
 
         assert_equal({ 'metadatafield2' => 'newvalue2', 'metadatafield3' => 'value3' }, @sample33.metadata)
         assert_equal(
-          { 'metadatafield2' => { 'id' => @user.id, 'source' => 'user' },
-            'metadatafield3' => { 'id' => @user.id, 'source' => 'user' } }, @sample33.metadata_provenance
+          { 'metadatafield2' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current },
+            'metadatafield3' => { 'id' => @user.id, 'source' => 'user',
+                                  'updated_at' => Time.current } }, @sample33.metadata_provenance
         )
         assert_equal(
           { added: %w[metadatafield3], updated: %w[metadatafield2], deleted: %w[metadatafield1],
@@ -341,6 +360,7 @@ module Samples
       end
 
       test 'user namespace metadata summary does not update' do
+        freeze_time
         params = { 'metadata' => { 'metadatafield4' => 'value4' } }
         project = projects(:john_doe_project2)
         sample = samples(:sample24)
@@ -351,7 +371,8 @@ module Samples
         end
 
         assert_equal({ 'metadatafield4' => 'value4' }, sample.metadata)
-        assert_equal({ 'metadatafield4' => { 'id' => @user.id, 'source' => 'user' } }, sample.metadata_provenance)
+        assert_equal({ 'metadatafield4' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current } },
+                     sample.metadata_provenance)
         assert_equal({ 'metadatafield4' => 1 }, project.namespace.metadata_summary)
       end
     end


### PR DESCRIPTION
## What does this PR do and why?
This PR updates the `Sample::Metadata::UpdateService` to include an `updated_at` field in `sample.metadata_provenance` with a timestamp when that metadata field was updated.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
Repeat the steps from [PR 311](https://github.com/phac-nml/irida-next/pull/311), and ensure when adding metadata, `sample.metadata_provenance['updated_at'] = Time.current` 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
