### PR TITLE
Pipelines - Add automatable

### DIFF
--- a/config/pipelines/pipelines.json
+++ b/config/pipelines/pipelines.json
@@ -9,12 +9,10 @@
         "automatable": true
       },
       {
-        "name": "1.0.1",
-        "automatable": false
+        "name": "1.0.1"
       },
       {
-        "name": "1.0.0",
-        "automatable": false
+        "name": "1.0.0"
       }
     ]
   }

--- a/config/pipelines/pipelines.json
+++ b/config/pipelines/pipelines.json
@@ -5,13 +5,16 @@
     "description": "IRIDA Next Example Pipeline",
     "versions": [
       {
-        "name": "1.0.2"
+        "name": "1.0.2",
+        "automatable": true
       },
       {
-        "name": "1.0.1"
+        "name": "1.0.1",
+        "automatable": false
       },
       {
-        "name": "1.0.0"
+        "name": "1.0.0",
+        "automatable": false
       }
     ]
   }

--- a/lib/irida/pipeline.rb
+++ b/lib/irida/pipeline.rb
@@ -4,7 +4,7 @@ module Irida
   # Class to store pipeline values
   class Pipeline
     attr_accessor :name, :description, :metadata, :type, :type_version,
-                  :engine, :engine_version, :url, :version, :schema_loc, :schema_input_loc
+                  :engine, :engine_version, :url, :version, :schema_loc, :schema_input_loc, :automatable
 
     IGNORED_PARAMS = %w[outdir email].freeze
 
@@ -20,6 +20,7 @@ module Irida
       @version = version['name']
       @schema_loc = schema_loc
       @schema_input_loc = schema_input_loc
+      @automatable = version['automatable'] || false
     end
 
     def workflow_params

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -140,6 +140,10 @@ module Irida
       @pipeline_schema_file_dir = dir
     end
 
+    def automatable_pipelines
+      available_pipelines.select { |_name, pipeline| pipeline.automatable }
+    end
+
     # If the pipelines have been initialized or not for the current process
     def initialized
       @initialized

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -14,6 +14,7 @@ module Irida
     @pipeline_config_file = 'pipelines.json'
     @pipeline_schema_status_file = 'status.json'
     @available_pipelines = {}
+    @automatable_pipelines = {}
     @initialized = false
 
     module_function
@@ -29,8 +30,10 @@ module Irida
 
           nextflow_schema_location = prepare_schema_download(entry, version, 'nextflow_schema')
           schema_input_location = prepare_schema_download(entry, version, 'schema_input')
-          @available_pipelines["#{entry['name']}_#{version['name']}"] =
-            Pipeline.new(entry, version, nextflow_schema_location, schema_input_location)
+
+          pipeline = Pipeline.new(entry, version, nextflow_schema_location, schema_input_location)
+          @available_pipelines["#{entry['name']}_#{version['name']}"] = pipeline
+          @automatable_pipelines["#{entry['name']}_#{version['name']}"] = pipeline if version['automatable']
         end
       end
       @initialized = true
@@ -141,7 +144,7 @@ module Irida
     end
 
     def automatable_pipelines
-      available_pipelines.select { |_name, pipeline| pipeline.automatable }
+      @automatable_pipelines
     end
 
     # If the pipelines have been initialized or not for the current process

--- a/test/config/pipelines/pipelines.json
+++ b/test/config/pipelines/pipelines.json
@@ -5,7 +5,8 @@
     "description": "IRIDA Next Example Pipeline",
     "versions": [
       {
-        "name": "1.0.2"
+        "name": "1.0.2",
+        "automatable": true
       },
       {
         "name": "1.0.1"

--- a/test/lib/irida/pipelines_test.rb
+++ b/test/lib/irida/pipelines_test.rb
@@ -47,4 +47,14 @@ class PipelinesTest < ActiveSupport::TestCase
     workflow = Irida::Pipelines.find_pipeline_by('phac-nml/iridanextexample', '1.0.0')
     assert_not_nil workflow
   end
+
+  test 'automatable pipelines' do
+    Irida::Pipelines.register_pipelines
+
+    assert_not Irida::Pipelines.automatable_pipelines.empty?
+
+    assert Irida::Pipelines.automatable_pipelines['phac-nml/iridanextexample_1.0.2']
+    assert_not Irida::Pipelines.automatable_pipelines['phac-nml/iridanextexample_1.0.1']
+    assert_not Irida::Pipelines.automatable_pipelines['phac-nml/iridanextexample_1.0.0']
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds the `automatable` attribute to pipelines and a `automatable_pipelines` call to return any automatable pipelines

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Open a `rails console`
2. Input the command
```
Irida::Pipelines.automatable_pipelines
```
3. Ensure only pipeline `phac-nml/iridanextexample_1.0.2` is returned

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
