### PR TITLE
Workflow Execution: Change state to enum

### DIFF
--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -5,6 +5,20 @@ class WorkflowExecution < ApplicationRecord
   include MetadataSortable
   METADATA_JSON_SCHEMA = Rails.root.join('config/schemas/workflow_execution_metadata.json')
 
+  # new is a keyword that cannot be used with enums, so we'll change new to initial and in the translation,
+  # translate initial back to new
+  WORKFLOW_EXECUTION_STATES = {
+    initial: 0,
+    prepared: 1,
+    submitted: 2,
+    running: 3,
+    completing: 4,
+    completed: 5,
+    error: 6,
+    canceling: 7,
+    canceled: 8
+  }.with_indifferent_access.freeze
+
   has_logidze
   acts_as_paranoid
 
@@ -21,20 +35,7 @@ class WorkflowExecution < ApplicationRecord
 
   validates :metadata, presence: true, json: { message: ->(errors) { errors }, schema: METADATA_JSON_SCHEMA }
 
-  # new is a keyword that cannot be used with enums, so we'll change new to initial and in the translation,
-  # translate initial back to new
-  enum state: {
-    initial: 0,
-    prepared: 1,
-    submitted: 2,
-    running: 3,
-    completing: 4,
-    completed: 5,
-    error: 6,
-    canceling: 7,
-    canceled: 8,
-    queued: 9
-  }
+  enum state: WORKFLOW_EXECUTION_STATES
 
   def send_email
     return unless email_notification

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -48,7 +48,7 @@ class WorkflowExecution < ApplicationRecord
   end
 
   def cancellable?
-    %w[submitted running queued prepared initial].include?(state)
+    %w[submitted running prepared initial].include?(state)
   end
 
   def deletable?

--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -21,6 +21,21 @@ class WorkflowExecution < ApplicationRecord
 
   validates :metadata, presence: true, json: { message: ->(errors) { errors }, schema: METADATA_JSON_SCHEMA }
 
+  # new is a keyword that cannot be used with enums, so we'll change new to initial and in the translation,
+  # translate initial back to new
+  enum state: {
+    initial: 0,
+    prepared: 1,
+    submitted: 2,
+    running: 3,
+    completing: 4,
+    completed: 5,
+    error: 6,
+    canceling: 7,
+    canceled: 8,
+    queued: 9
+  }
+
   def send_email
     return unless email_notification
 
@@ -31,48 +46,8 @@ class WorkflowExecution < ApplicationRecord
     end
   end
 
-  def prepared?
-    state == 'prepared'
-  end
-
-  def submitted?
-    state == 'submitted'
-  end
-
-  def completing?
-    state == 'completing'
-  end
-
-  def completed?
-    state == 'completed'
-  end
-
-  def error?
-    state == 'error'
-  end
-
-  def canceling?
-    state == 'canceling'
-  end
-
-  def canceled?
-    state == 'canceled'
-  end
-
-  def running?
-    state == 'running'
-  end
-
-  def queued?
-    state == 'queued'
-  end
-
-  def new?
-    state == 'new'
-  end
-
   def cancellable?
-    %w[submitted running queued prepared new].include?(state)
+    %w[submitted running queued prepared initial].include?(state)
   end
 
   def deletable?
@@ -80,7 +55,7 @@ class WorkflowExecution < ApplicationRecord
   end
 
   def sent_to_ga4gh?
-    %w[prepared new].exclude?(state)
+    %w[prepared initial].exclude?(state)
   end
 
   def as_wes_params

--- a/app/services/workflow_executions/cancel_service.rb
+++ b/app/services/workflow_executions/cancel_service.rb
@@ -13,12 +13,12 @@ module WorkflowExecutions
 
       # Early exit if workflow execution has not been submitted to ga4gh wes yet
       unless @workflow_execution.sent_to_ga4gh?
-        @workflow_execution.state = 'canceled'
+        @workflow_execution.state = :canceled
         @workflow_execution.save
         return @workflow_execution
       end
 
