### PR TITLE
Group history view

### DIFF
--- a/app/controllers/groups/history_controller.rb
+++ b/app/controllers/groups/history_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Groups
+  # Controller actions for group history
+  class HistoryController < Groups::ApplicationController
+    include HistoryActions
+
+    before_action :current_page
+
+    private
+
+    # The model the log data is attached to
+    def set_model
+      @model = group
+    end
+
+    # The record to authorize the user against
+    def set_authorization_object
+      @authorize_object = group
+    end
+
+    def group
+      @group ||= Group.find_by_full_path(request.params[:group_id]) # rubocop:disable Rails/DynamicFindBy
+      @group
+    end
+
+    protected
+
+    def context_crumbs
+      @context_crumbs = @group.nil? ? [] : route_to_context_crumbs(@group.route)
+      case action_name
+      when 'index', 'new'
+        @context_crumbs += [{
+          name: I18n.t('groups.history.index.title'),
+          path: group_history_path
+        }]
+      end
+    end
+
+    def current_page
+      @current_page = 'history'
+    end
+  end
+end

--- a/app/models/concerns/history.rb
+++ b/app/models/concerns/history.rb
@@ -72,7 +72,7 @@ module History
 
   # Add puid to the first version (create)
   def add_puid_to_current_version(current_version)
-    return current_version if type != 'Project'
+    return current_version if self.class.name != 'Namespaces::ProjectNamespace'
 
     current_version['c'].merge!(puid: project.puid) if project && !current_version['c'].key?('puid')
     current_version

--- a/app/models/concerns/history.rb
+++ b/app/models/concerns/history.rb
@@ -72,6 +72,8 @@ module History
 
   # Add puid to the first version (create)
   def add_puid_to_current_version(current_version)
+    return current_version if type != 'Project'
+
     current_version['c'].merge!(puid: project.puid) if project && !current_version['c'].key?('puid')
     current_version
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,6 +2,8 @@
 
 # Namespace for Groups
 class Group < Namespace
+  include History
+
   has_many :group_members, foreign_key: :namespace_id, inverse_of: :group,
                            class_name: 'Member', dependent: :destroy
   has_many :project_namespaces,

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -244,7 +244,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   # Method to restore namespace routes when the namespace is restored
   def restore_routes
-    Route.restore(Route.only_deleted.find_by(source_id: id).id, recursive: true)
+    Route.restore(Route.only_deleted.find_by(source_id: id)&.id, recursive: true)
   end
 
   # The add and subtract_from_metadata_summary count functions are used by all update_metadata_summary functions

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Policy for groups authorization
-class GroupPolicy < NamespacePolicy
+class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
   def create?
     return true if Member.can_create?(user, record) == true
 
@@ -11,6 +11,13 @@ class GroupPolicy < NamespacePolicy
 
   def create_subgroup?
     return true if Member.can_create?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
+  def view_history?
+    return true if Member.can_view?(user, record, false) == true
 
     details[:name] = record.name
     false

--- a/app/views/groups/history/_group_history_modal.html.erb
+++ b/app/views/groups/history/_group_history_modal.html.erb
@@ -1,0 +1,17 @@
+<%= viral_dialog(open: true, size: :large) do |dialog| %>
+  <%= dialog.with_header(
+    title: t(".version_number", version_number: log_data[:version])
+  ) %>
+  <%= dialog.with_section do %>
+    <div>
+      <%= render partial: "group_history_modal_description", locals: { log_data: } %>
+      <%= render HistoryVersionComponent.new(log_data: log_data) %>
+    </div>
+    <% dialog.with_secondary_action do %>
+      <%= viral_button(data: { action: 'click->viral--dialog#close' }) do %>
+        <%= t(".close") %>
+      <% end %>
+    <% end %>
+
+  <% end %>
+<% end %>

