### PR TITLE
Localize pipeline mailer

### DIFF
--- a/app/mailers/pipeline_mailer.rb
+++ b/app/mailers/pipeline_mailer.rb
@@ -4,13 +4,19 @@
 class PipelineMailer < ApplicationMailer
   def complete_email(workflow_execution)
     @workflow_execution = workflow_execution
-    mail(to: @workflow_execution.submitter.email,
-         subject: t(:'mailers.pipeline_mailer.complete_email.subject', id: @workflow_execution.id))
+    submitter = @workflow_execution.submitter
+    I18n.with_locale(submitter.locale) do
+      mail(to: submitter.email,
+           subject: t(:'mailers.pipeline_mailer.complete_email.subject', id: @workflow_execution.id))
+    end
   end
 
   def error_email(workflow_execution)
     @workflow_execution = workflow_execution
-    mail(to: @workflow_execution.submitter.email,
-         subject: t(:'mailers.pipeline_mailer.error_email.subject', id: @workflow_execution.id))
+    submitter = @workflow_execution.submitter
+    I18n.with_locale(submitter.locale) do
+      mail(to: submitter.email,
+           subject: t(:'mailers.pipeline_mailer.error_email.subject', id: @workflow_execution.id))
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,7 @@ module Irida
     end
 
     # Only enables en and fr locales, avoiding unnecessarily loading other locales
-    config.i18n.available_locales = %i[en fr en-CA]
+    config.i18n.available_locales = %i[en fr]
     # Set default locale
     config.i18n.default_locale = :en
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1179,9 +1179,9 @@ fr:
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
       copy_paste: "Or copy and paste this link into your browser:"
-      greeting: Hello,
+      greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
-      thanks: Thanks,
+      thanks: Merci,
     data_export_mailer:
       email_subject: "Exportation Prêt - %{name}"
       export_ready:
@@ -1206,10 +1206,10 @@ fr:
         view_details: "To view all the members of %{type} '%{name}', click the button below:"
     pipeline_mailer:
       complete_email:
-        subject: Pipeline Completed - %{id}
+        subject: Pipeline Complété - %{id}
         body_html: Your pipeline <strong>%{id}</strong> has completed successfully.
       error_email:
-        subject: Pipeline Errored - %{id}
+        subject: Pipeline Erroné - %{id}
         body_html: Your pipeline <strong>%{id}</strong> has errors that need to be addressed.
       view_details: "To view the pipeline summary, click the button below:"
   data_exports:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@
 
 require 'faker'
 
-Faker::Config.locale = 'en-CA'
+Faker::Config.locale = 'en'
 
 @namespace_group_link_expiry_date = (Time.zone.today + 14).strftime('%Y-%m-%d')
 

--- a/test/mailers/pipeline_mailer_test.rb
+++ b/test/mailers/pipeline_mailer_test.rb
@@ -21,27 +21,29 @@ class PipelineMailerTest < ActionMailer::TestCase
                  email.body.to_s)
   end
 
-  def test_complete_email_in_french
-    locale = :fr
-    workflow_execution = workflow_executions(:irida_next_example_completed)
-    workflow_execution.submitter.locale = locale
-    email = PipelineMailer.complete_email(workflow_execution)
-    assert_equal [workflow_execution.submitter.email], email.to
-    assert_equal I18n.t(:'mailers.pipeline_mailer.complete_email.subject', id: workflow_execution.id, locale:),
-                 email.subject
-    assert_match(/#{I18n.t(:'mailers.pipeline_mailer.complete_email.body_html',
-                           id: workflow_execution.id, locale:)}/, email.body.to_s)
+  def test_localized_complete_email
+    I18n.available_locales do |locale|
+      workflow_execution = workflow_executions(:irida_next_example_completed)
+      workflow_execution.submitter.locale = locale
+      email = PipelineMailer.complete_email(workflow_execution)
+      assert_equal [workflow_execution.submitter.email], email.to
+      assert_equal I18n.t(:'mailers.pipeline_mailer.complete_email.subject', id: workflow_execution.id, locale:),
+                   email.subject
+      assert_match(/#{I18n.t(:'mailers.pipeline_mailer.complete_email.body_html',
+                             id: workflow_execution.id, locale:)}/, email.body.to_s)
+    end
   end
 
-  def test_error_email_in_french
-    locale = :fr
-    workflow_execution = workflow_executions(:irida_next_example_error)
-    workflow_execution.submitter.locale = locale
-    email = PipelineMailer.error_email(workflow_execution)
-    assert_equal [workflow_execution.submitter.email], email.to
-    assert_equal I18n.t(:'mailers.pipeline_mailer.error_email.subject', id: workflow_execution.id, locale:),
-                 email.subject
-    assert_match(/#{I18n.t(:'mailers.pipeline_mailer.error_email.body_html', id: workflow_execution.id, locale:)}/,
-                 email.body.to_s)
+  def test_localized_error_email
+    I18n.available_locales do |locale|
+      workflow_execution = workflow_executions(:irida_next_example_error)
+      workflow_execution.submitter.locale = locale
+      email = PipelineMailer.error_email(workflow_execution)
+      assert_equal [workflow_execution.submitter.email], email.to
+      assert_equal I18n.t(:'mailers.pipeline_mailer.error_email.subject', id: workflow_execution.id, locale:),
+                   email.subject
+      assert_match(/#{I18n.t(:'mailers.pipeline_mailer.error_email.body_html', id: workflow_execution.id, locale:)}/,
+                   email.body.to_s)
+    end
   end
 end

--- a/test/mailers/pipeline_mailer_test.rb
+++ b/test/mailers/pipeline_mailer_test.rb
@@ -20,4 +20,28 @@ class PipelineMailerTest < ActionMailer::TestCase
     assert_match(/#{I18n.t(:'mailers.pipeline_mailer.error_email.body_html', id: workflow_execution.id)}/,
                  email.body.to_s)
   end
