### PR TITLE
Samples table metadata sorting

### DIFF
--- a/app/components/ransack/sort_component.rb
+++ b/app/components/ransack/sort_component.rb
@@ -13,7 +13,7 @@ module Ransack
     end
 
     def icon
-      unless @ransack_obj.present? && @ransack_obj.sorts.present? && @ransack_obj.sorts[0].attr_name == @field.to_s
+      unless @ransack_obj.present? && @ransack_obj.sorts.present? && @ransack_obj.sorts[0].name == URI.encode_www_form_component(@field.to_s)
         return
       end
 

--- a/app/components/ransack/sort_component.rb
+++ b/app/components/ransack/sort_component.rb
@@ -13,7 +13,7 @@ module Ransack
     end
 
     def icon
-      unless @ransack_obj.present? && @ransack_obj.sorts.present? && @ransack_obj.sorts[0].name == URI.encode_www_form_component(@field.to_s)
+      unless @ransack_obj&.sorts.present? && @ransack_obj.sorts[0].name == URI.encode_www_form_component(@field.to_s)
         return
       end
 

--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -4,8 +4,14 @@
 module Metadata
   extend ActiveSupport::Concern
 
-  included do
-    helper_method :fields_for_namespace
+  def pagy_with_metadata_sort(result)
+    if !@q.sorts.empty? && Sample.ransackable_attributes.exclude?(@q.sorts.first.name)
+      field = @q.sorts.first.name.gsub('metadata_', '')
+      dir = @q.sorts.first.dir
+      result = result.order(Sample.metadata_sort(field, dir))
+    end
+
+    pagy(result)
   end
 
   def fields_for_namespace(namespace: nil, show_fields: false)

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -17,7 +17,7 @@ module Groups
           @has_samples = @q.result.count.positive?
         end
         format.turbo_stream do
-          @pagy, @samples = pagy(@q.result)
+          @pagy, @samples = pagy_with_metadata_sort(@q.result)
           fields_for_namespace(namespace: @group, show_fields: params[:q] && params[:q][:metadata].to_i == 1)
         end
       end
@@ -51,6 +51,11 @@ module Groups
     end
 
     def set_default_sort
+      # remove metadata sort if metadata not visible
+      if !@q.sorts.empty? && @q.sorts[0].name.start_with?('metadata_') && params[:q][:metadata].to_i != 1
+        @q.sorts.slice!(0)
+      end
+
       @q.sorts = 'updated_at desc' if @q.sorts.empty?
     end
   end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -18,7 +18,7 @@ module Projects
           @has_samples = @q.result.count.positive?
         end
         format.turbo_stream do
-          @pagy, @samples = custom_pagy
+          @pagy, @samples = pagy_with_metadata_sort(@q.result)
           fields_for_namespace(
             namespace: @project.namespace,
             show_fields: params[:q] && params[:q][:metadata].to_i == 1
@@ -120,18 +120,6 @@ module Projects
 
     def current_page
       @current_page = 'samples'
-    end
-
-    def custom_pagy
-      result = @q.result
-
-      if !@q.sorts.empty? && Sample.ransackable_attributes.exclude?(@q.sorts.first.name)
-        field = @q.sorts.first.name.gsub('metadata_', '')
-        dir = @q.sorts.first.dir
-        result = result.order(Sample.metadata_sort(field, dir))
-      end
-
-      pagy(result)
     end
 
     def set_default_sort

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -29,6 +29,20 @@ class Sample < ApplicationRecord
     %w[]
   end
 
+  def self.metadata_sort(field, dir)
+    metadata_field = Arel::Nodes::InfixOperation.new(
+      '->',
+      Sample.arel_table[:metadata],
+      Arel::Nodes.build_quoted(URI.decode_www_form_component(field))
+    )
+
+    if dir.to_sym == :asc
+      metadata_field.asc
+    else
+      metadata_field.desc
+    end
+  end
+
   def metadata_with_provenance
     sample_metadata = []
     metadata.each do |key, value|

--- a/app/views/groups/samples/_table.html.erb
+++ b/app/views/groups/samples/_table.html.erb
@@ -64,10 +64,13 @@
         ) %>
       </th>
       <% @fields.each do |column| %>
-        <th
-          scope="col"
-          class="px-6 py-3 text-left whitespace-nowrap cursor-not-allowed"
-        ><%= column %></th>
+        <th scope="col" class="px-6 py-3 text-left whitespace-nowrap">
+            <%= render Ransack::SortComponent.new(
+              ransack_obj: @q,
+              label: column,
+              url: sorting_url(@q, URI.encode_www_form_component("metadata_#{column}")),
+              field: "metadata_#{column}"
+            ) %>
       <% end %>
     </tr>
     </thead>

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -1,102 +1,163 @@
 <div class="relative overflow-x-auto" data-turbo-temporary>
   <table