--- a/app/views/groups/history/_group_history_modal_description.html.erb
+++ b/app/views/groups/history/_group_history_modal_description.html.erb
@@ -1,0 +1,17 @@
+<div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
+  <p class="dark:text-slate-400">
+    <% if log_data[:version] == 1 %>
+      <%= t(".group_created", user: log_data[:user]) %>
+    <% elsif log_data[:changes_from_prev_version].key?('deleted_at') %>
+      <% if log_data[:changes_from_prev_version]['deleted_at'].blank? %>
+        <%= t(".group_restored", user: log_data[:user]) %>
+      <% elsif log_data[:changes_from_prev_version]['deleted_at'].present? %>
+        <%= t(".group_deleted", user: log_data[:user]) %>
+      <% end %>
+    <% elsif log_data[:changes_from_prev_version]['parent_id'].present? %>
+      <%= t(".group_transferred", user: log_data[:user]) %>
+    <% else %>
+      <%= t(".group_modified", user: log_data[:user]) %>
+    <% end %>
+  </p>
+</div>

--- a/app/views/groups/history/index.html.erb
+++ b/app/views/groups/history/index.html.erb
@@ -1,0 +1,11 @@
+<%= render Viral::PageHeaderComponent.new(title: t(:".title")) do |component| %>
+  <%= component.with_icon(name: "list_bullet", classes: "h-14 w-14 text-primary-700") %>
+<% end %>
+
+<div class="px-4">
+  <%= turbo_frame_tag "history_modal" %>
+
+  <%= turbo_frame_tag "group_history",
+  src: group_history_url(format: :turbo_stream, **request.query_parameters),
+  loading: :lazy %>
+</div>

--- a/app/views/groups/history/index.turbo_stream.erb
+++ b/app/views/groups/history/index.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update "group_history" do %>
+  <%= render HistoryComponent.new(
+    data: @log_data.reverse,
+    type: "Group",
+    url: group_view_history_path(@group)
+  ) %>
+<% end %>

--- a/app/views/groups/history/new.turbo_stream.erb
+++ b/app/views/groups/history/new.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.update "history_modal",
+                    partial: "group_history_modal",
+                    locals: {
+                      open: true,
+                      log_data: @log_data
+                    } %>

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -23,6 +23,14 @@
             label: t(:"groups.sidebar.members"),
             selected: @current_page == t(:"groups.sidebar.members").downcase
           ) %>
