### PR TITLE
Fixing displaying local account sign in errors

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,11 @@ class SessionsController < Devise::SessionsController
       if resource_class.omniauth_providers.empty?
         render :new_with_no_providers
       else
-        @local_account = params[:local]
+        @local_account = if flash.empty?
+                           params[:local]
+                         else
+                           'true'
+                         end
         render :new_with_providers
       end
       return

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,11 +12,8 @@ class SessionsController < Devise::SessionsController
       if resource_class.omniauth_providers.empty?
         render :new_with_no_providers
       else
-        @local_account = if flash.empty?
-                           params[:local]
-                         else
-                           'true'
-                         end
+        @local_account = params[:local]
+
         render :new_with_providers
       end
       return

--- a/app/views/devise/shared/_form.html.erb
+++ b/app/views/devise/shared/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
 
-  <%= f.hidden_field :local, value: params[:local], id: :local, name: :local %>
+  <input type="hidden" name="local" value="<%=params[:local]%>"/>
 
   <div class="form-field">
     <%= f.label :email %>

--- a/app/views/devise/shared/_form.html.erb
+++ b/app/views/devise/shared/_form.html.erb
@@ -1,4 +1,7 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+
+  <%= f.hidden_field :local, value: params[:local], id: :local, name: :local %>
+
   <div class="form-field">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/test/system/sessions_test.rb
+++ b/test/system/sessions_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class SessionsTest < ApplicationSystemTestCase
-  test 'should redirect during sign in with local account' do
+  test 'should display sign in with local account' do
     visit new_user_session_path
 
     assert_selector 'h1', text: I18n.t(:'devise.layout.title'), count: 1
@@ -14,5 +14,29 @@ class SessionsTest < ApplicationSystemTestCase
 
     assert_text I18n.t(:'devise.sessions.new_with_providers.return_button')
     assert_current_path '/users/sign_in?local=true'
+  end
+
+  test 'should display error during with local account' do
+    user = users(:john_doe)
+
+    visit new_user_session_path
+
+    assert_selector 'h1', text: I18n.t(:'devise.layout.title'), count: 1
+
+    within %(div[class="grid gap-2"]) do
+      click_link I18n.t(:'devise.sessions.new_with_providers.local_button')
+    end
+
+    within %(form[action="/users/sign_in"]) do
+      fill_in 'Email', with: user.email
+      click_on I18n.t('devise.shared.form.sign_in')
+    end
+
+    assert_text 'Invalid Email or password'
+    within %(form[action="/users/sign_in"]) do
+      assert_selector 'label', text: 'Email', count: 1
+      assert_selector 'label', text: 'Password', count: 1
+    end
+    assert_current_path '/users/sign_in'
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
Removed the redirect when attempting to login with local account when an omniauth provider is enabled. Login errors are now displayed above the local account sign in form. 
Fixes #399.

## Screenshots or screen recordings
![image](https://github.com/phac-nml/irida-next/assets/325703/93f9bef5-09b3-4398-8ab8-f709e95be07c)

## How to set up and validate locally
1. Run `OMNIAUTH_PROVIDERS=developer bin/dev` in a terminal.
2. Click `Sign in with Local Account`
3. Attempt to login with invalid credentials.
4. Verify the form errors appear above the local account sign in form.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
