### PR TITLE
Fix submissions test

### DIFF
--- a/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
+++ b/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
@@ -4,7 +4,7 @@
   ) %>
   <%= dialog.with_section do %>
     <ul class="divide-y divide-slate-200 dark:divide-slate-700">
-      <% workflows.each do |workflow| %>
+      <% workflows.each do |key, workflow| %>
         <li>
           <%= form_with url: workflow_executions_submissions_path, data: { turbo_stream: true } do |form| %>
             <%= form.hidden_field :workflow_name, value: workflow.name %>

--- a/config/initializers/pipelines.rb
+++ b/config/initializers/pipelines.rb
@@ -2,4 +2,4 @@
 
 require 'irida/pipelines'
 
-Irida::Pipelines.register_pipelines
+Irida::Pipelines.register_pipelines unless Irida::Pipelines.initialized

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -13,7 +13,7 @@ module Irida
     @pipeline_schema_file_dir = 'private/pipelines'
     @pipeline_config_file = 'pipelines.json'
     @pipeline_schema_status_file = 'status.json'
-    @available_pipelines = []
+    @available_pipelines = {}
     @initialized = false
 
     module_function
@@ -25,9 +25,12 @@ module Irida
 
       data.each do |entry|
         entry['versions'].each do |version|
+          next if @available_pipelines.key?("#{entry['name']}_#{version['name']}")
+
           nextflow_schema_location = prepare_schema_download(entry, version, 'nextflow_schema')
           schema_input_location = prepare_schema_download(entry, version, 'schema_input')
-          @available_pipelines << Pipeline.new(entry, version, nextflow_schema_location, schema_input_location)
+          @available_pipelines["#{entry['name']}_#{version['name']}"] =
+            Pipeline.new(entry, version, nextflow_schema_location, schema_input_location)
         end
       end
       @initialized = true
@@ -122,7 +125,7 @@ module Irida
     end
 
     def find_pipeline_by(name, version)
-      @available_pipelines.detect { |pipeline| (pipeline.name == name) && (pipeline.version == version) }
+      @available_pipelines["#{name}_#{version}"]
     end
 
     def available_pipelines

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -132,16 +132,17 @@ module Irida
       @available_pipelines
     end
 
-    def initialized
-      @initialized
-    end
-
     def pipeline_config_dir=(dir)
       @pipeline_config_dir = dir
     end
 
     def pipeline_schema_file_dir=(dir)
       @pipeline_schema_file_dir = dir
+    end
+
+    # If the pipelines have been initialized or not for the current process
+    def initialized
+      @initialized
     end
   end
 end

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -20,6 +20,7 @@ module Irida
     # Registers the available pipelines. This method is called
     # by an initializer which runs when the server is started up
     def register_pipelines
+      puts "\n\nREGISTERING PIPELINES\n\n"
       data = read_json_config
 
       data.each do |entry|

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -30,6 +30,8 @@ module Irida
           @available_pipelines << Pipeline.new(entry, version, nextflow_schema_location, schema_input_location)
         end
       end
+      puts "Available pipelines count\n"
+      puts @available_pipelines.count
     end
 
     # read in the json pipeline config

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -14,13 +14,13 @@ module Irida
     @pipeline_config_file = 'pipelines.json'
     @pipeline_schema_status_file = 'status.json'
     @available_pipelines = []
+    @initialized = false
 
     module_function
 
     # Registers the available pipelines. This method is called
     # by an initializer which runs when the server is started up
     def register_pipelines
-      puts "\n\nREGISTERING PIPELINES\n\n"
       data = read_json_config
 
       data.each do |entry|
@@ -30,8 +30,7 @@ module Irida
           @available_pipelines << Pipeline.new(entry, version, nextflow_schema_location, schema_input_location)
         end
       end
-      puts "Available pipelines count\n"
-      puts @available_pipelines.count
+      @initialized = true
     end
 
     # read in the json pipeline config
