### PR TITLE
Bot generate personal access token

### DIFF
--- a/app/controllers/concerns/bot_actions.rb
+++ b/app/controllers/concerns/bot_actions.rb
@@ -7,7 +7,7 @@ module BotActions
   included do
     before_action proc { namespace }
     before_action proc { access_levels }
-    before_action proc { bot_account }, only: %i[destroy]
+    before_action proc { bot_account }, only: %i[destroy generate_personal_access_token]
   end
 
   def index
@@ -70,7 +70,33 @@ module BotActions
     end
   end
 
+  def generate_personal_access_token
+    @personal_access_token = PersonalAccessTokens::CreateService.new(current_user, personal_access_token_params,
+                                                                     @namespace, @bot_account.user).execute
+
+    respond_to do |format|
+      format.turbo_stream do
+        if @personal_access_token.persisted?
+          render locals: { personal_access_token: @personal_access_token, type: 'success',
+                           message: t('.success') }
+        else
+          render status: :unprocessable_entity,
+                 locals: { type: 'alert',
+                           message: @personal_access_token.errors.full_messages.first }
+        end
+      end
+    end
+  end
+
   private
+
+  def personal_access_token_params
+    {
+      name: bot_params[:token_name],
+      expires_at: bot_params[:expires_at],
+      scopes: bot_params[:scopes]
+    }
+  end
 
   def bot_account
     @bot_account = @namespace.namespace_bots.find_by(id: params[:id]) || not_found

--- a/app/controllers/profiles/personal_access_tokens_controller.rb
+++ b/app/controllers/profiles/personal_access_tokens_controller.rb
@@ -12,11 +12,11 @@ module Profiles
     end
 
     def create
-      authorize! @user
-      @personal_access_token = PersonalAccessToken.new(personal_access_token_params.merge(user: current_user))
+      @personal_access_token = PersonalAccessTokens::CreateService.new(current_user,
+                                                                       personal_access_token_params).execute
 
       respond_to do |format|
-        if @personal_access_token.save
+        if @personal_access_token.persisted?
           format.turbo_stream do
             render locals: { personal_access_token: PersonalAccessToken.new(scopes: []),
                              new_personal_access_token: @personal_access_token }

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -82,5 +82,13 @@ module Namespaces
       details[:name] = record.name
       false
     end
+
+    def generate_bot_personal_access_token?
+      return true if record.parent.user_namespace? && record.parent.owner == user
+      return true if Member.can_modify?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,27 +3,27 @@
 # Policy for profiles authorization
 class UserPolicy < ApplicationPolicy
   def create?
-    return true if record == user
+    true if record == user
   end
 
   def destroy?
-    return true if record == user
+    true if record == user
   end
 
   def edit?
-    return true if record == user
+    true if record == user
   end
 
   def index?
-    return true if record == user
+    true if record == user
   end
 
   def new?
-    return true if record == user
+    true if record == user
   end
 
   def revoke?
-    return true if record == user
+    true if record == user
   end
 
   def read?
@@ -34,11 +34,15 @@ class UserPolicy < ApplicationPolicy
   end
 
   def update?
-    return true if record == user
+    true if record == user
   end
 
   def edit_password?
     # Passwords on OmniAuth Users is not allowed
     update? && user.provider.nil?
+  end
+
+  def generate_bot_personal_access_token?
+    true if record == user
   end
 end

--- a/app/services/personal_access_tokens/create_service.rb
+++ b/app/services/personal_access_tokens/create_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PersonalAccessTokens
+  # Service used to create personal access tokens
+  class CreateService < BaseService
+    PersonalAccessTokenCreateError = Class.new(StandardError)
+    attr_accessor :namespace, :bot_user
+
+    def initialize(user, params, namespace = nil, bot_user = nil)
+      super(user, params)
+
+      @bot_user = bot_user
+      @namespace = namespace
+    end
+
+    def execute
+      authorize! current_user, to: :generate_bot_personal_access_token? if bot_user.nil?
+      authorize! namespace, to: :generate_bot_personal_access_token? unless bot_user.nil?
+
+      personal_access_token = PersonalAccessToken.new(params.merge(user: bot_user.nil? ? current_user : bot_user))
+      personal_access_token.save
+
+      personal_access_token
+    end
+  end
+end

