### PR TITLE
Workflow executions/completion job

### DIFF
--- a/app/jobs/workflow_execution_completion_job.rb
+++ b/app/jobs/workflow_execution_completion_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Queues the workflow execution completion job
+class WorkflowExecutionCompletionJob < ApplicationJob
+  queue_as :default
+
+  def perform(workflow_execution)
+    WorkflowExecutions::CompletionService.new(workflow_execution).execute
+  end
+end

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,13 +8,12 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    return unless !workflow_execution.completing? && !workflow_execution.canceled? && !workflow_execution.error?
-    # return unless !workflow_execution.canceled? && !workflow_execution.error?
+    return unless !workflow_execution.canceled? && !workflow_execution.error?
 
-    # if workflow_execution.completing?
-      # WorkflowExecutionCompletionJob.set(asdf)#todo
-    # else
+    if workflow_execution.completing?
+      WorkflowExecutionCompletionJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
+    else
       WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
-    # end
+    end
   end
 end

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,8 +8,13 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    return unless !workflow_execution.completed? && !workflow_execution.canceled? && !workflow_execution.error?
+    return unless !workflow_execution.completing? && !workflow_execution.canceled? && !workflow_execution.error?
+    # return unless !workflow_execution.canceled? && !workflow_execution.error?
 
-    WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
+    # if workflow_execution.completing?
+      # WorkflowExecutionCompletionJob.set(asdf)#todo
+    # else
+      WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)
+    # end
   end
 end

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -27,11 +27,15 @@ class WorkflowExecution < ApplicationRecord
     state == 'submitted'
   end
 
+  def completing?
+    state == 'completing'
+  end
+
   def completed?
     state == 'completed'
   end
 
-  def finalized?
+  def finalized?#todo delete
     state == 'finalized'
   end
 

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -35,10 +35,6 @@ class WorkflowExecution < ApplicationRecord
     state == 'completed'
   end
 
-  def finalized?#todo delete
-    state == 'finalized'
-  end
-
   def error?
     state == 'error'
   end

--- a/app/services/workflow_executions/completion_service.rb
+++ b/app/services/workflow_executions/completion_service.rb
@@ -15,7 +15,7 @@ module WorkflowExecutions
     end
 
     def execute
-      return false unless @workflow_execution.completed?
+      return false unless @workflow_execution.completing?
 
       run_output_data = download_decompress_parse_gziped_json("#{@output_base_path}iridanext.output.json.gz")
 
@@ -33,7 +33,7 @@ module WorkflowExecutions
       # attach blob lists to attachables
       attach_blobs_to_attachables
 
-      @workflow_execution.state = 'finalized'
+      @workflow_execution.state = 'completed'
 
       @workflow_execution.save
 

--- a/app/services/workflow_executions/status_service.rb
+++ b/app/services/workflow_executions/status_service.rb
@@ -17,7 +17,7 @@ module WorkflowExecutions
 
       state = run_status[:state]
 
-      @workflow_execution.state = 'completed' if state == 'COMPLETE'
+      @workflow_execution.state = 'completing' if state == 'COMPLETE'
 
       if Integrations::Ga4ghWesApi::V1::States::CANCELATION_STATES.include?(state)
         @workflow_execution.state = 'canceled'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -153,8 +153,8 @@ def seed_workflow_executions # rubocop:disable Metrics/MethodLength
     workflow_execution: workflow_execution_basic
   )
 
-  workflow_execution_finalized = WorkflowExecution.create(
-    metadata: { workflow_name: 'irida-next-example-finalized', workflow_version: '1.0dev' },
+  workflow_execution_completed = WorkflowExecution.create(
+    metadata: { workflow_name: 'irida-next-example-completed', workflow_version: '1.0dev' },
     workflow_params: { '-r': 'dev' },
     workflow_type: 'DSL2',
     workflow_type_version: '22.10.7',
@@ -165,18 +165,18 @@ def seed_workflow_executions # rubocop:disable Metrics/MethodLength
     workflow_url: 'https://github.com/phac-nml/iridanextexample',
     submitter: User.find_by(email: 'user1@email.com'),
     blob_run_directory: 'this should be a generated key',
-    state: 'finalized'
+    state: 'completed'
   )
 
   filename = 'summary.txt'
-  attachment = workflow_execution_finalized.outputs.build
+  attachment = workflow_execution_completed.outputs.build
   attachment.file.attach(io: Rails.root.join('test/fixtures/files/blob_outputs/normal', filename).open, filename:)
   attachment.save!
 
   SamplesWorkflowExecution.create(
     samplesheet_params: { my_key1: 'my_value_2', my_key2: 'my_value_3' },
     sample: Sample.first,
-    workflow_execution: workflow_execution_finalized
+    workflow_execution: workflow_execution_completed
   )
 end
 

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -114,36 +114,36 @@ sample1_irida_next_example_new:
     "fastq_2": ""
   }
 
