### PR TITLE
GraphQL: Add querying by PUID to Sample and Project

### DIFF
--- a/app/graphql/resolvers/project_resolver.rb
+++ b/app/graphql/resolvers/project_resolver.rb
@@ -4,13 +4,21 @@ module Resolvers
   # Project Resolver
   class ProjectResolver < BaseResolver
     argument :full_path, GraphQL::Types::ID,
-             required: true,
+             required: false,
              description: 'Full path of the project. For example, `pathogen/surveillance/2023`.'
+    argument :puid, GraphQL::Types::ID,
+             required: false,
+             description: 'Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.'
+    validates required: { one_of: %i[full_path puid] }
 
     type Types::ProjectType, null: true
 
-    def resolve(full_path:)
-      Namespaces::ProjectNamespace.find_by_full_path(full_path)&.project # rubocop:disable Rails/DynamicFindBy
+    def resolve(args)
+      if args[:full_path]
+        Namespaces::ProjectNamespace.find_by_full_path(args[:full_path])&.project # rubocop:disable Rails/DynamicFindBy
+      else
+        Project.find_by(puid: args[:puid])
+      end
     end
   end
 end

--- a/app/graphql/resolvers/sample_resolver.rb
+++ b/app/graphql/resolvers/sample_resolver.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Resolvers
+  # Project Resolver
+  class SampleResolver < BaseResolver
+    argument :puid, GraphQL::Types::ID,
+             required: true,
+             description: 'Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAA`.'
+
+    type Types::ProjectType, null: true
+
+    def resolve(puid:)
+      Sample.find_by(puid:)
+    end
+  end
+end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -568,6 +568,11 @@ type Project implements Node {
   path: String!
 
   """
+  Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.
+  """
+  puid: ID!
+
+  """
   Samples on the project
   """
   samples(
@@ -714,7 +719,12 @@ type Query {
     """
     Full path of the project. For example, `pathogen/surveillance/2023`.
     """
-    fullPath: ID!
+    fullPath: ID
+
+    """
+    Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.
+    """
+    puid: ID
   ): Project
 
   """
@@ -831,6 +841,11 @@ type Sample implements Node {
   Project the sample is on.
   """
   project: Project!
+
+  """
+  Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAAAA`.
+  """
+  puid: ID!
 }
 
 """

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -81,6 +81,11 @@ type Attachment implements Node {
     """
     keys: [String!] = null
   ): JSON!
+
+  """
+  Persistent Unique Identifier of the attachment. For example, `INXT_ATT_AAAAAAAAAAAA`.
+  """
+  puid: ID!
 }
 
 """
@@ -751,6 +756,16 @@ type Query {
     """
     last: Int
   ): ProjectConnection
