### PR TITLE
Workflow executions: Requeue jobs

### DIFF
--- a/app/jobs/workflow_execution_cancelation_job.rb
+++ b/app/jobs/workflow_execution_cancelation_job.rb
@@ -4,6 +4,14 @@
 class WorkflowExecutionCancelationJob < ApplicationJob
   queue_as :default
 
+  # When server is unreachable, continually retry
+  retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
+  # TODO: retry on 401
+  # TODO: retry on 403
+  # TODO: edge case where canceling a workflow that is actually completed (delay caused)
+  # expects 401/403. Sapporo responds with 200
+  # Need to check run status in retry block
+
   def perform(workflow_execution, user)
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     WorkflowExecutions::CancelationService.new(workflow_execution, wes_connection, user).execute

--- a/app/jobs/workflow_execution_cancelation_job.rb
+++ b/app/jobs/workflow_execution_cancelation_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionCancelationJob < ApplicationJob
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
-  retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
+  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :polynomially_longer, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
 
     # Errors 401 and 403 can mean that the run was actually completed
@@ -27,7 +27,7 @@ class WorkflowExecutionCancelationJob < ApplicationJob
     end
 
     workflow_execution.state = :error
-    workflow_execution.error_code = exception.http_error_code
+    workflow_execution.http_error_code = exception.http_error_code
     workflow_execution.save
   end
 

--- a/app/jobs/workflow_execution_cancelation_job.rb
+++ b/app/jobs/workflow_execution_cancelation_job.rb
@@ -13,11 +13,11 @@ class WorkflowExecutionCancelationJob < ApplicationJob
 
     # Errors 401 and 403 can mean that the run was actually completed
     # So we check the run status to check if it's completed or an actual error
-    if [401, 403].contains? exception.http_error_code
+    if [401, 403].include? exception.http_error_code
       # get actual status from wes client
       wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
       wes_client = Integrations::Ga4ghWesApi::V1::Client.new(conn: wes_connection)
-      status = wes_client.get_run_status(@workflow_execution.run_id)
+      status = wes_client.get_run_status(workflow_execution.run_id)
 
       if status[:state] == 'COMPLETE'
         workflow_execution.state = 'canceled'

--- a/app/jobs/workflow_execution_cancelation_job.rb
+++ b/app/jobs/workflow_execution_cancelation_job.rb
@@ -20,13 +20,13 @@ class WorkflowExecutionCancelationJob < ApplicationJob
       status = wes_client.get_run_status(workflow_execution.run_id)
 
       if status[:state] == 'COMPLETE'
-        workflow_execution.state = 'canceled'
+        workflow_execution.state = :canceled
         workflow_execution.save
         return
       end
     end
 
-    workflow_execution.state = 'error'
+    workflow_execution.state = :error
     workflow_execution.error_code = exception.http_error_code
     workflow_execution.save
   end

--- a/app/jobs/workflow_execution_cancelation_job.rb
+++ b/app/jobs/workflow_execution_cancelation_job.rb
@@ -7,15 +7,20 @@ class WorkflowExecutionCancelationJob < ApplicationJob
   # When server is unreachable, continually retry
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
 
-  # When server is unreachable, continually retry
-  retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
-
   # Puts workflow execution into error state and records the error code
   retry_on Integrations::ApiExceptions::APIExceptionError, wait: :exponentially_longer, attempts: 5 do |job, exception|
     workflow_execution = job.arguments[0]
     workflow_execution.state = 'error'
     workflow_execution.error_code = exception.http_error_code
-    workflow_execution.save!
+    workflow_execution.save
+  end
+
+  rescue_from Integrations::ApiExceptions::UnauthorizedError do |job, exception|
+    handle_completed_run_errors(job, exception)
+  end
+
+  rescue_from Integrations::ApiExceptions::ForbiddenError do |job, exception|
+    handle_completed_run_errors(job, exception)
   end
 
   # TODO: retry on 401
@@ -27,5 +32,17 @@ class WorkflowExecutionCancelationJob < ApplicationJob
   def perform(workflow_execution, user)
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     WorkflowExecutions::CancelationService.new(workflow_execution, wes_connection, user).execute
+  end
+
+  private
+
+  def handle_completed_run_errors(job, exception)
+    # check status
+    #
+    # on completed, exit and set to canceled
+    # workflow execution should not continue to completion steps
+    #
+    # otherwise, set error
+    puts job.http_error_code
   end
 end

--- a/app/jobs/workflow_execution_cancelation_job.rb
+++ b/app/jobs/workflow_execution_cancelation_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionCancelationJob < ApplicationJob
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
-  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :exponentially_longer, attempts: 5 do |job, exception|
+  retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
 
     # Errors 401 and 403 can mean that the run was actually completed

