### PR TITLE
Add locale to Data Export Mailer

### DIFF
--- a/app/mailers/data_export_mailer.rb
+++ b/app/mailers/data_export_mailer.rb
@@ -5,7 +5,9 @@ class DataExportMailer < ApplicationMailer
   def export_ready(data_export)
     @user = data_export.user
     @data_export = data_export
-    mail(to: @user.email,
-         subject: t(:'mailers.data_export_mailer.email_subject', name: @data_export.name || @data_export.id))
+    I18n.with_locale(@user.locale) do
+      mail(to: @user.email,
+           subject: t(:'mailers.data_export_mailer.email_subject', name: @data_export.name || @data_export.id))
+    end
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1170,10 +1170,10 @@ fr:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
       copy_paste: "Or copy and paste this link into your browser:"
       greeting: Hello,
-      greeting_with_name: Hello %{name},
+      greeting_with_name: Bonjour %{name},
       thanks: Thanks,
     data_export_mailer:
-      email_subject: "Export Ready - %{name}"
+      email_subject: "Exportation Prêt - %{name}"
       export_ready:
         ready_for_download_html: "Your export <strong>%{name}</strong> is ready for download."
         view_exports: "To view and download the export, click the button below:"

--- a/test/mailers/data_export_mailer_test.rb
+++ b/test/mailers/data_export_mailer_test.rb
@@ -58,4 +58,25 @@ class DataExportMailerTest < ActionMailer::TestCase
       DataExports::CreateJob.perform_now(@data_export3)
     end
   end
+
+  test 'export ready email in fr locale' do
+    freeze_time
+    email = DataExportMailer.export_ready(@data_export4)
+    @data_export4.user.locale = :fr
+    I18n.with_locale(:fr) do
+      assert_emails 1 do
+        email.deliver_now
+      end
+
+      assert_equal [@data_export4.user.email], email.to
+      assert_equal I18n.t('mailers.data_export_mailer.email_subject', name: @data_export4.name), email.subject
+      assert_match I18n.t('mailers.email_template.greeting_with_name', name: @data_export4.user.first_name),
+                   email.body.to_s
+
+      #  In link url
+      assert_match @data_export4.id, email.body.to_s, count: 1
+      assert_match @data_export4.expires_at.strftime('%A, %B %d, %Y'), email.body.to_s
+      assert_match Rails.application.routes.url_helpers.data_export_url(@data_export4), email.body.to_s
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds locale to the data export mailer.

## Screenshots or screen recordings
![image](https://github.com/phac-nml/irida-next/assets/82407232/8c14ef47-fd43-41de-b497-d30e82340343)

## How to set up and validate locally
1. Load up mailhog with
```
~/go/bin/MailHog
```

2.  In a rails console, create a data export with email notification
```
user = User.find_by(email: 'user7@email.com')
params_1 = {'export_type' => 'sample', 'export_parameters' => {'ids' => [Sample.find_by(name: 'Yersinia pestis/Outbreak 2022 Sample 10').id]}, 'email_notification' => true, 'name' => 'test export'}
DataExports::CreateService.new(user, params_1).execute
```
3. After 30s, you should receive an email notification in maihog in english.
4. Repeat the above but set the user locale to fr
```
user = User.find_by(email: 'user7@email.com')
user.locale = :fr
user.save
params_1 = {'export_type' => 'sample', 'export_parameters' => {'ids' => [Sample.find_by(name: 'Yersinia pestis/Outbreak 2022 Sample 10').id]}, 'email_notification' => true, 'name' => 'test export'}
DataExports::CreateService.new(user, params_1).execute
```
5. After 30s, the data export will complete, check the email notification in mailhog. The subject should contain `Exportation Prêt` and the greeting should contain `Bonjour`, meaning you've received the french localized email.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
