### PR TITLE
Workflow Submissions: Added email notification for worklfow completion

### DIFF
--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -82,32 +82,57 @@
       <% end %>
 
       <%- if @allowed_to_update_samples %>
+        <div class="flex mb-4 items-center h-5">
+          <%= workflow.check_box :update_samples,
+                             {
+                               checked: false,
+                               class:
+                                 "w-4
+                                  h-4
+                                  mr-2.5
+                                  text-primary-600
+                                  bg-slate-100
+                                  border-slate-300
+                                  rounded
+                                  focus:ring-primary-500
+                                  dark:focus:ring-primary-600
+                                  dark:ring-offset-slate-800
+                                  focus:ring-2
+                                  dark:bg-slate-700
+                                  dark:border-slate-600"
+                             },
+                             true,
+                             false %>
+          <%= workflow.label :update_samples,
+                         t(:"components.nextflow.update_samples"),
+                         class: "mr-2 text-sm font-medium text-slate-900 dark:text-white" %>
+        </div>
+      <%- end %>
       <div class="flex mb-4 items-center h-5">
-        <%= workflow.check_box :update_samples,
+        <%= workflow.check_box :email_notification,
                            {
                              checked: false,
                              class:
                                "w-4
-                          h-4
-                          mr-2.5
-                          text-primary-600
-                          bg-slate-100
-                          border-slate-300
-                          rounded
-                          focus:ring-primary-500
-                          dark:focus:ring-primary-600
-                          dark:ring-offset-slate-800
-                          focus:ring-2
-                          dark:bg-slate-700
-                          dark:border-slate-600"
+                                h-4
+                                mr-2.5
+                                text-primary-600
+                                bg-slate-100
+                                border-slate-300
+                                rounded
+                                focus:ring-primary-500
+                                dark:focus:ring-primary-600
+                                dark:ring-offset-slate-800
+                                focus:ring-2
+                                dark:bg-slate-700
+                                dark:border-slate-600"
                            },
                            true,
                            false %>
-        <%= workflow.label :update_samples,
-                       t(:"components.nextflow.update_samples"),
+        <%= workflow.label :email_notification,
+                       t(:"components.nextflow.email_notification"),
                        class: "mr-2 text-sm font-medium text-slate-900 dark:text-white" %>
       </div>
-      <%- end %>
     <% end %>
 
     <button type="submit" class="button button--state-primary button--size-default">

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -114,6 +114,7 @@ class WorkflowExecutionsController < ApplicationController # rubocop:disable Met
       :workflow_engine_version,
       :workflow_url,
       :update_samples,
+      :email_notification,
       { tags: [],
         metadata: {},
         workflow_params: {},

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,7 @@ en:
     nextflow:
       required: Required
       update_samples: Update samples with analysis results
+      email_notification: Receive an email notification when your analysis has completed?
     history:
       latest: Latest
       created_by: "%{type} created by %{user}"
@@ -1437,4 +1438,3 @@ en:
         processing: processing
         ready: ready
       title: Data Export
-

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -25,6 +25,7 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
                workflow_engine_version: '23.10.0',
                workflow_engine_parameters: { '-r': 'dev' },
                workflow_url: 'https://github.com/phac-nml/iridanextexample',
+               email_notification: true,
                samples_workflow_executions_attributes: [
                  {
                    sample_id: @sample1.id,
@@ -47,6 +48,7 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, created_workflow_execution.samples_workflow_executions.count
     assert_equal @sample1, created_workflow_execution.samples_workflow_executions.first.sample
+    assert_equal true, created_workflow_execution.email_notification
   end
 
   test 'should cancel a new workflow with valid params' do

--- a/test/system/workflow_executions/submissions_test.rb
+++ b/test/system/workflow_executions/submissions_test.rb
@@ -39,6 +39,7 @@ module WorkflowExecutions
         end
 
         assert_text I18n.t(:'components.nextflow.update_samples')
+        assert_text I18n.t(:'components.nextflow.email_notification')
       end
     end
 
@@ -70,6 +71,7 @@ module WorkflowExecutions
         end
 
         assert_text I18n.t(:'components.nextflow.update_samples')
+        assert_text I18n.t(:'components.nextflow.email_notification')
       end
     end
 
@@ -101,6 +103,7 @@ module WorkflowExecutions
         end
 
         assert_no_text I18n.t(:'components.nextflow.update_samples')
+        assert_text I18n.t(:'components.nextflow.email_notification')
       end
     end
 
@@ -134,6 +137,7 @@ module WorkflowExecutions
         end
 
         assert_no_text I18n.t(:'components.nextflow.update_samples')
+        assert_text I18n.t(:'components.nextflow.email_notification')
       end
     end
 
@@ -173,6 +177,7 @@ module WorkflowExecutions
         end
 
         assert_text I18n.t(:'components.nextflow.update_samples')
+        assert_text I18n.t(:'components.nextflow.email_notification')
       end
     end
 
@@ -204,6 +209,7 @@ module WorkflowExecutions
         end
 
         assert_text I18n.t(:'components.nextflow.update_samples')
+        assert_text I18n.t(:'components.nextflow.email_notification')
       end
     end
 
@@ -235,6 +241,7 @@ module WorkflowExecutions
         end
 
         assert_no_text I18n.t(:'components.nextflow.update_samples')
+        assert_text I18n.t(:'components.nextflow.email_notification')
       end
     end
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Added a checkbox to allow the user to opt in for an email notification when a workflow submission is completed.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/11295750/9d5121bb-71bc-4265-ac76-499ab41473ba)

![image](https://github.com/phac-nml/irida-next/assets/11295750/1dfa717f-0cc8-4fd8-a49a-3e5d9e3bcc27)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Ensure `sapporo` and `mailhog` are running
2. Login as users and go to [Yersinia > Yersinia pseudotuberculosis > Outbreak 2023 > Samples]( http://localhost:3000/yersinia/yersinia-pseudotuberculosis/outbreak-2023/-/samples) 
3. Select a couple sample and click the launch workflow button
4. Select workflow **phac-nml/iridanextexample v1.0.2**
5. Leave the default options selected and select the checkbox at the bottom `Receive an email notification when your analysis has completed?`
6. Click the `Submit` button
7. Once the pipeline has reached it `Completed` state, check to ensure that an email is present for the completion within Mailhog.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
