### PR TITLE
Attachments: PUID

### DIFF
--- a/app/javascript/controllers/projects/samples/attachments/files_controller.js
+++ b/app/javascript/controllers/projects/samples/attachments/files_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
 
         for (let cell of row.cells) {
           // copy file name, type, and sze
-          if ([1, 3, 4].includes(cell.cellIndex)) {
+          if ([1, 2, 4, 5].includes(cell.cellIndex)) {
             newRow.append(cell.cloneNode(true));
           }
         }

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -5,6 +5,8 @@ class Attachment < ApplicationRecord
   has_logidze
   acts_as_paranoid
 
+  include HasPuid
+
   belongs_to :attachable, polymorphic: true
 
   has_one_attached :file
@@ -13,11 +15,15 @@ class Attachment < ApplicationRecord
 
   validates_with AttachmentChecksumValidator
 
-  before_create :assign_metadata
+  after_initialize :assign_metadata
 
   delegate :filename, to: :file
 
   delegate :byte_size, to: :file
+
+  def self.model_prefix
+    'ATT'
+  end
 
   # override destroy so that on soft delete we don't delete the ActiveStorage::Attachment
   def destroy

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -23,6 +23,9 @@
         "w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
     </td>
   <% end %>
+  <td class="px-6 py-4">
+    <%= attachment.puid %>
+  </td>
   <% if attachment.associated_attachment && attachment.metadata['direction'] == 'forward' %>
     <td class="px-6 py-4">
       <div>

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -10,6 +10,7 @@
         <% if allowed_to?(:update_sample?, @project) %>
           <th aria-hidden="true" class="px-6 py-3"></th>
         <% end %>
+        <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.puid") %></th>
         <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.filename") %></th>
         <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.format") %></th>
         <th scope="col" class="px-6 py-3"><%= t("projects.samples.show.table_header.type") %></th>

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -1,10 +1,18 @@
-<%= viral_dialog(open: open, classes: ["overflow-x-visible"]) do |dialog| %>
+<%= viral_dialog(open: open, size: :large) do |dialog| %>
   <%= dialog.with_header(title: t(".title")) %>
   <%= dialog.with_section do %>
 
     <%= turbo_frame_tag("concatenation-alert") %>
 
-    <div class="mb-4 font-normal text-gray-500 dark:text-gray-400">
+    <div
+      class="
+        mb-4
+        font-normal
+        text-gray-500
+        dark:text-gray-400
+        overflow-x-visible
+      "
+    >
       <p class="mb-4"><%= t(".description") %></p>
       <div
         data-controller="projects--samples--attachments--files"

--- a/app/views/projects/samples/attachments/deletions/_modal.html.erb
+++ b/app/views/projects/samples/attachments/deletions/_modal.html.erb
@@ -1,10 +1,10 @@
-<%= viral_dialog(open: open, classes: ["overflow-x-visible"]) do |dialog| %>
+<%= viral_dialog(open: open, size: :large) do |dialog| %>
   <%= dialog.with_header(title: t(".title")) %>
   <%= dialog.with_section do %>
 
     <%= turbo_frame_tag("deletion-alert") %>
 
-    <div class="mb-4 font-normal text-gray-500 dark:text-gray-400">
+    <div class="mb-4 font-normal text-gray-500 dark:text-gray-400 overflow-x-visible">
       <p class="mb-4"><%= t(".description") %></p>
       <div
         data-controller="projects--samples--attachments--files"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -879,6 +879,7 @@ en:
         upload_files: Upload Files
         uploading: Uploading
         table_header:
+          puid: ID
           filename: Filename
           format: Format
           type: Type

--- a/db/migrate/20240311145704_add_puid_to_attachment.rb
+++ b/db/migrate/20240311145704_add_puid_to_attachment.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Migration to add Persistent Unique Identifier column to Attachment model
+class AddPuidToAttachment < ActiveRecord::Migration[7.1]
+  def change # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    add_column :attachments, :puid, :string
+
+    reversible do |dir|
+      dir.up do
+        Attachment
+          .with_deleted
+          .where('metadata @> ? OR metadata @> ?', { 'type' => 'pe', 'direction' => 'forward' }.to_json,
+                 { 'type' => 'illumina_pe', 'direction' => 'forward' }.to_json).each do |att|
+          puid = Irida::PersistentUniqueId.generate(att, time: att.created_at)
+          att.update!(puid:)
+          att.associated_attachment.update!(puid:)
+        end
+        Attachment
+          .with_deleted
+          .where('NOT metadata @> ? AND NOT metadata @> ?', { 'type' => 'pe' }.to_json,
+                 { 'type' => 'illumina_pe' }.to_json).each do |att|
+          att.update!(puid: Irida::PersistentUniqueId.generate(att, time: att.created_at))
+        end
+        change_column :attachments, :puid, :string, null: false
+      end
+    end
+
+    add_index :attachments, :puid, unique: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_29_165646) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_11_145704) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -53,9 +53,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_165646) do
     t.datetime "updated_at", null: false
     t.jsonb "log_data"
     t.uuid "attachable_id", null: false