-sample41_irida_next_example_completed_c:
+sample41_irida_next_example_completing_c:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample41, :uuid) %>
-  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_c, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_c, :uuid) %>
   samplesheet_params: {
     "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample41, :uuid)}" %>,
     "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
     "fastq_2": ""
   }
 
-sample42_irida_next_example_completed_c:
+sample42_irida_next_example_completing_c:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample42, :uuid) %>
-  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_c, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_c, :uuid) %>
   samplesheet_params: {
     "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample42, :uuid)}" %>,
     "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment2, :uuid)}" %>,
     "fastq_2": ""
   }
 
-sample41_irida_next_example_completed_d:
+sample41_irida_next_example_completing_d:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample41, :uuid) %>
-  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_d, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_d, :uuid) %>
   samplesheet_params: {
     "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample41, :uuid)}" %>,
     "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
     "fastq_2": ""
   }
 
-sample42_irida_next_example_completed_d:
+sample42_irida_next_example_completing_d:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample42, :uuid) %>
-  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_d, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_d, :uuid) %>
   samplesheet_params: {
     "sample": <%= "Sample_#{ActiveRecord::FixtureSet.identify(:sample42, :uuid)}" %>,
     "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment2, :uuid)}" %>,

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -244,10 +244,10 @@ irida_next_example_new:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "new"
 
-irida_next_example_completed_a:
+irida_next_example_completing_a:
   metadata:
     {
-      "workflow_name": "irida_next_example_completed",
+      "workflow_name": "irida_next_example_completing",
       "workflow_version": "1.0dev",
     }
   workflow_params:
@@ -265,13 +265,13 @@ irida_next_example_completed_a:
   workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
   run_id: "my_run_id_a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
-  state: "completed"
+  state: "completing"
   blob_run_directory: "not a run dir"
 
-irida_next_example_completed_b:
+irida_next_example_completing_b:
   metadata:
     {
-      "workflow_name": "irida_next_example_completed",
+      "workflow_name": "irida_next_example_completing",
       "workflow_version": "1.0dev",
     }
   workflow_params:
@@ -289,13 +289,13 @@ irida_next_example_completed_b:
   workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
   run_id: "my_run_id_b"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
-  state: "completed"
+  state: "completing"
   blob_run_directory: "not a run dir"
 
-irida_next_example_completed_c:
+irida_next_example_completing_c:
   metadata:
     {
-      "workflow_name": "irida_next_example_completed",
+      "workflow_name": "irida_next_example_completing",
       "workflow_version": "1.0dev",
     }
   workflow_params:
@@ -313,13 +313,13 @@ irida_next_example_completed_c:
   workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
   run_id: "my_run_id_c"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
-  state: "completed"
+  state: "completing"
   blob_run_directory: "not a run dir"
 
-irida_next_example_completed_d:
+irida_next_example_completing_d:
   metadata:
     {
-      "workflow_name": "irida_next_example_completed",
+      "workflow_name": "irida_next_example_completing",
       "workflow_version": "1.0dev",
     }
   workflow_params:
@@ -337,7 +337,7 @@ irida_next_example_completed_d:
   workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
   run_id: "my_run_id_d"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
-  state: "completed"
+  state: "completing"
   blob_run_directory: "not a run dir"
 
 <% (1..25).each do |n| %>

--- a/test/services/workflow_executions/completion_service_test.rb
+++ b/test/services/workflow_executions/completion_service_test.rb
@@ -7,9 +7,9 @@ module WorkflowExecutions
     def setup # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       # normal/
       # get a new secure token for each workflow execution
-      @workflow_execution_completed = workflow_executions(:irida_next_example_completed_a)
+      @workflow_execution_completing = workflow_executions(:irida_next_example_completing_a)
       blob_run_directory_a = ActiveStorage::Blob.generate_unique_secure_token
-      @workflow_execution_completed.blob_run_directory = blob_run_directory_a
+      @workflow_execution_completing.blob_run_directory = blob_run_directory_a
 
       # create file blobs
       @normal_output_json_file_blob = make_and_upload_blob(
@@ -24,7 +24,7 @@ module WorkflowExecutions
 
       # no_files/
       # get a new secure token for each workflow execution
-      @workflow_execution_no_files = workflow_executions(:irida_next_example_completed_b)
+      @workflow_execution_no_files = workflow_executions(:irida_next_example_completing_b)
       blob_run_directory_b = ActiveStorage::Blob.generate_unique_secure_token
       @workflow_execution_no_files.blob_run_directory = blob_run_directory_b
 
@@ -37,7 +37,7 @@ module WorkflowExecutions
 
       # normal2/
       # get a new secure token for each workflow execution
-      @workflow_execution_with_samples = workflow_executions(:irida_next_example_completed_c)
+      @workflow_execution_with_samples = workflow_executions(:irida_next_example_completing_c)
       blob_run_directory_c = ActiveStorage::Blob.generate_unique_secure_token
       @workflow_execution_with_samples.blob_run_directory = blob_run_directory_c
 
@@ -66,7 +66,7 @@ module WorkflowExecutions
 
       # missing_entry/
       # get a new secure token for each workflow execution
-      @workflow_execution_missing_entry = workflow_executions(:irida_next_example_completed_d)
+      @workflow_execution_missing_entry = workflow_executions(:irida_next_example_completing_d)
       blob_run_directory_d = ActiveStorage::Blob.generate_unique_secure_token
       @workflow_execution_missing_entry.blob_run_directory = blob_run_directory_d
 
@@ -90,10 +90,10 @@ module WorkflowExecutions
       @sample42 = samples(:sample42)
     end
 
-    test 'finalize completed workflow_execution' do
-      workflow_execution = @workflow_execution_completed
+    test 'complete completing workflow_execution' do
+      workflow_execution = @workflow_execution_completing
 
-      assert 'completed', workflow_execution.state
+      assert 'completing', workflow_execution.state
 
       assert WorkflowExecutions::CompletionService.new(workflow_execution, {}).execute
 
@@ -105,24 +105,24 @@ module WorkflowExecutions
       assert_equal @normal_output_summary_file_blob.filename, output_summary_file.filename
       assert_equal @normal_output_summary_file_blob.checksum, output_summary_file.file.checksum
 
-      assert_equal 'finalized', workflow_execution.state
+      assert_equal 'completed', workflow_execution.state
     end
 
     test 'finalize non complete workflow_execution' do
       workflow_execution = workflow_executions(:irida_next_example)
 
-      assert_not_equal 'completed', workflow_execution.state
+      assert_not_equal 'completing', workflow_execution.state
 
       assert_not WorkflowExecutions::CompletionService.new(workflow_execution, {}).execute
 
+      assert_not_equal 'completing', workflow_execution.state
       assert_not_equal 'completed', workflow_execution.state
-      assert_not_equal 'finalized', workflow_execution.state
     end
 
-    test 'finalize completed workflow_execution with no files' do
+    test 'complete completing workflow_execution with no files' do
       workflow_execution = @workflow_execution_no_files
 
-      assert 'completed', workflow_execution.state
+      assert 'completing', workflow_execution.state
 
       assert WorkflowExecutions::CompletionService.new(workflow_execution, {}).execute
 
@@ -130,13 +130,13 @@ module WorkflowExecutions
       # no files should be added to the run
       assert_equal 0, workflow_execution.outputs.count
 
-      assert_equal 'finalized', workflow_execution.state
+      assert_equal 'completed', workflow_execution.state
     end
 
     test 'sample outputs on samples_workflow_executions' do
       workflow_execution = @workflow_execution_with_samples
 
-      assert 'completed', workflow_execution.state
+      assert 'completing', workflow_execution.state
 
       assert WorkflowExecutions::CompletionService.new(workflow_execution, {}).execute
 
@@ -170,14 +170,14 @@ module WorkflowExecutions
       assert_equal @normal2_output_analysis3_file_blob.filename, output3.filename
       assert_equal @normal2_output_analysis3_file_blob.checksum, output3.file.checksum
 
-      assert_equal 'finalized', workflow_execution.state
+      assert_equal 'completed', workflow_execution.state
     end
 
     test 'sample metadata on samples_workflow_executions' do
       workflow_execution = @workflow_execution_with_samples
 
       # Test start
-      assert 'completed', workflow_execution.state
+      assert 'completing', workflow_execution.state
 
       assert WorkflowExecutions::CompletionService.new(workflow_execution, {}).execute
 
@@ -192,23 +192,32 @@ module WorkflowExecutions
       assert_equal metadata1, workflow_execution.samples_workflow_executions[0].metadata
       assert_equal metadata2, workflow_execution.samples_workflow_executions[1].metadata
 
-      assert_equal 'finalized', workflow_execution.state
+      assert_equal 'completed', workflow_execution.state
     end
 
     test 'sample outputs metadata on samples_workflow_executions missing entry' do
       workflow_execution = @workflow_execution_missing_entry
 
       # Test start
-      assert 'completed', workflow_execution.state
+      assert 'completing', workflow_execution.state
 
       assert WorkflowExecutions::CompletionService.new(workflow_execution, {}).execute
 
       assert_equal 'my_run_id_d', workflow_execution.run_id
 
-      assert_equal 0, workflow_execution.samples_workflow_executions[0].outputs.count
+      # samples_workflow_executions can be in either order
+      if workflow_execution.samples_workflow_executions[0].sample.name == 'WorkflowExecutions test sample 1'
+        swe1 = workflow_execution.samples_workflow_executions[0]
+        swe2 = workflow_execution.samples_workflow_executions[1]
+      else
+        swe2 = workflow_execution.samples_workflow_executions[0]
+        swe1 = workflow_execution.samples_workflow_executions[1]
+      end
 
-      assert_equal 1, workflow_execution.samples_workflow_executions[1].outputs.count
-      output3 = workflow_execution.samples_workflow_executions[1].outputs[0]
+      assert_equal 0, swe1.outputs.count
+
+      assert_equal 1, swe2.outputs.count
+      output3 = swe2.outputs[0]
       # original file blob should not be the same as the output file blob, but contain the same file
       assert_not_equal @missing_entry_output_analysis3_file_blob.id, output3.id
       assert_equal @missing_entry_output_analysis3_file_blob.filename, output3.filename
@@ -218,10 +227,10 @@ module WorkflowExecutions
                     'organism' => 'an organism' }
 
       assert_equal 2, workflow_execution.samples_workflow_executions.count
-      assert_equal metadata1, workflow_execution.samples_workflow_executions[0].metadata
-      assert workflow_execution.samples_workflow_executions[1].metadata.empty?
+      assert_equal metadata1, swe1.metadata
+      assert swe2.metadata.empty?
 
-      assert_equal 'finalized', workflow_execution.state
+      assert_equal 'completed', workflow_execution.state
     end
   end
 end

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -50,42 +50,44 @@ module WorkflowExecutions
         state: 'new'
       }
 
