### PR TITLE
Fix: Select all JavaScript error when not available 

### DIFF
--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -13,24 +13,27 @@ export default class extends Controller {
       type: String,
     },
     total: Number,
+    active: Boolean
   };
 
   connect() {
-    this.#storageKey =
-      this.storageKeyValue ||
-      `${location.protocol}//${location.host}${location.pathname}${location.search}`;
+    if (this.activeValue) {
+      this.#storageKey =
+        this.storageKeyValue ||
+        `${location.protocol}//${location.host}${location.pathname}${location.search}`;
 
-    this.element.setAttribute("data-controller-connected", "true");
+      this.element.setAttribute("data-controller-connected", "true");
 
-    const storageValue = this.#getStoredSamples();
+      const storageValue = this.#getStoredSamples();
 
-    if (storageValue) {
-      this.#updateUI(storageValue);
-    } else {
-      this.save([]);
+      if (storageValue) {
+        this.#updateUI(storageValue);
+      } else {
+        this.save([]);
+      }
+
+      this.#updatedCounts(storageValue.length);
     }
-
-    this.#updatedCounts(storageValue.length);
   }
 
   actionLinkOutletConnected(outlet) {

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -13,11 +13,10 @@ export default class extends Controller {
       type: String,
     },
     total: Number,
-    active: Boolean
   };
 
   connect() {
-    if (this.activeValue) {
+    if (this.hasSelectAllTarget) {
       this.#storageKey =
         this.storageKeyValue ||
         `${location.protocol}//${location.host}${location.pathname}${location.search}`;

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -16,23 +16,21 @@ export default class extends Controller {
   };
 
   connect() {
-    if (this.hasSelectAllTarget) {
-      this.#storageKey =
-        this.storageKeyValue ||
-        `${location.protocol}//${location.host}${location.pathname}${location.search}`;
+    this.#storageKey =
+      this.storageKeyValue ||
+      `${location.protocol}//${location.host}${location.pathname}${location.search}`;
 
-      this.element.setAttribute("data-controller-connected", "true");
+    this.element.setAttribute("data-controller-connected", "true");
 
-      const storageValue = this.#getStoredSamples();
+    const storageValue = this.#getStoredSamples();
 
-      if (storageValue) {
-        this.#updateUI(storageValue);
-      } else {
-        this.save([]);
-      }
-
-      this.#updatedCounts(storageValue.length);
+    if (storageValue) {
+      this.#updateUI(storageValue);
+    } else {
+      this.save([]);
     }
+
+    this.#updatedCounts(storageValue.length);
   }
 
   actionLinkOutletConnected(outlet) {
@@ -100,11 +98,15 @@ export default class extends Controller {
   }
 
   #setSelectAllCheckboxValue(total) {
-    this.selectAllTarget.checked = this.totalValue === total;
+    if (this.hasSelectAllTarget) {
+      this.selectAllTarget.checked = this.totalValue === total;
+    }
   }
 
   #updatedCounts(selected) {
-    this.totalTarget.innerText = this.totalValue;
-    this.selectedTarget.innerText = selected;
+    if (this.hasTotalTarget && this.hasSelectedTarget) {
+      this.totalTarget.innerText = this.totalValue;
+      this.selectedTarget.innerText = selected;
+    }
   }
 }

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -10,7 +10,6 @@
       dark:text-slate-400
     "
     data-controller="selection"
-    data-selection-active-value="<%= allowed_to?(:transfer_sample?, project) %>"
     data-selection-total-value="<%= @pagy.count %>"
     data-selection-action-link-outlet=".action-link"
     aria-label="<%= t(:'.description')%>"

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -52,8 +52,8 @@
               <% end %>
             <% end %>
 
-            <% if allowed_to?(:transfer_sample?, project) %>
-              <label for="select-all" class="sr-only"><%= t(:'.selectAll') %></label>
+            <% if allowed_to?(:submit_workflow?, project) || allowed_to?(:clone_sample?, project) || allowed_to?(:transfer_sample?, project) %>
+              <label for="select-all" class="sr-only"><%= t(:".selectAll") %></label>
               <input
                 type="checkbox"
                 id="select-all"
@@ -243,25 +243,21 @@
         </tr>
       <% end %>
     </tbody>
-    <%- if allowed_to?(:transfer_sample?, project) %>
-    <tfoot>
-      <tr>
-        <td colspan="100%">
-          <div
+    <% if allowed_to?(:submit_workflow?, project) || allowed_to?(:clone_sample?, project) || allowed_to?(:transfer_sample?, project) %>
+      <tfoot>
+        <tr>
+          <td
             class="
+              px-6
+              py-3
+              whitespace-nowrap
               sticky
-              bottom-0
-              right-0
-              items-center
-              w-full
-              p-4
-              bg-white
-              border-t
-              border-gray-200
-              dark:bg-gray-800
-              dark:border-gray-700
+              left-0
+              bg-slate-50
+              dark:bg-slate-900
             "
           >
+
             <span>
               <%= t(".counts.samples") %>:
               <strong data-selection-target="total">0</strong>
@@ -270,10 +266,9 @@
               <%= t(".counts.selected") %>:
               <strong data-selection-target="selected">0</strong>
             </span>
-          </div>
-        </td>
-      </tr>
-    </tfoot>
+          </td>
+        </tr>
+      </tfoot>
     <% end %>
   </table>
 </div>

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -255,7 +255,11 @@
               left-0
               bg-slate-50
               dark:bg-slate-900
+              border-t
+              dark:border-slate-700
+              border-slate-200
             "
+            colspan="<%= @fields.size + 5 %>"
           >
 
             <span>

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -10,6 +10,7 @@
       dark:text-slate-400
     "
     data-controller="selection"
+    data-selection-active-value="<%= allowed_to?(:transfer_sample?, project) %>"
     data-selection-total-value="<%= @pagy.count %>"
     data-selection-action-link-outlet=".action-link"
     aria-label="<%= t(:'.description')%>"
@@ -243,6 +244,7 @@
         </tr>
       <% end %>
     </tbody>
+    <%- if allowed_to?(:transfer_sample?, project) %>
     <tfoot>
       <tr>
         <td colspan="100%">
@@ -273,5 +275,6 @@
         </td>
       </tr>
     </tfoot>
+    <% end %>
   </table>
 </div>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

- Fixes an issue where when an analyst goes to a project sample page the selection controller throws an error because it cannot find the select all checkbox (it's not there because they don't have the authority to do anything).
- Fixes issue where the table footer displayed the wrong information since the selection controller was not functioning.  Fixed by removing the table footer on tables without the ability to select

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Console error:
![image](https://github.com/phac-nml/irida-next/assets/11295750/3a81b692-9aa5-4bcf-8d38-1e822cdc4027)

Wrong table footer data:
![image](https://github.com/phac-nml/irida-next/assets/11295750/b225c4f1-59ec-4532-9bcc-c714c8e9e289)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Selection should still work normally on projects that the user is an owner of
2. Go to a project that the user is not an owner. (user5 and http://localhost:3000/vibrio/vibrio-cholerae/outbreak-2022)
3. Go to the samples page and ensure there are no errors in the developer console.
4. Ensure that the table footer is not present.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