-      @workflow_execution.state = 'canceling'
+      @workflow_execution.state = :canceling
       @workflow_execution.save
 
       WorkflowExecutionCancelationJob.set(wait_until: 30.seconds.from_now).perform_later(@workflow_execution,

--- a/app/services/workflow_executions/cancelation_service.rb
+++ b/app/services/workflow_executions/cancelation_service.rb
@@ -16,7 +16,7 @@ module WorkflowExecutions
       @wes_client.cancel_run(@workflow_execution.run_id)
 
       # mark workflow execution as canceled
-      @workflow_execution.state = 'canceled'
+      @workflow_execution.state = :canceled
 
       @workflow_execution.save
     end

--- a/app/services/workflow_executions/completion_service.rb
+++ b/app/services/workflow_executions/completion_service.rb
@@ -40,7 +40,7 @@ module WorkflowExecutions
         put_output_attachments_onto_samples
       end
 
-      @workflow_execution.state = 'completed'
+      @workflow_execution.state = :completed
 
       @workflow_execution.save
 

--- a/app/services/workflow_executions/create_service.rb
+++ b/app/services/workflow_executions/create_service.rb
@@ -12,7 +12,7 @@ module WorkflowExecutions
 
       @workflow_execution = WorkflowExecution.new(params)
       @workflow_execution.submitter = current_user
-      @workflow_execution.state = 'initial'
+      @workflow_execution.state = :initial
 
       @workflow_execution.tags = { createdBy: current_user.email }
 

--- a/app/services/workflow_executions/create_service.rb
+++ b/app/services/workflow_executions/create_service.rb
@@ -12,7 +12,7 @@ module WorkflowExecutions
 
       @workflow_execution = WorkflowExecution.new(params)
       @workflow_execution.submitter = current_user
-      @workflow_execution.state = 'new'
+      @workflow_execution.state = 'initial'
 
       @workflow_execution.tags = { createdBy: current_user.email }
 

--- a/app/services/workflow_executions/create_service.rb
+++ b/app/services/workflow_executions/create_service.rb
@@ -7,12 +7,11 @@ module WorkflowExecutions
       super(user, params)
     end
 
-    def execute # rubocop:disable Metrics/AbcSize
+    def execute
       return false if params.empty?
 
       @workflow_execution = WorkflowExecution.new(params)
       @workflow_execution.submitter = current_user
-      @workflow_execution.state = :initial
 
       @workflow_execution.tags = { createdBy: current_user.email }
 

--- a/app/services/workflow_executions/preparation_service.rb
+++ b/app/services/workflow_executions/preparation_service.rb
@@ -35,7 +35,7 @@ module WorkflowExecutions
       )
 
       # mark workflow execution as prepared
-      @workflow_execution.state = 'prepared'
+      @workflow_execution.state = :prepared
 
       @workflow_execution.save
     end

--- a/app/services/workflow_executions/status_service.rb
+++ b/app/services/workflow_executions/status_service.rb
@@ -17,15 +17,13 @@ module WorkflowExecutions
 
       state = run_status[:state]
       @workflow_execution.state = if state == 'RUNNING'
-                                    'running'
+                                    :running
                                   elsif state == 'COMPLETE'
-                                    'completing'
+                                    :completed
                                   end
-      if Integrations::Ga4ghWesApi::V1::States::CANCELATION_STATES.include?(state)
-        @workflow_execution.state = 'canceled'
-      end
+      @workflow_execution.state = :canceled if Integrations::Ga4ghWesApi::V1::States::CANCELATION_STATES.include?(state)
 
-      @workflow_execution.state = 'error' if Integrations::Ga4ghWesApi::V1::States::ERROR_STATES.include?(state)
+      @workflow_execution.state = :error if Integrations::Ga4ghWesApi::V1::States::ERROR_STATES.include?(state)
 
       @workflow_execution.save
 

--- a/app/services/workflow_executions/status_service.rb
+++ b/app/services/workflow_executions/status_service.rb
@@ -16,9 +16,11 @@ module WorkflowExecutions
       run_status = @wes_client.get_run_status(@workflow_execution.run_id)
 
       state = run_status[:state]
-
-      @workflow_execution.state = 'completing' if state == 'COMPLETE'
-
+      @workflow_execution.state = if state == 'RUNNING'
+                                    'running'
+                                  elsif state == 'COMPLETE'
+                                    'completing'
+                                  end
       if Integrations::Ga4ghWesApi::V1::States::CANCELATION_STATES.include?(state)
         @workflow_execution.state = 'canceled'
       end

--- a/app/services/workflow_executions/status_service.rb
+++ b/app/services/workflow_executions/status_service.rb
@@ -19,7 +19,7 @@ module WorkflowExecutions
       @workflow_execution.state = if state == 'RUNNING'
                                     :running
                                   elsif state == 'COMPLETE'
-                                    :completed
+                                    :completing
                                   end
       @workflow_execution.state = :canceled if Integrations::Ga4ghWesApi::V1::States::CANCELATION_STATES.include?(state)
 

--- a/app/services/workflow_executions/submission_service.rb
+++ b/app/services/workflow_executions/submission_service.rb
@@ -17,7 +17,7 @@ module WorkflowExecutions
       @workflow_execution.run_id = run[:run_id]
 
       # mark workflow execution as submitted
-      @workflow_execution.state = 'submitted'
+      @workflow_execution.state = :submitted
 
       @workflow_execution.save
 

--- a/app/views/workflow_executions/_workflow_execution.html.erb
+++ b/app/views/workflow_executions/_workflow_execution.html.erb
@@ -29,11 +29,7 @@
     <%= workflow_execution.metadata["workflow_version"] %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
-    <% unless workflow_execution["state"].nil? %>
-      <%= t(:"workflow_executions.state.#{workflow_execution["state"]}") %>
-    <% else %>
-      <%= t(:"workflow_executions.state.initial") %>
-    <% end %>
+    <%= t(:"workflow_executions.state.#{workflow_execution["state"]}") %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
     <%= l(workflow_execution["created_at"].localtime, format: :full_date) %>

--- a/app/views/workflow_executions/_workflow_execution.html.erb
+++ b/app/views/workflow_executions/_workflow_execution.html.erb
@@ -29,7 +29,11 @@
     <%= workflow_execution.metadata["workflow_version"] %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