+    t.string "puid", null: false
     t.index ["attachable_id"], name: "index_attachments_on_attachable_id"
     t.index ["created_at"], name: "index_attachments_on_created_at"
     t.index ["metadata"], name: "index_attachments_on_metadata", using: :gin
+    t.index ["puid"], name: "index_attachments_on_puid"
   end
 
   create_table "data_exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -3,22 +3,27 @@
 attachment1:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sample1 (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 1.weeks.ago) %>
 
 attachment2:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sample1 (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 2.weeks.ago) %>
 
 attachmentA:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sampleA (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 3.weeks.ago) %>
 
 attachmentB:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sampleA (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 4.weeks.ago) %>
 
 attachmentC:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sampleA (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 5.weeks.ago) %>
 
 attachmentPEFWD1:
   metadata:
@@ -30,6 +35,7 @@ attachmentPEFWD1:
       "associated_attachment_id": <%= ActiveRecord::FixtureSet.identify(:attachmentPEREV1, :uuid) %>,
     }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 6.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEREV1:
   metadata:
@@ -41,6 +47,7 @@ attachmentPEREV1:
       "associated_attachment_id": <%= ActiveRecord::FixtureSet.identify(:attachmentPEFWD1, :uuid) %>,
     }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 6.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEFWD2:
   metadata:
@@ -52,6 +59,7 @@ attachmentPEFWD2:
       "associated_attachment_id": <%= ActiveRecord::FixtureSet.identify(:attachmentPEREV2, :uuid) %>,
     }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 7.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEREV2:
   metadata:
@@ -63,6 +71,7 @@ attachmentPEREV2:
       "associated_attachment_id": <%= ActiveRecord::FixtureSet.identify(:attachmentPEFWD2, :uuid) %>,
     }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 7.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEFWD3:
   metadata:
@@ -74,6 +83,7 @@ attachmentPEFWD3:
       "associated_attachment_id": <%= ActiveRecord::FixtureSet.identify(:attachmentPEREV3, :uuid) %>,
     }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 8.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEREV3:
   metadata:
@@ -85,6 +95,7 @@ attachmentPEREV3:
       "associated_attachment_id": <%= ActiveRecord::FixtureSet.identify(:attachmentPEFWD3, :uuid) %>,
     }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 8.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEFWD4:
   metadata:
@@ -95,6 +106,7 @@ attachmentPEFWD4:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 9.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEREV4:
   metadata:
@@ -105,6 +117,7 @@ attachmentPEREV4:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 9.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEFWD5:
   metadata:
@@ -115,6 +128,7 @@ attachmentPEFWD5:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 10.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEREV5:
   metadata:
@@ -125,26 +139,32 @@ attachmentPEREV5:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 10.weeks.ago.at_beginning_of_day) %>
 
 attachmentD:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 11.weeks.ago.at_beginning_of_day) %>
 
 attachmentE:
   metadata: { "compression": "gzip", "format": "fastq" }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 12.weeks.ago.at_beginning_of_day) %>
 
 attachmentF:
   metadata: { "compression": "gzip", "format": "fastq" }
   attachable: sampleB (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 13.weeks.ago.at_beginning_of_day) %>
 
 attachmentG:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 14.weeks.ago.at_beginning_of_day) %>
 
 attachmentH:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 15.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEFWD6:
   metadata:
@@ -155,6 +175,7 @@ attachmentPEFWD6:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 16.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEREV6:
   metadata:
@@ -165,6 +186,7 @@ attachmentPEREV6:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 16.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEFWD7:
   metadata:
@@ -175,6 +197,7 @@ attachmentPEFWD7:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 17.weeks.ago.at_beginning_of_day) %>
 
 attachmentPEREV7:
   metadata:
@@ -185,11 +208,14 @@ attachmentPEREV7:
       "compression": "none",
     }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 18.weeks.ago.at_beginning_of_day) %>
 
 attachmentI:
   metadata: { "compression": "gzip", "format": "fastq" }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 19.weeks.ago.at_beginning_of_day) %>
 
 attachmentJ:
   metadata: { "compression": "gzip", "format": "fastq" }
   attachable: sampleC (Sample)
+  puid: <%= Irida::PersistentUniqueId.generate(object_class: Attachment, time: 20.weeks.ago.at_beginning_of_day) %>

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -26,65 +26,75 @@ class AttachmentTest < ActiveSupport::TestCase
   end
 
   test 'metadata fastq file types' do
-    new_fastq_attachment_ext_fastq = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_1.fastq').open,
-                                                                       filename: 'test_file_1.fastq' })
+    new_fastq_attachment_ext_fastq =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_1.fastq').open,
+                                        filename: 'test_file_1.fastq' })
     new_fastq_attachment_ext_fastq.save
     assert_equal 'fastq', new_fastq_attachment_ext_fastq.metadata['format']
 
-    new_fastq_attachment_ext_fastq_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_2.fastq.gz').open,
-                                                                          filename: 'test_file_2.fastq.gz' })
+    new_fastq_attachment_ext_fastq_gz =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_2.fastq.gz').open,
+                                        filename: 'test_file_2.fastq.gz' })
     new_fastq_attachment_ext_fastq_gz.save
     assert_equal 'fastq', new_fastq_attachment_ext_fastq_gz.metadata['format']
 
-    new_fastq_attachment_ext_fq = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_3.fq').open,
-                                                                    filename: 'test_file_3.fq' })
+    new_fastq_attachment_ext_fq =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_3.fq').open,
+                                        filename: 'test_file_3.fq' })
     new_fastq_attachment_ext_fq.save
     assert_equal 'fastq', new_fastq_attachment_ext_fq.metadata['format']
 
-    new_fastq_attachment_ext_fq_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_4.fq.gz').open,
-                                                                       filename: 'test_file_4.fq.gz' })
+    new_fastq_attachment_ext_fq_gz =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_4.fq.gz').open,
+                                        filename: 'test_file_4.fq.gz' })
     new_fastq_attachment_ext_fq_gz.save
     assert_equal 'fastq', new_fastq_attachment_ext_fq_gz.metadata['format']
   end
 
   test 'metadata fasta file types' do
-    new_fasta_attachment_ext_fasta = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_5.fasta').open,
-                                                                       filename: 'test_file_5.fasta' })
+    new_fasta_attachment_ext_fasta =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_5.fasta').open,
+                                        filename: 'test_file_5.fasta' })
     new_fasta_attachment_ext_fasta.save
     assert_equal 'fasta', new_fasta_attachment_ext_fasta.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fasta.metadata['type']
     assert new_fasta_attachment_ext_fasta.fasta?
 
-    new_fasta_attachment_ext_fasta_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_6.fasta.gz').open,
-                                                                          filename: 'test_file_6.fasta.gz' })
+    new_fasta_attachment_ext_fasta_gz =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_6.fasta.gz').open,
+                                        filename: 'test_file_6.fasta.gz' })
     new_fasta_attachment_ext_fasta_gz.save
     assert_equal 'fasta', new_fasta_attachment_ext_fasta_gz.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fasta_gz.metadata['type']
     assert new_fasta_attachment_ext_fasta_gz.fasta?
 
-    new_fasta_attachment_ext_fa = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_7.fa').open,
-                                                                    filename: 'test_file_7.fa' })
+    new_fasta_attachment_ext_fa =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_7.fa').open,
+                                        filename: 'test_file_7.fa' })
     new_fasta_attachment_ext_fa.save
     assert_equal 'fasta', new_fasta_attachment_ext_fa.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fa.metadata['type']
     assert new_fasta_attachment_ext_fa.fasta?
 
-    new_fasta_attachment_ext_fa_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_8.fa.gz').open,
-                                                                       filename: 'test_file_8.fa.gz' })
+    new_fasta_attachment_ext_fa_gz =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_8.fa.gz').open,
+                                        filename: 'test_file_8.fa.gz' })
     new_fasta_attachment_ext_fa_gz.save
     assert_equal 'fasta', new_fasta_attachment_ext_fa_gz.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fa_gz.metadata['type']
     assert new_fasta_attachment_ext_fa_gz.fasta?
 