@@ -128,6 +127,10 @@ module Irida
 
     def available_pipelines
       @available_pipelines
+    end
+
+    def initialized
+      @initialized
     end
 
     def pipeline_config_dir=(dir)

--- a/test/lib/irida/pipelines_test.rb
+++ b/test/lib/irida/pipelines_test.rb
@@ -5,6 +5,11 @@ require 'webmock/minitest'
 
 class PipelinesTest < ActiveSupport::TestCase
   setup do
+    @pipeline_schema_file_dir = 'tmp/storage/pipelines'
+
+    Irida::Pipelines.pipeline_config_dir = 'test/config/pipelines'
+    Irida::Pipelines.pipeline_schema_file_dir = @pipeline_schema_file_dir
+
     stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.2/nextflow_schema.json')
       .to_return(status: 200, body: '', headers: { etag: '[W/"a1Ab"]' })
 
@@ -24,15 +29,8 @@ class PipelinesTest < ActiveSupport::TestCase
       .to_return(status: 200, body: '', headers: { etag:  '[W/"f1Fg"]' })
   end
 
-  setup do
-    @pipeline_schema_file_dir = 'tmp/storage/pipelines'
-
-    Irida::Pipelines.pipeline_config_dir = 'test/config/pipelines'
-    Irida::Pipelines.pipeline_schema_file_dir = @pipeline_schema_file_dir
-  end
-
   teardown do
-    FileUtils.remove_dir(@pipeline_schema_file_dir)
+    FileUtils.remove_dir(@pipeline_schema_file_dir, true)
   end
 
   test 'registers pipelines' do

--- a/test/system/workflow_executions/submissions_test.rb
+++ b/test/system/workflow_executions/submissions_test.rb
@@ -29,7 +29,7 @@ module WorkflowExecutions
         # The below line is currently commented out as it is finding 6 instances when there are only 3
         # on the page. We need to dig further into why this is happening on the CI and not locally.
 
-        # assert_button text: 'phac-nml/iridanextexample', count: 3
+        assert_button text: 'phac-nml/iridanextexample', count: 3
         first('button', text: 'phac-nml/iridanextexample').click
       end
 
@@ -60,7 +60,7 @@ module WorkflowExecutions
         # The below line is currently commented out as it is finding 6 instances when there are only 3
         # on the page. We need to dig further into why this is happening on the CI and not locally.
 
-        # assert_button text: 'phac-nml/iridanextexample', count: 3
+        assert_button text: 'phac-nml/iridanextexample', count: 3
         first('button', text: 'phac-nml/iridanextexample').click
       end
 
@@ -94,7 +94,7 @@ module WorkflowExecutions
         # The below line is currently commented out as it is finding 6 instances when there are only 3
         # on the page. We need to dig further into why this is happening on the CI and not locally.
 
-        # assert_button text: 'phac-nml/iridanextexample', count: 3
+        assert_button text: 'phac-nml/iridanextexample', count: 3
         first('button', text: 'phac-nml/iridanextexample').click
       end
 
@@ -128,7 +128,7 @@ module WorkflowExecutions
         # The below line is currently commented out as it is finding 6 instances when there are only 3
         # on the page. We need to dig further into why this is happening on the CI and not locally.
 
-        # assert_button text: 'phac-nml/iridanextexample', count: 3
+        assert_button text: 'phac-nml/iridanextexample', count: 3
         first('button', text: 'phac-nml/iridanextexample').click
       end
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes the workflow executions submissions test that had assertions commented out in a previous PR due to failures. The issue was arising due to parallelization when running the test suite. Depending on how many capybara processes `n` were started `(n*3)` pipelines were being registered. This has now been fixed by only registering pipelines if they have not already been registered for the process, and the available_pipelines are now returned as a hash with each key being a combination of the name and version (for example `phac/iridanextexample_1.0.2`) which will prevent duplicate entries

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Verify that the `submissions_test` passes repeatedly
2. Verify the CI tests for this PR pass repeatedly

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