-    <%= workflow_execution["state"] || "NEW" %>
+    <% unless workflow_execution["state"].nil? %>
+      <%= t(:"workflow_executions.state.#{workflow_execution["state"]}") %>
+    <% else %>
+      <%= t(:"workflow_executions.state.initial") %>
+    <% end %>
   </td>
   <td class="px-6 py-4 whitespace-nowrap">
     <%= l(workflow_execution["created_at"].localtime, format: :full_date) %>

--- a/app/views/workflow_executions/show.html.erb
+++ b/app/views/workflow_executions/show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "export_dialog" %>
 
-<%= render Viral::PageHeaderComponent.new(title: @workflow_execution.id, id: @workflow_execution.state) do |component| %>
+<%= render Viral::PageHeaderComponent.new(title: @workflow_execution.id, id: t("workflow_executions.state.#{@workflow_execution.state}")) do |component| %>
   <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
     <div class="flex flex-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1268,6 +1268,17 @@ en:
       create:
         title: "%{workflow} parameters"
         submit: Submit
+    state:
+      initial: New
+      prepared: Prepared
+      submitted: Submitted
+      running: Running
+      completing: Completing
+      completed: Completed
+      error: Error
+      canceling: Canceling
+      canceled: Canceled
+      queued: Queued
   services:
     attachments:
       concatenation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1278,7 +1278,6 @@ en:
       error: Error
       canceling: Canceling
       canceled: Canceled
-      queued: Queued
   services:
     attachments:
       concatenation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1074,6 +1074,17 @@ fr:
       create:
         title: "%{workflow} parameters"
         submit: Submit
+    state:
+      initial: New
+      prepared: Prepared
+      submitted: Submitted
+      running: Running
+      completing: Completing
+      completed: Completed
+      error: Error
+      canceling: Canceling
+      canceled: Canceled
+      queued: Queued
   services:
     attachments:
       concatenation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1084,7 +1084,6 @@ fr:
       error: Error
       canceling: Canceling
       canceled: Canceled
-      queued: Queued
   services:
     attachments:
       concatenation:

--- a/db/migrate/20240423155817_change_workflow_execution_state_to_enum.rb
+++ b/db/migrate/20240423155817_change_workflow_execution_state_to_enum.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Migration to update state column in workflow executions from type string to int to utilize enums
+class ChangeWorkflowExecutionStateToEnum < ActiveRecord::Migration[7.1]
+  def up # rubocop:disable Metrics/MethodLength
+    rename_column :workflow_executions, :state, :old_state
+    add_column :workflow_executions, :state, :integer
+
+    enum_values = {
+      initial: 0,
+      prepared: 1,
+      submitted: 2,
+      running: 3,
+      completing: 4,
+      completed: 5,
+      error: 6,
+      canceling: 7,
+      canceled: 8,
+      queued: 9
+    }
+
+    execute <<-SQL.squish
+      UPDATE workflow_executions SET state = #{enum_values[:initial]} WHERE old_state = 'new';
+      UPDATE workflow_executions SET state = #{enum_values[:prepared]} WHERE old_state = 'prepared';
+      UPDATE workflow_executions SET state = #{enum_values[:submitted]} WHERE old_state = 'submitted';
+      UPDATE workflow_executions SET state = #{enum_values[:running]} WHERE old_state = 'running';
+      UPDATE workflow_executions SET state = #{enum_values[:completing]} WHERE old_state = 'completing';
+      UPDATE workflow_executions SET state = #{enum_values[:completed]} WHERE old_state = 'completed';
+      UPDATE workflow_executions SET state = #{enum_values[:error]} WHERE old_state = 'error';
+      UPDATE workflow_executions SET state = #{enum_values[:canceling]} WHERE old_state = 'canceling';
+      UPDATE workflow_executions SET state = #{enum_values[:canceled]} WHERE old_state = 'canceled';
+      UPDATE workflow_executions SET state = #{enum_values[:queued]} WHERE old_state = 'queued';
+    SQL
+
+    add_index :workflow_executions, :state
+    remove_column :workflow_executions, :old_state
+  end
+end

--- a/db/migrate/20240423155817_change_workflow_execution_state_to_enum.rb
+++ b/db/migrate/20240423155817_change_workflow_execution_state_to_enum.rb
@@ -15,8 +15,7 @@ class ChangeWorkflowExecutionStateToEnum < ActiveRecord::Migration[7.1]
       completed: 5,
       error: 6,
       canceling: 7,
-      canceled: 8,
-      queued: 9
+      canceled: 8
     }
 
     execute <<-SQL.squish
@@ -29,7 +28,6 @@ class ChangeWorkflowExecutionStateToEnum < ActiveRecord::Migration[7.1]
       UPDATE workflow_executions SET state = #{enum_values[:error]} WHERE old_state = 'error';
       UPDATE workflow_executions SET state = #{enum_values[:canceling]} WHERE old_state = 'canceling';
       UPDATE workflow_executions SET state = #{enum_values[:canceled]} WHERE old_state = 'canceled';