-    new_fasta_attachment_ext_fna = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_9.fna').open,
-                                                                     filename: 'test_file_9.fna' })
+    new_fasta_attachment_ext_fna =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_9.fna').open,
+                                        filename: 'test_file_9.fna' })
     new_fasta_attachment_ext_fna.save
     assert_equal 'fasta', new_fasta_attachment_ext_fna.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fna.metadata['type']
     assert new_fasta_attachment_ext_fna.fasta?
 
-    new_fasta_attachment_ext_fna_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_10.fna.gz').open,
-                                                                        filename: 'test_file_10.fna.gz' })
+    new_fasta_attachment_ext_fna_gz =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_10.fna.gz').open,
+                                        filename: 'test_file_10.fna.gz' })
     new_fasta_attachment_ext_fna_gz.save
     assert_equal 'fasta', new_fasta_attachment_ext_fna_gz.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fna_gz.metadata['type']
@@ -92,23 +102,27 @@ class AttachmentTest < ActiveSupport::TestCase
   end
 
   test 'metadata unknown file types' do
-    new_unknown_attachment_ext_docx = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_11.docx').open,
-                                                                        filename: 'test_file_11.docx' })
+    new_unknown_attachment_ext_docx =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_11.docx').open,
+                                        filename: 'test_file_11.docx' })
     new_unknown_attachment_ext_docx.save
     assert_equal 'unknown', new_unknown_attachment_ext_docx.metadata['format']
 
-    new_unknown_attachment_ext_pdf = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_12.pdf').open,
-                                                                       filename: 'test_file_12.pdf' })
+    new_unknown_attachment_ext_pdf =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_12.pdf').open,
+                                        filename: 'test_file_12.pdf' })
     new_unknown_attachment_ext_pdf.save
     assert_equal 'unknown', new_unknown_attachment_ext_pdf.metadata['format']
 
-    new_unknown_attachment_ext_rtf = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_13.rtf').open,
-                                                                       filename: 'test_file_13.rtf' })
+    new_unknown_attachment_ext_rtf =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_13.rtf').open,
+                                        filename: 'test_file_13.rtf' })
     new_unknown_attachment_ext_rtf.save
     assert_equal 'unknown', new_unknown_attachment_ext_rtf.metadata['format']
 
-    new_unknown_attachment_ext_txt = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_14.txt').open,
-                                                                       filename: 'test_file_14.txt' })
+    new_unknown_attachment_ext_txt =
+      @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_14.txt').open,
+                                        filename: 'test_file_14.txt' })
     new_unknown_attachment_ext_txt.save
     assert_equal 'unknown', new_unknown_attachment_ext_txt.metadata['format']
   end

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -19,83 +19,72 @@ class AttachmentTest < ActiveSupport::TestCase
   end
 
   test 'invalid when file checksum matches another Attachment associated with the Attachable' do
-    new_attachment = @sample.attachments.build
-    new_attachment.file.attach(io: Rails.root.join('test/fixtures/files/test_file.fastq').open,
-                               filename: 'test_file.fastq')
+    new_attachment = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file.fastq').open,
+                                                       filename: 'test_file.fastq' })
     assert_not new_attachment.valid?
     assert new_attachment.errors.added?(:file, :checksum_uniqueness)
   end
 
   test 'metadata fastq file types' do
-    new_fastq_attachment_ext_fastq = @sample.attachments.build
-    new_fastq_attachment_ext_fastq.file.attach(io: Rails.root.join('test/fixtures/files/test_file_1.fastq').open,
-                                               filename: 'test_file_1.fastq')
+    new_fastq_attachment_ext_fastq = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_1.fastq').open,
+                                                                       filename: 'test_file_1.fastq' })
     new_fastq_attachment_ext_fastq.save
     assert_equal 'fastq', new_fastq_attachment_ext_fastq.metadata['format']
 
-    new_fastq_attachment_ext_fastq_gz = @sample.attachments.build
-    new_fastq_attachment_ext_fastq_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_2.fastq.gz').open,
-                                                  filename: 'test_file_2.fastq.gz')
+    new_fastq_attachment_ext_fastq_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_2.fastq.gz').open,
+                                                                          filename: 'test_file_2.fastq.gz' })
     new_fastq_attachment_ext_fastq_gz.save
     assert_equal 'fastq', new_fastq_attachment_ext_fastq_gz.metadata['format']
 
