### PR TITLE
GraphQL: Puid enabled mutations

### DIFF
--- a/app/graphql/mutations/attach_files_to_sample.rb
+++ b/app/graphql/mutations/attach_files_to_sample.rb
@@ -21,7 +21,7 @@ module Mutations
       sample = if args[:sample_id]
                  IridaSchema.object_from_id(args[:sample_id], { expected_type: Sample })
                else
-                 Sample.find(args[:sample_puid])
+                 Sample.find_by(puid: args[:sample_puid])
                end
       files_attached = Attachments::CreateService.new(current_user, sample, { files: args[:files] }).execute
 

--- a/app/graphql/mutations/create_sample.rb
+++ b/app/graphql/mutations/create_sample.rb
@@ -9,7 +9,7 @@ module Mutations
     argument :name, String, required: true, description: 'The name to give the sample.'
     argument :project_id, ID, # rubocop:disable GraphQL/ExtractInputType
              required: false,
-             description: 'The Node ID of the project. For example, `gid://irida/Project/a84cd757-dedb-4c64-8b01-097020163077`.'
+             description: 'The Node ID of the project. For example, `gid://irida/Project/a84cd757-dedb-4c64-8b01-097020163077`.' # rubocop:disable Layout/LineLength
     argument :project_puid, ID, # rubocop:disable GraphQL/ExtractInputType
              required: false,
              description: 'Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.'

--- a/app/graphql/mutations/create_sample.rb
+++ b/app/graphql/mutations/create_sample.rb
@@ -22,7 +22,7 @@ module Mutations
       project = if args[:project_id]
                   IridaSchema.object_from_id(args[:project_id], { expected_type: Project })
                 else
-                  Project.find(args[:project_puid])
+                  Project.find_by(puid: args[:project_puid])
                 end
       sample = Samples::CreateService.new(current_user, project,
                                           { name: args[:name], description: args[:description] }).execute

--- a/app/graphql/mutations/create_sample.rb
+++ b/app/graphql/mutations/create_sample.rb
@@ -8,15 +8,24 @@ module Mutations
     argument :description, String, description: 'The description to give the sample.'
     argument :name, String, required: true, description: 'The name to give the sample.'
     argument :project_id, ID, # rubocop:disable GraphQL/ExtractInputType
-             required: true,
-             description: 'The Node ID of the project to switch the sample will be created in.'
+             required: false,
+             description: 'The Node ID of the project. For example, `gid://irida/Project/a84cd757-dedb-4c64-8b01-097020163077`.'
+    argument :project_puid, ID, # rubocop:disable GraphQL/ExtractInputType
+             required: false,
+             description: 'Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.'
+    validates required: { one_of: %i[project_id project_puid] }
 
     field :errors, [String], null: false, description: 'A list of errors that prevented the mutation.'
     field :sample, Types::SampleType, description: 'The newly created sample.'
 
-    def resolve(name:, description:, project_id:)
-      project = IridaSchema.object_from_id(project_id, { expected_type: Project })
-      sample = Samples::CreateService.new(current_user, project, { name:, description: }).execute
+    def resolve(args) # rubocop:disable Metrics/MethodLength
+      project = if args[:project_id]
+                  IridaSchema.object_from_id(args[:project_id], { expected_type: Project })
+                else
+                  Project.find(args[:project_puid])
+                end
+      sample = Samples::CreateService.new(current_user, project,
+                                          { name: args[:name], description: args[:description] }).execute
       if sample.persisted?
         {
           sample:,
@@ -24,7 +33,7 @@ module Mutations
         }
       else
         {
-          comment: nil,
+          sample: nil,
           errors: sample.errors.full_messages
         }
       end

--- a/app/graphql/mutations/update_sample_metadata.rb
+++ b/app/graphql/mutations/update_sample_metadata.rb
@@ -6,17 +6,25 @@ module Mutations
     description 'Update metadata for a sample.'
     argument :metadata, GraphQL::Types::JSON, required: true, description: 'The metadata to update the sample with.'
     argument :sample_id, ID,