--- a/app/services/personal_access_tokens/create_service.rb
+++ b/app/services/personal_access_tokens/create_service.rb
@@ -4,23 +4,40 @@ module PersonalAccessTokens
   # Service used to create personal access tokens
   class CreateService < BaseService
     PersonalAccessTokenCreateError = Class.new(StandardError)
-    attr_accessor :namespace, :bot_user
+    attr_accessor :namespace, :bot_user, :personal_access_token
 
     def initialize(user, params, namespace = nil, bot_user = nil)
       super(user, params)
 
       @bot_user = bot_user
       @namespace = namespace
+      @personal_access_token = PersonalAccessToken.new(params.merge(user: bot_user.nil? ? current_user : bot_user))
     end
 
     def execute
       authorize! current_user, to: :generate_bot_personal_access_token? if bot_user.nil?
       authorize! namespace, to: :generate_bot_personal_access_token? unless bot_user.nil?
 
-      personal_access_token = PersonalAccessToken.new(params.merge(user: bot_user.nil? ? current_user : bot_user))
+      validate_params
+
       personal_access_token.save
 
       personal_access_token
+    rescue PersonalAccessTokens::CreateService::PersonalAccessTokenCreateError => e
+      personal_access_token.errors.add(:base, e.message)
+      personal_access_token
+    end
+
+    def validate_params
+      if params[:name].blank?
+        raise PersonalAccessTokenCreateError,
+              I18n.t('services.personal_access_tokens.create.required.token_name')
+      end
+
+      return if params[:scopes].present?
+
+      raise PersonalAccessTokenCreateError,
+            I18n.t('services.personal_access_tokens.create.required.scopes')
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1213,6 +1213,11 @@ en:
           missing_metadata_row: The file does not have any metadata rows. Please add some rows of metadata to the file and retry uploading.
           sample_not_found: "Sample '%{sample_name}' is not found within this project"
           sample_metadata_fields_not_updated: "Sample '%{sample_name}' with field(s) '%{metadata_fields}' cannot be updated."
+    personal_access_tokens:
+      create:
+        required:
+          token_name: Unable to create bot account as the token name is required
+          scopes: Unable to create bot account as the bot API scope must be selected
     namespaces:
       share:
         invalid_namespace_type: Only a group or project namespace can be shared with a group.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -749,6 +749,8 @@ en:
         success: "Bot account was successfully added to the project"
       destroy:
         success: "Bot account was successfully removed from the project"
+      generate_personal_access_token:
+        success: "Personal access token successfully generated for bot account"
     new:
       title: Create project
       placeholder: Awesome project name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1216,8 +1216,8 @@ en:
     personal_access_tokens:
       create:
         required:
-          token_name: Unable to create bot account as the token name is required
-          scopes: Unable to create bot account as the bot API scope must be selected
+          token_name: Unable to generate personal access token as the name is required
+          scopes: Unable to generate personal access token as the API scope must be selected
     namespaces:
       share:
         invalid_namespace_type: Only a group or project namespace can be shared with a group.

--- a/config/routes/project.rb
+++ b/config/routes/project.rb
@@ -18,7 +18,11 @@ constraints(::Constraints::ProjectUrlConstrainer.new) do
       get :edit
       post :transfer
       resources :members, only: %i[create destroy index new update]
-      resources :bots, only: %i[create destroy index new]
+      resources :bots, only: %i[create destroy index new] do
+        member do
+          post :generate_personal_access_token
+        end
+      end
       resources :group_links, only: %i[create destroy update index new]
       resources :samples do
         scope module: :samples, as: :samples do