-    new_fastq_attachment_ext_fq = @sample.attachments.build
-    new_fastq_attachment_ext_fq.file.attach(io: Rails.root.join('test/fixtures/files/test_file_3.fq').open,
-                                            filename: 'test_file_3.fq')
+    new_fastq_attachment_ext_fq = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_3.fq').open,
+                                                                    filename: 'test_file_3.fq' })
     new_fastq_attachment_ext_fq.save
     assert_equal 'fastq', new_fastq_attachment_ext_fq.metadata['format']
 
-    new_fastq_attachment_ext_fq_gz = @sample.attachments.build
-    new_fastq_attachment_ext_fq_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_4.fq.gz').open,
-                                               filename: 'test_file_4.fq.gz')
+    new_fastq_attachment_ext_fq_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_4.fq.gz').open,
+                                                                       filename: 'test_file_4.fq.gz' })
     new_fastq_attachment_ext_fq_gz.save
     assert_equal 'fastq', new_fastq_attachment_ext_fq_gz.metadata['format']
   end
 
   test 'metadata fasta file types' do
-    new_fasta_attachment_ext_fasta = @sample.attachments.build
-    new_fasta_attachment_ext_fasta.file.attach(io: Rails.root.join('test/fixtures/files/test_file_5.fasta').open,
-                                               filename: 'test_file_5.fasta')
+    new_fasta_attachment_ext_fasta = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_5.fasta').open,
+                                                                       filename: 'test_file_5.fasta' })
     new_fasta_attachment_ext_fasta.save
     assert_equal 'fasta', new_fasta_attachment_ext_fasta.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fasta.metadata['type']
     assert new_fasta_attachment_ext_fasta.fasta?
 
-    new_fasta_attachment_ext_fasta_gz = @sample.attachments.build
-    new_fasta_attachment_ext_fasta_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_6.fasta.gz').open,
-                                                  filename: 'test_file_6.fasta.gz')
+    new_fasta_attachment_ext_fasta_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_6.fasta.gz').open,
+                                                                          filename: 'test_file_6.fasta.gz' })
     new_fasta_attachment_ext_fasta_gz.save
     assert_equal 'fasta', new_fasta_attachment_ext_fasta_gz.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fasta_gz.metadata['type']
     assert new_fasta_attachment_ext_fasta_gz.fasta?
 
-    new_fasta_attachment_ext_fa = @sample.attachments.build
-    new_fasta_attachment_ext_fa.file.attach(io: Rails.root.join('test/fixtures/files/test_file_7.fa').open,
-                                            filename: 'test_file_7.fa')
+    new_fasta_attachment_ext_fa = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_7.fa').open,
+                                                                    filename: 'test_file_7.fa' })
     new_fasta_attachment_ext_fa.save
     assert_equal 'fasta', new_fasta_attachment_ext_fa.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fa.metadata['type']
     assert new_fasta_attachment_ext_fa.fasta?
 
-    new_fasta_attachment_ext_fa_gz = @sample.attachments.build
-    new_fasta_attachment_ext_fa_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_8.fa.gz').open,
-                                               filename: 'test_file_8.fa.gz')
+    new_fasta_attachment_ext_fa_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_8.fa.gz').open,
+                                                                       filename: 'test_file_8.fa.gz' })
     new_fasta_attachment_ext_fa_gz.save
     assert_equal 'fasta', new_fasta_attachment_ext_fa_gz.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fa_gz.metadata['type']
     assert new_fasta_attachment_ext_fa_gz.fasta?
 
-    new_fasta_attachment_ext_fna = @sample.attachments.build
-    new_fasta_attachment_ext_fna.file.attach(io: Rails.root.join('test/fixtures/files/test_file_9.fna').open,
-                                             filename: 'test_file_9.fna')
+    new_fasta_attachment_ext_fna = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_9.fna').open,
+                                                                     filename: 'test_file_9.fna' })
     new_fasta_attachment_ext_fna.save
     assert_equal 'fasta', new_fasta_attachment_ext_fna.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fna.metadata['type']
     assert new_fasta_attachment_ext_fna.fasta?
 
-    new_fasta_attachment_ext_fna_gz = @sample.attachments.build
-    new_fasta_attachment_ext_fna_gz.file.attach(io: Rails.root.join('test/fixtures/files/test_file_10.fna.gz').open,
-                                                filename: 'test_file_10.fna.gz')
+    new_fasta_attachment_ext_fna_gz = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_10.fna.gz').open,
+                                                                        filename: 'test_file_10.fna.gz' })
     new_fasta_attachment_ext_fna_gz.save
     assert_equal 'fasta', new_fasta_attachment_ext_fna_gz.metadata['format']
     assert_equal 'assembly', new_fasta_attachment_ext_fna_gz.metadata['type']