-      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_1" }',
-                                                                                headers: { content_type:
-                                                                                           'application/json' })
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs')
+        .to_return(body: '{ "run_id": "create_run_1" }',
+                   headers: { content_type:
+                            'application/json' })
 
       stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/create_run_1/status')
         .to_return(body: '{ "run_id": "create_run_1", "state": "COMPLETE" }',
                    headers: { content_type:
                             'application/json' })
 
-      @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params1).execute
-      @workflow_execution2 = WorkflowExecutions::CreateService.new(@user, workflow_params2).execute
-
-      assert_equal 'new', @workflow_execution.state
-      assert_equal 'new', @workflow_execution2.state
-
-      perform_enqueued_jobs do
-        WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
+      # do not perform completion job as this tests scope does not contain blob storage files
+      assert_performed_jobs 3, except: WorkflowExecutionCompletionJob do
+        @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params1).execute
       end
 
-      assert_equal 'completing', @workflow_execution.reload.state #todo, when last job is added, this needs to be completed
+      # don't perform the preparation job as we want to check that the workflow execution is new
+      assert_performed_jobs 0, except: WorkflowExecutionPreparationJob do
+        @workflow_execution2 = WorkflowExecutions::CreateService.new(@user, workflow_params2).execute
+      end
+
+      assert_equal 'completing', @workflow_execution.reload.state
       assert_equal 'new', @workflow_execution2.reload.state
 