-  id="samples-table"
-  class="w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400"
-  data-controller="selection"
-  data-selection-action-link-outlet=".action-link"
->
-    <thead class="text-xs text-slate-700 uppercase bg-slate-50 dark:bg-slate-700 dark:text-slate-400">
-    <tr>
-      <th scope="col" class="px-6 py-3 whitespace-nowrap text-left bg-slate-50 dark:bg-slate-700 sticky left-0 z-10">
-        <%= render Ransack::SortComponent.new(ransack_obj: @q, label: t(".sample"), url: sorting_url(@q, :name), field: :name) %>
-      </th>
-      <th scope="col" class="px-6 py-3 whitespace-nowrap text-left">
-        <%= render Ransack::SortComponent.new(ransack_obj: @q, label: t(".created_at"), url: sorting_url(@q, :created_at), field: :created_at) %>
-      </th>
-      <th scope="col" class="px-6 py-3 whitespace-nowrap text-left">
-        <%= render Ransack::SortComponent.new(ransack_obj: @q, label: t(".updated_at"), url: sorting_url(@q, :updated_at), field: :updated_at) %>
-      </th>
-      <% @fields.each do |column| %>
-        <th scope="col" class="px-6 py-3 text-left whitespace-nowrap cursor-not-allowed"><%= column %></th>
-      <% end %>
-      <% if allowed_to?(:update_sample?, project) %>
-        <th scope="col" class="px-6 py-3 whitespace-nowrap text-right"><%= t(".action") %></th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody
+    id="samples-table"
     class="
-      bg-white
-      divide-y
-      divide-slate-200
-      dark:bg-slate-800
-      dark:divide-slate-700
+      w-full
+      text-sm
+      text-left
+      rtl:text-right
+      text-slate-500
+      dark:text-slate-400
     "
+    data-controller="selection"
+    data-selection-action-link-outlet=".action-link"
   >
-    <% samples.each do |sample| %>
-      <tr
-        id="<%= sample.id %>"
-        class="bg-white border-b dark:bg-slate-800 dark:border-slate-700"
-      >
-        <td class="px-6 py-3 whitespace-nowrap sticky left-0 bg-slate-50 dark:bg-slate-900">
-          <% if allowed_to?(:transfer_sample?, project) %>
-            <%= check_box_tag "sample_ids[]",
-                              sample.id,
-                              nil,
-                              id: dom_id(sample),
-                              "aria-label": sample.name,
-                              data: {
-                                action: "input->selection#toggle",
-                                selection_target: "rowSelection"
-                              },
-                              class:
-                                "w-4 h-4 mr-2.5 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
-          <% end %>
-          <%= link_to sample.name,
-          namespace_project_sample_path(id: sample.id),
-          data: {
-            turbo: false
-          },
-                      class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
-        </td>
-        <td class="px-6 py-3 whitespace-nowrap">
-          <%= l(sample.created_at.localtime, format: :full_date) %>
-        </td>
-        <td class="px-6 py-3 whitespace-nowrap">
-          <%= viral_time_ago(original_time: sample.updated_at) %>
-        </td>
+    <thead
+      class="
+        text-xs
+        text-slate-700
+        uppercase
+        bg-slate-50
+        dark:bg-slate-700
+        dark:text-slate-400
+      "
+    >
+      <tr>
+        <th
+          scope="col"
+          class="
+            px-6
+            py-3
+            whitespace-nowrap
+            text-left
+            bg-slate-50
+            dark:bg-slate-700
+            sticky
+            left-0
+            z-10
+          "
+        >
+          <%= render Ransack::SortComponent.new(
+            ransack_obj: @q,
+            label: t(".sample"),
+            url: sorting_url(@q, :name),
+            field: :name
+          ) %>
+        </th>
+        <th scope="col" class="px-6 py-3 whitespace-nowrap text-left">
+          <%= render Ransack::SortComponent.new(
+            ransack_obj: @q,
+            label: t(".created_at"),
+            url: sorting_url(@q, :created_at),
+            field: :created_at
+          ) %>
+        </th>
+        <th scope="col" class="px-6 py-3 whitespace-nowrap text-left">
+          <%= render Ransack::SortComponent.new(
+            ransack_obj: @q,
+            label: t(".updated_at"),
+            url: sorting_url(@q, :updated_at),
+            field: :updated_at
+          ) %>
+        </th>
         <% @fields.each do |column| %>