+          <% if allowed_to?(:view_history?, @group) %>
+            <%= render section.with_item(
+              url: group_history_path(@group),
+              icon: "list_bullet",
+              label: t(:"groups.sidebar.history"),
+              selected: @current_page == t(:"groups.sidebar.history").downcase
+            ) %>
+          <% end %>
           <% if allowed_to?(:update?, @group) %>
             <%= render section.with_item(
               url: edit_group_path(@group),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -458,6 +458,7 @@ en:
     sidebar:
       details: Details
       members: Members
+      history: History
       settings: Settings
     index:
       create_group_button: New group
@@ -473,6 +474,18 @@ en:
       path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores
       submit: Create group
       cancel: Cancel
+    history:
+      index:
+        title: History
+      group_history_modal:
+        close: Close
+        version_number: "Version %{version_number}"
+      group_history_modal_description:
+        group_created: "Group was created by %{user}"
+        group_deleted: "Group was deleted by %{user}"
+        group_modified: "Group attributes were modified by %{user}"
+        group_restored: "Group was restored by %{user}"
+        group_transferred: "Group was transferred by %{user}"
     destroy:
       success: "Group %{group_name} was deleted"
       error: "Could not delete %{group_name}"

--- a/config/routes/group.rb
+++ b/config/routes/group.rb
@@ -20,6 +20,9 @@ constraints(::Constraints::GroupUrlConstrainer.new) do
     resources :samples, only: %i[index]
     resources :subgroups, only: %i[index]
     resources :shared_projects, only: %i[index]
+
+    get '/history' => 'history#index', as: :history
+    get '/history/new' => 'history#new', as: :view_history
   end
 
   scope(path: '*id',

--- a/test/controllers/concerns/history_actions_concern_test.rb
+++ b/test/controllers/concerns/history_actions_concern_test.rb
@@ -28,4 +28,30 @@ class HistoryActionsConcernTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test 'group history index' do
+    sign_in users(:john_doe)
+
+    group = groups(:group_one)
+
+    group.create_logidze_snapshot!
+
+    get group_history_path(group)
+
+    assert_response :success
+  end
+
+  test 'view group history version' do
+    sign_in users(:john_doe)
+
+    group = groups(:group_one)
+
+    group.create_logidze_snapshot!
+
+    get group_history_path(group)
+
+    get group_view_history_path(group, version: 1, format: :turbo_stream)
+
+    assert_response :success
+  end
 end

--- a/test/controllers/groups/history_controller_test.rb
+++ b/test/controllers/groups/history_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Groups
+  class HistoryControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    test 'should get group history listing' do
+      sign_in users(:john_doe)
+
+      group = groups(:group_one)
+
+      group.create_logidze_snapshot!
+
+      get group_history_path(group)
+      assert_response :success
+    end
+
+    test 'should display project history version' do
+      sign_in users(:john_doe)
+
+      group = groups(:group_one)
+
+      group.create_logidze_snapshot!
+
+      get group_view_history_path(group, version: 1, format: :turbo_stream)
+      assert_response :success
+    end
+  end
+end

--- a/test/models/concerns/history_concern_test.rb
+++ b/test/models/concerns/history_concern_test.rb
@@ -209,6 +209,7 @@ class HistoryConcernTest < ActionDispatch::IntegrationTest
     assert_equal false, log_data[2][:deleted]
     assert_equal true, log_data[2][:restored]
   end
+
   test 'get group logidze log data with delete and restore actions' do
     sign_in users(:john_doe)
     group = groups(:group_one)

--- a/test/models/concerns/history_concern_test.rb
+++ b/test/models/concerns/history_concern_test.rb
@@ -107,6 +107,29 @@ class HistoryConcernTest < ActionDispatch::IntegrationTest
     assert_equal expected_result, log_data
   end
 
+  test 'get group logidze log data without changes' do
+    sign_in users(:john_doe)
+    group = groups(:group_one)
+
+    freeze_time
+
+    group.create_logidze_snapshot!
+
+    current_ts = DateTime.now.strftime('%Q').to_i
+    updated_at = DateTime.parse(Time.zone.at(0, current_ts, :millisecond).to_s)
+                         .strftime('%a %b%e %Y %H:%M')
+
+    expected_result = [{ version: 1, user: 'System', updated_at:, restored: false,
+                         deleted: false, transferred: false }]
+
+    log_data = group.log_data_without_changes
+
+    assert log_data.is_a?(Array)
+
+    assert log_data.length == 1
+    assert_equal expected_result, log_data
+  end
+
   test 'get sample logidze log data with changes' do
     sign_in users(:john_doe)
     sample = samples(:sample1)
@@ -121,6 +144,29 @@ class HistoryConcernTest < ActionDispatch::IntegrationTest
 
     version = 1
     log_data = sample.log_data_with_changes(version)
+
+    assert log_data.is_a?(Hash)
+
+    assert_equal version, log_data[:version]
+    assert_equal 'System', log_data[:user]
+    assert_not_nil log_data[:changes_from_prev_version]
+    assert_not_nil log_data[:previous_version]
+  end
+
+  test 'get group logidze log data with changes' do
+    sign_in users(:john_doe)
+    group = groups(:group_one)
+
+    group.create_logidze_snapshot!
+
+    group.name = 'Group 1 Modified'
+    group.save!
+    group.create_logidze_snapshot!
+
+    assert group.reload_log_data.versions.length == 2
+
+    version = 1
+    log_data = group.log_data_with_changes(version)
 
     assert log_data.is_a?(Hash)
 
@@ -145,6 +191,39 @@ class HistoryConcernTest < ActionDispatch::IntegrationTest
     assert sample.reload_log_data.versions.length == 3
 
     log_data = sample.log_data_without_changes
+
+    assert log_data.is_a?(Array)
+
+    assert log_data[0][:version] == 1
+    assert_equal 'System', log_data[0][:user]
+    assert_equal false, log_data[0][:deleted]
+    assert_equal false, log_data[0][:restored]
+
+    assert log_data[1][:version] == 2
+    assert_equal 'System', log_data[1][:user]
+    assert_equal true, log_data[1][:deleted]
+    assert_equal false, log_data[1][:restored]
+
+    assert log_data[2][:version] == 3
+    assert_equal 'System', log_data[2][:user]
+    assert_equal false, log_data[2][:deleted]
+    assert_equal true, log_data[2][:restored]
+  end
+  test 'get group logidze log data with delete and restore actions' do
+    sign_in users(:john_doe)
+    group = groups(:group_one)
+
+    group.create_logidze_snapshot!
+
+    group.destroy
+    group.create_logidze_snapshot!
+
+    Group.restore(group.id, recursive: true)
+    group.create_logidze_snapshot!
+
+    assert group.reload_log_data.versions.length == 3
+
+    log_data = group.log_data_without_changes
 
     assert log_data.is_a?(Array)
 

--- a/test/system/groups/history_test.rb
+++ b/test/system/groups/history_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module Groups
+  class HistoryTest < ApplicationSystemTestCase
+    def setup
+      @user = users(:john_doe)
+      login_as @user
+      @group = groups(:group_one)
+
+      @group.create_logidze_snapshot!
+    end
+
+    test 'can see the list of group change versions' do
+      visit group_history_path(@group)
+
+      assert_selector 'h1', text: I18n.t(:'groups.history.index.title')
+
+      within('#group_history') do
+        assert_selector 'ol', count: 1
+        assert_selector 'li', count: 1
+
+        assert_selector 'h2', text: I18n.t(:'components.history.link_text', version: 1)
+
+        assert_selector 'p', text: I18n.t(:'components.history.created_by', type: 'Group', user: 'System')
+      end
+    end
+
+    test 'can see group history version changes' do
+      visit group_history_path(@group)
+
+      click_on 'Version 1'
+
+      within('#history_modal') do
+        assert_selector 'h1', text: I18n.t(:'components.history.link_text', version: 1)
+        assert_selector 'p', text: I18n.t(:'groups.history.group_history_modal_description.group_created',
+                                          user: 'System')
+
+        assert_no_text I18n.t(:'components.history_version.previous_version')
+        assert_text I18n.t(:'components.history_version.current_version', version: 1)
+
+        assert_selector 'dt', text: 'name'
+        assert_selector 'dt', text: 'path'
+        assert_selector 'dt', text: 'type'
+        assert_selector 'dt', text: 'owner_id'
+        assert_selector 'dt', text: 'description'
+
+        assert_selector 'dd', text: 'Group 1'
+        assert_selector 'dd', text: 'group-1'
+        assert_selector 'dd', text: 'Group'
+        assert_selector 'dd', text: @group.owner.id
+        assert_selector 'dd', text: 'Group 1 description'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in a History page for groups which displays the record level changes made to the group (name, description, parent id, type). The versions are displayed in a timeline view and clicking on the version number displays a modal with which attributes were changed and by whom.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/25466211/9769c297-4aeb-4d6d-b6a5-2d46cf019e57)

![image](https://github.com/phac-nml/irida-next/assets/25466211/17451bc6-7d7a-4b7e-8cab-433fccd4d680)

![image](https://github.com/phac-nml/irida-next/assets/25466211/9771d2e8-9ed4-4d53-8b58-599286be8033)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Reset db (drop, create, migrate, seed) 
2. Login as a user
3. Create a group
4. Go to the `History` page for the group 
5. You should see 1 version, and clicking the `Version 1` should launch a modal that displays the attributes which the group was created with
6. Go to the group settings page. Change the name
7. On the `History` page for the group you should now see 2 versions. Clicking the `Version 2` should launch a modal which displays the change to the name attribute. On the left hand side is the previous version of that attribute and on the right is the current version
8. Try the same for description, path, transferring the group to a different parent group
9. Also try to view history for other groups that were seeded that the user has direct membership or inherited membership on (shared group members should not be able to see the history for a group)

**Note:** In `rails console` you can get the log_data for a group with `.reload_log_data` on the group model.

Log data is in the format

``` @data=
  {"h"=>
    [{"c"=>
       {"id"=>254,
        "name"=>"NewGroup",
        "path"=>"new-group",
        "type"=>"Group",
        "owner_id"=>1,
        "parent_id"=>nil,
        "deleted_at"=>nil,
        "description"=>""},
      "m"=>{"_r"=>1},
      "v"=>1,
      "ts"=>1707857140072},
     {"c"=>{"description"=>"New description for this group"}, "m"=>{"_r"=>1}, "v"=>2, "ts"=>1707857194830}],
   "v"=>2}>

```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
