### PR TITLE
Fix cancel unsubmitted job error

### DIFF
--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -38,7 +38,12 @@ class WorkflowExecutionsController < ApplicationController # rubocop:disable Met
   def cancel
     @workflow_execution = WorkflowExecutions::CancelService.new(@workflow_execution, current_user).execute
 
+    return nil if @workflow_execution == false
+
+    # nil unless @workflow_execution && @workflow_execution.persisted?
+
     nil unless @workflow_execution.persisted?
+    # nil unless @workflow_execution.persisted?
   end
 
   def destroy # rubocop:disable Metrics/AbcSize,Metrics/MethodLength

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -36,14 +36,22 @@ class WorkflowExecutionsController < ApplicationController # rubocop:disable Met
   end
 
   def cancel
-    @workflow_execution = WorkflowExecutions::CancelService.new(@workflow_execution, current_user).execute
+    WorkflowExecutions::CancelService.new(@workflow_execution, current_user).execute
 
-    return nil if @workflow_execution == false
+    respond_to do |format|
+      format.turbo_stream do
+        if @workflow_execution.canceled? || @workflow_execution.canceling?
+          render status: :ok,
+                 locals: { type: 'success',
+                           message: t('.success', workflow_name: @workflow_execution.metadata['workflow_name']) }
 
-    # nil unless @workflow_execution && @workflow_execution.persisted?
-
-    nil unless @workflow_execution.persisted?
-    # nil unless @workflow_execution.persisted?
+        else
+          render status: :unprocessable_entity, locals: {
+            type: 'alert', message: t('.error', workflow_name: @workflow_execution.metadata['workflow_name'])
+          }
+        end
+      end
+    end
   end
 
   def destroy # rubocop:disable Metrics/AbcSize,Metrics/MethodLength

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    return if workflow_execution.canceling? || @workflow_execution.canceled? || workflow_execution.error?
+    return if workflow_execution.canceling? || workflow_execution.canceled? || workflow_execution.error?
 
     if workflow_execution.completing?
       WorkflowExecutionCompletionJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute
 
-    return unless !workflow_execution.canceled? && !workflow_execution.error?
+    return if workflow_execution.canceling? || @workflow_execution.canceled? || workflow_execution.error?
 
     if workflow_execution.completing?
       WorkflowExecutionCompletionJob.set(wait_until: 30.seconds.from_now).perform_later(workflow_execution)

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -67,6 +67,10 @@ class WorkflowExecution < ApplicationRecord
     %w[completed error canceled].include?(state)
   end
 
+  def sent_to_ga4gh?
+    %w[prepared new].exclude?(state)
+  end
+
   def as_wes_params
     {
       workflow_params:,

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -60,7 +60,7 @@ class WorkflowExecution < ApplicationRecord
   end
 
   def cancellable?
-    %w[running queued prepared new].include?(state)
+    %w[submitted running queued prepared new].include?(state)
   end
 
   def deletable?

--- a/app/services/workflow_executions/cancel_service.rb
+++ b/app/services/workflow_executions/cancel_service.rb
@@ -11,9 +11,15 @@ module WorkflowExecutions
     def execute
       return false unless @workflow_execution.cancellable?
 
-      @workflow_execution.state = 'canceling'
+      # Early exit if workflow execution has not been submitted to ga4gh wes yet
+      unless @workflow_execution.sent_to_ga4gh?
+        @workflow_execution.state = 'canceled'
+        @workflow_execution.save
+        return @workflow_execution
+      end
 
-      return unless @workflow_execution.save
+      @workflow_execution.state = 'canceling'
+      @workflow_execution.save
 
       WorkflowExecutionCancelationJob.set(wait_until: 30.seconds.from_now).perform_later(@workflow_execution)
 

--- a/app/views/workflow_executions/cancel.turbo_stream.erb
+++ b/app/views/workflow_executions/cancel.turbo_stream.erb
@@ -1,1 +1,5 @@
 <%= turbo_stream.replace dom_id(@workflow_execution), @workflow_execution %>
+
+<%= turbo_stream.append "flashes" do %>
+  <%= viral_flash(type:, data: message) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1138,6 +1138,9 @@ en:
         type: Type
         size: Size
         created_at: Created At
+    cancel:
+      error: "Could not cancel workflow %{workflow_name}"
+      success: "Workflow %{workflow_name} was successfully canceled"
     destroy:
       error: "Could not delete workflow %{workflow_name}"
       success: "Workflow %{workflow_name} was successfully deleted"

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -77,12 +77,14 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
-  test 'should not cancel a submitted workflow' do
+  test 'should cancel a submitted workflow with valid params' do
     workflow_execution = workflow_executions(:irida_next_example_submitted)
     assert workflow_execution.submitted?
 
     put cancel_workflow_execution_path(workflow_execution, format: :turbo_stream)
-    assert_response :failure
+    assert_response :success
+    # A submitted workflow goes to the canceling state as ga4gh must be sent a cancel request
+    assert_equal 'canceling', workflow_execution.reload.state
   end
 
   test 'should not delete a submitted workflow' do
@@ -93,6 +95,16 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
       delete workflow_execution_path(workflow_execution, format: :turbo_stream)
     end
     assert_response :unprocessable_entity
+  end
+
+  test 'should not cancel a completed workflow' do
+    workflow_execution = workflow_executions(:irida_next_example_completed)
+    assert workflow_execution.completed?
+
+    put cancel_workflow_execution_path(workflow_execution, format: :turbo_stream)
+    assert_response :unprocessable_entity
+
+    assert workflow_execution.completed?
   end
 
   test 'should delete a completed workflow' do

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -121,6 +121,13 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_text 'Confirmation required'
     click_button 'Confirm'
 
+    within %(div[data-controller='viral--flash']) do
+      assert_text I18n.t(
+        :'workflow_executions.cancel.success',
+        workflow_name: workflow_execution.metadata['workflow_name']
+      )
+    end
+
     assert_selector 'tbody tr td:nth-child(5)', text: 'canceling'
     assert_no_selector "tbody tr td:nth-child(5) a[text='Cancel']"
   end
@@ -172,6 +179,13 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_text 'Confirmation required'
     click_button 'Confirm'
+
+    within %(div[data-controller='viral--flash']) do
+      assert_text I18n.t(
+        :'workflow_executions.destroy.success',
+        workflow_name: workflow_execution.metadata['workflow_name']
+      )
+    end
 
     assert_no_text workflow_execution.id
   end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Fixes #510 

Fixes error that happened when attempting to cancel a job that hadn't reached the submitted state

Adds `submitted` to the list of states that are cancelable

Also fixes bug where workflow execution will ignore `canceling` state when queuing completion/status job, causing a run to move to `completion` state when run has been queue'd to be canceled.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Submit a new workflow execution
2. While in the `new` or `prepared` state, cancel it. It should go directly to the `canceled` state
3. Submit a new workflow execution
4. Wait until it reaches the `submitted`, `queued` or `running` state then cancel it.
5. Verify that it goes to the `canceling` state, wait and verify that it then makes it to the `canceled` state

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