--- a/app/jobs/workflow_execution_cancelation_job.rb
+++ b/app/jobs/workflow_execution_cancelation_job.rb
@@ -5,7 +5,7 @@ class WorkflowExecutionCancelationJob < ApplicationJob
   queue_as :default
 
   # When server is unreachable, continually retry
-  retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
+  retry_on Integrations::ApiExceptions::ConnectionError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
   retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -5,7 +5,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
   queue_as :default
 
   # When server is unreachable, continually retry
-  retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
+  retry_on Integrations::ApiExceptions::ConnectionError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
   retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,10 +8,10 @@ class WorkflowExecutionStatusJob < ApplicationJob
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
-  retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
+  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :polynomially_longer, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
     workflow_execution.state = :error
-    workflow_execution.error_code = exception.http_error_code
+    workflow_execution.http_error_code = exception.http_error_code
     workflow_execution.save
   end
 

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -10,7 +10,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
   # Puts workflow execution into error state and records the error code
   retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
-    workflow_execution.state = 'error'
+    workflow_execution.state = :error
     workflow_execution.error_code = exception.http_error_code
     workflow_execution.save
   end

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -4,6 +4,9 @@
 class WorkflowExecutionStatusJob < ApplicationJob
   queue_as :default
 
+  # When server is unreachable, continually retry
+  retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
+
   def perform(workflow_execution)
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -7,6 +7,14 @@ class WorkflowExecutionStatusJob < ApplicationJob
   # When server is unreachable, continually retry
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
 
+  # Puts workflow execution into error state and records the error code
+  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :exponentially_longer, attempts: 5 do |job, exception|
+    workflow_execution = job.arguments[0]
+    workflow_execution.state = 'error'
+    workflow_execution.error_code = exception.http_error_code
+    workflow_execution.save!
+  end
+
   def perform(workflow_execution)
     wes_connection = Integrations::Ga4ghWesApi::V1::ApiConnection.new.conn
     workflow_execution = WorkflowExecutions::StatusService.new(workflow_execution, wes_connection).execute

--- a/app/jobs/workflow_execution_status_job.rb
+++ b/app/jobs/workflow_execution_status_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionStatusJob < ApplicationJob
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
-  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :exponentially_longer, attempts: 5 do |job, exception|
+  retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
     workflow_execution.state = 'error'
     workflow_execution.error_code = exception.http_error_code

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -12,7 +12,7 @@ class WorkflowExecutionSubmissionJob < ApplicationJob
     workflow_execution = job.arguments[0]
     workflow_execution.state = 'error'
     workflow_execution.error_code = exception.http_error_code
-    workflow_execution.save!
+    workflow_execution.save
   end
 
   def perform(workflow_execution)

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -7,6 +7,14 @@ class WorkflowExecutionSubmissionJob < ApplicationJob
   # When server is unreachable, continually retry
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
 
+  # Puts workflow execution into error state and records the error code
+  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :exponentially_longer, attempts: 5 do |job, exception|
+    workflow_execution = job.arguments[0]
+    workflow_execution.state = 'error'
+    workflow_execution.error_code = exception.http_error_code
+    workflow_execution.save!
+  end
+
   def perform(workflow_execution)
     return if workflow_execution.canceling? || workflow_execution.canceled?
 

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -10,7 +10,7 @@ class WorkflowExecutionSubmissionJob < ApplicationJob
   # Puts workflow execution into error state and records the error code
   retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
-    workflow_execution.state = 'error'
+    workflow_execution.state = :error
     workflow_execution.error_code = exception.http_error_code
     workflow_execution.save
   end

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -4,7 +4,7 @@
 class WorkflowExecutionSubmissionJob < ApplicationJob
   queue_as :default
 
-  # When server is reachable, continually retry
+  # When server is unreachable, continually retry
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
 
   def perform(workflow_execution)

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -8,7 +8,7 @@ class WorkflowExecutionSubmissionJob < ApplicationJob
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
-  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :exponentially_longer, attempts: 5 do |job, exception|
+  retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
     workflow_execution.state = 'error'
     workflow_execution.error_code = exception.http_error_code

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -8,10 +8,10 @@ class WorkflowExecutionSubmissionJob < ApplicationJob
   retry_on Integrations::ApiExceptions::ConnectionError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
-  retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|
+  retry_on Integrations::ApiExceptions::APIExceptionError, wait: :polynomially_longer, attempts: 3 do |job, exception|
     workflow_execution = job.arguments[0]
     workflow_execution.state = :error
-    workflow_execution.error_code = exception.http_error_code
+    workflow_execution.http_error_code = exception.http_error_code
     workflow_execution.save
   end
 

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -4,6 +4,9 @@
 class WorkflowExecutionSubmissionJob < ApplicationJob
   queue_as :default
 
