### PR TITLE
Fix: samplesheet column ordering

### DIFF
--- a/app/services/workflow_executions/preparation_service.rb
+++ b/app/services/workflow_executions/preparation_service.rb
@@ -68,7 +68,7 @@ module WorkflowExecutions
           samplesheet_params[key] = copy_attachment_to_run_dir(attachment, sample_workflow_execution)
         end
 
-        @samplesheet_rows << samplesheet_params
+        @samplesheet_rows << @samplesheet_headers.map { |header| samplesheet_params[header] }
       end
     end
 
@@ -124,7 +124,7 @@ module WorkflowExecutions
           csv << @samplesheet_headers
 
           @samplesheet_rows.each do |samplesheet_row|
-            csv << samplesheet_row.values
+            csv << samplesheet_row
           end
         end
       end

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -29,8 +29,8 @@ sample1_irida_next_example:
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example, :uuid) %>
   samplesheet_params: {
     "sample": INXT_SAM_AAAAAAAAAA,
-    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
-    "fastq_2": ""
+    "fastq_2": "",
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>
   }
 
 sample1_irida_next_example_prepared:

--- a/test/services/workflow_executions/preparation_service_test.rb
+++ b/test/services/workflow_executions/preparation_service_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'csv'
 
 module WorkflowExecutions
   class PreparationServiceTest < ActiveSupport::TestCase
@@ -24,6 +25,20 @@ module WorkflowExecutions
       assert_match @workflow_execution.inputs.first.blob.key, @workflow_execution.workflow_params['input']
       assert @workflow_execution.workflow_params['outdir'].ends_with?('/')
       assert @workflow_execution.blob_run_directory
+
+      samplesheet_headers = %w[sample fastq_1 fastq_2]
+      sample1_row = [@workflow_execution.samples_workflow_executions.first.sample.puid,
+                     ActiveStorage::Blob.service.path_for(
+                       format('%<run_dir>s/input/Sample_%<sample_id>s/%<filename>s',
+                              run_dir: @workflow_execution.blob_run_directory,
+                              sample_id: @workflow_execution.samples_workflow_executions.first.sample.id,
+                              filename: attachments(:attachment1).filename)
+                     ),
+                     '']
+      # ensure samplesheet csv has the correct order
+      samplesheet_csv = CSV.parse(@workflow_execution.inputs.first.blob.download)
+      assert_equal samplesheet_headers, samplesheet_csv[0]
+      assert_equal sample1_row, samplesheet_csv[1]
 
       assert_equal 'prepared', @workflow_execution.state
     end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Update `WorkflowExecutions::PreparationService` to ensure that the generated samplesheet.csv has the correct column ordering.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

* Run Tests verify that they work
* Add a pipeline that has both metadata and files to `config/pipelines/pipelines.json`
```json
{
    "url": "https://github.com/phac-nml/gasclustering",
    "name": "phac-nml/gasclustering",
    "description": "IRIDA clustering",
    "versions": [
      {
        "name": "metadata"
      }
    ]
  }
```
* Submit a new workflow execution for the newly configured pipeline
* Look at the samplesheet.csv and verify that the columns are ordered correctly. To find the file do this in rails console after it is prepared:
```irb
ActiveStorage::Blob.service.path_for(WorkflowExecutions.last.blob_run_directory)
```
* Open that file in your editor of choice

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
