### PR TITLE
Add freeze_time to time_ago tests

### DIFF
--- a/test/components/viral/system/time_ago_component_test.rb
+++ b/test/components/viral/system/time_ago_component_test.rb
@@ -5,6 +5,7 @@ require 'application_system_test_case'
 module System
   class TimeAgoComponentTest < ApplicationSystemTestCase
     test 'default tooltip' do
+      freeze_time
       visit('/rails/view_components/viral_time_ago_component/default')
       assert_text '15 days ago'
       within('.Viral-Preview > [data-controller-connected="true"]') do
@@ -16,6 +17,7 @@ module System
     end
 
     test 'current time input tooltip' do
+      freeze_time
       visit('/rails/view_components/viral_time_ago_component/current_time_input')
       assert_text '5 days ago'
       within('.Viral-Preview > [data-controller-connected="true"]') do


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes the `viral_time_ago` tests where they would fail if the snapshot in time at the beginning of the test and by the time the system hovered and `assert_text` the hover time text was off (presumably the test started at ~59s, and the hover occurred in the new minute).

Adding `freeze_time` should remove this variability and eliminate the 'unlucky' failures.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