-      UPDATE workflow_executions SET state = #{enum_values[:queued]} WHERE old_state = 'queued';
     SQL
 
     add_index :workflow_executions, :state

--- a/db/migrate/20240423155817_change_workflow_execution_state_to_enum.rb
+++ b/db/migrate/20240423155817_change_workflow_execution_state_to_enum.rb
@@ -4,7 +4,7 @@
 class ChangeWorkflowExecutionStateToEnum < ActiveRecord::Migration[7.1]
   def up # rubocop:disable Metrics/MethodLength
     rename_column :workflow_executions, :state, :old_state
-    add_column :workflow_executions, :state, :integer
+    add_column :workflow_executions, :state, :integer, null: false, default: 0
 
     enum_values = {
       initial: 0,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -261,8 +261,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_23_155817) do
     t.string "blob_run_directory"
     t.boolean "email_notification", default: false, null: false
     t.boolean "update_samples", default: false, null: false
-    t.integer "state"
     t.jsonb "tags", default: {}, null: false
+    t.integer "state", default: 0, null: false
     t.index ["created_at"], name: "index_workflow_executions_on_created_at"
     t.index ["state"], name: "index_workflow_executions_on_state"
     t.index ["submitter_id"], name: "index_workflow_executions_on_submitter_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_22_160144) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_23_155817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -253,7 +253,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_160144) do
     t.jsonb "workflow_engine_parameters", default: {}, null: false
     t.string "workflow_url"
     t.string "run_id"
-    t.string "state"
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -262,8 +261,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_160144) do
     t.string "blob_run_directory"
     t.boolean "email_notification", default: false, null: false
     t.boolean "update_samples", default: false, null: false
+    t.integer "state"
     t.jsonb "tags", default: {}, null: false
     t.index ["created_at"], name: "index_workflow_executions_on_created_at"
+    t.index ["state"], name: "index_workflow_executions_on_state"
     t.index ["submitter_id"], name: "index_workflow_executions_on_submitter_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -157,8 +157,7 @@ def seed_workflow_executions # rubocop:disable Metrics/MethodLength
     workflow_engine_version: '23.10.0',
     workflow_engine_parameters: { '-r': 'dev' },
     workflow_url: 'https://github.com/phac-nml/iridanextexample',
-    submitter: User.find_by(email: 'user1@email.com'),
-    state: :initial
+    submitter: User.find_by(email: 'user1@email.com')
   )
 
   SamplesWorkflowExecution.create(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -157,7 +157,8 @@ def seed_workflow_executions # rubocop:disable Metrics/MethodLength
     workflow_engine_version: '23.10.0',
     workflow_engine_parameters: { '-r': 'dev' },
     workflow_url: 'https://github.com/phac-nml/iridanextexample',
-    submitter: User.find_by(email: 'user1@email.com')
+    submitter: User.find_by(email: 'user1@email.com'),
+    state: :initial
   )
 
   SamplesWorkflowExecution.create(
@@ -178,7 +179,7 @@ def seed_workflow_executions # rubocop:disable Metrics/MethodLength
     workflow_url: 'https://github.com/phac-nml/iridanextexample',
     submitter: User.find_by(email: 'user1@email.com'),
     blob_run_directory: 'this should be a generated key',
-    state: 'completed'
+    state: :completed
   )
 
   filename = 'summary.txt'

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -190,7 +190,7 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should not delete a new workflow' do
     workflow_execution = workflow_executions(:irida_next_example_new)
-    assert workflow_execution.new?
+    assert workflow_execution.initial?
     assert_difference -> { WorkflowExecution.count } => 0,
                       -> { SamplesWorkflowExecution.count } => 0 do
       delete workflow_execution_path(workflow_execution, format: :turbo_stream)

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -168,26 +168,6 @@ class WorfklowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'canceling', workflow_execution.reload.state
   end
 
-  test 'should not delete a queued workflow' do
-    workflow_execution = workflow_executions(:irida_next_example_queued)
-    assert workflow_execution.queued?
-    assert_difference -> { WorkflowExecution.count } => 0,
-                      -> { SamplesWorkflowExecution.count } => 0 do
-      delete workflow_execution_path(workflow_execution, format: :turbo_stream)
-    end
-    assert_response :unprocessable_entity
-  end
-
-  test 'should cancel a queued workflow' do
-    workflow_execution = workflow_executions(:irida_next_example_queued)
-    assert workflow_execution.queued?
-
-    put cancel_workflow_execution_path(workflow_execution, format: :turbo_stream)
-    assert_response :success
-    # A queued workflow goes to the canceling state as ga4gh must be sent a cancel request
-    assert_equal 'canceling', workflow_execution.reload.state
-  end
-
   test 'should not delete a new workflow' do
     workflow_execution = workflow_executions(:irida_next_example_new)
     assert workflow_execution.initial?

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -96,15 +96,6 @@ sample1_irida_next_example_running:
     "fastq_2": ""
   }
 
