### PR TITLE
Group Samples Table Performance Speedups

### DIFF
--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -30,7 +30,9 @@ module Groups
     end
 
     def authorized_samples
-      authorized_scope(Sample, type: :relation, as: :group_samples, scope_options: { group: @group })
+      authorized_scope(Sample, type: :relation, as: :group_samples,
+                               scope_options: { group: @group }).includes(project: { namespace: [{ parent: :route },
+                                                                                                 :route] })
     end
 
     def context_crumbs

--- a/app/models/concerns/routable.rb
+++ b/app/models/concerns/routable.rb
@@ -42,11 +42,7 @@ module Routable
   end
 
   def full_path
-    if route&.persisted? && route&.invalid?
-      route.reload.path
-    else
-      (route&.path || build_full_path)
-    end
+    (route&.path || build_full_path)
   end
 
   def abbreviated_path

--- a/app/views/groups/_edit_advanced_delete.html.erb
+++ b/app/views/groups/_edit_advanced_delete.html.erb
@@ -6,7 +6,7 @@
     </p>
     <div class="mt-4">
       <%= link_to t(:"groups.edit.advanced.delete.submit"),
-      group_path(group),
+      group_path,
       data: {
         turbo_method: :delete,
         turbo_confirm: t(:"groups.edit.advanced.delete.confirm")

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -1,7 +1,7 @@
 <%= viral_card do |card| %>
   <% card.with_header(title: t(:"groups.edit.advanced.path.title")) %>
   <% card.with_section do %>
-    <%= form_with(model: @group, url: group_path(@group), method: :patch) do |form| %>
+    <%= form_with(model: @group, url: group_path, method: :patch) do |form| %>
       <div class="grid gap-4">
         <p class="text-slate-600 dark:text-slate-400">
           <%= t(:"groups.edit.advanced.path.description") %>

--- a/app/views/groups/_edit_name_and_description_form.html.erb
+++ b/app/views/groups/_edit_name_and_description_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: group, url: group_path(group), method: :patch) do |form| %>
+<%= form_with(model: group, url: group_path, method: :patch) do |form| %>
   <div class="grid gap-4">
     <%= render partial: "form_fields",
     locals: {

--- a/app/views/projects/_destroy.html.erb
+++ b/app/views/projects/_destroy.html.erb
@@ -6,7 +6,7 @@
     </p>
     <div class="mt-4">
       <%= link_to t(:"projects.edit.advanced.destroy.submit"),
-      project_path(project),
+      namespace_project_path,
       data: {
         turbo_method: :delete,
         turbo_confirm: t(:"projects.edit.advanced.destroy.confirm")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -949,11 +949,6 @@ en:
       destroy:
         does_not_belong_to_attachable: This attachment does not belong to this sample.
         associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.
-    groups:
-      transfer:
-        namespace_empty: The new namespace is empty.
-        same_group_and_namespace: The new namespace must be different from the group.
-        namespace_group_exists: A group with the same name/path already exists in the new namespace.
     members:
       create:
         role_not_allowed: "A maintainer can only add members to the %{namespace_type} %{namespace_name} up to the Maintainer role"
@@ -983,15 +978,19 @@ en:
           missing_metadata_column: The file does not have any metadata columns. Please add some columns of metadata to the file and retry uploading.
           missing_metadata_row: The file does not have any metadata rows. Please add some rows of metadata to the file and retry uploading.
           sample_not_found: "'%{sample_name}' is not found within this project"
-    projects:
-      transfer:
-        namespace_project_exists: Project with the same name or path already exists in the target namespace.
-    groups:
-      share:
-        group_not_found: Group with id %{group_id} to share namespace with cannot be found.
     namespaces:
       share:
         invalid_namespace_type: Only a group or project namespace can be shared with a group.
+    groups:
+      transfer:
+        namespace_empty: The new namespace is empty.
+        same_group_and_namespace: The new namespace must be different from the group.
+        namespace_group_exists: A group with the same name/path already exists in the new namespace.
+      share:
+        group_not_found: Group with id %{group_id} to share namespace with cannot be found.
+    projects:
+      transfer:
+        namespace_project_exists: Project with the same name or path already exists in the target namespace.
   application:
     errors:
       access_denied: Access Denied.


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Remove logic in routable.rb `full_path` that was present to handle updates to Groups and Projects to `path` that resulted in validation errors, and reload `route` to get correct path. Using route helpers without params in forms will use the correct url and no need to reload the route. In addition all updates to path and name are done via turbo streams so we only reload project/group name on page when a valid update has happened.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

* Verify that Project/Group updates to taken paths, don't change the url in the forms

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