+
+  def test_french_complete_email
+    locale = :fr
+    workflow_execution = workflow_executions(:irida_next_example_completed)
+    workflow_execution.submitter.locale = locale
+    email = PipelineMailer.complete_email(workflow_execution)
+    assert_equal [workflow_execution.submitter.email], email.to
+    assert_equal I18n.t(:'mailers.pipeline_mailer.complete_email.subject', id: workflow_execution.id, locale:),
+                 email.subject
+    assert_match(/#{I18n.t(:'mailers.pipeline_mailer.complete_email.body_html',
+                           id: workflow_execution.id, locale:)}/, email.body.to_s)
+  end
+
+  def test_french_error_email
+    locale = :fr
+    workflow_execution = workflow_executions(:irida_next_example_error)
+    workflow_execution.submitter.locale = locale
+    email = PipelineMailer.error_email(workflow_execution)
+    assert_equal [workflow_execution.submitter.email], email.to
+    assert_equal I18n.t(:'mailers.pipeline_mailer.error_email.subject', id: workflow_execution.id, locale:),
+                 email.subject
+    assert_match(/#{I18n.t(:'mailers.pipeline_mailer.error_email.body_html', id: workflow_execution.id, locale:)}/,
+                 email.body.to_s)
+  end
 end

--- a/test/mailers/pipeline_mailer_test.rb
+++ b/test/mailers/pipeline_mailer_test.rb
@@ -21,7 +21,7 @@ class PipelineMailerTest < ActionMailer::TestCase
                  email.body.to_s)
   end
 
-  def test_french_complete_email
+  def test_complete_email_in_french
     locale = :fr
     workflow_execution = workflow_executions(:irida_next_example_completed)
     workflow_execution.submitter.locale = locale
@@ -33,7 +33,7 @@ class PipelineMailerTest < ActionMailer::TestCase
                            id: workflow_execution.id, locale:)}/, email.body.to_s)
   end
 
-  def test_french_error_email
+  def test_error_email_in_french
     locale = :fr
     workflow_execution = workflow_executions(:irida_next_example_error)
     workflow_execution.submitter.locale = locale

--- a/test/mailers/previews/pipeline_mailer_preview.rb
+++ b/test/mailers/previews/pipeline_mailer_preview.rb
@@ -4,23 +4,13 @@
 class PipelineMailerPreview < ActionMailer::Preview
   def complete_email
     workflow_execution = WorkflowExecution.first
-    PipelineMailer.complete_email(workflow_execution)
-  end
-
-  def complete_email_in_french
-    workflow_execution = WorkflowExecution.first
-    workflow_execution.submitter.locale = :fr
+    workflow_execution.submitter.locale = params[:locale]
     PipelineMailer.complete_email(workflow_execution)
   end
 
   def error_email
     workflow_execution = WorkflowExecution.first
-    PipelineMailer.error_email(workflow_execution)
-  end
-
-  def error_email_in_french
-    workflow_execution = WorkflowExecution.first
-    workflow_execution.submitter.locale = :fr
+    workflow_execution.submitter.locale = params[:locale]
     PipelineMailer.error_email(workflow_execution)
   end
 end

--- a/test/mailers/previews/pipeline_mailer_preview.rb
+++ b/test/mailers/previews/pipeline_mailer_preview.rb
@@ -7,8 +7,20 @@ class PipelineMailerPreview < ActionMailer::Preview
     PipelineMailer.complete_email(workflow_execution)
   end
 
+  def complete_email_in_french
+    workflow_execution = WorkflowExecution.first
+    workflow_execution.submitter.locale = :fr
+    PipelineMailer.complete_email(workflow_execution)
+  end
+
   def error_email
     workflow_execution = WorkflowExecution.first
+    PipelineMailer.error_email(workflow_execution)
+  end
+
+  def error_email_in_french
+    workflow_execution = WorkflowExecution.first
+    workflow_execution.submitter.locale = :fr
     PipelineMailer.error_email(workflow_execution)
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
Localized the pipeline mailer.

## Screenshots or screen recordings
Pipeline **completed** email in **English**:
![image](https://github.com/phac-nml/irida-next/assets/325703/4f7e09a1-cd5d-42d4-8ade-8f2237809408)
Pipeline **completed** email in **French**:
![image](https://github.com/phac-nml/irida-next/assets/325703/9601a156-e342-40f0-acd9-b4f33467c106)
Pipeline **errored** email in **English**:
![image](https://github.com/phac-nml/irida-next/assets/325703/d87749fb-d78d-42b1-99ba-af9eb70e084e)
Pipeline **errored** email in **French**:
![image](https://github.com/phac-nml/irida-next/assets/325703/533fa5a9-0c44-4b12-b0c4-c1d1d2c4d99e)

## How to set up and validate locally
1. Install local mock email service, [Mailhog](https://github.com/mailhog/MailHog).
1. After setup, open a terminal and run `~/go/bin/MailHog`.
1. Run irida-next.
1. Open a rails console.
1. Select a workflow execution.
`w = WorkflowExecution.first`
1. Make sure email notifications are enabled.
`w.email_notification = true`
1. Set submitter locale:
`w.submitter.locale = :en`
1. Change state to `completed` or `error`.
`w.state = "completed"`
1. Save the workflow execution.
`w.save`
1.  Open a browser and navigate to http://0.0.0.0:8025/. Check mock email service for sent email.
1. Repeat steps for locale :fr.

Note: Email previews are located at http://localhost:3000/rails/mailers/pipeline_mailer. Try changing the locale drop-down.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