-sample1_irida_next_example_queued:
-  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
-  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_queued, :uuid) %>
-  samplesheet_params: {
-    "sample": INXT_SAM_AAAAAAAAAA,
-    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
-    "fastq_2": ""
-  }
-
 sample1_irida_next_example_new:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_new, :uuid) %>

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -193,7 +193,7 @@ irida_next_example_new:
   workflow_url: "https://github.com/phac-nml/irida_next_example_new"
   run_id: "my_run_id_12"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
-  state: "new"
+  state: "initial"
 
 irida_next_example_completing_a:
   <<: *DEFAULTS
@@ -345,6 +345,6 @@ workflow_execution<%= (n) %>:
   workflow_url: "https://github.com/phac-nml/irida_next_example_new"
   run_id: <%= "my_run_id_#{n}" %>
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jane_doe, :uuid) %>
-  state: "new"
+  state: "initial"
 <% end %>
 

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -162,24 +162,6 @@ irida_next_example_running:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   state: "running"
 
-irida_next_example_queued:
-  <<: *DEFAULTS
-  metadata:
-    {
-      "workflow_name": "irida_next_example_queued",
-      "workflow_version": "1.0dev",
-    }
-  workflow_params:
-    {
-      "input": "/blah/samplesheet.csv",
-      "outdir": "/blah/output",
-    }
-  workflow_engine_parameters: { "-r": "dev" }
-  workflow_url: "https://github.com/phac-nml/irida_next_example_queued"
-  run_id: "my_run_id_11"
-  submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
-  state: "queued"
-
 irida_next_example_new:
   <<: *DEFAULTS
   metadata:

--- a/test/models/workflow_execution_test.rb
+++ b/test/models/workflow_execution_test.rb
@@ -56,10 +56,6 @@ class WorkflowExecutionTest < ActiveSupport::TestCase
     @workflow_execution_valid.state = 'canceled'
     assert_not @workflow_execution_valid.canceling?
     assert @workflow_execution_valid.canceled?
-
-    @workflow_execution_valid.state = 'queued'
-    assert_not @workflow_execution_valid.canceled?
-    assert @workflow_execution_valid.queued?
   end
 
   test 'state with type enum using int assignment' do
@@ -97,9 +93,5 @@ class WorkflowExecutionTest < ActiveSupport::TestCase
     @workflow_execution_valid.state = 8
     assert_not @workflow_execution_valid.canceling?
     assert @workflow_execution_valid.canceled?
-
-    @workflow_execution_valid.state = 9
-    assert_not @workflow_execution_valid.canceled?
-    assert @workflow_execution_valid.queued?
   end
 end

--- a/test/models/workflow_execution_test.rb
+++ b/test/models/workflow_execution_test.rb
@@ -21,39 +21,39 @@ class WorkflowExecutionTest < ActiveSupport::TestCase
     )
   end
 
-  test 'state with type enum using string assignment' do
-    @workflow_execution_valid.state = 'initial'
+  test 'state with type enum using key assignment' do
+    @workflow_execution_valid.state = :initial
     assert @workflow_execution_valid.initial?
 
-    @workflow_execution_valid.state = 'prepared'
+    @workflow_execution_valid.state = :prepared
     assert_not @workflow_execution_valid.initial?
     assert @workflow_execution_valid.prepared?
 
-    @workflow_execution_valid.state = 'submitted'
+    @workflow_execution_valid.state = :submitted
     assert_not @workflow_execution_valid.prepared?
     assert @workflow_execution_valid.submitted?
 
-    @workflow_execution_valid.state = 'running'
+    @workflow_execution_valid.state = :running
     assert_not @workflow_execution_valid.submitted?
     assert @workflow_execution_valid.running?
 
-    @workflow_execution_valid.state = 'completing'
+    @workflow_execution_valid.state = :completing
     assert_not @workflow_execution_valid.running?
     assert @workflow_execution_valid.completing?
 
-    @workflow_execution_valid.state = 'completed'
+    @workflow_execution_valid.state = :completed
     assert_not @workflow_execution_valid.completing?
     assert @workflow_execution_valid.completed?
 
-    @workflow_execution_valid.state = 'error'
+    @workflow_execution_valid.state = :error
     assert_not @workflow_execution_valid.completed?
     assert @workflow_execution_valid.error?
 
-    @workflow_execution_valid.state = 'canceling'
+    @workflow_execution_valid.state = :canceling
     assert_not @workflow_execution_valid.error?
     assert @workflow_execution_valid.canceling?
 
-    @workflow_execution_valid.state = 'canceled'
+    @workflow_execution_valid.state = :canceled
     assert_not @workflow_execution_valid.canceling?
     assert @workflow_execution_valid.canceled?
   end

--- a/test/models/workflow_execution_test.rb
+++ b/test/models/workflow_execution_test.rb
@@ -20,4 +20,86 @@ class WorkflowExecutionTest < ActiveSupport::TestCase
       @workflow_execution_invalid_metadata.errors.full_messages
     )
   end
