### PR TITLE
Workflow destroy service

### DIFF
--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -33,9 +33,9 @@ class WorkflowExecutionsController < ApplicationController
     WorkflowExecutions::DestroyService.new(@workflow_execution, current_user).execute
 
     if @workflow_execution.deleted?
-      flash[:success] = 'Success'
+      flash[:success] = t('.success', workflow_name: @workflow_execution.metadata['workflow_name'])
     else
-      flash[:error] = 'Error'
+      flash[:error] = t('.error', workflow_name: @workflow_execution.metadata['workflow_name'])
     end
     redirect_to workflow_executions_path
   end

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -28,6 +28,18 @@ class WorkflowExecutionsController < ApplicationController
     render 'cancel'
   end
 
+  def destroy
+    @workflow_execution = WorkflowExecution.find(params[:id])
+    WorkflowExecutions::DestroyService.new(@workflow_execution, current_user).execute
+
+    if @workflow_execution.deleted?
+      flash[:success] = 'Success'
+    else
+      flash[:error] = 'Error'
+    end
+    redirect_to workflow_executions_path
+  end
+
   private
 
   def workflow_execution_params

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -15,8 +15,6 @@ class WorkflowExecution < ApplicationRecord
 
   accepts_nested_attributes_for :samples_workflow_executions
 
-  accepts_nested_attributes_for :samples_workflow_executions
-
   validates :metadata, presence: true, json: { message: ->(errors) { errors }, schema: METADATA_JSON_SCHEMA }
 
   def prepared?

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -42,10 +42,7 @@ class WorkflowExecution < ApplicationRecord
   end
 
   def cancellable?
-    state == 'running' ||
-      state == 'queued' ||
-      state == 'prepared' ||
-      state == 'new'
+    %w[running queued prepared new].include?(state)
   end
 
   def as_wes_params

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -41,6 +41,18 @@ class WorkflowExecution < ApplicationRecord
     state == 'canceled'
   end
 
+  def running?
+    state == 'running'
+  end
+
+  def queued?
+    state == 'queued'
+  end
+
+  def new?
+    state == 'new'
+  end
+
   def cancellable?
     %w[running queued prepared new].include?(state)
   end

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -45,6 +45,10 @@ class WorkflowExecution < ApplicationRecord
     %w[running queued prepared new].include?(state)
   end
 