+  # When server is reachable, continually retry
+  retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
+
   def perform(workflow_execution)
     return if workflow_execution.canceling? || workflow_execution.canceled?
 

--- a/app/jobs/workflow_execution_submission_job.rb
+++ b/app/jobs/workflow_execution_submission_job.rb
@@ -5,7 +5,7 @@ class WorkflowExecutionSubmissionJob < ApplicationJob
   queue_as :default
 
   # When server is unreachable, continually retry
-  retry_on Integrations::ApiExceptions::ConnectionError, wait: :exponentially_longer, attempts: Float::INFINITY
+  retry_on Integrations::ApiExceptions::ConnectionError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   # Puts workflow execution into error state and records the error code
   retry_on Integrations::ApiExceptions::APIExceptionError, attempts: 3 do |job, exception|

--- a/app/services/workflow_executions/cancelation_service.rb
+++ b/app/services/workflow_executions/cancelation_service.rb
@@ -12,7 +12,6 @@ module WorkflowExecutions
     def execute
       return false unless @workflow_execution.canceling?
 
-      # throws exception if failed
       @wes_client.cancel_run(@workflow_execution.run_id)
 
       # mark workflow execution as canceled

--- a/db/migrate/20240418180337_add_error_code_to_workflow_execution.rb
+++ b/db/migrate/20240418180337_add_error_code_to_workflow_execution.rb
@@ -3,6 +3,6 @@
 # Migration to add error_code column to workflow_executions table
 class AddErrorCodeToWorkflowExecution < ActiveRecord::Migration[7.1]
   def change
-    add_column :workflow_executions, :error_code, :integer
+    add_column :workflow_executions, :http_error_code, :integer
   end
 end

--- a/db/migrate/20240418180337_add_error_code_to_workflow_execution.rb
+++ b/db/migrate/20240418180337_add_error_code_to_workflow_execution.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Migration to add error_code column to workflow_executions table
+class AddErrorCodeToWorkflowExecution < ActiveRecord::Migration[7.1]
+  def change
+    add_column :workflow_executions, :error_code, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -278,6 +278,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_25_163945) do
     t.jsonb "tags", default: {}, null: false
     t.integer "state", default: 0, null: false
     t.integer "error_code"
+    t.jsonb "tags", default: {}, null: false
     t.index ["created_at"], name: "index_workflow_executions_on_created_at"
     t.index ["state"], name: "index_workflow_executions_on_state"
     t.index ["submitter_id"], name: "index_workflow_executions_on_submitter_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -275,7 +275,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_25_163945) do
     t.string "blob_run_directory"
     t.boolean "email_notification", default: false, null: false
     t.boolean "update_samples", default: false, null: false
-    t.integer "error_code"
+    t.integer "http_error_code"
     t.jsonb "tags", default: {}, null: false
     t.integer "state", default: 0, null: false
     t.index ["created_at"], name: "index_workflow_executions_on_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -275,10 +275,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_25_163945) do
     t.string "blob_run_directory"
     t.boolean "email_notification", default: false, null: false
     t.boolean "update_samples", default: false, null: false
-    t.jsonb "tags", default: {}, null: false
-    t.integer "state", default: 0, null: false
     t.integer "error_code"
     t.jsonb "tags", default: {}, null: false
+    t.integer "state", default: 0, null: false
     t.index ["created_at"], name: "index_workflow_executions_on_created_at"
     t.index ["state"], name: "index_workflow_executions_on_state"
     t.index ["submitter_id"], name: "index_workflow_executions_on_submitter_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -277,6 +277,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_25_163945) do
     t.boolean "update_samples", default: false, null: false
     t.jsonb "tags", default: {}, null: false
     t.integer "state", default: 0, null: false
+    t.integer "error_code"
     t.index ["created_at"], name: "index_workflow_executions_on_created_at"
     t.index ["state"], name: "index_workflow_executions_on_state"
     t.index ["submitter_id"], name: "index_workflow_executions_on_submitter_id"

--- a/lib/integrations/api_exceptions.rb
+++ b/lib/integrations/api_exceptions.rb
@@ -8,6 +8,6 @@ module Integrations
     ForbiddenError = Class.new(APIExceptionError)
     NotFoundError = Class.new(APIExceptionError)
     ApiError = Class.new(APIExceptionError)
-    ServerError = Class.new(APIExceptionError)
+    ConnectionError = Class.new(APIExceptionError)
   end
 end

--- a/lib/integrations/api_exceptions.rb
+++ b/lib/integrations/api_exceptions.rb
@@ -1,13 +1,54 @@
 # frozen_string_literal: true
 
 module Integrations
+  # Defines exceptions classes for API integrations
   module ApiExceptions
