### PR TITLE
Fix: Sample sheet rendering to nextflow submission form

### DIFF
--- a/app/components/nextflow/samplesheet_component.html.erb
+++ b/app/components/nextflow/samplesheet_component.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="sample-sheet">
   <label class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"><%= t(".label") %></label>
   <table class="w-full text-sm text-left text-slate-500 dark:text-slate-400">
     <thead

--- a/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
+++ b/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
@@ -11,7 +11,7 @@
             <%= form.hidden_field :workflow_version, value: workflow.version %>
             <div
               data-controller="sessionstorage-amend-form"
-              data-sessionstorage-amend-forms-target="field"
+              data-sessionstorage-amend-form-target="field"
               data-sessionstorage-amend-form-field-name-value="sample_ids[]"
             />
             <button

--- a/test/system/workflow_executions/submissions_test.rb
+++ b/test/system/workflow_executions/submissions_test.rb
@@ -21,7 +21,18 @@ class SubmissionsTest < ApplicationSystemTestCase
     click_on I18n.t(:'projects.samples.index.workflows.button_sr')
     assert_selector 'dialog' do
       assert_selector '.dialog--header', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
-      assert_selector 'button', text: 'phac-nml/iridanextexample'
+      assert_selector 'button', text: 'phac-nml/iridanextexample', count: 3
+      first('button', text: 'phac-nml/iridanextexample').click
+    end
+
+    assert_selector 'dialog.dialog--size-xl' do
+      assert_selector 'div.sample-sheet' do
+        assert_selector 'table' do
+          assert_selector 'tr[data-controller="nextflow--samplesheet"]', count: 2
+          assert_selector 'tr[data-controller="nextflow--samplesheet"]', text: @sample1.name, count: 1
+          assert_selector 'tr[data-controller="nextflow--samplesheet"]', text: @sample2.name, count: 1
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

1. Fixed issue where the incorrect javascript controller name (small typo in `_pipeline_selection_dialog.html.erb`) was preventing the samplesheet component from rendering within the nextflow component.
2. Added testing as there were none to test for this.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

None required: No new components added

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

- Select multiple samples from a project samples page (e.g. `http://localhost:3000/yersinia/yersinia-pseudotuberculosis/outbreak-2023/-/samples`)
- Click the workflow submission launch button and select a workflow
- Ensure that there are no errors in the console, and that the samplesheet is rendered with the selected samples.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