+  def deletable?
+    %w[completed error canceled].include?(state)
+  end
+
   def as_wes_params
     {
       workflow_params:,

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -9,7 +9,7 @@ class WorkflowExecution < ApplicationRecord
 
   belongs_to :submitter, class_name: 'User'
 
-  has_many :samples_workflow_executions, dependent: :nullify
+  has_many :samples_workflow_executions, dependent: :destroy
   has_many :samples, through: :samples_workflow_executions
   has_many_attached :inputs
 

--- a/app/services/workflow_executions/destroy_service.rb
+++ b/app/services/workflow_executions/destroy_service.rb
@@ -9,7 +9,7 @@ module WorkflowExecutions
     end
 
     def execute
-      return unless @workflow_execution.deletable?
+      return unless @workflow_execution.submitter == current_user && @workflow_execution.deletable?
 
       @workflow_execution.destroy
     end

--- a/app/services/workflow_executions/destroy_service.rb
+++ b/app/services/workflow_executions/destroy_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module WorkflowExecutions
+  # Service used to delete a WorkflowExecution
+  class DestroyService < BaseService
+    def initialize(workflow_execution, user = nil, params = {})
+      super(user, params)
+      @workflow_execution = workflow_execution
+    end
+
+    def execute
+      return unless @workflow_execution.completed? || @workflow_execution.error?
+
+      @workflow_execution.destroy
+    end
+  end
+end

--- a/app/services/workflow_executions/destroy_service.rb
+++ b/app/services/workflow_executions/destroy_service.rb
@@ -9,7 +9,7 @@ module WorkflowExecutions
     end
 
     def execute
-      return unless @workflow_execution.completed? || @workflow_execution.error?
+      return unless @workflow_execution.deletable?
 
       @workflow_execution.destroy
     end

--- a/app/views/workflow_executions/_table.html.erb
+++ b/app/views/workflow_executions/_table.html.erb
@@ -1,0 +1,57 @@
+<% if @workflows.length > 0 %>
+  <div class="bg-white dark:bg-slate-800">
+    <div class="flex flex-col">
+      <table
+        id="workflow_executions"
+        class="
+          w-full
+          text-sm
+          text-left
+          rtl:text-right
+          text-gray-500
+          dark:text-gray-400
+        "
+      >
+        <thead
+          class="
+            text-xs
+            text-gray-700
+            uppercase
+            bg-gray-50
+            dark:bg-gray-700
+            dark:text-gray-400
+          "
+        >
+          <tr>
+            <th scope="col" class="px-6 py-3">
+              <%= t(:".headers.id") %>
+            </th>
+            <th scope="col" class="px-6 py-3">
+              <%= t(:".headers.name") %>
+            </th>
+            <th scope="col" class="px-6 py-3">
+              <%= t(:".headers.version") %>
+            </th>
+            <th scope="col" class="px-6 py-3">
+              <%= t(:".headers.state") %>
+            </th>
+            <th scope="col" class="px-6 py-3">
+              <%= t(:".headers.created_at") %>
+            </th>
+            <th scope="col" class="px-6 py-3">
+              <%= t(:".headers.updated_at") %>
+            </th>
+            <th scope="col" class="px-6 py-3">
+              <%= t(:".headers.actions") %>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: "workflow_execution", collection: @workflows %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% else %>
+  <%= viral_alert(type: :info, message: t(:".empty")) %>
+<% end %>

--- a/app/views/workflow_executions/_workflow_execution.html.erb
+++ b/app/views/workflow_executions/_workflow_execution.html.erb
@@ -1,32 +1,56 @@
-<tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700" id="<%= dom_id(workflow_execution) %>">
+<tr
+  class="bg-white border-b dark:bg-gray-800 dark:border-gray-700"
+  id="<%= dom_id(workflow_execution) %>"
+>
   <td class="px-6 py-4 whitespace-nowrap">
-    <%=workflow_execution.run_id %>
+    <%= workflow_execution.run_id %>
   </td>
   <td
-    class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+    class="
+      px-6
+      py-4
+      font-medium
+      text-gray-900
+      whitespace-nowrap
+      dark:text-white
+    "
   >
-    <%=workflow_execution.metadata["workflow_name"] %>
+    <%= workflow_execution.metadata["workflow_name"] %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
-    <%=workflow_execution.metadata["workflow_version"] %>
+    <%= workflow_execution.metadata["workflow_version"] %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
-    <%=workflow_execution["state"] || "NEW" %>
+    <%= workflow_execution["state"] || "NEW" %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
     <%= l(workflow_execution["created_at"].localtime, format: :full_date) %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
-    <%= viral_time_ago(original_time:workflow_execution["updated_at"]) %>
+    <%= viral_time_ago(original_time: workflow_execution["updated_at"]) %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
     <% if workflow_execution.cancellable? %>
       <%= form_with method: :put, url: workflow_execution_cancel_path(workflow_execution) do |form| %>
-        <%= form.submit t(:'workflow_executions.index.actions.cancel'),
-                        class:
-                          "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
-                        data: { turbo_confirm: t(:'workflow_executions.index.actions.confirm') } %>
+        <%= form.submit t(:"workflow_executions.index.actions.cancel_button"),
+                    class:
+                      "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
+                    data: {
+                      turbo_confirm:
+                        t(:"workflow_executions.index.actions.cancel_confirm")
+                    } %>
       <% end %>
     <% end %>
+    <%# <% if workflow_execution.completed? || workflow_execution.error? %>
+    <%= form_with method: :delete, url: workflow_execution_path(workflow_execution) do |form| %>
+      <%= form.submit t(:"workflow_executions.index.actions.delete_button"),
+                  class:
+                    "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
+                  data: {
+                    turbo_confirm:
+                      t(:"workflow_executions.index.actions.delete_confirm")
+                  } %>
+    <% end %>
+    <%# <% end %>
   </td>
 </tr>

--- a/app/views/workflow_executions/_workflow_execution.html.erb
+++ b/app/views/workflow_executions/_workflow_execution.html.erb
@@ -41,7 +41,7 @@
                     } %>
       <% end %>
     <% end %>
-    <% if workflow_execution.completed? || workflow_execution.error? %>
+    <% if workflow_execution.deletable? %>
       <%= form_with method: :delete, url: workflow_execution_path(workflow_execution) do |form| %>
         <%= form.submit t(:"workflow_executions.index.actions.delete_button"),
                     class:

--- a/app/views/workflow_executions/_workflow_execution.html.erb
+++ b/app/views/workflow_executions/_workflow_execution.html.erb
@@ -41,16 +41,16 @@
                     } %>
       <% end %>
     <% end %>
-    <%# <% if workflow_execution.completed? || workflow_execution.error? %>
-    <%= form_with method: :delete, url: workflow_execution_path(workflow_execution) do |form| %>
-      <%= form.submit t(:"workflow_executions.index.actions.delete_button"),
-                  class:
-                    "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
-                  data: {
-                    turbo_confirm:
-                      t(:"workflow_executions.index.actions.delete_confirm")
-                  } %>
+    <% if workflow_execution.completed? || workflow_execution.error? %>
+      <%= form_with method: :delete, url: workflow_execution_path(workflow_execution) do |form| %>
+        <%= form.submit t(:"workflow_executions.index.actions.delete_button"),
+                    class:
+                      "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
+                    data: {
+                      turbo_confirm:
+                        t(:"workflow_executions.index.actions.delete_confirm")
+                    } %>
+      <% end %>
     <% end %>
-    <%# <% end %>
   </td>
 </tr>

