### PR TITLE
Dashboard: Effective access role display

### DIFF
--- a/app/components/namespace_tree/row/row_contents_component.html.erb
+++ b/app/components/namespace_tree/row/row_contents_component.html.erb
@@ -26,7 +26,24 @@
   <div class="flex flex-col namespace-text">
     <div class="namespace-text grow shrink">
       <div class="flex flex-wrap items-center mr-3 font-semibold title">
-        <%= link_to @namespace.name, group_path(@namespace), data: { turbo: false } %>
+        <% if @namespace.type == "Group" %>
+          <%= link_to @namespace.name, group_path(@namespace), data: { turbo: false } %>
+        <% else %>
+          <%= link_to @namespace.name,
+          project_path(@namespace.project),
+          data: {
+            turbo: false
+          } %>
+        <% end %>
+        <%= viral_pill(
+          text:
+            t(
+              :"groups.members.index.access_level.level_#{Member.effective_access_level(@namespace, Current.user)}"
+            ),
+          color: "transparent",
+          border: true,
+          classes: "ml-2"
+        ) %>
       </div>
       <div class="description">
         <p><%= @namespace.description %></p>

--- a/app/components/viral/pill_component.rb
+++ b/app/components/viral/pill_component.rb
@@ -14,19 +14,36 @@ module Viral
       indigo: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300',
       purple: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300',
       pink: 'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-300',
-      primary: 'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-400'
+      primary: 'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-400',
+      transparent: 'text-slate-500 dark:text-slate-400'
     }.freeze
+
+    BORDER_COLORS = {
+      blue: 'border border-blue-800 dark:border-blue-300',
+      gray: 'border border-gray-800 dark:border-gray-300',
+      red: 'border border-red-800 dark:border-red-300',
+      green: 'border border-green-800 dark:border-green-300',
+      yellow: 'border border-yellow-800 dark:border-yellow-300',
+      indigo: 'border border-indigo-800 dark:border-indigo-300',
+      purple: 'border border-purple-800 dark:border-purple-300',
+      pink: 'border border-pink-800 dark:border-pink-300',
+      primary: 'border border-primary-800 dark:border-primary-400',
+      transparent: 'border border-slate-500 dark:border-slate-400'
+    }
 
     def initialize(
       text: nil,
       color: nil,
+      border: false,
       **system_arguments
     )
       @text = text
       @color = color.to_sym if color
