### PR TITLE
Fix for group samples test can sort the list of samples

### DIFF
--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -16,6 +16,16 @@ module Groups
       @sample31 = samples(:sample31)
     end
 
+    def retrieve_puids
+      within first('table tbody#group-samples-table-body') do
+        puids = []
+        puids << first('tr:nth-child(1) td:first-child').text
+        puids << first('tr:nth-child(2) td:first-child').text
+        puids << first('tr:nth-child(3) td:first-child').text
+        puids << first('tr:nth-child(4) td:first-child').text
+        puids
+      end
+    end
     test 'visiting the index' do
       visit group_samples_url(@group)
 
@@ -97,29 +107,20 @@ module Groups
     test 'can sort the list of samples' do
       visit group_samples_url(@group)
 
+      # Because PUIDs are not always generated the same, issues regarding order have occurred when hard testing
+      # the expected ordering of samples based on PUID. To resolve this, we will gather the first 4 PUIDs and ensure
+      # they are ordered as expected against one another.
       assert_selector 'table tbody#group-samples-table-body tr', count: 20
-      within first('table tbody#group-samples-table-body') do
-        puids = []
-        puids << first('tr:nth-child(1) td:first-child').text
-        puids << first('tr:nth-child(2) td:first-child').text
-        puids << first('tr:nth-child(3) td:first-child').text
-        puids << first('tr:nth-child(4) td:first-child').text
-        3.times do |n|
-          assert puids[n] > puids[n + 1]
-        end
+      puids = retrieve_puids
+      3.times do |n|
+        assert puids[n] > puids[n + 1]
       end
 
       click_on I18n.t('groups.samples.table.puid')
       assert_selector 'table thead th:first-child svg.icon-arrow_up'
-      within first('table tbody#group-samples-table-body') do
-        puids = []
-        puids << first('tr:nth-child(1) td:first-child').text
-        puids << first('tr:nth-child(2) td:first-child').text
-        puids << first('tr:nth-child(3) td:first-child').text
-        puids << first('tr:nth-child(4) td:first-child').text
-        3.times do |n|
-          assert puids[n] < puids[n + 1]
-        end
+      puids = retrieve_puids
+      3.times do |n|
+        assert puids[n] < puids[n + 1]
       end
 
       click_on I18n.t('groups.samples.table.puid')

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -19,10 +19,9 @@ module Groups
     def retrieve_puids
       within first('table tbody#group-samples-table-body') do
         puids = []
-        puids << first('tr:nth-child(1) td:first-child').text
-        puids << first('tr:nth-child(2) td:first-child').text
-        puids << first('tr:nth-child(3) td:first-child').text
-        puids << first('tr:nth-child(4) td:first-child').text
+        (1..4).each do |n|
+          puids << first("tr:nth-child(#{n}) td:first-child").text
+        end
         puids
       end
     end

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -17,13 +17,13 @@ module Groups
     end
 
     def retrieve_puids
+      puids = []
       within first('table tbody#group-samples-table-body') do
-        puids = []
         (1..4).each do |n|
           puids << first("tr:nth-child(#{n}) td:first-child").text
         end
-        puids
       end
+      puids
     end
     test 'visiting the index' do
       visit group_samples_url(@group)

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -111,14 +111,14 @@ module Groups
       # they are ordered as expected against one another.
       assert_selector 'table tbody#group-samples-table-body tr', count: 20
       puids = retrieve_puids
-      3.times do |n|
+      (0...(puids.length - 1)).each do |n|
         assert puids[n] > puids[n + 1]
       end
 
       click_on I18n.t('groups.samples.table.puid')
       assert_selector 'table thead th:first-child svg.icon-arrow_up'
       puids = retrieve_puids
-      3.times do |n|
+      (0...(puids.length - 1)).each do |n|
         assert puids[n] < puids[n + 1]
       end
 

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -111,14 +111,14 @@ module Groups
       # they are ordered as expected against one another.
       assert_selector 'table tbody#group-samples-table-body tr', count: 20
       puids = retrieve_puids
-      (0...(puids.length - 1)).each do |n|
+      (puids.length - 1).times do |n|
         assert puids[n] > puids[n + 1]
       end
 
       click_on I18n.t('groups.samples.table.puid')
       assert_selector 'table thead th:first-child svg.icon-arrow_up'
       puids = retrieve_puids
-      (0...(puids.length - 1)).each do |n|
+      (puids.length - 1).times do |n|
         assert puids[n] < puids[n + 1]
       end
 

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -95,22 +95,31 @@ module Groups
     end
 
     test 'can sort the list of samples' do
-      freeze_time
       visit group_samples_url(@group)
 
       assert_selector 'table tbody#group-samples-table-body tr', count: 20
       within first('table tbody#group-samples-table-body') do
-        assert_selector 'tr:first-child td:first-child', text: @sample1.puid
-        assert_selector 'tr:first-child td:nth-child(2)', text: @sample1.name
+        puids = []
+        puids << first('tr:nth-child(1) td:first-child').text
+        puids << first('tr:nth-child(2) td:first-child').text
+        puids << first('tr:nth-child(3) td:first-child').text
+        puids << first('tr:nth-child(4) td:first-child').text
+        3.times do |n|
+          assert puids[n] > puids[n + 1]
+        end
       end
 
       click_on I18n.t('groups.samples.table.puid')
       assert_selector 'table thead th:first-child svg.icon-arrow_up'
       within first('table tbody#group-samples-table-body') do
-        assert_selector 'tr:nth-child(3) td:first-child', text: @sample28.puid
-        assert_selector 'tr:nth-child(3) td:nth-child(2)', text: @sample28.name
-        assert_selector 'tr:nth-child(4) td:first-child', text: @sample25.puid
-        assert_selector 'tr:nth-child(4) td:nth-child(2)', text: @sample25.name
+        puids = []
+        puids << first('tr:nth-child(1) td:first-child').text
+        puids << first('tr:nth-child(2) td:first-child').text
+        puids << first('tr:nth-child(3) td:first-child').text
+        puids << first('tr:nth-child(4) td:first-child').text
+        3.times do |n|
+          assert puids[n] < puids[n + 1]
+        end
       end
 
       click_on I18n.t('groups.samples.table.puid')


### PR DESCRIPTION
## What does this PR do and why?
The group samples test 'can sort the list of samples' would sometimes error. This is because the PUIDs generated for testing are not always the same, and therefore, the samples ordering when sorting by PUID would sometimes change.

Rather than expecting specific samples in a certain order, we now gather the first four PUIDs of the table listing, and compare them against one another to ensure they are listed properly.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Ensure tests pass locally

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
