### PR TITLE
FIX: Fixed auto selection of fastq_2

### DIFF
--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -3,19 +3,33 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["select"];
 
+  connect() {
+    if (this.hasSelectTarget) {
+      // Find the first select selectedIndex
+      const selectedOption =
+        this.selectTargets[0].options[this.selectTargets[0].selectedIndex];
+      this.#updateMatchingSelect(
+        this.selectTargets[1],
+        selectedOption.dataset.puid,
+      );
+    }
+  }
+
   file_selected(event) {
     // find the selected option from the event target select
     const selectedOption = event.target.options[event.target.selectedIndex];
-
-    if (selectedOption.value) return;
 
     const updateSelect =
       event.target === this.selectTargets[0]
         ? this.selectTargets[1]
         : this.selectTargets[0];
 
+    this.#updateMatchingSelect(updateSelect, selectedOption.dataset.puid);
+  }
+
+  #updateMatchingSelect(updateSelect, puid) {
     const index = [...updateSelect.options].findIndex(
-      (options) => options.dataset.puid === selectedOption.dataset.puid,
+      (options) => options.dataset.puid === puid,
     );
 
     if (index > -1) {


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes an issue where when a fastq pair is required for workflow submission the second file was not being selected.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

N/A

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

- Login was user5
- Go to http://localhost:3000/yersinia/yersinia-pseudotuberculosis/outbreak-2023/-/samples
- I uploaded a couple pairs of fastq files to the first sample
- Select the first sample or two
- Open the submission window and select the first pipeline
- In the samples table, both fastq files should be selected
- In the fastq_1 column for the first sample, select the one you upload and it's pair should be selected in the fastq_2 column.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