+
+  test 'state with type enum using string assignment' do
+    @workflow_execution_valid.state = 'initial'
+    assert @workflow_execution_valid.initial?
+
+    @workflow_execution_valid.state = 'prepared'
+    assert_not @workflow_execution_valid.initial?
+    assert @workflow_execution_valid.prepared?
+
+    @workflow_execution_valid.state = 'submitted'
+    assert_not @workflow_execution_valid.prepared?
+    assert @workflow_execution_valid.submitted?
+
+    @workflow_execution_valid.state = 'running'
+    assert_not @workflow_execution_valid.submitted?
+    assert @workflow_execution_valid.running?
+
+    @workflow_execution_valid.state = 'completing'
+    assert_not @workflow_execution_valid.running?
+    assert @workflow_execution_valid.completing?
+
+    @workflow_execution_valid.state = 'completed'
+    assert_not @workflow_execution_valid.completing?
+    assert @workflow_execution_valid.completed?
+
+    @workflow_execution_valid.state = 'error'
+    assert_not @workflow_execution_valid.completed?
+    assert @workflow_execution_valid.error?
+
+    @workflow_execution_valid.state = 'canceling'
+    assert_not @workflow_execution_valid.error?
+    assert @workflow_execution_valid.canceling?
+
+    @workflow_execution_valid.state = 'canceled'
+    assert_not @workflow_execution_valid.canceling?
+    assert @workflow_execution_valid.canceled?
+
+    @workflow_execution_valid.state = 'queued'
+    assert_not @workflow_execution_valid.canceled?
+    assert @workflow_execution_valid.queued?
+  end
+
+  test 'state with type enum using int assignment' do
+    @workflow_execution_valid.state = 0
+    assert @workflow_execution_valid.initial?
+
+    @workflow_execution_valid.state = 1
+    assert_not @workflow_execution_valid.initial?
+    assert @workflow_execution_valid.prepared?
+
+    @workflow_execution_valid.state = 2
+    assert_not @workflow_execution_valid.prepared?
+    assert @workflow_execution_valid.submitted?
+
+    @workflow_execution_valid.state = 3
+    assert_not @workflow_execution_valid.submitted?
+    assert @workflow_execution_valid.running?
+
+    @workflow_execution_valid.state = 4
+    assert_not @workflow_execution_valid.running?
+    assert @workflow_execution_valid.completing?
+
+    @workflow_execution_valid.state = 5
+    assert_not @workflow_execution_valid.completing?
+    assert @workflow_execution_valid.completed?
+
+    @workflow_execution_valid.state = 6
+    assert_not @workflow_execution_valid.completed?
+    assert @workflow_execution_valid.error?
+
+    @workflow_execution_valid.state = 7
+    assert_not @workflow_execution_valid.error?
+    assert @workflow_execution_valid.canceling?
+
+    @workflow_execution_valid.state = 8
+    assert_not @workflow_execution_valid.canceling?
+    assert @workflow_execution_valid.canceled?
+
+    @workflow_execution_valid.state = 9
+    assert_not @workflow_execution_valid.canceled?
+    assert @workflow_execution_valid.queued?
+  end
 end

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -26,7 +26,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'initial'
+        state: :initial
       }
 
       workflow_params2 = {
@@ -44,7 +44,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew2',
         submitter_id: @user.id,
-        state: 'initial'
+        state: :initial
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs')
@@ -136,7 +136,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'initial'
+        state: :initial
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
@@ -161,7 +161,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'initial'
+        state: :initial
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
@@ -187,7 +187,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'initial'
+        state: :initial
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_4" }',
@@ -228,7 +228,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'initial'
+        state: :initial
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_5" }',
@@ -250,7 +250,7 @@ module WorkflowExecutions
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
       end
 
-      # assert_equal 'error', @workflow_execution.reload.state
+      assert_equal 'error', @workflow_execution.reload.state
     end
 
     test 'test create new workflow execution sanitizes params' do
@@ -271,7 +271,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { engine: 'nextflow', execute_loc: 'azure' },
         workflow_url: 'https://github.com/phac-nml/iridanextexample',
         submitter_id: @user.id,
-        state: 'initial'
+        state: :initial
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -25,8 +25,7 @@ module WorkflowExecutions
         workflow_engine_version: '23.10.0',
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
-        submitter_id: @user.id,
-        state: :initial
+        submitter_id: @user.id
       }
 
       workflow_params2 = {
@@ -43,8 +42,7 @@ module WorkflowExecutions
         workflow_engine_version: '23.10.0',
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew2',
-        submitter_id: @user.id,
-        state: :initial
+        submitter_id: @user.id
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs')
@@ -135,8 +133,7 @@ module WorkflowExecutions
         workflow_engine_version: '23.10.0',
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
-        submitter_id: @user.id,
-        state: :initial
+        submitter_id: @user.id
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
@@ -160,8 +157,7 @@ module WorkflowExecutions
         workflow_engine_version: '23.10.0',
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
-        submitter_id: @user.id,
-        state: :initial
+        submitter_id: @user.id
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
@@ -186,8 +182,7 @@ module WorkflowExecutions
         workflow_engine_version: '23.10.0',
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
-        submitter_id: @user.id,
-        state: :initial
+        submitter_id: @user.id
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_4" }',
@@ -227,8 +222,7 @@ module WorkflowExecutions
         workflow_engine_version: '23.10.0',
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
-        submitter_id: @user.id,
-        state: :initial
+        submitter_id: @user.id
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_5" }',
@@ -270,8 +264,7 @@ module WorkflowExecutions
         workflow_engine_version: '23.10.0',
         workflow_engine_parameters: { engine: 'nextflow', execute_loc: 'azure' },
         workflow_url: 'https://github.com/phac-nml/iridanextexample',
-        submitter_id: @user.id,
-        state: :initial
+        submitter_id: @user.id
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -26,7 +26,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'new'
+        state: 'initial'
       }
 
       workflow_params2 = {
@@ -44,7 +44,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew2',
         submitter_id: @user.id,
-        state: 'new'
+        state: 'initial'
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs')
@@ -68,7 +68,7 @@ module WorkflowExecutions
       end
 
       assert_equal 'completing', @workflow_execution.reload.state
-      assert_equal 'new', @workflow_execution2.reload.state
+      assert_equal 'initial', @workflow_execution2.reload.state
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs')
         .to_return(body: '{ "run_id": "create_run_2" }',
@@ -136,7 +136,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'new'
+        state: 'initial'
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
@@ -161,7 +161,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'new'
+        state: 'initial'
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
@@ -187,7 +187,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'new'
+        state: 'initial'
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_4" }',
@@ -203,7 +203,7 @@ module WorkflowExecutions
         @user, workflow_params
       ).execute
 
-      assert_equal 'new', @workflow_execution.state
+      assert_equal 'initial', @workflow_execution.state
 
       perform_enqueued_jobs do
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
@@ -228,7 +228,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { '-r': 'dev' },
         workflow_url: 'https://github.com/phac-nml/iridanextexamplenew',
         submitter_id: @user.id,
-        state: 'new'
+        state: 'initial'
       }
 
       stub_request(:post, 'http://www.example.com/ga4gh/wes/v1/runs').to_return(body: '{ "run_id": "create_run_5" }',
@@ -244,13 +244,13 @@ module WorkflowExecutions
         @user, workflow_params
       ).execute
 