-             required: true,
-             description: 'The Node ID of the sample to be updated.'
+             required: false,
+             description: 'The Node ID of the sample to be updated. For example, `gid://irida/Sample/a84cd757-dedb-4c64-8b01-097020163077`' # rubocop:disable Layout/LineLength
+    argument :sample_puid, ID, # rubocop:disable GraphQL/ExtractInputType
+             required: false,
+             description: 'Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAA`.'
+    validates required: { one_of: %i[sample_id sample_puid] }
 
     field :errors, [String], null: false, description: 'A list of errors that prevented the mutation.'
     field :sample, Types::SampleType, null: false, description: 'The updated sample.'
     field :status, GraphQL::Types::JSON, null: false, description: 'The status of the mutation.'
 
-    def resolve(sample_id:, metadata:)
-      sample = IridaSchema.object_from_id(sample_id, { expected_type: Sample })
+    def resolve(args)
+      sample = if args[:sample_id]
+                 IridaSchema.object_from_id(args[:sample_id], { expected_type: Sample })
+               else
+                 Sample.find(args[:sample_puid])
+               end
       metadata_changes = Samples::Metadata::UpdateService.new(sample.project, sample, current_user,
-                                                              { 'metadata' => metadata }).execute
+                                                              { 'metadata' => args[:metadata] }).execute
       {
         sample:,
         status: metadata_changes,

--- a/app/graphql/mutations/update_sample_metadata.rb
+++ b/app/graphql/mutations/update_sample_metadata.rb
@@ -21,7 +21,7 @@ module Mutations
       sample = if args[:sample_id]
                  IridaSchema.object_from_id(args[:sample_id], { expected_type: Sample })
                else
-                 Sample.find(args[:sample_puid])
+                 Sample.find_by(puid: args[:sample_puid])
                end
       metadata_changes = Samples::Metadata::UpdateService.new(sample.project, sample, current_user,
                                                               { 'metadata' => args[:metadata] }).execute

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -13,9 +13,14 @@ input AttachFilesToSampleInput {
   files: [String!]!
 
   """
-  The Node ID of the sample to be updated.
+  The Node ID of the sample to be updated. For example, `gid://irida/Sample/a84cd757-dedb-4c64-8b01-097020163077`
   """
-  sampleId: ID!
+  sampleId: ID
+
+  """
+  Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAA`.
+  """
+  samplePuid: ID
 }
 
 """
@@ -193,9 +198,14 @@ input CreateSampleInput {
   name: String!
 
   """
-  The Node ID of the project to switch the sample will be created in.
+  The Node ID of the project. For example, `gid://irida/Project/a84cd757-dedb-4c64-8b01-097020163077`.
   """
-  projectId: ID!
+  projectId: ID
+
+  """
+  Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.
+  """
+  projectPuid: ID
 }
 
 """
@@ -918,9 +928,14 @@ input UpdateSampleMetadataInput {
   metadata: JSON!
 
   """
-  The Node ID of the sample to be updated.
+  The Node ID of the sample to be updated. For example, `gid://irida/Sample/a84cd757-dedb-4c64-8b01-097020163077`
   """
-  sampleId: ID!
+  sampleId: ID
+
+  """
+  Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAA`.
+  """
+  samplePuid: ID
 }
 
 """

--- a/test/graphql/attach_files_to_sample_test.rb
+++ b/test/graphql/attach_files_to_sample_test.rb
@@ -68,7 +68,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_PUID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: [blob_file.signed_id],
-                                              samplePuid: sample.id })
+                                              samplePuid: sample.puid })
 
     assert_nil result['errors'], 'should work and have no errors.'
 

--- a/test/graphql/attach_files_to_sample_test.rb
+++ b/test/graphql/attach_files_to_sample_test.rb
@@ -3,9 +3,21 @@
 require 'test_helper'
 
 class AttachFilesToSampleTest < ActiveSupport::TestCase
-  ATTACH_FILES_TO_SAMPLE_MUTATION = <<~GRAPHQL
+  ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION = <<~GRAPHQL
     mutation($files: [String!]!, $sampleId: ID!) {
       attachFilesToSample(input: { files: $files, sampleId: $sampleId,
+      })
+      {
+        sample{id},
+        status,
+        errors
+      }
+    }
+  GRAPHQL
+
+  ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_PUID_MUTATION = <<~GRAPHQL
+    mutation($files: [String!]!, $samplePuid: ID!) {
+      attachFilesToSample(input: { files: $files, samplePuid: $samplePuid,
       })
       {
         sample{id},
@@ -21,16 +33,42 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     @read_api_scope_token = personal_access_tokens(:jeff_doe_valid_read_pat)
   end
 
-  test 'attachFilesToSample mutation should work with valid params and api scope token' do
+  test 'attachFilesToSample mutation should work with valid params, global id, and api scope token' do
     sample = samples(:sampleJeff)
     blob_file = active_storage_blobs(:attachment_attach_files_to_sample_test_blob)
 
     assert_equal 0, sample.attachments.count
 
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: [blob_file.signed_id],
                                               sampleId: sample.to_global_id.to_s })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['attachFilesToSample']
+
+    assert_not_empty data, 'attachFilesToSample should be populated when no authorization errors'
+    expected_status = { blob_file.signed_id => :success }
+    assert_equal expected_status, data['status']
+    assert_not_empty data['sample']
+
+    assert_equal 1, sample.attachments.count
+
+    # check that filename matches
+    assert_equal 'afts.fastq', sample.attachments[0].filename.to_s
+  end
+
+  test 'attachFilesToSample mutation should work with valid params, puid, and api scope token' do
+    sample = samples(:sampleJeff)
+    blob_file = active_storage_blobs(:attachment_attach_files_to_sample_test_blob)
+
+    assert_equal 0, sample.attachments.count
+
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_PUID_MUTATION,
+                                 context: { current_user: @user, token: @api_scope_token },
+                                 variables: { files: [blob_file.signed_id],
+                                              samplePuid: sample.id })
 
     assert_nil result['errors'], 'should work and have no errors.'
 
@@ -53,7 +91,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
     assert_equal 0, sample.attachments.count
 
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @read_api_scope_token },
                                  variables: { files: [blob_file.signed_id],
                                               sampleId: sample.to_global_id.to_s })
@@ -73,7 +111,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
     assert_equal 0, sample.attachments.count
 
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: [blob_file.signed_id],
                                               sampleId: sample.to_global_id.to_s })
@@ -84,7 +122,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     expected_status = { blob_file.signed_id => :success }
     assert_equal expected_status, data['status']
 
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: [blob_file.signed_id],
                                               sampleId: sample.to_global_id.to_s })
@@ -107,7 +145,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
     assert_equal 0, sample.attachments.count
 
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: [blob_file_a.signed_id],
                                               sampleId: sample.to_global_id.to_s })
@@ -124,7 +162,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     assert_equal 'md5_a', sample.attachments[0].filename.to_s
 
     # Second file
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: [blob_file_b.signed_id],
                                               sampleId: sample.to_global_id.to_s })
@@ -149,7 +187,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
     assert_equal 0, sample.attachments.count
 
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: [blob_file_a.signed_id, blob_file_b.signed_id],
                                               sampleId: sample.to_global_id.to_s })
@@ -178,7 +216,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
     assert_equal 0, sample.attachments.count
 
-    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+    result = IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { files: ['NAN'],
                                               sampleId: sample.to_global_id.to_s })
@@ -197,7 +235,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     blob_file = active_storage_blobs(:attachment_attach_files_to_sample_test_blob)
 
     assert_raises RuntimeError do
-      IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_MUTATION,
+      IridaSchema.execute(ATTACH_FILES_TO_SAMPLE_BY_SAMPLE_ID_MUTATION,
                           context: { current_user: @user, token: @api_scope_token },
                           variables: { files: [blob_file.signed_id],
                                        sampleId: 'this is not a valid sample id' })

--- a/test/graphql/create_sample_mutation_test.rb
+++ b/test/graphql/create_sample_mutation_test.rb
@@ -61,7 +61,7 @@ class CreateSampleMutationTest < ActiveSupport::TestCase
 
     result = IridaSchema.execute(CREATE_SAMPLE_USING_PROJECT_PUID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
-                                 variables: { projectPuid: project.id,
+                                 variables: { projectPuid: project.puid,
                                               name: 'New Sample Two',
                                               description: 'New Sample Two Description' })
 

--- a/test/graphql/update_sample_metadata_test.rb
+++ b/test/graphql/update_sample_metadata_test.rb
@@ -64,7 +64,7 @@ class UpdateSampleMetadataMutationTest < ActiveSupport::TestCase
   test 'updateSampleMetadata mutation should work with valid params, puid, and api scope token' do
     result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_BY_SAMPLE_PUID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
-                                 variables: { samplePuid: @sample.id,
+                                 variables: { samplePuid: @sample.puid,
                                               metadata: { key1: 'value1' } })
 
     assert_nil result['errors'], 'should work and have no errors.'

--- a/test/graphql/update_sample_metadata_test.rb
+++ b/test/graphql/update_sample_metadata_test.rb
@@ -3,9 +3,24 @@
 require 'test_helper'
 
 class UpdateSampleMetadataMutationTest < ActiveSupport::TestCase
-  UPDATE_SAMPLE_METADATA_MUTATION = <<~GRAPHQL
+  UPDATE_SAMPLE_METADATA_BY_SAMPLE_ID_MUTATION = <<~GRAPHQL
     mutation($sampleId: ID!, $metadata: JSON!) {
       updateSampleMetadata(input: { sampleId: $sampleId, metadata: $metadata }) {
+        sample {
+          id,
+          name,
+          description,
+          metadata
+        },
+        status,
+        errors
+      }
+    }
+  GRAPHQL
+
+  UPDATE_SAMPLE_METADATA_BY_SAMPLE_PUID_MUTATION = <<~GRAPHQL
+    mutation($samplePuid: ID!, $metadata: JSON!) {
+      updateSampleMetadata(input: { samplePuid: $samplePuid, metadata: $metadata }) {
         sample {
           id,
           name,
@@ -25,8 +40,8 @@ class UpdateSampleMetadataMutationTest < ActiveSupport::TestCase
     @sample = samples(:sample1)
   end
 
-  test 'updateSampleMetadata mutation should work with valid params and api scope token' do
-    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_MUTATION,
+  test 'updateSampleMetadata mutation should work with valid params, global id, and api scope token' do
+    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { sampleId: @sample.to_global_id.to_s,
                                               metadata: { key1: 'value1' } })
@@ -46,8 +61,29 @@ class UpdateSampleMetadataMutationTest < ActiveSupport::TestCase
     assert_equal 'value1', data['sample']['metadata']['key1']
   end
 
+  test 'updateSampleMetadata mutation should work with valid params, puid, and api scope token' do
+    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_BY_SAMPLE_PUID_MUTATION,
+                                 context: { current_user: @user, token: @api_scope_token },
+                                 variables: { samplePuid: @sample.id,
+                                              metadata: { key1: 'value1' } })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['updateSampleMetadata']
+
+    assert_not_empty data, 'updateSampleMetadata should be populated when no authorization errors'
+    assert_empty data['errors']
+    assert_not_empty data['status']
+    assert_not_empty data['status'][:added]
+    assert_equal 'key1', data['status'][:added].first
+    assert_not_empty data['sample']
+    assert_not_empty data['sample']['metadata']
+    assert_not_empty data['sample']['metadata']['key1']
+    assert_equal 'value1', data['sample']['metadata']['key1']
+  end
+
   test 'updateSampleMetadata mutation should error with empty metadata params and api scope token' do
-    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_MUTATION,
+    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @api_scope_token },
                                  variables: { sampleId: @sample.to_global_id.to_s,
                                               metadata: {} })
@@ -67,7 +103,7 @@ class UpdateSampleMetadataMutationTest < ActiveSupport::TestCase
   end
 
   test 'updateSampleMetadata mutation should not work with valid params and read api scope token' do
-    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_MUTATION,
+    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: @user, token: @read_api_scope_token },
                                  variables: { sampleId: @sample.to_global_id.to_s,
                                               metadata: { key1: 'value1' } })
@@ -83,7 +119,7 @@ class UpdateSampleMetadataMutationTest < ActiveSupport::TestCase
     user = users(:jane_doe)
     api_scope_token = personal_access_tokens(:jane_doe_valid_pat)
 
-    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_MUTATION,
+    result = IridaSchema.execute(UPDATE_SAMPLE_METADATA_BY_SAMPLE_ID_MUTATION,
                                  context: { current_user: user, token: api_scope_token },
                                  variables: { sampleId: @sample.to_global_id.to_s,
                                               metadata: { key1: 'value1' } })


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updates mutations which accepted global ids for Sample and Project, to also accept Puids for Sample and Project.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

### Testing createSample mutation

1. Login as admin@email.com
2. Open the graphiql interface http://localhost:3000/graphiql
3. Query for a Project that you can access.
```graphql
{
  project(fullPath: "bacillus/bacillus-anthracis/outbreak-2022") {
    id
    puid
    name
    path
  }
}
```
4. See that you get a valid result
5. Execute a mutation to create a Sample.
```graphql
{
  createSample(input: { projectPuid: PUID_VALUE_FROM_ABOVE, name: "Sample Name", description: "Sample Description" }) {
    errors
    sample {
      id,
      name,
      description
    }
  }
}
```
6. See that you get a valid result
7. Repeat mutation above
8. See that you get an error noting that Sample name has already been taken

### Testing updateSampleMetadata mutation
1. Login as `admin@email.com`.
2. Navigate to `http://localhost:3000/graphiql` to open the graphiql interface .
3. Execute a mutation to update metadata for a Sample.
```graphql
{
  updateSampleMetadata(input: {samplePuid: $sample_puid, metadata: $metadata}) {
    sample{
      id,
      name,
      description,
      metadata
    },
    status,
    errors
  }
}
```
4. Verify that you see all the metadata for the sample was updated.

### Testing attachFilesToSample mutation
1. `./scripts/clean_dev.sh`
2. Login as `user1@email.com`
3. Navigate to `http://localhost:3000/graphiql` to open the graphql interface .
4. Verify you can query sample from graphql and rails console

This graphql query gets you sample 51
```graphql
{
query getonesamp {
  node(id: "gid://irida/Sample/51"){
    ... on Sample{
      id,
      name,
      description,
      metadata
    }
  }
}
}
```

In a terminal, open rails console with `rails c`

The following command gets you the sample object matching above
```ruby
> Sample.all[59]
```
querying for attachments should result in an empty list
```ruby
> Sample.all[59].attachments
```

5. find a file to upload, get the content type, md5 checksum and bytesize. Or download this file and use the provided values in step 6

[myfile.json](https://github.com/phac-nml/irida-next/files/14129150/myfile.json)

6. Create a blob for your file

```graphql
mutation makeblob {
  createDirectUpload(
    input: {
      filename: "myfile.json", # file name
      contentType: "application/json", # file content type
      checksum: "Y33CgI35hFoI6p+WBXYl+A==", # md5
      byteSize: 151 # size in bytes
    }
  ) {
    directUpload {
      url,
      headers,
      blobId,
      signedBlobId
    }
  }
}
```

We will use the `url`, `headers` and `signedBlobId`

7. Upload your file. This is simplest with Postman
Make a `PUT` request, putting the returned `url` in the URL field

![image](https://github.com/phac-nml/irida-next/assets/16961365/d960b0c3-706e-4311-9986-e512ab7731a5)

Attach the file as binary

![image](https://github.com/phac-nml/irida-next/assets/16961365/b3d0f8af-269b-4b71-820d-bdf8f5d99db7)

Verify your content type header matches the `headers` from above. Postman should auto-generate this based on the file you attached.

When `Send` is clicked, you should receive a `204 No Content`

8. Execute the mutation to attach files to a Sample.

```graphql
mutation attachfilestosample {
  attachFilesToSample (
    input: {
      files: ["YOUR signedBlobId FROM ABOVE"],
      samplePuid: "SAMPLE_51_PUID"
    }
  ) {
    sample{id},
    status,
    errors
  }
}
```
response
```json
{
  "data": {
    "attachFilesToSample": {
      "sample": {
        "puid": "SAMPLE_51_PUID"
      },
      "status": {
        "eyJfcmFpbHMiOnsiZGF0YSI6NTIsInB1ciI6ImJsb2JfaWQifX0=--1aae6b4a9798a4593e24499df749f20ad862af00": "success"
      },
      "errors": []
    }
  }
}
```

9. Verify that you see all the files you attached

Querying for attachments should result in one attachment, which you uploaded.
```ruby
> Sample.all[59].attachments
```

```ruby
[#<Attachment:0x00007fe0db6ae9d8
  id: 51,
  metadata: {"format"=>"unknown", "compression"=>"none"},
  deleted_at: nil,
  attachable_type: "Sample",
  attachable_id: 51,
  created_at: Thu, 01 Feb 2024 17:59:39.890147000 UTC +00:00,
  updated_at: Thu, 01 Feb 2024 17:59:39.921974000 UTC +00:00,
  log_data: nil>]
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