--- a/test/controllers/concerns/bot_actions_concern_test.rb
+++ b/test/controllers/concerns/bot_actions_concern_test.rb
@@ -81,4 +81,28 @@ class BotActionsConcernTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
   end
+
+  test 'generate new personal access token for bot account' do
+    sign_in users(:john_doe)
+
+    namespace_bot = namespace_bots(:project1_bot)
+
+    namespace = groups(:group_one)
+    project = projects(:project1)
+
+    assert_equal 1, namespace_bot.user.personal_access_tokens.count
+
+    post generate_personal_access_token_namespace_project_bot_path(namespace, project, id: namespace_bot.id,
+                                                                                       format: :turbo_stream),
+         params: { bot: {
+           token_name: 'newtesttoken',
+           access_level: Member::AccessLevel::UPLOADER,
+           scopes: ['read_api']
+         } }
+
+    assert_equal 2,
+                 namespace_bot.user.personal_access_tokens.count
+
+    assert_response :success
+  end
 end

--- a/test/controllers/projects/bots_controller_test.rb
+++ b/test/controllers/projects/bots_controller_test.rb
@@ -131,5 +131,29 @@ module Projects
 
       assert_response :not_found
     end
+
+    test 'generate new personal access token for bot account' do
+      sign_in users(:john_doe)
+
+      namespace_bot = namespace_bots(:project1_bot)
+
+      namespace = groups(:group_one)
+      project = projects(:project1)
+
+      assert_equal 1, namespace_bot.user.personal_access_tokens.count
+
+      post generate_personal_access_token_namespace_project_bot_path(namespace, project, id: namespace_bot.id,
+                                                                                         format: :turbo_stream),
+           params: { bot: {
+             token_name: 'newtesttoken',
+             access_level: Member::AccessLevel::UPLOADER,
+             scopes: ['read_api']
+           } }
+
+      assert_equal 2,
+                   namespace_bot.user.personal_access_tokens.count
+
+      assert_response :success
+    end
   end
 end

--- a/test/services/personal_access_tokens/create_service_test.rb
+++ b/test/services/personal_access_tokens/create_service_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module PersonalAccessTokens
+  class CreateServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:john_doe)
+      @project = projects(:project1)
+    end
+
+    test 'create new personal access token for bot account' do
+      valid_params = {
+        name: 'Uploader',
+        scopes: %w[read_api api]
+      }
+
+      namespace_bot = namespace_bots(:project1_bot)
+
+      assert_difference -> { PersonalAccessToken.count } => 1 do
+        PersonalAccessTokens::CreateService.new(@user, valid_params, @project.namespace, namespace_bot.user).execute
+      end
+    end
+
+    test 'create new personal access token for bot account with missing token name' do
+      valid_params = {
+        scopes: %w[read_api api]
+      }
+
+      namespace_bot = namespace_bots(:project1_bot)
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, valid_params, @project.namespace, namespace_bot.user).execute
+      end
+    end
+
+    test 'create new personal access token for bot account with missing scopes' do
+      valid_params = {
+        name: 'Uploader'
+      }
+
+      namespace_bot = namespace_bots(:project1_bot)
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, valid_params, @project.namespace, namespace_bot.user).execute
+      end
+    end
+
+    test 'create new personal access token for user' do
+      valid_params = {
+        name: 'Uploader',
+        scopes: %w[read_api api]
+      }
+
+      assert_difference -> { PersonalAccessToken.count } => 1 do
+        PersonalAccessTokens::CreateService.new(@user, valid_params).execute
+      end
+    end
+
+    test 'create new personal access token for user with missing token name' do
+      valid_params = {
+        scopes: %w[read_api api]
+      }
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, valid_params).execute
+      end
+    end
+
+    test 'create new personal access token for user with missing scopes' do
+      valid_params = {
+        name: 'Uploader'
+      }
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, valid_params).execute
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in an endpoint to allow us to generate new personal access tokens for bot accounts. A new personal access tokens create service was also added which is used to generate personal access tokens for profiles and bot accounts.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