-          <td class="px-6 py-3 whitespace-nowrap">
-            <%= sample.metadata[column] %>
-          </td>
+          <th scope="col" class="px-6 py-3 text-left whitespace-nowrap">
+            <%= render Ransack::SortComponent.new(
+              ransack_obj: @q,
+              label: column,
+              url: sorting_url(@q, URI.encode_www_form_component("metadata_#{column}")),
+              field: "metadata_#{column}"
+            ) %>
+          </th>
         <% end %>
         <% if allowed_to?(:update_sample?, project) %>
-          <td class="px-6 py-3 whitespace-nowrap">
-            <div class="flex items-center justify-end">
-              <%= viral_dropdown(icon: "ellipsis_vertical", aria: { label: t(:'projects.samples.index.actions.dropdown_aria_label', sample_name: sample.name) }) do |dropdown| %>
-                <%= dropdown.with_item(
-                  label: t(:"projects.samples.index.edit_button"),
-                  url: edit_namespace_project_sample_path(id: sample.id),
-                  data: {
-                    turbo: false
-                  }
-                ) %>
-                <% if allowed_to?(:destroy_sample?, @project) %>
-                  <%= dropdown.with_item(
-                    label: t(:"projects.samples.index.remove_button"),
-                    url: namespace_project_sample_path(id: sample.id),
-                    data: {
-                      turbo_method: :delete,
-                      turbo_confirm: t(:"projects.samples.index.remove_button_confirmation")
-                    }
-                  ) %>
-                <% end %>
-              <% end %>
-            </div>
-          </td>
+          <th scope="col" class="px-6 py-3 whitespace-nowrap text-right"><%= t(".action") %></th>
         <% end %>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody
+      class="
+        bg-white
+        divide-y
+        divide-slate-200
+        dark:bg-slate-800
+        dark:divide-slate-700
+      "
+    >
+      <% samples.each do |sample| %>
+        <tr
+          id="<%= sample.id %>"
+          class="bg-white border-b dark:bg-slate-800 dark:border-slate-700"
+        >
+          <td
+            class="
+              px-6
+              py-3
+              whitespace-nowrap
+              sticky
+              left-0
+              bg-slate-50
+              dark:bg-slate-900
+            "
+          >
+            <% if allowed_to?(:transfer_sample?, project) %>
+              <%= check_box_tag "sample_ids[]",
+              sample.id,
+              nil,
+              id: dom_id(sample),
+              "aria-label": sample.name,
+              data: {
+                action: "input->selection#toggle",
+                selection_target: "rowSelection"
+              },
+              class:
+                "w-4 h-4 mr-2.5 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
+            <% end %>
+            <%= link_to sample.name,
+            namespace_project_sample_path(id: sample.id),
+            data: {
+              turbo: false
+            },
+            class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
+          </td>
+          <td class="px-6 py-3 whitespace-nowrap">
+            <%= l(sample.created_at.localtime, format: :full_date) %>
+          </td>
+          <td class="px-6 py-3 whitespace-nowrap">
+            <%= viral_time_ago(original_time: sample.updated_at) %>
+          </td>
+          <% @fields.each do |column| %>
+            <td class="px-6 py-3 whitespace-nowrap">
+              <%= sample.metadata[column] %>
+            </td>
+          <% end %>
+          <% if allowed_to?(:update_sample?, project) %>
+            <td class="px-6 py-3 whitespace-nowrap">
+              <div class="flex items-center justify-end">
+                <%= viral_dropdown(icon: "ellipsis_vertical", aria: { label: t(:'projects.samples.index.actions.dropdown_aria_label', sample_name: sample.name) }) do |dropdown| %>
+                  <%= dropdown.with_item(
+                    label: t(:"projects.samples.index.edit_button"),
+                    url: edit_namespace_project_sample_path(id: sample.id),
+                    data: {
+                      turbo: false
+                    }
+                  ) %>
+                  <% if allowed_to?(:destroy_sample?, @project) %>
+                    <%= dropdown.with_item(
+                      label: t(:"projects.samples.index.remove_button"),
+                      url: namespace_project_sample_path(id: sample.id),
+                      data: {
+                        turbo_method: :delete,
+                        turbo_confirm: t(:"projects.samples.index.remove_button_confirmation")
+                      }
+                    ) %>
+                  <% end %>
+                <% end %>
+              </div>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -193,5 +193,39 @@ module Groups
       find('label', text: I18n.t('groups.samples.index.search.metadata')).click
       assert_selector 'table thead tr th', count: 4
     end
