### PR TITLE
add custom text to signin success/failure popup

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ module Users
 
       if @user.persisted?
         sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
-        set_flash_message(:notice, :success, kind: OmniAuth::Utils.camelize(action_name))
+        set_flash_message(:notice, :success, kind: Rails.configuration.auth_config["#{action_name}_text"])
       else
         # Removing extra and credentials as it can overflow some session stores
         session['devise.omniauth_data'] = request.env['omniauth.auth'].except(:extra, :credentials)
@@ -25,7 +25,7 @@ module Users
 
     def failure
       if @user.respond_to?(:errors) && @user.errors.present? && @user.errors.full_messages.present?
-        set_flash_message :alert, :failure, kind: OmniAuth::Utils.camelize(action_name),
+        set_flash_message :alert, :failure, kind: Rails.configuration.auth_config["#{action_name}_text"],
                                             reason: @user.errors.full_messages.to_sentence
       end
       redirect_to new_user_session_path

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ module Users
 
       if @user.persisted?
         sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
-        set_flash_message(:notice, :success, kind: Rails.configuration.auth_config["#{action_name}_text"])
+        set_flash_message(:notice, :success, kind: action_kind)
       else
         # Removing extra and credentials as it can overflow some session stores
         session['devise.omniauth_data'] = request.env['omniauth.auth'].except(:extra, :credentials)
@@ -25,10 +25,15 @@ module Users
 
     def failure
       if @user.respond_to?(:errors) && @user.errors.present? && @user.errors.full_messages.present?
-        set_flash_message :alert, :failure, kind: Rails.configuration.auth_config["#{action_name}_text"],
-                                            reason: @user.errors.full_messages.to_sentence
+        set_flash_message :alert, :failure, kind: action_kind, reason: @user.errors.full_messages.to_sentence
       end
       redirect_to new_user_session_path
+    end
+
+    private
+
+    def action_kind
+      Rails.configuration.auth_config["#{action_name}_text"] || OmniAuth::Utils.camelize(action_name)
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
When a user logs in, it should show the custom authentication label instead of the underlying omni auth type.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Edit your `config/authentication/auth-config.yml` to have custom values.

example:
```yml
development:
  omniauth_providers: [developer]
  developer_text: 'my custom authenticator'
```

See here for detailed instructions: https://github.com/phac-nml/irida-next/pull/420

Sign in and verify that the popup shows your custom text.
![image](https://github.com/phac-nml/irida-next/assets/16961365/3a38708e-b40d-4f5c-9bbd-b95d724b9d92)


## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