--- a/app/views/workflow_executions/destroy.turbo_stream.erb
+++ b/app/views/workflow_executions/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.append "flashes" do %>
+  <%= viral_flash(type:, data: message) %>
+<% end %>
+
+<% if @workflow_execution.deleted? %>
+  <%= turbo_stream.update "workflow_execution_table", partial: "table" %>
+<% end %>

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -1,39 +1,4 @@
 <%= render Viral::PageHeaderComponent.new(title: t(".title")) %>
-<% if @workflows.length > 0 %>
-  <div class="bg-white dark:bg-slate-800">
-    <div class="flex flex-col">
-      <table id="workflow_executions" class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
-        <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
-        <tr>
-          <th scope="col" class="px-6 py-3">
-            <%= t(:'.headers.id') %>
-          </th>
-          <th scope="col" class="px-6 py-3">
-            <%= t(:'.headers.name') %>
-          </th>
-          <th scope="col" class="px-6 py-3">
-            <%= t(:'.headers.version') %>
-          </th>
-          <th scope="col" class="px-6 py-3">
-            <%= t(:'.headers.state') %>
-          </th>
-          <th scope="col" class="px-6 py-3">
-            <%= t(:'.headers.created_at') %>
-          </th>
-          <th scope="col" class="px-6 py-3">
-            <%= t(:'.headers.updated_at') %>
-          </th>
-          <th scope="col" class="px-6 py-3">
-            <%= t(:'.headers.actions') %>
-          </th>
-        </tr>
-        </thead>
-        <tbody>
-        <%= render partial: "workflow_execution", collection: @workflows %>
-        </tbody>
-      </table>
-    </div>
-  </div>
-<% else %>
-  <%= viral_alert(type: :info, message: t(:'.empty')) %>
+<%= turbo_frame_tag "workflow_execution_table" do %>
+  <%= render partial: "table" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1064,6 +1064,12 @@ en:
   workflow_executions:
     index:
       title: Workflow Executions
+      actions:
+        cancel_button: Cancel
+        cancel_confirm: Are you sure you want to cancel this workflow execution?
+        delete_button: Delete
+        delete_confirm: Are you sure you want to delete this workflow execution?
+    table:
       empty: There are no workflow executions.
       headers:
         id: ID
@@ -1073,11 +1079,6 @@ en:
         created_at: Created
         updated_at: Last Updated
         actions: Actions
-      actions:
-        cancel_button: Cancel
-        cancel_confirm: Are you sure you want to cancel this workflow execution?
-        delete_button: Delete
-        delete_confirm: Are you sure you want to delete this workflow execution?
     destroy:
       error: "Could not delete workflow %{workflow_name}"
       success: "Workflow %{workflow_name} was successfully deleted"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1074,8 +1074,10 @@ en:
         updated_at: Last Updated
         actions: Actions
       actions:
-        cancel: Cancel
-        confirm: Are you sure you want to cancel this workflow execution?
+        cancel_button: Cancel
+        cancel_confirm: Are you sure you want to cancel this workflow execution?
+        delete_button: Delete
+        delete_confirm: Are you sure you want to delete this workflow execution?
     submissions:
       pipeline_selection:
         title: Workflow Selection

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1078,6 +1078,9 @@ en:
         cancel_confirm: Are you sure you want to cancel this workflow execution?
         delete_button: Delete
         delete_confirm: Are you sure you want to delete this workflow execution?
+    destroy:
+      error: "Could not delete workflow %{workflow_name}"
+      success: "Workflow %{workflow_name} was successfully deleted"
     submissions:
       pipeline_selection:
         title: Workflow Selection

--- a/config/routes/workflow_executions.rb
+++ b/config/routes/workflow_executions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-resources :workflow_executions, only: %i[create cancel] do
+resources :workflow_executions, only: %i[create cancel destroy] do
   scope '-' do
     put :cancel
   end

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -98,4 +98,14 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :unprocessable_entity
   end
+
+  test 'should delete a canceled workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_canceled)
+    assert workflow_execution.canceled?
+    assert_difference -> { WorkflowExecution.count } => -1,
+                      -> { SamplesWorkflowExecution.count } => -1 do
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
+    end
+    assert_response :success
+  end
 end

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -69,6 +69,16 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test 'should not delete a submitted workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_submitted)
+    assert workflow_execution.submitted?
+    assert_difference -> { WorkflowExecution.count } => 0,
+                      -> { SamplesWorkflowExecution.count } => 0 do
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
+    end
+    assert_response :unprocessable_entity
+  end
+
   test 'should delete a completed workflow' do
     workflow_execution = workflow_executions(:irida_next_example_completed)
     assert workflow_execution.completed?
@@ -107,5 +117,35 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
       delete workflow_execution_path(workflow_execution, format: :turbo_stream)
     end
     assert_response :success
