### PR TITLE
GraphQL: Sample Metadata Field Query

### DIFF
--- a/app/graphql/resolvers/sample_metadata_resolver.rb
+++ b/app/graphql/resolvers/sample_metadata_resolver.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Resolvers
+  # Sample Metadata Resolver
+  class SampleMetadataResolver < BaseResolver
+    type GraphQL::Types::JSON, null: false
+
+    alias sample object
+
+    def resolve
+      scope = sample
+      scope.metadata
+    end
+  end
+end

--- a/app/graphql/resolvers/sample_metadata_resolver.rb
+++ b/app/graphql/resolvers/sample_metadata_resolver.rb
@@ -5,11 +5,19 @@ module Resolvers
   class SampleMetadataResolver < BaseResolver
     type GraphQL::Types::JSON, null: false
 
+    argument :keys, [GraphQL::Types::String],
+             required: false,
+             description: 'Optional array of keys to limit metadata result to.',
+             default_value: nil
+
     alias sample object
 
-    def resolve
+    def resolve(args)
       scope = sample
-      scope.metadata
+
+      return scope.metadata unless args[:keys]
+
+      scope.metadata.slice(*args[:keys])
     end
   end
 end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -560,7 +560,12 @@ type Sample implements Node {
   """
   Metadata for the sample
   """
-  metadata: JSON!
+  metadata(
+    """
+    Optional array of keys to limit metadata result to.
+    """
+    keys: [String!] = null
+  ): JSON!
 
   """
   Name of the sample.

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -184,6 +184,11 @@ type GroupEdge {
 }
 
 """
+Represents untyped JSON
+"""
+scalar JSON
+
+"""
 The mutation root of this schema
 """
 type Mutation {
@@ -551,6 +556,11 @@ type Sample implements Node {
   ID of the object.
   """
   id: ID!
+
+  """
+  Metadata for the sample
+  """
+  metadata: JSON!
 
   """
   Name of the sample.

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -10,6 +10,12 @@ module Types
     field :name, String, null: false, description: 'Name of the sample.'
     field :project, ProjectType, null: false, description: 'Project the sample is on.'
 
+    field :metadata,
+          GraphQL::Types::JSON,
+          null: false,
+          description: 'Metadata for the sample',
+          resolver: Resolvers::SampleMetadataResolver
+
     def self.authorized?(object, context)
       super &&
         allowed_to?(

--- a/test/graphql/samples_query_test.rb
+++ b/test/graphql/samples_query_test.rb
@@ -32,6 +32,19 @@ class SamplesQueryTest < ActiveSupport::TestCase
     }
   GRAPHQL
 
+  SAMPLE_AND_LIMITED_METADATA_QUERY = <<~GRAPHQL
+    query($sample_id: ID!, $keys: [String!]) {
+      sample: node(id: $sample_id) {
+        ... on Sample {
+          name
+          description
+          id
+          metadata(keys: $keys)
+        }
+      }
+    }
+  GRAPHQL
+
   def setup
     @user = users(:john_doe)
     @sample = samples(:sample1)
@@ -60,5 +73,22 @@ class SamplesQueryTest < ActiveSupport::TestCase
 
     assert_not_empty data, 'sample type should work'
     assert_equal @sample32.metadata, data['metadata']
+    assert data['metadata'].key?('metadatafield1')
+    assert data['metadata'].key?('metadatafield2')
+  end
+
+  test 'sample and metadata fields query should be able to limit to a specific set of keys' do
+    result = IridaSchema.execute(SAMPLE_AND_LIMITED_METADATA_QUERY,
+                                 context: { current_user: @user },
+                                 variables: { sample_id: @sample32.to_global_id.to_s, keys: ['metadatafield1'] })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['sample']
+
+    assert_not_empty data, 'sample type should work'
+    assert_not_equal @sample32.metadata, data['metadata']
+    assert data['metadata'].key?('metadatafield1')
+    assert_not data['metadata'].key?('metadatafield2')
   end
 end

--- a/test/graphql/samples_query_test.rb
+++ b/test/graphql/samples_query_test.rb
@@ -19,8 +19,23 @@ class SamplesQueryTest < ActiveSupport::TestCase
     }
   GRAPHQL
 
+  SAMPLE_AND_METADATA_QUERY = <<~GRAPHQL
+    query($sample_id: ID!) {
+      sample: node(id: $sample_id) {
+        ... on Sample {
+          name
+          description
+          id
+          metadata
+        }
+      }
+    }
+  GRAPHQL
+
   def setup
     @user = users(:john_doe)
+    @sample = samples(:sample1)
+    @sample32 = samples(:sample32)
   end
 
   test 'samples query should work' do
@@ -33,5 +48,17 @@ class SamplesQueryTest < ActiveSupport::TestCase
 
     assert_not_empty data, 'samples type should work'
     assert_not_empty data['nodes']
+  end
+
+  test 'sample and metadata fields query should work' do
+    result = IridaSchema.execute(SAMPLE_AND_METADATA_QUERY, context: { current_user: @user },
+                                                            variables: { sample_id: @sample32.to_global_id.to_s })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['sample']
+
+    assert_not_empty data, 'sample type should work'
+    assert_equal @sample32.metadata, data['metadata']
   end
 end

--- a/test/graphql/samples_query_test.rb
+++ b/test/graphql/samples_query_test.rb
@@ -91,4 +91,20 @@ class SamplesQueryTest < ActiveSupport::TestCase
     assert data['metadata'].key?('metadatafield1')
     assert_not data['metadata'].key?('metadatafield2')
   end
+
+  test 'sample and metadata fields query with non-existing keys should return empty metadata hash' do
+    result = IridaSchema.execute(SAMPLE_AND_LIMITED_METADATA_QUERY,
+                                 context: { current_user: @user },
+                                 variables: { sample_id: @sample32.to_global_id.to_s, keys: ['nometadatafield'] })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['sample']
+
+    assert_not_empty data, 'sample type should work'
+    assert_not_equal @sample32.metadata, data['metadata']
+    assert_not data['metadata'].key?('metadatafield1')
+    assert_not data['metadata'].key?('metadatafield2')
+    assert_empty data['metadata']
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates SampleType in the GraphQL API to include a Metadata field, to access the metadata associated with a Sample.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

To test out this GraphQL query you need to first add metadata to a Sample, since there is no method to do this through the UI currently you will have to use the rails console directly.

Setting up required data:
1. Create a new Project under a Users namespace (e.g. user1@email.com), called `metadata-test`.
2. Create a new Sample in the newly created Project called `sample1`.
3. Launch the rails console and assign the following variables `sample`, `project` using the commands below:
```
project = Project.last
sample = project1.samples.last
user = User.find_by(email: 'user1@email.com')
```
4. Add metadata to the sample:
```
params = { 'metadata' => { 'metadatafield1' => 'value1', 'metadatafield2' => 'value2'}}
Samples::Metadata::UpdateService.new(project, sample, user, params).execute
```

Testing GraphQL SampleType Metadata Field:
1. Navigate to the graphiql interface normally at `localhost:3000/graphiql`
2. Run the following query to get all metadata for the first and only sample in the project that you created above.
```
query viewProjectSampleMetadata {
  project(fullPath: "user1_at_email.com/metadata-test") {
    fullName
    fullPath
    id
    name
    path
    samples(first: 1) {
      totalCount
      nodes {
        id
        name
        metadata
      }
    }
  }
}
```
3. Verify that you see all the metadata for the sample that was added above.
4. Run the following query to get a subset of the metadata for the first and only sample in the project that you created above.
```
query viewProjectSampleSubsettedMetadata {
  project(fullPath: "user1_at_email.com/metadata-test") {
    fullName
    fullPath
    id
    name
    path
    samples(first: 1) {
      totalCount
      nodes {
        id
        name
        metadata(keys: ['metadatafield1'])
      }
    }
  }
}
```
5. Verify that you only see the metadata for field `metadatafield1`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
