### PR TITLE
Fix filter highlight on projects dashboard

### DIFF
--- a/app/views/shared/project/_row.html.erb
+++ b/app/views/shared/project/_row.html.erb
@@ -14,9 +14,6 @@
 
   </td>
   <td class="p-4 whitespace-nowrap">
-    <% if defined?params[:q][:namespace_name_cont] %>
-      <%= params[:q][:namespace_name_cont] %>
-    <% end %>
     <%= link_to namespace_project_path(project.namespace.parent, project),
                 data: {
                   turbo: false
@@ -24,16 +21,13 @@
                 class: "text-slate-800 dark:text-slate-300 hover:underline" do %>
       <span><%= project.namespace.parent.full_name %>
         /
-      </span><span class="font-semibold"><%= highlight(
-          project.namespace.name,
-          (
-            if defined?(params[:q][:namespace_name_cont])
-              params[:q][:namespace_name_cont]
-            else
-              ""
-            end
-          )
-        ) %></span>
+      </span>
+      <span class="font-semibold">
+          <%= highlight(
+            project.namespace.name, defined?(params[:q][:namespace_name_cont]) && params[:q][:namespace_name_cont],
+            highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>'
+          ) %>
+        </span>
     <% end %>
     <div class="text-sm font-normal text-slate-500 dark:text-slate-400"><%= project.description %></div>
   </td>


### PR DESCRIPTION
## What does this PR do and why?
This PR changes the projects dashboard ransack filter to use the `primary` highlight color (similar to what was implemented in the project/groups samples tables). The filter phrase was also added to each projects row (highlighted 2022 in screenshot below), which was removed.

## Screenshots or screen recordings
Before:
![image](https://github.com/phac-nml/irida-next/assets/82407232/f807b38b-e02e-449b-9717-c5b44e7a4523)

After:
![image](https://github.com/phac-nml/irida-next/assets/82407232/a87de42c-a121-43ab-8f81-189f85931667)

## How to set up and validate locally
1. Navigate to the projects dashboard page
2. Test the ransack filter
3. Ensure the corresponding filter phrase is highlighted in the projects listing with the `primary` color.
4. Ensure ransack filtering behaves as expected.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