-    APIExceptionError = Class.new(StandardError)
-    BadRequestError = Class.new(APIExceptionError)
-    UnauthorizedError = Class.new(APIExceptionError)
-    ForbiddenError = Class.new(APIExceptionError)
-    NotFoundError = Class.new(APIExceptionError)
-    ApiError = Class.new(APIExceptionError)
-    ConnectionError = Class.new(APIExceptionError)
+    # Only occurs if the API is unreachable
+    ConnectionError = Class.new(StandardError)
+
+    # parent class for API exceptions
+    class APIExceptionError < StandardError
+      attr_reader :http_error_code
+
+      def initialize(http_error_code)
+        super
+        @http_error_code = http_error_code
+      end
+    end
+
+    # HTTP 400
+    class BadRequestError < APIExceptionError
+      def initialize
+        super(400)
+      end
+    end
+
+    # HTTP 401
+    class UnauthorizedError < APIExceptionError
+      def initialize
+        super(401)
+      end
+    end
+
+    # HTTP 403
+    class ForbiddenError < APIExceptionError
+      def initialize
+        super(403)
+      end
+    end
+
+    # HTTP 404
+    class NotFoundError < APIExceptionError
+      def initialize
+        super(404)
+      end
+    end
+
+    # HTTP 500
+    class ApiError < APIExceptionError
+      def initialize
+        super(500)
+      end
+    end
   end
 end

--- a/lib/integrations/api_exceptions.rb
+++ b/lib/integrations/api_exceptions.rb
@@ -8,5 +8,6 @@ module Integrations
     ForbiddenError = Class.new(APIExceptionError)
     NotFoundError = Class.new(APIExceptionError)
     ApiError = Class.new(APIExceptionError)
+    ServerError = Class.new(APIExceptionError)
   end
 end

--- a/lib/integrations/api_exceptions.rb
+++ b/lib/integrations/api_exceptions.rb
@@ -10,44 +10,44 @@ module Integrations
     class APIExceptionError < StandardError
       attr_reader :http_error_code
 
-      def initialize(http_error_code)
-        super
+      def initialize(msg, http_error_code)
         @http_error_code = http_error_code
+        super(msg)
       end
     end
 
     # HTTP 400
     class BadRequestError < APIExceptionError
-      def initialize
-        super(400)
+      def initialize(msg)
+        super(msg, 400)
       end
     end
 
     # HTTP 401
     class UnauthorizedError < APIExceptionError
-      def initialize
-        super(401)
+      def initialize(msg)
+        super(msg, 401)
       end
     end
 
     # HTTP 403
     class ForbiddenError < APIExceptionError
-      def initialize
-        super(403)
+      def initialize(msg)
+        super(msg, 403)
       end
     end
 
     # HTTP 404
     class NotFoundError < APIExceptionError
-      def initialize
-        super(404)
+      def initialize(msg)
+        super(msg, 404)
       end
     end
 
     # HTTP 500
     class ApiError < APIExceptionError
-      def initialize
-        super(500)
+      def initialize(msg)
+        super(msg, 500)
       end
     end
   end

--- a/lib/integrations/ga4gh_wes_api/v1/api_requester.rb
+++ b/lib/integrations/ga4gh_wes_api/v1/api_requester.rb
@@ -45,14 +45,18 @@ module Integrations
           handle_error e
         end
 
-        def handle_error(err) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def handle_error(err) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
           Rails.logger.debug do
-            "DEBUG: Handling error for ga4gh_wes_api\n" \
-              "status: #{err.response[:status]}\n" \
-              "headers: #{err.response[:headers]}\n" \
-              "body: #{err.response[:body]}\n" \
-              "urlpath: #{err.response[:request][:url_path]}"
+            output = "DEBUG: Handling error #{err.class.name} for ga4gh_wes_api\n"
+            if err.response
+              output += "status: #{err.response[:status]}\n" \
+                        "headers: #{err.response[:headers]}\n" \
+                        "body: #{err.response[:body]}\n" \
+                        "urlpath: #{err.response[:request][:url_path]}"
+            end
+            output
           end
+
           case err # These are all the error responses defined by Ga4ghW Wes Api v1
           when Faraday::BadRequestError # 400
             raise BadRequestError, err.message
@@ -64,6 +68,8 @@ module Integrations
             raise NotFoundError, err.message
           when Faraday::ServerError # 500
             raise ApiError, err.message
+          when Faraday::ConnectionFailed # end of file error when server is not responsive
+            raise ServerError, err.message
           end
         end
       end

--- a/lib/integrations/ga4gh_wes_api/v1/api_requester.rb
+++ b/lib/integrations/ga4gh_wes_api/v1/api_requester.rb
@@ -69,7 +69,7 @@ module Integrations
           when Faraday::ServerError # 500
             raise ApiError, err.message
           when Faraday::ConnectionFailed # end of file error when server is not responsive