+
+    test 'can sort samples by metadata column' do
+      visit group_samples_url(@group)
+      assert_selector 'label', text: I18n.t('groups.samples.index.search.metadata'), count: 1
+      assert_selector 'table thead tr th', count: 4
+      find('label', text: I18n.t('groups.samples.index.search.metadata')).click
+      assert_selector 'table thead tr th', count: 6
+
+      click_on 'metadatafield1'
+
+      assert_selector 'table thead th:nth-child(5) svg.icon-arrow_up'
+      within first('tbody') do
+        assert_selector 'tr:first-child td:first-child', text: @sample30.name
+        assert_selector 'tr:nth-child(2) td:first-child', text: @sample2.name
+      end
+
+      click_on 'metadatafield2'
+
+      assert_selector 'table thead th:nth-child(6) svg.icon-arrow_up'
+      within first('tbody') do
+        assert_selector 'tr:first-child td:first-child', text: @sample30.name
+        assert_selector 'tr:nth-child(2) td:first-child', text: @sample2.name
+      end
+
+      # toggling metadata again causes sort to be reset
+      find('label', text: I18n.t('projects.samples.index.search.metadata')).click
+      assert_selector 'table thead tr th', count: 4
+
+      assert_selector 'table thead th:nth-child(4) svg.icon-arrow_down'
+      within first('tbody') do
+        assert_selector 'tr:first-child td:first-child', text: @sample1.name
+        assert_selector 'tr:nth-child(2) td:first-child', text: @sample2.name
+      end
+    end
   end
 end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -901,5 +901,45 @@ module Projects
       find('label', text: I18n.t('projects.samples.index.search.metadata')).click
       assert_selector 'table#samples-table thead tr th', count: 4
     end
+
+    test 'can sort samples by metadata column' do
+      visit namespace_project_samples_url(@namespace, @project)
+      assert_selector 'label', text: I18n.t('projects.samples.index.search.metadata'), count: 1
+      assert_selector 'table#samples-table thead tr th', count: 4
+      find('label', text: I18n.t('projects.samples.index.search.metadata')).click
+      assert_selector 'table#samples-table thead tr th', count: 6
+
+      click_on 'metadatafield1'
+
+      assert_selector 'table thead th:nth-child(4) svg.icon-arrow_up'
+      assert_selector 'table#samples-table tbody tr', count: 3
+      within first('tbody') do
+        assert_selector 'tr:first-child td:first-child', text: @sample3.name
+        assert_selector 'tr:nth-child(2) td:first-child', text: @sample1.name
+        assert_selector 'tr:last-child td:first-child', text: @sample2.name
+      end
+
+      click_on 'metadatafield2'
+
+      assert_selector 'table thead th:nth-child(5) svg.icon-arrow_up'
+      assert_selector 'table#samples-table tbody tr', count: 3
+      within first('tbody') do
+        assert_selector 'tr:first-child td:first-child', text: @sample3.name
+        assert_selector 'tr:nth-child(2) td:first-child', text: @sample1.name
+        assert_selector 'tr:last-child td:first-child', text: @sample2.name
+      end
+
+      # toggling metadata again causes sort to be reset
+      find('label', text: I18n.t('projects.samples.index.search.metadata')).click
+      assert_selector 'table#samples-table thead tr th', count: 4
+
+      assert_selector 'table thead th:nth-child(3) svg.icon-arrow_down'
+      assert_selector 'table#samples-table tbody tr', count: 3
+      within first('tbody') do
+        assert_selector 'tr:first-child td:first-child', text: @sample1.name
+        assert_selector 'tr:nth-child(2) td:first-child', text: @sample2.name
+        assert_selector 'tr:last-child td:first-child', text: @sample3.name
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds support to sort by a metadata column on the Group and Project Samples tables.

Resolves #277 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/492127/b6c03714-44bc-4fb2-81ca-d40ed3852c88)

![image](https://github.com/phac-nml/irida-next/assets/492127/0890ba60-e39b-47e1-ae4d-cc85637d69ce)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Login as `admin@email.com`
2. Navigate to Group `Bacillus` Samples table
3. Toggle metadata and click on any metadata field to sort on it
4. Verify that the table is now sorted by metadata field
5. Toggle metadata
6. Verify that sort reverted to `Last Updated` column
7. Repeats step 3 - 6 on Project `Bacillus / Bacillus Anthracis / Outbreak 2023` Samples table

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