+  end
+
+  test 'should not delete a running workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_running)
+    assert workflow_execution.running?
+    assert_difference -> { WorkflowExecution.count } => 0,
+                      -> { SamplesWorkflowExecution.count } => 0 do
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test 'should not delete a queued workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_queued)
+    assert workflow_execution.queued?
+    assert_difference -> { WorkflowExecution.count } => 0,
+                      -> { SamplesWorkflowExecution.count } => 0 do
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test 'should not delete a new workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_new)
+    assert workflow_execution.new?
+    assert_difference -> { WorkflowExecution.count } => 0,
+                      -> { SamplesWorkflowExecution.count } => 0 do
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
+    end
+    assert_response :unprocessable_entity
   end
 end

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -58,4 +58,44 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # rubocop:enable Naming/VariableNumber
+
+  test 'should not delete a prepared workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_prepared)
+    assert workflow_execution.prepared?
+    assert_difference -> { WorkflowExecution.count } => 0,
+                      -> { SamplesWorkflowExecution.count } => 0 do
+      delete workflow_execution_path(workflow_execution)
+    end
+    assert_redirected_to workflow_executions_path
+  end
+
+  test 'should delete a completed workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_completed)
+    assert workflow_execution.completed?
+    assert_difference -> { WorkflowExecution.count } => -1,
+                      -> { SamplesWorkflowExecution.count } => -1 do
+      delete workflow_execution_path(workflow_execution)
+    end
+    assert_redirected_to workflow_executions_path
+  end
+
+  test 'should delete an errored workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_error)
+    assert workflow_execution.error?
+    assert_difference -> { WorkflowExecution.count } => -1,
+                      -> { SamplesWorkflowExecution.count } => -1 do
+      delete workflow_execution_path(workflow_execution)
+    end
+    assert_redirected_to workflow_executions_path
+  end
+
+  test 'should not delete a canceling workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_canceling)
+    assert workflow_execution.canceling?
+    assert_difference -> { WorkflowExecution.count } => 0,
+                      -> { SamplesWorkflowExecution.count } => 0 do
+      delete workflow_execution_path(workflow_execution)
+    end
+    assert_redirected_to workflow_executions_path
+  end
 end

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -64,9 +64,9 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert workflow_execution.prepared?
     assert_difference -> { WorkflowExecution.count } => 0,
                       -> { SamplesWorkflowExecution.count } => 0 do
-      delete workflow_execution_path(workflow_execution)
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
     end
-    assert_redirected_to workflow_executions_path
+    assert_response :unprocessable_entity
   end
 
   test 'should delete a completed workflow' do
@@ -74,9 +74,9 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert workflow_execution.completed?
     assert_difference -> { WorkflowExecution.count } => -1,
                       -> { SamplesWorkflowExecution.count } => -1 do
-      delete workflow_execution_path(workflow_execution)
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
     end
-    assert_redirected_to workflow_executions_path
+    assert_response :success
   end
 
   test 'should delete an errored workflow' do
@@ -84,9 +84,9 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert workflow_execution.error?
     assert_difference -> { WorkflowExecution.count } => -1,
                       -> { SamplesWorkflowExecution.count } => -1 do
-      delete workflow_execution_path(workflow_execution)
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
     end
-    assert_redirected_to workflow_executions_path
+    assert_response :success
   end
 
   test 'should not delete a canceling workflow' do
@@ -94,8 +94,8 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert workflow_execution.canceling?
     assert_difference -> { WorkflowExecution.count } => 0,
                       -> { SamplesWorkflowExecution.count } => 0 do
-      delete workflow_execution_path(workflow_execution)
+      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
     end
-    assert_redirected_to workflow_executions_path
+    assert_response :unprocessable_entity
   end
 end

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -43,26 +43,35 @@ sample1_irida_next_example_prepared:
   }
 
 sample1_irida_next_example_completed:
-  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1) %>
-  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed) %>
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed, :uuid) %>
   samplesheet_params: {
-    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1)}" %>,
-    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1)}" %>,
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
     "fastq_2": ""
   }
 
 sample1_irida_next_example_error:
-  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1) %>
-  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_error) %>
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_error, :uuid) %>
   samplesheet_params: {
-    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1)}" %>,
-    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1)}" %>,
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
     "fastq_2": ""
   }
 
 sample1_irida_next_example_canceling:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_canceling, :uuid) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
+    "fastq_2": ""
+  }
+
+sample1_irida_next_example_canceled:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_canceled, :uuid) %>
   samplesheet_params: {
     "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
     "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -42,6 +42,24 @@ sample1_irida_next_example_prepared:
     "fastq_2": ""
   }
 
+sample1_irida_next_example_completed:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1)}" %>,
+    "fastq_2": ""
+  }
+
+sample1_irida_next_example_error:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_error) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1)}" %>,
+    "fastq_2": ""
+  }
+
 sample1_irida_next_example_canceling:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_canceling, :uuid) %>

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -42,6 +42,15 @@ sample1_irida_next_example_prepared:
     "fastq_2": ""
   }
 
+sample1_irida_next_example_submitted:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_submitted, :uuid) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
+    "fastq_2": ""
+  }
+
 sample1_irida_next_example_completed:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed, :uuid) %>