-            raise ServerError, err.message
+            raise ConnectionError, err.message
           end
         end
       end

--- a/test/active_job_test_case.rb
+++ b/test/active_job_test_case.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'test_helpers/active_job_test_helpers'
+
+class ActiveJobTestCase < ActiveJob::TestCase
+  include ActiveJobTestHelpers
+end

--- a/test/jobs/workflow_execution_cancelation_job_test.rb
+++ b/test/jobs/workflow_execution_cancelation_job_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_job_test_case'
+
+class WorkflowExecutionCancelationJobTest < ActiveJobTestCase
+  def setup
+    @workflow_execution = workflow_executions(:irida_next_example_canceling)
+    @user = users(:john_doe)
+    @stubs = faraday_test_adapter_stubs
+  end
+
+  def teardown
+    # reset connections after each test to clear cache
+    Faraday.default_connection = nil
+  end
+
+  test 'successful job execution' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 1)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      @stubs.post("/runs/#{@workflow_execution.run_id}/cancel") do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      perform_enqueued_jobs(only: WorkflowExecutionCancelationJob) do
+        WorkflowExecutionCancelationJob.perform_later(@workflow_execution, @user)
+      end
+    end
+
+    assert_performed_jobs 1
+    assert @workflow_execution.reload.canceled?
+  end
+
+  test 'repeated connection errors' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 6)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = "/runs/#{@workflow_execution.run_id}/cancel"
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      # a success after 5 failed attempts
+      @stubs.post(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      WorkflowExecutionCancelationJob.perform_later(@workflow_execution, @user)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionCancelationJob)
+    end
+
+    assert_performed_jobs 6
+    assert @workflow_execution.reload.canceled?
+  end
+
+  test 'repeated api exception errors' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 3)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = "/runs/#{@workflow_execution.run_id}/cancel"
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      # a success (never reached) after 3 failed attempts
+      @stubs.post(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      WorkflowExecutionCancelationJob.perform_later(@workflow_execution, @user)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionCancelationJob)
+    end
+
+    assert_performed_jobs 3
+    @workflow_execution.reload
+    assert @workflow_execution.error?
+    assert @workflow_execution.error_code == 400
+  end
+
+  test 'api exception error then a success' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 2)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = "/runs/#{@workflow_execution.run_id}/cancel"
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      # a success after 1 failed attempt
+      @stubs.post(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      WorkflowExecutionCancelationJob.perform_later(@workflow_execution, @user)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionCancelationJob)
+    end
+
+    assert_performed_jobs 2
+    assert @workflow_execution.reload.canceled?
+  end
+end

--- a/test/jobs/workflow_execution_cancelation_job_test.rb
+++ b/test/jobs/workflow_execution_cancelation_job_test.rb
@@ -87,7 +87,7 @@ class WorkflowExecutionCancelationJobTest < ActiveJobTestCase
     assert_performed_jobs 3
     @workflow_execution.reload
     assert @workflow_execution.error?
-    assert @workflow_execution.error_code == 400
+    assert @workflow_execution.http_error_code == 400
   end
 
   test 'api exception error then a success' do

--- a/test/jobs/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_execution_status_job_test.rb
@@ -99,7 +99,7 @@ class WorkflowExecutionStatusJobTest < ActiveJobTestCase
   end
 
   test 'api exception error then a success' do
-    mock_client = connection_builder(stubs: @stubs, connection_count: 3)
+    mock_client = connection_builder(stubs: @stubs, connection_count: 2)
 
     Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
       endpoint = "/runs/#{@workflow_execution.run_id}/status"

--- a/test/jobs/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_execution_status_job_test.rb
@@ -1,52 +1,12 @@
 # frozen_string_literal: true
 
-require 'minitest/mock'
 require 'test_helper'
+require 'active_job_test_case'
 
-class WorkflowExecutionStatusJobTest < ActiveJob::TestCase
+class WorkflowExecutionStatusJobTest < ActiveJobTestCase
   def setup
     @workflow_execution = workflow_executions(:irida_next_example_submitted)
-
-    # Mutable stubs, allowing adding/changing stubbed endpoints mid test
-    @stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.get('/service-info') do |_env|
-        [
-          200,
-          { 'Content-Type': 'text/plain' },
-          'stubbed text'
-        ]
-      end
-    end
-
-    # test adapter for Faraday with above stubs
-    @test_conn = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-  end
-
-  # the mock client needs an `expect` for each connection
-  def connections_to_expect(connection_count)
-    # Client to mock api connections
-    @mock_client = Minitest::Mock.new
-    while connection_count >= 1
-      @mock_client.expect(:conn, @test_conn)
-      connection_count -= 1
-    end
-  end
-
-  # jobs that are retried must be run one at a time to prevent stack errors
-  # This functions the same as `perform_enqueued_jobs(only: MyJob)` but one at a time
-  def perform_enqueued_jobs_one_at_a_time(only_class:)
-    while enqueued_jobs.count >= 1 && enqueued_jobs.first['job_class'] == only_class.name
-      # run a single queued job
-      currently_queued_job = enqueued_jobs.first
-      perform_enqueued_jobs(
-        only: lambda { |job|
-          job['job_id'] == currently_queued_job['job_id'] && \
-          job['job_class'] == only_class.name
-        }
-      )
-    end
+    @stubs = faraday_test_adapter_stubs
   end
 
   def teardown
