### PR TITLE
GraphQL: Add token to context for Policy checking

### DIFF
--- a/app/controllers/concerns/sessionless_authentication.rb
+++ b/app/controllers/concerns/sessionless_authentication.rb
@@ -9,16 +9,20 @@ module SessionlessAuthentication
     user = User.find_by(email: username)
     return unless user
 
-    pat = user.personal_access_tokens.find_by_token(access_token) # rubocop:disable Rails/DynamicFindBy
-    return unless pat&.active?
+    @token = user.personal_access_tokens.find_by_token(access_token) # rubocop:disable Rails/DynamicFindBy
+    return unless token&.active?
 
-    pat.touch(:last_used_at) # rubocop:disable Rails/SkipsModelValidations
+    token.touch(:last_used_at) # rubocop:disable Rails/SkipsModelValidations
 
     sessionless_sign_in(user)
   end
 
   def sessionless_sign_in(user)
     sign_in(user, store: false)
+  end
+
+  def token
+    @token
   end
 
   private
@@ -41,7 +45,7 @@ module SessionlessAuthentication
   end
 
   def decode_basic_credentials_token(encoded_header)
-    Base64.decode64(encoded_header).split(/:/, 2).last
+    Base64.decode64(encoded_header).split(':', 2).last
   end
 
   def username_from_basic_header(header, pattern)
@@ -50,7 +54,7 @@ module SessionlessAuthentication
   end
 
   def decode_basic_credentials_username(encoded_header)
-    Base64.decode64(encoded_header).split(/:/, 2).first
+    Base64.decode64(encoded_header).split(':', 2).first
   end
 
   def base64?(value)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -31,7 +31,7 @@ class GraphqlController < ApplicationController
   end
 
   def context
-    @context ||= { current_user: }
+    @context ||= { current_user:, token: }
   end
 
   private

--- a/app/graphql/types/group_type.rb
+++ b/app/graphql/types/group_type.rb
@@ -19,7 +19,7 @@ module Types
         allowed_to?(
           :read?,
           object,
-          context: { user: context[:current_user] }
+          context: { user: context[:current_user], token: context[:token] }
         )
     end
   end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -9,6 +9,7 @@ module Types
     field :test_field, String, null: false,
                                description: 'An example field added by the generator'
     def test_field
+      authorize!(to: :mutate?, with: GraphqlPolicy, context: { user: context[:current_user], token: context[:token] })
       'Hello World'
     end
   end

--- a/app/graphql/types/namespace_type.rb
+++ b/app/graphql/types/namespace_type.rb
@@ -23,7 +23,7 @@ module Types
         allowed_to?(
           :read?,
           object,
-          context: { user: context[:current_user] }
+          context: { user: context[:current_user], token: context[:token] }
         )
     end
   end

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -26,7 +26,7 @@ module Types
         allowed_to?(
           :read?,
           object,
-          context: { user: context[:current_user] }
+          context: { user: context[:current_user], token: context[:token] }
         )
     end
   end

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -15,7 +15,7 @@ module Types
         allowed_to?(
           :read_sample?,
           object.project,
-          context: { user: context[:current_user] }
+          context: { user: context[:current_user], token: context[:token] }
         )
     end
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,6 +8,7 @@ class ApplicationPolicy < ActionPolicy::Base
   #   authorize :account, optional: true
   #
   # Read more about authorization context: https://actionpolicy.evilmartians.io/#/authorization_context
+  authorize :token, optional: true
 
   # Define shared methods useful for most policies.
   # For example:

--- a/app/policies/graphql_policy.rb
+++ b/app/policies/graphql_policy.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
-# Policy for groups authorization
+# Policy for graphql authorization
 class GraphqlPolicy < ApplicationPolicy
-  authorize :token
+  # nil is allowed as a user accessing the api through graphiql while logged into the website would not have a token
+  authorize :token, allow_nil: true
 
   def query?
-    return true if token&.scopes&.include?(:api) || token&.scopes&.include?(:read_api)
+    return true if token&.scopes&.any? { |scope| %w[api read_api].include? scope }
+    return true if token.nil? && !user.nil? # allow users with a session to query the api
 
     false
   end
 
   def mutate?
-    return true if token&.scopes&.include?(:api)
+    return true if token&.scopes&.include?('api')
+    return true if token.nil? && !user.nil? # allow users with a session to mutate the api
 
     false
   end

--- a/app/policies/graphql_policy.rb
+++ b/app/policies/graphql_policy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Policy for groups authorization
+class GraphqlPolicy < ApplicationPolicy
+  authorize :token
+
+  def query?
+    return true if token&.scopes&.include?(:api) || token&.scopes&.include?(:read_api)
+
+    false
+  end
+
+  def mutate?
+    return true if token&.scopes&.include?(:api)
+
+    false
+  end
+end

--- a/test/fixtures/personal_access_tokens.yml
+++ b/test/fixtures/personal_access_tokens.yml
@@ -30,6 +30,16 @@ john_doe_valid_pat:
   token_digest: <%= Devise.token_generator.digest(PersonalAccessToken, :token_digest, "JQ2w5maQc4zgvC8GGMEp") %>
   last_used_at: nil
 
+john_doe_valid_read_pat:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  scopes:
+    - read_api
+  name: Valid PAT
+  revoked: false
+  expires_at: <%= 10.days.from_now.to_date %>
+  token_digest: <%= Devise.token_generator.digest(PersonalAccessToken, :token_digest, "X83wwK3sWCjn4xdCyZtH") %>
+  last_used_at: nil
+
 john_doe_non_expirable_pat:
   user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   scopes:

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,7 +27,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '#personal_access_tokens' do
-    assert_equal 4, @user.personal_access_tokens.size
+    assert_equal 5, @user.personal_access_tokens.size
   end
 
   test '#destroy removes dependant user namespace, and projects' do

--- a/test/policies/graphql_policy_test.rb
+++ b/test/policies/graphql_policy_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GraphqlPolicyTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:john_doe)
+    @api_scope_token = personal_access_tokens(:john_doe_valid_pat)
+    @read_api_scope_token = personal_access_tokens(:john_doe_valid_read_pat)
+    @policy_with_api_scope_token = GraphqlPolicy.new(user: @user, token: @api_scope_token)
+    @policy_with_read_api_scope_token = GraphqlPolicy.new(user: @user, token: @read_api_scope_token)
+    @policy_without_token = GraphqlPolicy.new(user: @user, token: nil)
+  end
+
+  test '#query? when token has api scope' do
+    assert @policy_with_api_scope_token.query?
+  end
+
+  test '#mutate? when token has api scope' do
+    assert @policy_with_api_scope_token.mutate?
+  end
+
+  test '#query? when token has read api scope' do
+    assert @policy_with_read_api_scope_token.query?
+  end
+
+  test '#mutate? when token has read api scope' do
+    assert_not @policy_with_read_api_scope_token.mutate?
+  end
+
+  test '#query? when nil token' do
+    assert @policy_without_token.query?
+  end
+
+  test '#mutate? when nil token' do
+    assert @policy_without_token.mutate?
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This updates the ApplicationPolicy to have an optional `token` in the context, this can be used to determine if access is via the API and then the `scopes` of the `token` can be checked to ensure the attempted operation is allowed with that token.

Note: I did not update all the policy methods to check token and scope before proceeding with verifying rest of access, this will still need to be done. This might be solved by calling `query?` and `mutate?` methods from the new `GraphqlPolicy`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