@@ -72,6 +81,33 @@ sample1_irida_next_example_canceling:
 sample1_irida_next_example_canceled:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_canceled, :uuid) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
+    "fastq_2": ""
+  }
+
+sample1_irida_next_example_running:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_running, :uuid) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
+    "fastq_2": ""
+  }
+
+sample1_irida_next_example_queued:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_queued, :uuid) %>
+  samplesheet_params: {
+    "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
+    "fastq_2": ""
+  }
+
+sample1_irida_next_example_new:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_new, :uuid) %>
   samplesheet_params: {
     "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample1, :uuid)}" %>,
     "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -58,6 +58,44 @@ irida_next_example_prepared:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "prepared"
 
+irida_next_example_completed:
+  metadata:
+    { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }
+  workflow_params:
+    {
+      "-r": "dev",
+      "--input": "/blah/samplesheet.csv",
+      "--outdir": "/blah/output",
+    }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/iridanextexample"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  state: "completed"
+
+irida_next_example_error:
+  metadata:
+    { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }
+  workflow_params:
+    {
+      "-r": "dev",
+      "--input": "/blah/samplesheet.csv",
+      "--outdir": "/blah/output",
+    }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/iridanextexample"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  state: "error"
+
 irida_next_example_canceling:
   metadata:
     { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -82,7 +82,7 @@ irida_next_example_completed:
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
   workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
   run_id: "my_run_id_5"
-  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "completed"
 
 irida_next_example_error:
@@ -105,7 +105,7 @@ irida_next_example_error:
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
   workflow_url: "https://github.com/phac-nml/irida_next_example_error"
   run_id: "my_run_id_6"
-  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "error"
 
 irida_next_example_canceling:
@@ -130,3 +130,26 @@ irida_next_example_canceling:
   run_id: "my_run_id_7"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "canceling"
+
+irida_next_example_canceled:
+  metadata:
+    {
+      "workflow_name": "irida_next_example_canceled",
+      "workflow_version": "1.0dev",
+    }
+  workflow_params:
+    {
+      "-r": "dev",
+      "--input": "/blah/samplesheet.csv",
+      "--outdir": "/blah/output",
+    }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/irida_next_example_canceled"
+  run_id: "my_run_id_8"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  state: "canceled"

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -62,6 +62,29 @@ irida_next_example_prepared:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "prepared"
 
+irida_next_example_submitted:
+  metadata:
+    {
+      "workflow_name": "irida_next_example_submitted",
+      "workflow_version": "1.0dev",
+    }
+  workflow_params:
+    {
+      "-r": "dev",
+      "--input": "/blah/samplesheet.csv",
+      "--outdir": "/blah/output",
+    }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/irida_next_example_prepared"
+  run_id: "my_run_id_5"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  state: "submitted"
+
 irida_next_example_completed:
   metadata:
     {
@@ -81,7 +104,7 @@ irida_next_example_completed:
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
   workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
-  run_id: "my_run_id_5"
+  run_id: "my_run_id_6"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "completed"
 
@@ -104,7 +127,7 @@ irida_next_example_error:
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
   workflow_url: "https://github.com/phac-nml/irida_next_example_error"
-  run_id: "my_run_id_6"
+  run_id: "my_run_id_7"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "error"
 
@@ -127,7 +150,7 @@ irida_next_example_canceling:
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
   workflow_url: "https://github.com/phac-nml/irida_next_example_canceling"
-  run_id: "my_run_id_7"
+  run_id: "my_run_id_8"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "canceling"
 
@@ -150,6 +173,72 @@ irida_next_example_canceled:
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
   workflow_url: "https://github.com/phac-nml/irida_next_example_canceled"
-  run_id: "my_run_id_8"
+  run_id: "my_run_id_9"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "canceled"
+
+irida_next_example_running:
+  metadata:
+    {
+      "workflow_name": "irida_next_example_running",
+      "workflow_version": "1.0dev",
+    }
+  workflow_params:
+    {
+      "-r": "dev",
+      "--input": "/blah/samplesheet.csv",
+      "--outdir": "/blah/output",
+    }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/irida_next_example_running"
+  run_id: "my_run_id_10"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  state: "running"
+
+irida_next_example_queued:
+  metadata:
+    {
+      "workflow_name": "irida_next_example_queued",
+      "workflow_version": "1.0dev",
+    }
+  workflow_params:
+    {
+      "-r": "dev",
+      "--input": "/blah/samplesheet.csv",
+      "--outdir": "/blah/output",
+    }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/irida_next_example_queued"
+  run_id: "my_run_id_11"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  state: "queued"
+
+irida_next_example_new:
+  metadata:
+    { "workflow_name": "irida_next_example_new", "workflow_version": "1.0dev" }
+  workflow_params:
+    {
+      "-r": "dev",
+      "--input": "/blah/samplesheet.csv",
+      "--outdir": "/blah/output",
+    }
+  workflow_type: "DSL2"
+  workflow_type_version: "22.10.7"
+  tags: []
+  workflow_engine: "nextflow"
+  workflow_engine_version: ""
+  workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
+  workflow_url: "https://github.com/phac-nml/irida_next_example_new"
+  run_id: "my_run_id_12"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  state: "new"

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -23,12 +23,12 @@ workflow_execution_invalid_metadata:
   workflow_engine_version: "my_workflow_engine_version_1"
   workflow_engine_parameters: { "key_b": "value_b" }
   workflow_url: "my_workflow_url"
-  run_id: "my_run_id_1"
+  run_id: "my_run_id_2"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
 
 irida_next_example:
   metadata:
-    { workflow_name: 'phac-nml/iridanextexample', workflow_version: '1.0.2' }
+    { workflow_name: "phac-nml/iridanextexample", workflow_version: "1.0.2" }
   workflow_params: { "-r": "dev" }
   workflow_type: "DSL2"
   workflow_type_version: "22.10.7"
@@ -41,7 +41,10 @@ irida_next_example:
 
 irida_next_example_prepared:
   metadata:
-    { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }
+    {
+      "workflow_name": "irida_next_example_prepared",
+      "workflow_version": "1.0dev",
+    }
   workflow_params:
     {
       "-r": "dev",
@@ -54,13 +57,17 @@ irida_next_example_prepared:
   workflow_engine: "nextflow"
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
-  workflow_url: "https://github.com/phac-nml/iridanextexample"
+  workflow_url: "https://github.com/phac-nml/irida_next_example_prepared"
+  run_id: "my_run_id_4"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "prepared"
 
 irida_next_example_completed:
   metadata:
-    { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }
+    {
+      "workflow_name": "irida_next_example_completed",
+      "workflow_version": "1.0dev",
+    }
   workflow_params:
     {
       "-r": "dev",
@@ -73,13 +80,17 @@ irida_next_example_completed:
   workflow_engine: "nextflow"
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
-  workflow_url: "https://github.com/phac-nml/iridanextexample"
+  workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
+  run_id: "my_run_id_5"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   state: "completed"
 
 irida_next_example_error:
   metadata:
-    { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }
+    {
+      "workflow_name": "irida_next_example_error",
+      "workflow_version": "1.0dev",
+    }
   workflow_params:
     {
       "-r": "dev",
@@ -92,13 +103,17 @@ irida_next_example_error:
   workflow_engine: "nextflow"
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
-  workflow_url: "https://github.com/phac-nml/iridanextexample"
+  workflow_url: "https://github.com/phac-nml/irida_next_example_error"
+  run_id: "my_run_id_6"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe) %>
   state: "error"
 
 irida_next_example_canceling:
   metadata:
-    { "workflow_name": "irida-next-example", "workflow_version": "1.0dev" }
+    {
+      "workflow_name": "irida_next_example_canceling",
+      "workflow_version": "1.0dev",
+    }
   workflow_params:
     {
       "-r": "dev",
@@ -111,7 +126,7 @@ irida_next_example_canceling:
   workflow_engine: "nextflow"
   workflow_engine_version: ""
   workflow_engine_parameters: { "engine": "nextflow", "execute_loc": "azure" }
-  workflow_url: "https://github.com/phac-nml/iridanextexample"
+  workflow_url: "https://github.com/phac-nml/irida_next_example_canceling"
+  run_id: "my_run_id_7"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "canceling"
-  run_id: "cancel123"

--- a/test/services/workflow_executions/cancelation_service_test.rb
+++ b/test/services/workflow_executions/cancelation_service_test.rb
@@ -12,7 +12,7 @@ module WorkflowExecutions
     test 'cancel canceling workflow_execution' do
       assert 'canceling', @workflow_execution.state
 
-      run_id = 'cancel123'
+      run_id = 'my_run_id_7'
 
       stubs = Faraday::Adapter::Test::Stubs.new
       stubs.post("/runs/#{run_id}/cancel") do

--- a/test/services/workflow_executions/cancelation_service_test.rb
+++ b/test/services/workflow_executions/cancelation_service_test.rb
@@ -12,7 +12,7 @@ module WorkflowExecutions
     test 'cancel canceling workflow_execution' do
       assert 'canceling', @workflow_execution.state
 
-      run_id = 'my_run_id_7'
+      run_id = @workflow_execution.run_id
 
       stubs = Faraday::Adapter::Test::Stubs.new
       stubs.post("/runs/#{run_id}/cancel") do

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -8,7 +8,7 @@ module WorkflowExecutions
       @user = users(:john_doe)
     end
 
-    test 'not destroy prepared workflow execution' do
+    test 'should not destroy a prepared workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_prepared)
       assert workflow_execution.prepared?
 
@@ -18,7 +18,7 @@ module WorkflowExecutions
       end
     end
 
-    test 'destroy completed workflow execution' do
+    test 'should destroy a completed workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_completed)
       assert workflow_execution.completed?
 
@@ -29,7 +29,7 @@ module WorkflowExecutions
       end
     end
 
-    test 'destroy error workflow execution' do
+    test 'should destroy an errored workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_error)
       assert workflow_execution.error?
 
@@ -40,7 +40,7 @@ module WorkflowExecutions
       end
     end
 
-    test 'not destroy canceling workflow execution' do
+    test 'should not destroy a canceling workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_canceling)
       assert workflow_execution.canceling?
 

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WorkflowExecutions
+  class DestroyServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:john_doe)
+      @workflow_execution = workflow_executions(:irida_next_example_completed)
+    end
+
+    test 'not destroy prepared workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_prepared)
+      assert workflow_execution.prepared?
+
+      assert_no_difference -> { WorkflowExecution.count },
+                           -> { SamplesWorkflowExecution.count } do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
+
+    test 'destroy completed workflow execution' do
+      assert @workflow_execution.completed?
+
+      assert_difference -> { WorkflowExecution.count } => -1,
+                        -> { SamplesWorkflowExecution.count } => 0 do
+        WorkflowExecutions::DestroyService.new(@workflow_execution, @user).execute
+      end
+    end
+  end
+end

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -6,7 +6,6 @@ module WorkflowExecutions
   class DestroyServiceTest < ActiveSupport::TestCase
     def setup
       @user = users(:john_doe)
-      @workflow_execution = workflow_executions(:irida_next_example_completed)
     end
 
     test 'not destroy prepared workflow execution' do
@@ -20,11 +19,34 @@ module WorkflowExecutions
     end
 
     test 'destroy completed workflow execution' do
-      assert @workflow_execution.completed?
+      workflow_execution = workflow_executions(:irida_next_example_completed)
+      assert workflow_execution.completed?
 
       assert_difference -> { WorkflowExecution.count } => -1,
-                        -> { SamplesWorkflowExecution.count } => 0 do
-        WorkflowExecutions::DestroyService.new(@workflow_execution, @user).execute
+                        -> { SamplesWorkflowExecution.count } => -1,
+                        -> { Sample.count } => 0 do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
+
+    test 'destroy error workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_error)
+      assert workflow_execution.error?
+
+      assert_difference -> { WorkflowExecution.count } => -1,
+                        -> { SamplesWorkflowExecution.count } => -1,
+                        -> { Sample.count } => 0 do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
+
+    test 'not destroy canceling workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_canceling)
+      assert workflow_execution.canceling?
+
+      assert_no_difference -> { WorkflowExecution.count },
+                           -> { SamplesWorkflowExecution.count } do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
       end
     end
   end

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -8,6 +8,17 @@ module WorkflowExecutions
       @user = users(:john_doe)
     end
 
+    test 'should not destroy a workflow execution if the user is not the submitter' do
+      user = users(:jane_doe)
+      workflow_execution = workflow_executions(:irida_next_example_completed)
+      assert workflow_execution.completed?
+
+      assert_no_difference -> { WorkflowExecution.count },
+                           -> { SamplesWorkflowExecution.count } do
+        WorkflowExecutions::DestroyService.new(workflow_execution, user).execute
+      end
+    end
+
     test 'should not destroy a prepared workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_prepared)
       assert workflow_execution.prepared?

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -29,6 +29,16 @@ module WorkflowExecutions
       end
     end
 
+    test 'should not destroy a submitted workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_submitted)
+      assert workflow_execution.submitted?
+
+      assert_no_difference -> { WorkflowExecution.count },
+                           -> { SamplesWorkflowExecution.count } do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
+
     test 'should destroy a completed workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_completed)
       assert workflow_execution.completed?
@@ -68,6 +78,36 @@ module WorkflowExecutions
       assert_difference -> { WorkflowExecution.count } => -1,
                         -> { SamplesWorkflowExecution.count } => -1,
                         -> { Sample.count } => 0 do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
+
+    test 'should not destroy a running workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_running)
+      assert workflow_execution.running?
+
+      assert_no_difference -> { WorkflowExecution.count },
+                           -> { SamplesWorkflowExecution.count } do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
+
+    test 'should not destroy a queued workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_queued)
+      assert workflow_execution.queued?
+
+      assert_no_difference -> { WorkflowExecution.count },
+                           -> { SamplesWorkflowExecution.count } do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
+
+    test 'should not destroy a new workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_new)
+      assert workflow_execution.new?
+
+      assert_no_difference -> { WorkflowExecution.count },
+                           -> { SamplesWorkflowExecution.count } do
         WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
       end
     end

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -49,5 +49,16 @@ module WorkflowExecutions
         WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
       end
     end
+
+    test 'should destroy a canceled workflow execution' do
+      workflow_execution = workflow_executions(:irida_next_example_canceled)
+      assert workflow_execution.canceled?
+
+      assert_difference -> { WorkflowExecution.count } => -1,
+                        -> { SamplesWorkflowExecution.count } => -1,
+                        -> { Sample.count } => 0 do
+        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
+      end
+    end
   end
 end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -17,14 +17,16 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
   end
 
   test 'should be able to cancel a workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_prepared)
+
     visit workflow_executions_path
 
     assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
 
-    tr = find('td', text: 'prepared').ancestor('tr')
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(4)', text: 'prepared'
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
       assert_selector 'input[type="submit"][value="Cancel"]', count: 1
       find('input[type="submit"][value="Cancel"]').click
     end
@@ -34,5 +36,77 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_selector 'tbody tr td:nth-child(4)', text: 'canceling'
     assert_no_selector 'tbody tr input[type="submit"][value="Cancel"]'
+  end
+
+  test 'should not delete a prepared workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_prepared)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_no_selector 'input[type="submit"][value="Delete"]'
+    end
+  end
+
+  test 'should delete a completed workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_completed)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_selector 'input[type="submit"][value="Delete"]', count: 1
+      find('input[type="submit"][value="Delete"]').click
+    end
+
+    assert_text 'Confirmation required'
+    click_button 'Confirm'
+
+    assert_no_text workflow_execution.run_id
+  end
+
+  test 'should delete an errored workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_error)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_selector 'input[type="submit"][value="Delete"]', count: 1
+      find('input[type="submit"][value="Delete"]').click
+    end
+
+    assert_text 'Confirmation required'
+    click_button 'Confirm'
+
+    assert_no_text workflow_execution.run_id
+  end
+
+  test 'should not delete a canceling workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_canceling)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_no_selector 'input[type="submit"][value="Delete"]'
+    end
   end
 end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -13,7 +13,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
 
-    assert_selector 'table#workflow_executions tbody tr', count: 5
+    assert_selector 'table#workflow_executions tbody tr', count: 7
   end
 
   test 'should be able to cancel a workflow' do

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -13,7 +13,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
 
-    assert_selector 'table#workflow_executions tbody tr', count: 7
+    assert_selector 'table#workflow_executions tbody tr', count: 8
   end
 
   test 'should be able to cancel a workflow' do
@@ -108,5 +108,26 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       assert_selector 'td:nth-child(4)', text: workflow_execution.state
       assert_no_selector 'input[type="submit"][value="Delete"]'
     end
+  end
+
+  test 'should delete a canceled workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_canceled)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_selector 'input[type="submit"][value="Delete"]', count: 1
+      find('input[type="submit"][value="Delete"]').click
+    end
+
+    assert_text 'Confirmation required'
+    click_button 'Confirm'
+
+    assert_no_text workflow_execution.run_id
   end
 end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -13,7 +13,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
 
-    assert_selector 'table#workflow_executions tbody tr', count: 8
+    assert_selector 'table#workflow_executions tbody tr', count: 12
   end
 
   test 'should be able to cancel a workflow' do
@@ -35,11 +35,26 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     click_button 'Confirm'
 
     assert_selector 'tbody tr td:nth-child(4)', text: 'canceling'
-    assert_no_selector 'tbody tr input[type="submit"][value="Cancel"]'
+    assert_no_selector 'tbody tr  td:nth-child(4) input[type="submit"][value="Cancel"]'
   end
 
   test 'should not delete a prepared workflow' do
     workflow_execution = workflow_executions(:irida_next_example_prepared)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_no_selector 'input[type="submit"][value="Delete"]'
+    end
+  end
+
+  test 'should not delete a submitted workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_submitted)
 
     visit workflow_executions_path
 
@@ -129,5 +144,50 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     click_button 'Confirm'
 
     assert_no_text workflow_execution.run_id
+  end
+
+  test 'should not delete a running workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_running)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_no_selector 'input[type="submit"][value="Delete"]'
+    end
+  end
+
+  test 'should not delete a queued workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_queued)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_no_selector 'input[type="submit"][value="Delete"]'
+    end
+  end
+
+  test 'should not delete a new workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_new)
+
+    visit workflow_executions_path
+
+    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
+
+    tr = find('td', text: workflow_execution.run_id).ancestor('tr')
+
+    within tr do
+      assert_selector 'td:nth-child(4)', text: workflow_execution.state
+      assert_no_selector 'input[type="submit"][value="Delete"]'
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
A user can delete a WorkflowExecution after it has been completed, errored, or canceled.
Fixes #249.

## Screenshots or screen recordings
![Screenshot from 2024-03-05 08-55-47](https://github.com/phac-nml/irida-next/assets/325703/7f723ae7-5257-4e2b-85d6-618484e176a9)
![Screenshot from 2024-03-05 08-55-56](https://github.com/phac-nml/irida-next/assets/325703/252d9af5-b827-4e87-ba76-ae19d3a26e96)
![image](https://github.com/phac-nml/irida-next/assets/325703/307d4a53-fe88-4916-9d19-e47d87560c83)

## How to set up and validate locally
1. Login to irida-next.
2. Create a new workflow execution.
3. Open a rails console and run the following:
```
w = WorkflowExecution.last
w.state = "completed"
w.save
```
5. Refresh the workflow execution page.
6. Click the `Delete` link.
7. Confirm the deletion.
8. Verify the workflow execution has been deleted.

Repeat with `w.state = "error"` and `w.state = "canceled"`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
