### PR TITLE
Fix: Breadcrumb Component Double Slashes

### DIFF
--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -11,14 +11,14 @@
         <% end %>
         <% if index < links.length - 1 %>
           <%= link_to link[:name],
-          [root_url, link[:path]].join(""),
+          URI.join(root_url, link[:path]).to_s,
           data: {
             turbo_frame: "_top"
           },
           class: "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400" %>
         <% else %>
           <%= link_to link[:name],
-          [root_url, link[:path]].join(""),
+          URI.join(root_url, link[:path]).to_s,
           data: {
             turbo_frame: "_top"
           },

--- a/test/components/viral/breadcrumb_component_test.rb
+++ b/test/components/viral/breadcrumb_component_test.rb
@@ -27,7 +27,7 @@ module Viral
       # Mock context breadcrumb
       context_crumbs = route_to_context_crumbs(mock_route)
       context_crumbs += [{ name: I18n.t('projects.edit.title', raise: true),
-                           path: "#{groups(:group_one).path}/-/edit`" }]
+                           path: "#{groups(:group_one).path}/-/edit" }]
 
       render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
@@ -54,7 +54,7 @@ module Viral
       # Mock context breadcrumb
       context_crumbs = route_to_context_crumbs(mock_route)
       context_crumbs += [{ name: I18n.t('projects.edit.title', raise: true),
-                           path: "#{groups(:group_one).path}/-/groups/new`" }]
+                           path: "#{groups(:group_one).path}/-/groups/new" }]
 
       render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updates BreadcrumbComponent to use `URI::join(root_url, path).to_s` instead of `[root_url, path].join("")` to prevent having double slashes in resulting URL which broke selection controller.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before:

![image](https://github.com/phac-nml/irida-next/assets/492127/f312b74d-83bf-4c5e-85bc-7b66d2186039)

After:

![image](https://github.com/phac-nml/irida-next/assets/492127/b8f59dff-ee66-45af-9cc2-e94c75ceffd9)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Start server
2. Navigate to a `Group` and then click on `Samples`, verify that the breadcrumb titled `Samples` does not contain a double slash
3. Repeat test on `Project`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