-      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_2" }',
-                                                                                headers: { content_type:
-                 'application/json' })
+      stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs')
+        .to_return(body: '{ "run_id": "create_run_2" }',
+                   headers: { content_type:
+                            'application/json' })
 
       stub_request(:get, 'http://www.example.com/ga4gh/wes/v1/runs/create_run_2/status')
         .to_return(body: '{ "run_id": "create_run_2", "state": "COMPLETE" }',
                    headers: { content_type:
                             'application/json' })
 
-      perform_enqueued_jobs do
+      perform_enqueued_jobs except: WorkflowExecutionCompletionJob do
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution2)
       end
 
-      assert_equal 'completing', @workflow_execution2.reload.state #todo, when last job is added, this needs to be completed
+      assert_equal 'completing', @workflow_execution2.reload.state
     end
 
     test 'test create new workflow execution with missing required workflow name' do

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -59,9 +59,7 @@ module WorkflowExecutions
                    headers: { content_type:
                             'application/json' })
 
-      @workflow_execution = WorkflowExecutions::CreateService.new(
-        @user, workflow_params1
-      ).execute
+      @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params1).execute
       @workflow_execution2 = WorkflowExecutions::CreateService.new(@user, workflow_params2).execute
 
       assert_equal 'new', @workflow_execution.state