-      assert_equal 'new', @workflow_execution.state
+      assert_equal 'initial', @workflow_execution.state
 
       perform_enqueued_jobs do
         WorkflowExecutionPreparationJob.perform_now(@workflow_execution)
       end
 
-      assert_equal 'error', @workflow_execution.reload.state
+      # assert_equal 'error', @workflow_execution.reload.state
     end
 
     test 'test create new workflow execution sanitizes params' do
@@ -271,7 +271,7 @@ module WorkflowExecutions
         workflow_engine_parameters: { engine: 'nextflow', execute_loc: 'azure' },
         workflow_url: 'https://github.com/phac-nml/iridanextexample',
         submitter_id: @user.id,
-        state: 'new'
+        state: 'initial'
       }
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -92,16 +92,6 @@ module WorkflowExecutions
       end
     end
 
-    test 'should not destroy a queued workflow execution' do
-      workflow_execution = workflow_executions(:irida_next_example_queued)
-      assert workflow_execution.queued?
-
-      assert_no_difference -> { WorkflowExecution.count },
-                           -> { SamplesWorkflowExecution.count } do
-        WorkflowExecutions::DestroyService.new(workflow_execution, @user).execute
-      end
-    end
-
     test 'should not destroy a new workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_new)
       assert workflow_execution.initial?

--- a/test/services/workflow_executions/destroy_service_test.rb
+++ b/test/services/workflow_executions/destroy_service_test.rb
@@ -104,7 +104,7 @@ module WorkflowExecutions
 
     test 'should not destroy a new workflow execution' do
       workflow_execution = workflow_executions(:irida_next_example_new)
-      assert workflow_execution.new?
+      assert workflow_execution.initial?
 
       assert_no_difference -> { WorkflowExecution.count },
                            -> { SamplesWorkflowExecution.count } do

--- a/test/services/workflow_executions/preparation_service_test.rb
+++ b/test/services/workflow_executions/preparation_service_test.rb
@@ -10,7 +10,7 @@ module WorkflowExecutions
     end
 
     test 'prepare workflow_execution with valid params' do
-      assert_nil @workflow_execution.state
+      assert @workflow_execution.initial?
 
       assert_difference -> { ActiveStorage::Attachment.count } => 2 do
         WorkflowExecutions::PreparationService.new(@workflow_execution, @user, {}).execute

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -113,7 +113,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_link 'Cancel', count: 1
       click_link 'Cancel'
     end
@@ -128,7 +128,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       )
     end
 
-    assert_selector 'tbody tr td:nth-child(5)', text: 'canceling'
+    assert_selector 'tbody tr td:nth-child(5)', text: 'Canceling'
     assert_no_selector "tbody tr td:nth-child(5) a[text='Cancel']"
   end
 
@@ -142,7 +142,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_no_link 'Delete'
     end
   end
@@ -157,7 +157,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_no_link 'Delete'
     end
   end
@@ -172,7 +172,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_link 'Delete', count: 1
       click_link 'Delete'
     end
@@ -200,7 +200,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_link 'Delete', count: 1
       click_link 'Delete'
     end
@@ -221,7 +221,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_no_link 'Delete'
     end
   end
