### PR TITLE
Fix: nextflow component and nextflow samplesheet component preview

### DIFF
--- a/test/components/previews/nextflow_component_preview.rb
+++ b/test/components/previews/nextflow_component_preview.rb
@@ -3,20 +3,21 @@
 class NextflowComponentPreview < ViewComponent::Preview
   # @param schema_file select :schema_file_options
   def default(schema_file: 'nextflow_schema.json')
-    sample1 = Sample.find_by(id: 1)
-    sample2 = Sample.find_by(id: 2)
+    sample1 = Sample.first
+    sample2 = Sample.second
 
-    workflow = Struct.new(:name, :id, :description, :version, :metadata, :type, :type_version, :engine,
-                          :engine_version, :url, :execute_loc)
-    metadata = { workflow_name: 'irida-next-example', workflow_version: '1.0dev' }
-    flow = workflow.new('phac-nml/iridanextexample', 1, 'IRIDA Next Example Pipeline', '1.0.1', metadata,
-                        'NFL', 'DSL2', 'nextflow', '23.10.0',
-                        'https://github.com/phac-nml/iridanextexample', 'azure')
+    entry = {
+      name: 'phac-nml/iridanextexample',
+      description: 'IRIDA Next Example Pipeline',
+      url: 'https://github.com/phac-nml/iridanextexample'
+    }
+    workflow = Irida::Pipeline.new(entry, '1.0.1',
+                                   Rails.root.join('test/fixtures/files/nextflow/', schema_file),
+                                   Rails.root.join('test/fixtures/files/nextflow/samplesheet_schema.json'))
 
     render_with_template(locals: {
-                           schema_file:,
                            samples: [sample1, sample2],
-                           workflow: flow
+                           workflow:
                          })
   end
 

--- a/test/components/previews/nextflow_component_preview/default.html.erb
+++ b/test/components/previews/nextflow_component_preview/default.html.erb
@@ -1,11 +1,1 @@
-<%= render NextflowComponent.new(
-  workflow: ,
-  schema:
-    JSON.parse(
-      File.read(
-        Rails.root.join("test", "fixtures", "files", "nextflow", schema_file)
-      )
-    ),
-  url: "no_where",
-  samples:
-) %>
+<%= render NextflowComponent.new(workflow:, url: "no_where", samples:) %>

--- a/test/components/previews/nextflow_samplesheet_component_preview.rb
+++ b/test/components/previews/nextflow_samplesheet_component_preview.rb
@@ -3,8 +3,8 @@
 class NextflowSamplesheetComponentPreview < ViewComponent::Preview
   # @param schema_file select :schema_file_options
   def default(schema_file: 'samplesheet_schema.json')
-    sample1 = Sample.find_by(id: 1)
-    sample2 = Sample.find_by(id: 2)
+    sample1 = Sample.first
+    sample2 = Sample.second
 
     render_with_template(locals: {
                            schema_file:,


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Currently the previews are broken for the nextflow component and the nextflow samplesheet component.  This was caused by removing hard-coded workflows.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._
N/A

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Ensure previews are working:

1. [Nextflow Component](http://localhost:3000/rails/lookbook/inspect/nextflow/default)
2. [Nextflow Samplesheet Component](http://localhost:3000/rails/lookbook/inspect/nextflow_samplesheet/default)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
