### PR TITLE
Sample delete fix

### DIFF
--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -14,7 +14,7 @@
       <% if allowed_to?(:destroy?, @project) %>
         <%= link_to(
           t("projects.samples.show.remove_button"),
-          namespace_project_sample_path(id: @sample.id),
+          namespace_project_sample_path(id: @sample.id, format: :html),
           data: {
             turbo_method: :delete,
             turbo_confirm: t("projects.samples.show.remove_button_confirmation")

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -179,10 +179,35 @@ module Projects
       end
     end
 
-    test 'should destroy Sample' do
+    test 'should destroy Sample from sample show page' do
       visit namespace_project_sample_url(namespace_id: @namespace.path, project_id: @project.path, id: @sample1.id)
       assert_selector 'a', text: I18n.t('projects.samples.index.remove_button'), count: 1
       click_link I18n.t(:'projects.samples.index.remove_button')
+
+      within('#turbo-confirm[open]') do
+        click_button I18n.t(:'components.confirmation.confirm')
+      end
+
+      assert_text I18n.t('projects.samples.destroy.success', sample_name: @sample1.name,
+                                                             project_name: @project.namespace.human_name)
+
+      assert_no_selector 'table#samples-table tbody tr', text: @sample1.name
+      assert_selector 'h1', text: I18n.t(:'projects.samples.index.title'), count: 1
+      assert_selector 'table#samples-table tbody tr', count: 2
+      within first('tbody tr td:nth-child(2)') do
+        assert_text @sample2.name
+      end
+    end
+
+    test 'should destroy Sample from sample listing page' do
+      visit namespace_project_samples_url(@namespace, @project)
+
+      table_row = find(:table_row, { 'Sample' => @sample1.name })
+
+      within table_row do
+        first('button.Viral-Dropdown--icon').click
+        click_link 'Remove'
+      end
 
       within('#turbo-confirm[open]') do
         click_button I18n.t(:'components.confirmation.confirm')


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes a bug on the samples table UI which would cause the page to just display a loading skeleton after a sample from deleted using the `actions` dropdown for a sample in the table.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Login as any user
2. Create a project and a few samples
3. Delete a sample from the table using the sample's action dropdown in the table
4. The sample should get removed (verify in the UI and the server log), and a flash message should display advising you that the sample was deleted
5. Now go to the show page of another sample in the project
6. Click the `Remove` button 
7. Verify that you are redirected to the samples page for the project, the sample is removed from the table (verify in UI and server log), and a flash message should display advising you that the sample was deleted

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