@@ -55,9 +15,9 @@ class WorkflowExecutionStatusJobTest < ActiveJob::TestCase
   end
 
   test 'successful job execution' do
-    connections_to_expect(1)
+    mock_client = connection_builder(stubs: @stubs, connection_count: 1)
 
-    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, @mock_client do
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
       @stubs.get("/runs/#{@workflow_execution.run_id}/status") do |_env|
         [
           200,
@@ -79,9 +39,9 @@ class WorkflowExecutionStatusJobTest < ActiveJob::TestCase
   end
 
   test 'repeated connection errors' do
-    connections_to_expect(6)
+    mock_client = connection_builder(stubs: @stubs, connection_count: 6)
 
-    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, @mock_client do
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
       endpoint = "/runs/#{@workflow_execution.run_id}/status"
       @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
       @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }

--- a/test/jobs/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_execution_status_job_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'minitest/mock'
+require 'test_helper'
+
+class WorkflowExecutionStatusJobTest < ActiveJob::TestCase
+  def setup
+    @workflow_execution = workflow_executions(:irida_next_example_submitted)
+  end
+
+  test 'retry on no connection' do
+    mock = Minitest::Mock.new
+    def mock.conn
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.get('/runs/my_run_id_5/status') do |_env|
+            [
+              401,
+              { 'Content-Type': 'text/plain' },
+              'aaaaaaaaaaaaaaaaa'
+            ]
+          end
+
+          stub.get('/boom') do
+            raise Faraday::ConnectionFailed
+          end
+        end
+      end
+    end
+
+    # stubs.get('/asdf') { |_env| [200, {}, 'qwerty'] }
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock do
+      perform_enqueued_jobs do
+        WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(@workflow_execution)
+      end
+    end
+  end
+end

--- a/test/jobs/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_execution_status_job_test.rb
@@ -95,7 +95,7 @@ class WorkflowExecutionStatusJobTest < ActiveJobTestCase
     assert_performed_jobs 3
     @workflow_execution.reload
     assert @workflow_execution.error?
-    assert @workflow_execution.error_code == 400
+    assert @workflow_execution.http_error_code == 400
   end
 
   test 'api exception error then a success' do

--- a/test/jobs/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_execution_status_job_test.rb
@@ -48,7 +48,7 @@ class WorkflowExecutionStatusJobTest < ActiveJobTestCase
       @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
       @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
       @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
-      # a success after 5 attempts
+      # a success after 5 failed attempts
       @stubs.get(endpoint) do |_env|
         [
           200,
@@ -65,6 +65,62 @@ class WorkflowExecutionStatusJobTest < ActiveJobTestCase
     end
 
     assert_performed_jobs 6
+    assert @workflow_execution.reload.completing?
+  end
+
+  test 'repeated api exception errors' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 3)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = "/runs/#{@workflow_execution.run_id}/status"
+      @stubs.get(endpoint) { |_env| raise Faraday::BadRequestError }
+      @stubs.get(endpoint) { |_env| raise Faraday::BadRequestError }
+      @stubs.get(endpoint) { |_env| raise Faraday::BadRequestError }
+      # a success (never reached) after 3 failed attempts
+      @stubs.get(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          {
+            run_id: @workflow_execution.run_id,
+            state: 'COMPLETE'
+          }
+        ]
+      end
+
+      WorkflowExecutionStatusJob.perform_later(@workflow_execution)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionStatusJob)
+    end
+
+    assert_performed_jobs 3
+    @workflow_execution.reload
+    assert @workflow_execution.error?
+    assert @workflow_execution.error_code == 400
+  end
+
+  test 'api exception error then a success' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 3)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = "/runs/#{@workflow_execution.run_id}/status"
+      @stubs.get(endpoint) { |_env| raise Faraday::BadRequestError }
+      # a success after 1 failed attempt
+      @stubs.get(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          {
+            run_id: @workflow_execution.run_id,
+            state: 'COMPLETE'
+          }
+        ]
+      end
+
+      WorkflowExecutionStatusJob.perform_later(@workflow_execution)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionStatusJob)
+    end
+
+    assert_performed_jobs 2
     assert @workflow_execution.reload.completing?
   end
 end