@@ -71,7 +69,7 @@ module WorkflowExecutions
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
       end
 
-      assert_equal 'completed', @workflow_execution.reload.state
+      assert_equal 'completing', @workflow_execution.reload.state #todo, when last job is added, this needs to be completed
       assert_equal 'new', @workflow_execution2.reload.state
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_2" }',
@@ -87,7 +85,7 @@ module WorkflowExecutions
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution2)
       end
 
-      assert_equal 'completed', @workflow_execution2.reload.state
+      assert_equal 'completing', @workflow_execution2.reload.state #todo, when last job is added, this needs to be completed
     end
 
     test 'test create new workflow execution with missing required workflow name' do

--- a/test/services/workflow_executions/status_service_test.rb
+++ b/test/services/workflow_executions/status_service_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module WorkflowExecutions
-  class CreateServiceTest < ActiveSupport::TestCase
+  class StatusServiceTest < ActiveSupport::TestCase
     def setup
       @user = users(:john_doe)
       @workflow_execution = workflow_executions(:irida_next_example_prepared)

--- a/test/services/workflow_executions/status_service_test.rb
+++ b/test/services/workflow_executions/status_service_test.rb
@@ -45,7 +45,7 @@ module WorkflowExecutions
 
       @workflow_execution = WorkflowExecutions::StatusService.new(@workflow_execution, conn, @user, {}).execute
 
-      assert_equal 'completed', @workflow_execution.state
+      assert_equal 'completing', @workflow_execution.state
     end
 
     test 'get status of workflow execution which has been canceled' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Fixes #437

* The WorkflowExecution `completed`  state has been renamed `completing`, which indicates the workflow execution has finished, but files have yet to be put onto WorkflowExecution/SamplesWorkflowExecutions objects
* The WorkflowExecution `finalized` state has been renamed `completed`, which indicates all jobs have finished
* Added WorkflowExecutionCompletionJob, which is queued by WorkflowExecutions::StatusService and related job
* reworked `workflow_executions/create_service_test`'s happy path test to stop at `completing`, and added a new test to validate the final `completing` to `completed` job steps.
  * This is mainly to break the test into more logical parts as the final step needs active storage blobs to be setup.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
Run a Workflow Execution through the web interface while connected to azure + ga4gh_wes, and see that it goes through all steps/states.

The `completed` state should be visible on the web Workflow Executions page

You can also check the output of the following rails console commands
```ruby
WorkflowExecution.last.state
=> "completed"

WorkflowExecution.last.samples_workflow_executions
=> [#<SamplesWorkflowExecution:0x00...
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