@@ -103,27 +92,23 @@ class AttachmentTest < ActiveSupport::TestCase
   end
 
   test 'metadata unknown file types' do
-    new_unknown_attachment_ext_docx = @sample.attachments.build
-    new_unknown_attachment_ext_docx.file.attach(io: Rails.root.join('test/fixtures/files/test_file_11.docx').open,
-                                                filename: 'test_file_11.docx')
+    new_unknown_attachment_ext_docx = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_11.docx').open,
+                                                                        filename: 'test_file_11.docx' })
     new_unknown_attachment_ext_docx.save
     assert_equal 'unknown', new_unknown_attachment_ext_docx.metadata['format']
 
-    new_unknown_attachment_ext_pdf = @sample.attachments.build
-    new_unknown_attachment_ext_pdf.file.attach(io: Rails.root.join('test/fixtures/files/test_file_12.pdf').open,
-                                               filename: 'test_file_12.pdf')
+    new_unknown_attachment_ext_pdf = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_12.pdf').open,
+                                                                       filename: 'test_file_12.pdf' })
     new_unknown_attachment_ext_pdf.save
     assert_equal 'unknown', new_unknown_attachment_ext_pdf.metadata['format']
 
-    new_unknown_attachment_ext_rtf = @sample.attachments.build
-    new_unknown_attachment_ext_rtf.file.attach(io: Rails.root.join('test/fixtures/files/test_file_13.rtf').open,
-                                               filename: 'test_file_13.rtf')
+    new_unknown_attachment_ext_rtf = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_13.rtf').open,
+                                                                       filename: 'test_file_13.rtf' })
     new_unknown_attachment_ext_rtf.save
     assert_equal 'unknown', new_unknown_attachment_ext_rtf.metadata['format']
 
-    new_unknown_attachment_ext_txt = @sample.attachments.build
-    new_unknown_attachment_ext_txt.file.attach(io: Rails.root.join('test/fixtures/files/test_file_14.txt').open,
-                                               filename: 'test_file_14.txt')
+    new_unknown_attachment_ext_txt = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_14.txt').open,
+                                                                       filename: 'test_file_14.txt' })
     new_unknown_attachment_ext_txt.save
     assert_equal 'unknown', new_unknown_attachment_ext_txt.metadata['format']
   end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -266,10 +266,8 @@ class GroupsTest < ApplicationSystemTestCase
   end
 
   test 'can delete a group' do
-    visit dashboard_groups_path
-    assert_text groups(:group_two).name
-
-    find('div.title a', text: groups(:group_two).name).click
+    group2 = groups(:group_two)
+    visit group_url(group2)
 
     click_link I18n.t('groups.sidebar.settings')
 

--- a/test/test_helpers/axe_helpers.rb
+++ b/test/test_helpers/axe_helpers.rb
@@ -98,6 +98,8 @@ module AxeHelpers
   def visit(path, **attributes)
     super
 
+    page.driver.wait_for_network_idle
+
     assert_accessible
   end
 end

--- a/test/test_helpers/cuprite_setup.rb
+++ b/test/test_helpers/cuprite_setup.rb
@@ -11,7 +11,9 @@ Capybara.register_driver(:irida_next_cuprite) do |app|
     # See additional options for Dockerized environment in the respective section of this article
     browser_options: {},
     # Increase Chrome startup wait time (required for stable CI builds)
-    process_timeout: 30,
+    process_timeout: 45,
+    # Page load timeout, default is 5
+    timeout: 10,
     # Enable debugging capabilities
     inspector: true,
     # Allow running Chrome in a headful mode by setting HEADLESS env


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This updates the Attachment model to include PUIDs, for `illumina_pe` and `pe` the forward and reverse individual attachments will have the same PUID.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/492127/fb750dd8-2095-4313-8db0-2d54081c1612)

![image](https://github.com/phac-nml/irida-next/assets/492127/5c1a2ac5-1fe9-43ba-9ddd-48544ef823c3)

![image](https://github.com/phac-nml/irida-next/assets/492127/f3544a97-18de-49aa-b5b3-a9c8a10e7ee1)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

First ensure that migrations succeed with existing database that has both `pe` and `illumina_pe` files.

Next ensure that uploading PE files have the same PUID and still works as expected.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