--- a/test/jobs/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_execution_status_job_test.rb
@@ -22,10 +22,31 @@ class WorkflowExecutionStatusJobTest < ActiveJob::TestCase
     @test_conn = Faraday.new do |builder|
       builder.adapter :test, @stubs
     end
+  end
 
+  # the mock client needs an `expect` for each connection
+  def connections_to_expect(connection_count)
     # Client to mock api connections
     @mock_client = Minitest::Mock.new
-    @mock_client.expect(:conn, @test_conn)
+    while connection_count >= 1
+      @mock_client.expect(:conn, @test_conn)
+      connection_count -= 1
+    end
+  end
+
+  # jobs that are retried must be run one at a time to prevent stack errors
+  # This functions the same as `perform_enqueued_jobs(only: MyJob)` but one at a time
+  def perform_enqueued_jobs_one_at_a_time(only_class:)
+    while enqueued_jobs.count >= 1 && enqueued_jobs.first['job_class'] == only_class.name
+      # run a single queued job
+      currently_queued_job = enqueued_jobs.first
+      perform_enqueued_jobs(
+        only: lambda { |job|
+          job['job_id'] == currently_queued_job['job_id'] && \
+          job['job_class'] == only_class.name
+        }
+      )
+    end
   end
 
   def teardown
@@ -33,17 +54,57 @@ class WorkflowExecutionStatusJobTest < ActiveJob::TestCase
     Faraday.default_connection = nil
   end
 
-  test 'proof of concept test' do
-    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, @mock_client do
-      @stubs.get('/asdf') { |_env| [200, {}, 'qwerty'] }
+  test 'successful job execution' do
+    connections_to_expect(1)
 
-      @stubs.get('/boom') do
-        raise Faraday::ConnectionFailed
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, @mock_client do
+      @stubs.get("/runs/#{@workflow_execution.run_id}/status") do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          {
+            run_id: @workflow_execution.run_id,
+            state: 'COMPLETE'
+          }
+        ]
       end
 
-      perform_enqueued_jobs do
-        WorkflowExecutionStatusJob.set(wait_until: 30.seconds.from_now).perform_later(@workflow_execution)
+      perform_enqueued_jobs(only: WorkflowExecutionStatusJob) do
+        WorkflowExecutionStatusJob.perform_later(@workflow_execution)
       end
     end
+
+    assert_performed_jobs 1
+    assert @workflow_execution.reload.completing?
+  end
+
+  test 'repeated connection errors' do
+    connections_to_expect(6)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, @mock_client do
+      endpoint = "/runs/#{@workflow_execution.run_id}/status"
+      @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.get(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      # a success after 5 attempts
+      @stubs.get(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          {
+            run_id: @workflow_execution.run_id,
+            state: 'COMPLETE'
+          }
+        ]
+      end
+
+      WorkflowExecutionStatusJob.perform_later(@workflow_execution)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionStatusJob)
+    end
+
+    assert_performed_jobs 6
+    assert @workflow_execution.reload.completing?
   end
 end

--- a/test/jobs/workflow_execution_submission_job_test.rb
+++ b/test/jobs/workflow_execution_submission_job_test.rb
@@ -86,7 +86,7 @@ class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
     assert_performed_jobs 3
     @workflow_execution.reload
     assert @workflow_execution.error?
-    assert @workflow_execution.error_code == 400
+    assert @workflow_execution.http_error_code == 400
   end
 
   test 'api exception error then a success' do

--- a/test/jobs/workflow_execution_submission_job_test.rb
+++ b/test/jobs/workflow_execution_submission_job_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_job_test_case'
+
+class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
+  def setup
+    @workflow_execution = workflow_executions(:irida_next_example_prepared)
+    @stubs = faraday_test_adapter_stubs
+  end
+
+  def teardown
+    # reset connections after each test to clear cache
+    Faraday.default_connection = nil
+  end
+
+  test 'successful job execution' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 1)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      @stubs.post('/runs') do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      perform_enqueued_jobs(only: WorkflowExecutionSubmissionJob) do
+        WorkflowExecutionSubmissionJob.perform_later(@workflow_execution)
+      end
+    end
+
+    assert_performed_jobs 1
+    assert @workflow_execution.reload.submitted?
+  end
+
+  test 'repeated connection errors' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 6)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = '/runs'
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      @stubs.post(endpoint) { |_env| raise Faraday::ConnectionFailed }
+      # a success after 5 failed attempts
+      @stubs.post(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      WorkflowExecutionSubmissionJob.perform_later(@workflow_execution)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionSubmissionJob)
+    end
+
+    assert_performed_jobs 6
+    assert @workflow_execution.reload.submitted?
+  end
+
+  test 'repeated api exception errors' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 3)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = '/runs'
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      # a success (never reached) after 3 failed attempts
+      @stubs.post(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      WorkflowExecutionSubmissionJob.perform_later(@workflow_execution)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionSubmissionJob)
+    end
+
+    assert_performed_jobs 3
+    @workflow_execution.reload
+    assert @workflow_execution.error?
+    assert @workflow_execution.error_code == 400
+  end
+
+  test 'api exception error then a success' do
+    mock_client = connection_builder(stubs: @stubs, connection_count: 3)
+
+    Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
+      endpoint = '/runs'
+      @stubs.post(endpoint) { |_env| raise Faraday::BadRequestError }
+      # a success after 1 failed attempt
+      @stubs.post(endpoint) do |_env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { run_id: @workflow_execution.run_id }
+        ]
+      end
+
+      WorkflowExecutionSubmissionJob.perform_later(@workflow_execution)
+      perform_enqueued_jobs_one_at_a_time(only_class: WorkflowExecutionSubmissionJob)
+    end
+
+    assert_performed_jobs 2
+    assert @workflow_execution.reload.submitted?
+  end
+end