+      border = BORDER_COLORS[@color] if border
       @system_arguments = system_arguments
       @system_arguments[:classes] = class_names(
         COLORS[@color],
+        border,
         # Tailwind classes pertaining to all pill component colors
         'text-xs font-medium px-2.5 py-0.5 rounded-full',
         @system_arguments[:classes]

--- a/app/components/viral/pill_component.rb
+++ b/app/components/viral/pill_component.rb
@@ -29,7 +29,7 @@ module Viral
       pink: 'border border-pink-800 dark:border-pink-300',
       primary: 'border border-primary-800 dark:border-primary-400',
       transparent: 'border border-slate-500 dark:border-slate-400'
-    }
+    }.freeze
 
     def initialize(
       text: nil,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,14 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :success, :info, :warning, :danger
   before_action :authenticate_user!
+  around_action :set_current_user
   around_action :use_logidze_responsible, only: %i[create destroy update transfer] # rubocop:disable Rails/LexicallyScopedActionFilter
   around_action :switch_locale
+
+  def set_current_user
+    Current.user = current_user
+    yield
+  end
 
   def switch_locale(&)
     locale = current_user.try(:locale) || I18n.default_locale

--- a/app/controllers/dashboard/groups_controller.rb
+++ b/app/controllers/dashboard/groups_controller.rb
@@ -35,9 +35,10 @@ module Dashboard
       @collapsed = params[:collapse] == 'true'
       @group = Group.find(params[:parent_id])
       @depth = params[:depth].to_i
+      @children = Group.none
       return if @collapsed
 
-      @sub_groups = @group.children
+      @children = @group.children
     end
 
     def authorized_groups

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# thread-isolated attributes class
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -139,8 +139,7 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     relation.with(
       user_groups: relation.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids
       .where(type: Group.sti_name),
-      linked_groups: NamespaceGroupLink.where(group: relation.where(id: user.members.joins(:namespace)
-      .where(namespace: { type: Group.sti_name }).not_expired.select(:namespace_id)).self_and_descendant_ids)
+      linked_groups: NamespaceGroupLink.where(Arel.sql('namespace_group_links.group_id in (select * from user_groups)'))
       .select(:namespace_id)
     ).where(
       Arel.sql(

--- a/app/views/dashboard/groups/group.turbo_stream.erb
+++ b/app/views/dashboard/groups/group.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.replace dom_id(@group) do %>
   <%= render NamespaceTree::Row::WithChildrenComponent.new(
     namespace: @group,
-    children: @group.children,
+    children: @children,
     collapsed: @collapsed,
     path: "dashboard_groups_path",
     type: [Group.sti_name]

--- a/app/views/shared/project/_row.html.erb
+++ b/app/views/shared/project/_row.html.erb
@@ -31,14 +31,15 @@
         ) %>
       </span>
     <% end %>
-    <span><%= viral_pill(
-        text:
-          t(
-            :"projects.members.index.access_level.level_#{Member.effective_access_level(project.namespace, current_user)}"
-          ),
-        color: "transparent",
-        border: true
-      ) %></span>
+    <%= viral_pill(
+      text:
+        t(
+          :"projects.members.index.access_level.level_#{Member.effective_access_level(project.namespace, current_user)}"
+        ),
+      color: "transparent",
+      border: true,
+      classes: "ml-2"
+    ) %>
     <div class="text-sm font-normal text-slate-500 dark:text-slate-400"><%= project.description %></div>
   </td>
   <td class="p-4 text-right whitespace-nowrap">

--- a/app/views/shared/project/_row.html.erb
+++ b/app/views/shared/project/_row.html.erb
@@ -23,12 +23,22 @@
         /
       </span>
       <span class="font-semibold">
-          <%= highlight(
-            project.namespace.name, defined?(params[:q][:namespace_name_cont]) && params[:q][:namespace_name_cont],
-            highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>'
-          ) %>
-        </span>
+        <%= highlight(
+          project.namespace.name,
+          defined?(params[:q][:namespace_name_cont]) &&
+            params[:q][:namespace_name_cont],
+          highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>'
+        ) %>
+      </span>
     <% end %>
+    <span><%= viral_pill(
+        text:
+          t(
+            :"projects.members.index.access_level.level_#{Member.effective_access_level(project.namespace, current_user)}"
+          ),
+        color: "transparent",
+        border: true
+      ) %></span>
     <div class="text-sm font-normal text-slate-500 dark:text-slate-400"><%= project.description %></div>
   </td>
   <td class="p-4 text-right whitespace-nowrap">

--- a/test/components/namespace_tree_component_test.rb
+++ b/test/components/namespace_tree_component_test.rb
@@ -20,6 +20,8 @@ class NamespaceTreeComponentTest < ViewComponent::TestCase
       assert_selector 'li a[href="/group-glt-3"][aria-label="Group GLT 3"]', count: 1
       assert_selector 'li', text: 'Group GLT 4'
       assert_selector 'li a[href="/group-glt-4"][aria-label="Group GLT 4"]', count: 1
+      # verify 4 effective role pills are visible
+      assert_selector 'span', text: 'Owner', count: 4
     end
   end
 end

--- a/test/components/namespace_tree_component_test.rb
+++ b/test/components/namespace_tree_component_test.rb
@@ -1,22 +1,25 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'minitest/autorun'
 
 class NamespaceTreeComponentTest < ViewComponent::TestCase
   test 'Should render a collapsed tree' do
     namespaces = Array.new(3) { |i| Group.create!(name: "Group GLT #{i + 1}", path: "group-glt-#{i + 1}") }
     namespaces.push(Group.create!(name: 'Group GLT 4', path: 'group-glt-4',
                                   children: [Group.create!(name: 'Group GLT 5', path: 'group-glt-5')]))
-    render_inline NamespaceTreeContainerComponent.new(namespaces:, path: 'dashboard_groups_path')
+    Member.stub :effective_access_level, Member::AccessLevel::OWNER do
+      render_inline NamespaceTreeContainerComponent.new(namespaces:, path: 'dashboard_groups_path')
 
-    assert_selector 'li', count: 4
-    assert_selector 'li', text: 'Group GLT 1'
-    assert_selector 'li a[href="/group-glt-1"][aria-label="Group GLT 1"]', count: 1
-    assert_selector 'li', text: 'Group GLT 2'
-    assert_selector 'li a[href="/group-glt-2"][aria-label="Group GLT 2"]', count: 1
-    assert_selector 'li', text: 'Group GLT 3'
-    assert_selector 'li a[href="/group-glt-3"][aria-label="Group GLT 3"]', count: 1
-    assert_selector 'li', text: 'Group GLT 4'
-    assert_selector 'li a[href="/group-glt-4"][aria-label="Group GLT 4"]', count: 1
+      assert_selector 'li', count: 4
+      assert_selector 'li', text: 'Group GLT 1'
+      assert_selector 'li a[href="/group-glt-1"][aria-label="Group GLT 1"]', count: 1
+      assert_selector 'li', text: 'Group GLT 2'
+      assert_selector 'li a[href="/group-glt-2"][aria-label="Group GLT 2"]', count: 1
+      assert_selector 'li', text: 'Group GLT 3'
+      assert_selector 'li a[href="/group-glt-3"][aria-label="Group GLT 3"]', count: 1
+      assert_selector 'li', text: 'Group GLT 4'
+      assert_selector 'li a[href="/group-glt-4"][aria-label="Group GLT 4"]', count: 1
+    end
   end
 end

--- a/test/components/previews/viral_pill_component_preview.rb
+++ b/test/components/previews/viral_pill_component_preview.rb
@@ -3,6 +3,8 @@
 class ViralPillComponentPreview < ViewComponent::Preview
   def default; end
 
+  def with_border; end
+
   def with_classes; end
 
   def with_content; end

--- a/test/components/previews/viral_pill_component_preview/with_border.html.erb
+++ b/test/components/previews/viral_pill_component_preview/with_border.html.erb
@@ -1,0 +1,7 @@
+<%= viral_pill(text: "This is blue", color: "blue", border: true) %>
+<%= viral_pill(text: "This is green", color: "green", border: true) %>
+<%= viral_pill(
+  text: "This has much more text and is purple",
+  color: "purple",
+  border: true
+) %>

--- a/test/components/viral/pill_component_test.rb
+++ b/test/components/viral/pill_component_test.rb
@@ -13,6 +13,17 @@ module Viral
       assert_selector '.bg-blue-100.text-blue-800.text-xs.font-medium.rounded-full', text: 'This is blue'
     end
 
+    test 'with_border' do
+      render_preview(:with_border)
+      assert_selector 'span', count: 3
+      assert_selector '.bg-purple-100.text-purple-800.text-xs.font-medium.rounded-full.border.border-purple-800',
+                      text: 'This has much more text and is purple'
+      assert_selector '.bg-green-100.text-green-800.text-xs.font-medium.rounded-full.border.border-green-800',
+                      text: 'This is green'
+      assert_selector '.bg-blue-100.text-blue-800.text-xs.font-medium.rounded-full.border.border-blue-800',
+                      text: 'This is blue'
+    end
+
     test 'with_classes' do
       render_preview(:with_classes)
       assert_selector 'span', count: 4


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates both the Groups Dashboard and Projects Dashboard to have a badge indicating the currently logged in Users access level for said Group or Project.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/492127/2dafeffe-6046-4e13-bed0-12efef8629b5)

![image](https://github.com/phac-nml/irida-next/assets/492127/f567c9f7-36e7-4195-996f-2a79b75e0cd2)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Verify that access role is displayed on Groups and Projects dashboard and that when you navigate to the members page for the Group or Project that it shows the same access level

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
