### PR TITLE
FIX: Update Reverse PE Attachments PUID to match Forward PE Attachments PUID

### DIFF
--- a/app/models/concerns/has_puid.rb
+++ b/app/models/concerns/has_puid.rb
@@ -15,6 +15,8 @@ module HasPuid
   end
 
   def generate_puid
+    return unless puid.nil?
+
     self.puid = Irida::PersistentUniqueId.generate(self)
   end
 end

--- a/app/models/concerns/has_puid.rb
+++ b/app/models/concerns/has_puid.rb
@@ -6,6 +6,13 @@ module HasPuid
 
   included do
     before_validation :generate_puid, on: :create
+
+    def dup
+      clone = super
+      clone.puid = nil # set clone puid to nil as puid is supposed to be unique
+
+      clone
+    end
   end
 
   class_methods do

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -96,14 +96,12 @@ module Attachments
       assign_metadata(pe, 'pe')
     end
 
-    def assign_metadata(paired_ends, type) # rubocop:disable Metrics/AbcSize
+    def assign_metadata(paired_ends, type)
       paired_ends.each do |_key, pe_attachments|
         next unless pe_attachments.key?('forward') && pe_attachments.key?('reverse')
 
-        # update the PUID to be same for forward and reverse and then save so that we have the ids
-        pe_attachments['reverse'].puid = pe_attachments['forward'].puid
-        pe_attachments['forward'].save
-        pe_attachments['reverse'].save
+        # assign the PUID to be same for forward and reverse and then save so that we have the ids
+        assign_pe_attachments_puid(pe_attachments)
 
         fwd_metadata = {
           associated_attachment_id: pe_attachments['reverse'].id, type:, direction: 'forward'
@@ -117,6 +115,14 @@ module Attachments
 
         pe_attachments['reverse'].metadata = pe_attachments['reverse'].metadata.merge(rev_metadata)
       end
+    end
+
+    def assign_pe_attachments_puid(pe_attachments)
+      puid = Irida::PersistentUniqueId.generate(pe_attachments['forward'], time: Time.now) # rubocop:disable Rails/TimeZone
+      pe_attachments['forward'].puid = puid
+      pe_attachments['reverse'].puid = puid
+      pe_attachments['forward'].save
+      pe_attachments['reverse'].save
     end
   end
 end

--- a/db/migrate/20240328145629_fix_pe_attachments_puid.rb
+++ b/db/migrate/20240328145629_fix_pe_attachments_puid.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# updates reverse pe attachment puid to match forward pe attachment puid
+class FixPeAttachmentsPuid < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL.squish
+      WITH forward_attachments AS (
+        SELECT id, puid, (metadata->>'associated_attachment_id')::uuid as associated_attachment_id
+        FROM attachments
+        WHERE metadata @> '{"type":"pe","direction":"forward"}'
+        OR metadata @> '{"type":"illumina_pe","direction":"forward"}'
+      )
+      UPDATE attachments
+      SET puid = fa.puid
+      FROM forward_attachments fa
+      WHERE attachments.id = fa.associated_attachment_id AND attachments.puid != fa.puid;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_161330) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_28_145629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Prior to this fix, forward and reverse attachments did not have matching PUIDs as the code to ensure that the PUIDs match happened before the PUIDs were even set. This PR corrects that behavior and has a migration to correct existing reverse attachments with PUIDs that don't match forward.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Run migration
2. Use rails console to validate that PUIDs for reverse and forward attachments match

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