--- a/test/jobs/workflow_execution_submission_job_test.rb
+++ b/test/jobs/workflow_execution_submission_job_test.rb
@@ -90,7 +90,7 @@ class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
   end
 
   test 'api exception error then a success' do
-    mock_client = connection_builder(stubs: @stubs, connection_count: 3)
+    mock_client = connection_builder(stubs: @stubs, connection_count: 2)
 
     Integrations::Ga4ghWesApi::V1::ApiConnection.stub :new, mock_client do
       endpoint = '/runs'

--- a/test/test_helpers/active_job_test_helpers.rb
+++ b/test/test_helpers/active_job_test_helpers.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'minitest/mock'
+
+module ActiveJobTestHelpers
+  # jobs that are retried must be run one at a time to prevent stack errors
+  # This functions the same as `perform_enqueued_jobs(only: MyJob)` but one at a time
+  def perform_enqueued_jobs_one_at_a_time(only_class:)
+    while enqueued_jobs.count >= 1 && enqueued_jobs.first['job_class'] == only_class.name
+      # run a single queued job
+      currently_queued_job = enqueued_jobs.first
+      perform_enqueued_jobs(
+        only: lambda { |job|
+          job['job_id'] == currently_queued_job['job_id'] && \
+          job['job_class'] == only_class.name
+        }
+      )
+    end
+  end
+
+  # Mutable stubs, allowing adding/changing stubbed endpoints mid test
+  def faraday_test_adapter_stubs
+    Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get('/service-info') do |_env|
+        [
+          200,
+          { 'Content-Type': 'text/plain' },
+          'stubbed text'
+        ]
+      end
+    end
+  end
+
+  # test adapter for Faraday using mutable stubs
+  def connection_builder(stubs:, connection_count:)
+    test_conn = Faraday.new do |builder|
+      builder.adapter :test, stubs
+    end
+
+    # Client to mock api connections
+    mock_client = Minitest::Mock.new
+    while connection_count >= 1
+      mock_client.expect(:conn, test_conn)
+      connection_count -= 1
+    end
+
+    mock_client
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Fixes #513

1. Adds retry and error rescue to jobs that connect to ga4gh wes. Details below.

2. Fixes a race condition bug where a job that a user cancelled sometimes finishes and completes(writes to samples) instead of cancelling.

3. Created a new set of helper functions `ActiveJobTestHelpers` to allow mocking Faraday based API integrations for active job tests.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

You will need to have `Sapporo` running and connected to test

The following 3 jobs reach out to ga4gh wes.

1. WorkflowExecutionStatusJob
2. WorkflowExecutionSubmissionJob
3. WorkflowExecutionCancelationJob

If ga4gh wes is unreachable or returns an error code, it must be handled so that the workflow execution doesn't get stuck in whatever state it was in when the error occurred.

#### For ConnectionError type
This error type should always be reattempted.

You can simply turn off your Sapporo instance at the different stages of the workflow execution.

Verify that the job is reattempted continually.

#### For APIExceptionError types 
These error types should be attempted 5 times before being put into the error state

You can make workflow_execution services throwto test the job re-queuing by adding a line to throw the exception. For example:

```ruby
# app/services/workflow_executions/submission_service.rb#execute
def execute
      return false unless @workflow_execution.prepared?

      raise Integrations::ApiExceptions::BadRequestError, 'my thrown exception'

      run = @wes_client.run_workflow(**@workflow_execution.as_wes_params)
...
```

#### WorkflowExecutionCancelationJob

WorkflowExecutionCancelationJob is a special case because ga4gh wes can return 401 and/or 403 errors when a cancel request is sent to a completed run (Sapporo always replies with 200). 

In this case, we want to mark those runs as `canceled` and not move on to completion steps. Other errors should still behave as above.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
