### PR TITLE
Fix Persistent Unique Identifier Migrations to include deleted records

### DIFF
--- a/db/migrate/20240122144035_add_puid_to_sample.rb
+++ b/db/migrate/20240122144035_add_puid_to_sample.rb
@@ -7,7 +7,7 @@ class AddPuidToSample < ActiveRecord::Migration[7.1]
 
     reversible do |dir|
       dir.up do
-        Sample.all.each do |sample|
+        Sample.with_deleted.all.each do |sample|
           sample.update!(puid: Irida::PersistentUniqueId.generate(sample, time: sample.created_at))
         end
         change_column :samples, :puid, :string, null: false

--- a/db/migrate/20240124170054_add_puid_to_project.rb
+++ b/db/migrate/20240124170054_add_puid_to_project.rb
@@ -7,7 +7,7 @@ class AddPuidToProject < ActiveRecord::Migration[7.1]
 
     reversible do |dir|
       dir.up do
-        Project.all.each do |project|
+        Project.with_deleted.all.each do |project|
           project.update!(puid: Irida::PersistentUniqueId.generate(project, time: project.created_at))
         end
         change_column :projects, :puid, :string, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -597,25 +597,25 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_170054) do
   SQL
 
 
-  create_trigger :logidze_on_users, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_namespaces, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_namespaces BEFORE INSERT OR UPDATE ON public.namespaces FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_attachments, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_attachments BEFORE INSERT OR UPDATE ON public.attachments FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_members, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_members BEFORE INSERT OR UPDATE ON public.members FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
-  create_trigger :logidze_on_samples, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_samples BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_namespace_group_links, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_namespace_group_links BEFORE INSERT OR UPDATE ON public.namespace_group_links FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_namespaces, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_namespaces BEFORE INSERT OR UPDATE ON public.namespaces FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_personal_access_tokens, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
-  create_trigger :logidze_on_namespace_group_links, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_namespace_group_links BEFORE INSERT OR UPDATE ON public.namespace_group_links FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_samples, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_samples BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
-  create_trigger :logidze_on_attachments, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_attachments BEFORE INSERT OR UPDATE ON public.attachments FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_users, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This updates the PUID migrations to use `with_deleted` scope to include deleted records.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Checkout an earlier version of the software without PUID `git checkout fea35326463202258a1177e259d0c8e978ae0405`
2. Reset the database so no trace of `puid` `./scripts/clean_dev.sh`
3. Launch the server and delete a Sample and a Project
4. Checkout this branch and run `./bin/rails db:migrate`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