+
+  """
+  Find a sample.
+  """
+  sample(
+    """
+    Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAA`.
+    """
+    puid: ID!
+  ): Sample
 
   """
   Find samples.

--- a/app/graphql/types/attachment_type.rb
+++ b/app/graphql/types/attachment_type.rb
@@ -9,6 +9,8 @@ module Types
     field :byte_size, Integer, null: false, description: 'Attachment file size'
     field :created_at, String, null: false, description: 'Attachment creation date'
     field :filename, String, null: false, description: 'Attachment file name'
+    field :puid, ID, null: false,
+                     description: 'Persistent Unique Identifier of the attachment. For example, `INXT_ATT_AAAAAAAAAAAA`.'
 
     field :metadata,
           GraphQL::Types::JSON,

--- a/app/graphql/types/attachment_type.rb
+++ b/app/graphql/types/attachment_type.rb
@@ -9,8 +9,10 @@ module Types
     field :byte_size, Integer, null: false, description: 'Attachment file size'
     field :created_at, String, null: false, description: 'Attachment creation date'
     field :filename, String, null: false, description: 'Attachment file name'
-    field :puid, ID, null: false,
-                     description: 'Persistent Unique Identifier of the attachment. For example, `INXT_ATT_AAAAAAAAAAAA`.'
+    field :puid,
+          ID,
+          null: false,
+          description: 'Persistent Unique Identifier of the attachment. For example, `INXT_ATT_AAAAAAAAAAAA`.'
 
     field :metadata,
           GraphQL::Types::JSON,

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -11,6 +11,8 @@ module Types
     field :full_path, ID, null: false, description: 'Full path of the project.' # rubocop:disable GraphQL/ExtractType
     field :name, String, null: false, description: 'Name of the project.'
     field :path, String, null: false, description: 'Path of the project.'
+    field :puid, ID, null: false,
+                     description: 'Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.'
 
     field :samples,
           SampleType.connection_type,

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -29,6 +29,9 @@ module Types
     field :projects, Types::ProjectType.connection_type, null: true, resolver: Resolvers::ProjectsResolver,
                                                          description: 'Find projects.'
 
+    field :sample, Types::SampleType, null: true, resolver: Resolvers::SampleResolver,
+                                      description: 'Find a sample.'
+
     field :samples, Types::SampleType.connection_type, null: true, resolver: Resolvers::SamplesResolver,
                                                        description: 'Find samples.'
 

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -9,6 +9,8 @@ module Types
     field :description, String, null: true, description: 'Description of the sample.'
     field :name, String, null: false, description: 'Name of the sample.'
     field :project, ProjectType, null: false, description: 'Project the sample is on.'
+    field :puid, ID, null: false,
+                     description: 'Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAAAA`.'
 
     field :metadata,
           GraphQL::Types::JSON,

--- a/test/graphql/sample_query_test.rb
+++ b/test/graphql/sample_query_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SampleQueryTest < ActiveSupport::TestCase
+  SAMPLE_QUERY = <<~GRAPHQL
+    query($samplePuid: ID!) {
+      sample(puid: $samplePuid) {
+        name
+        description
+        id
+      }
+    }
+  GRAPHQL
+
+  def setup
+    @user = users(:john_doe)
+  end
+
+  test 'sample query should work' do
+    project = projects(:project1)
+    sample = project.samples.first
+
+    result = IridaSchema.execute(SAMPLE_QUERY, context: { current_user: @user },
+                                               variables: { samplePuid: sample.puid })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['sample']
+
+    assert_not_empty data, 'sample type should work'
+    assert_equal sample.name, data['name']
+
+    assert_equal sample.to_global_id.to_s, data['id'], 'id should be GlobalID'
+  end
+
+  test 'sample query should not return a result when unauthorized' do
+    project = projects(:project1)
+    sample = project.samples.first
+
+    result = IridaSchema.execute(SAMPLE_QUERY, context: { current_user: users(:jane_doe) },
+                                               variables: { samplePuid: sample.puid })
+
+    assert_nil result['data']['sample']
+
+    assert_not_nil result['errors'], 'shouldn\'t work and have errors.'
+
+    error_message = result['errors'][0]['message']
+
+    assert_equal 'An object of type Sample was hidden due to permissions', error_message
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds a `puid` field to `Attachment`, `Sample` and `Project` types. It also updates `Project` query to accept either a `puid` or a `full_path` to find a `Project`. In addition a new `Sample` query has been added which allows a `Sample` to be found by its `puid`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. clean dev and run
2. sign in as admin
3. on localhost:3000/graphiql query a known sample by `puid` (Can view the samples table to identify a puid)
```
sample(puid: "PUID_HERE") {
  id,
  puid,
  name
}
```
4. query a known project by `puid` (Can view a projects puid on the projects page)
```
project(puid: "PUID_HERE") {
  id,
  puid,
  name
}
```
5. query a sample and its attachments and see puid
```
sample(puid: "PUID_HERE") {
  id,
  puid,
  name,
  attachments {
    nodes {
       ... on Attachment {
          puid,
          filename
       }
   }
}
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