@@ -236,7 +236,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_link 'Delete', count: 1
       click_link 'Delete'
     end
@@ -257,7 +257,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_no_link 'Delete'
     end
   end
@@ -272,7 +272,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_no_link 'Delete'
     end
   end
@@ -287,7 +287,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     tr = find('td', text: workflow_execution.id).ancestor('tr')
 
     within tr do
-      assert_selector 'td:nth-child(5)', text: workflow_execution.state
+      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
       assert_no_link 'Delete'
     end
   end
@@ -298,7 +298,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     visit workflow_execution_path(workflow_execution)
 
     assert_text workflow_execution.id
-    assert_text workflow_execution.state
+    assert_text I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
     assert_text workflow_execution.metadata['workflow_name']
     assert_text workflow_execution.metadata['workflow_version']
 

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -13,7 +13,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
 
-    assert_selector 'table#workflow_executions tbody tr', count: 13
+    assert_selector 'table#workflow_executions tbody tr', count: 12
   end
 
   test 'should display pages of workflow executions' do
@@ -53,7 +53,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'table#workflow_executions thead th:nth-child(2) svg.icon-arrow_up'
 
     within first('table#workflow_executions tbody') do
-      assert_selector 'tr', count: 13
+      assert_selector 'tr', count: 12
       assert_selector 'tr:first-child td:nth-child(2)', text: workflow_execution1.run_id
       assert_selector 'tr:nth-child(2) td:nth-child(2)', text: workflow_execution10.run_id
       assert_selector 'tr:last-child td:nth-child(2)', text: workflow_execution.run_id
@@ -63,7 +63,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'table#workflow_executions thead th:nth-child(2) svg.icon-arrow_down'
 
     within first('table#workflow_executions tbody') do
-      assert_selector 'tr', count: 13
+      assert_selector 'tr', count: 12
       assert_selector 'tr:first-child td:nth-child(2)', text: workflow_execution.run_id
       assert_selector 'tr:nth-child(2) td:nth-child(2)', text: workflow_execution9.run_id
       assert_selector 'tr:last-child td:nth-child(2)', text: workflow_execution1.run_id
@@ -73,7 +73,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'table#workflow_executions thead th:nth-child(3) svg.icon-arrow_up'
 
     within first('table#workflow_executions tbody') do
-      assert_selector 'tr', count: 13
+      assert_selector 'tr', count: 12
       assert_selector 'tr:first-child td:nth-child(3)', text: workflow_execution9.metadata['workflow_name']
       assert_selector 'tr:nth-child(2) td:nth-child(3)', text: workflow_execution8.metadata['workflow_name']
       assert_selector 'tr:last-child td:nth-child(3)', text: workflow_execution1.metadata['workflow_name']
@@ -83,7 +83,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'table#workflow_executions thead th:nth-child(3) svg.icon-arrow_down'
 
     within first('table#workflow_executions tbody') do
-      assert_selector 'tr', count: 13
+      assert_selector 'tr', count: 12
       assert_selector 'tr:first-child td:nth-child(3)', text: workflow_execution1.metadata['workflow_name']
       assert_selector 'tr:nth-child(2) td:nth-child(3)', text: workflow_execution2.metadata['workflow_name']
       assert_selector 'tr:last-child td:nth-child(3)', text: workflow_execution9.metadata['workflow_name']
@@ -93,7 +93,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'table#workflow_executions thead th:nth-child(6) svg.icon-arrow_up'
 
     within first('table#workflow_executions tbody') do
-      assert_selector 'tr', count: 13
+      assert_selector 'tr', count: 12
       assert_selector 'tr:first-child td:nth-child(6)',
                       text: I18n.l(workflow_execution1.created_at.localtime, format: :full_date)
       assert_selector 'tr:nth-child(2) td:nth-child(6)',
@@ -304,7 +304,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
 
     within %(#workflow_executions-table-body) do
-      assert_selector 'tr', count: 12
+      assert_selector 'tr', count: 11
       assert_no_text workflow_execution.id
     end
   end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -262,21 +262,6 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'should not delete a queued workflow' do
-    workflow_execution = workflow_executions(:irida_next_example_queued)
-
-    visit workflow_executions_path
-
-    assert_selector 'h1', text: I18n.t(:'workflow_executions.index.title')
-
-    tr = find('td', text: workflow_execution.id).ancestor('tr')
-
-    within tr do
-      assert_selector 'td:nth-child(5)', text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_no_link 'Delete'
-    end
-  end
-
   test 'should not delete a new workflow' do
     workflow_execution = workflow_executions(:irida_next_example_new)
 


### PR DESCRIPTION
## What does this PR do and why?
This PR changes workflow execution state from type string to enum. It also sets the state to `running` when the returned state is `RUNNING` and removes the state `queued`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. With workflow executions stored in your database, run `bin/rails db:migrate`. Ensure the migration is successful
2. Through the UI, check the workflow executions page displays the expected states per WE
3. Run a workflow execution containing a large number of samples. After sometime in the `submitted` state, ensure the WE state eventually changes to `running`. Afterwards, check that the WE completes.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
