### PR TITLE
Automated Workflow Execution launching

### DIFF
--- a/app/jobs/automated_workflow_executions/launch_job.rb
+++ b/app/jobs/automated_workflow_executions/launch_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AutomatedWorkflowExecutions
+  # Queues the automated workflow execution launch job
+  class LaunchJob < ApplicationJob
+    queue_as :default
+
+    def perform(sample, pe_attachment_pair)
+      sample.project.namespace.automated_workflow_executions.each do |awe|
+        AutomatedWorkflowExecutions::LaunchService.new(awe, sample, pe_attachment_pair,
+                                                       sample.project.namespace.automation_bot).execute
+      end
+    end
+  end
+end

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -137,10 +137,7 @@ module Attachments
 
       return if @attachable.project.namespace.automated_workflow_executions.blank?
 
-      @attachable.project.namespace.automated_workflow_executions.each do |awe|
-        AutomatedWorkflowExecutions::LaunchService.new(awe, @attachable, pe_attachment_pair,
-                                                       @attachable.project.namespace.automation_bot).execute
-      end
+      AutomatedWorkflowExecutions::LaunchJob.perform_later(@attachable, pe_attachment_pair)
     end
   end
 end

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -37,7 +37,9 @@ module Attachments
 
       @attachments.each(&:save)
 
-      launch_automated_workflow_executions(@pe_attachments&.last) if @attachable.instance_of?(Sample)
+      if @attachable.instance_of?(Sample) && @attachable.project.namespace.automated_workflow_executions.present?
+        launch_automated_workflow_executions(@pe_attachments&.last)
+      end
 
       @attachments
     end
@@ -134,8 +136,6 @@ module Attachments
       unless pe_attachment_pair.present? && pe_attachment_pair.key?('forward') && pe_attachment_pair.key?('reverse')
         return
       end
-
-      return if @attachable.project.namespace.automated_workflow_executions.blank?
 
       AutomatedWorkflowExecutions::LaunchJob.perform_later(@attachable, pe_attachment_pair)
     end

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -22,7 +22,7 @@ module Attachments
       @attachments
     end
 
-    def execute # rubocop:disable Metrics/CyclomaticComplexity
+    def execute # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
       authorize! @attachable.project, to: :update_sample? if @attachable.instance_of?(Sample)
 
       valid_fastq_attachments = @attachments.select { |attachment| attachment.valid? && attachment.fastq? }
@@ -99,7 +99,7 @@ module Attachments
       assign_metadata(pe, 'pe')
     end
 
-    def assign_metadata(paired_ends, type)
+    def assign_metadata(paired_ends, type) # rubocop:disable Metrics/AbcSize
       paired_ends.each do |key, pe_attachments|
         next unless pe_attachments.key?('forward') && pe_attachments.key?('reverse')
 
@@ -135,7 +135,7 @@ module Attachments
         return
       end
 
-      return unless @attachable.project.namespace.automated_workflow_executions.present?
+      return if @attachable.project.namespace.automated_workflow_executions.blank?
 
       @attachable.project.namespace.automated_workflow_executions.each do |awe|
         AutomatedWorkflowExecutions::LaunchService.new(awe, @attachable, pe_attachment_pair,

--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module AutomatedWorkflowExecutions
+  # Service used to Launch an AutomatedWorkflowExecution
+  class LaunchService < BaseService
+    attr_accessor :automated_workflow_execution, :sample, :pe_attachment_pair, :workflow
+
+    def initialize(automated_workflow_execution, sample, pe_attachment_pair, user = nil, params = {})
+      super(user, params)
+      @automated_workflow_execution = automated_workflow_execution
+      @sample = sample
+      @pe_attachment_pair = pe_attachment_pair
+      @workflow = Irida::Pipelines.find_pipeline_by(@automated_workflow_execution.metadata['workflow_name'],
+                                                    @automated_workflow_execution.metadata['workflow_version'])
+    end
+
+    def execute
+      WorkflowExecutions::CreateService.new(@current_user, workflow_execution_params).execute
+    end
+
+    private
+
+    def workflow_execution_params
+      {
+        metadata: @automated_workflow_execution.metadata,
+        workflow_params: @automated_workflow_execution.workflow_params,
+        workflow_type: @workflow.type,
+        workflow_type_version: @workflow.type_version,
+        workflow_engine: @workflow.engine,
+        workflow_engine_version: @workflow.engine_version,
+        workflow_engine_parameters: { '-r': @workflow.version },
+        workflow_url: @workflow.url,
+        email_notification: @automated_workflow_execution.email_notification?,
+        update_samples: @automated_workflow_execution.update_samples?,
+        samples_workflow_executions_attributes: [
+          {
+            sample_id: @sample.id,
+            samplesheet_params: {
+              sample: @sample.puid,
+              fastq_1: @pe_attachment_pair['forward'].to_global_id,
+              fastq_2: @pe_attachment_pair['reverse'].to_global_id
+            }
+          }
+        ]
+      }.with_indifferent_access
+    end
+  end
+end

--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -16,7 +16,7 @@ module AutomatedWorkflowExecutions
     end
 
     def execute
-      return false if @worklow.nil?
+      return false if @workflow.nil?
 
       WorkflowExecutions::CreateService.new(@current_user, workflow_execution_params).execute
     end

--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -20,7 +20,7 @@ module AutomatedWorkflowExecutions
 
     private
 
-    def workflow_execution_params
+    def workflow_execution_params # rubocop:disable Metrics/MethodLength
       {
         metadata: @automated_workflow_execution.metadata,
         workflow_params: @automated_workflow_execution.workflow_params,

--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -3,6 +3,7 @@
 module AutomatedWorkflowExecutions
   # Service used to Launch an AutomatedWorkflowExecution
   class LaunchService < BaseService
+    LaunchError = Class.new(StandardError)
     attr_accessor :automated_workflow_execution, :sample, :pe_attachment_pair, :workflow
 
     def initialize(automated_workflow_execution, sample, pe_attachment_pair, user = nil, params = {})
@@ -15,6 +16,8 @@ module AutomatedWorkflowExecutions
     end
 
     def execute
+      return false if @worklow.nil?
+
       WorkflowExecutions::CreateService.new(@current_user, workflow_execution_params).execute
     end
 

--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -37,8 +37,8 @@ module AutomatedWorkflowExecutions
             sample_id: @sample.id,
             samplesheet_params: {
               sample: @sample.puid,
-              fastq_1: @pe_attachment_pair['forward'].to_global_id,
-              fastq_2: @pe_attachment_pair['reverse'].to_global_id
+              fastq_1: @pe_attachment_pair['forward'].to_global_id, # rubocop:disable Naming/VariableNumber
+              fastq_2: @pe_attachment_pair['reverse'].to_global_id # rubocop:disable Naming/VariableNumber
             }
           }
         ]

--- a/test/fixtures/automated_workflow_executions.yml
+++ b/test/fixtures/automated_workflow_executions.yml
@@ -15,3 +15,11 @@ invalid_metadata_automated_workflow_execution:
   workflow_params: { "assembler": "stub" }
   email_notification: true
   update_samples: false
+
+projectA_automated_workflow_execution:
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
+  metadata: { "workflow_name": "phac-nml/iridanextexample", "workflow_version": "1.0.2" }
+  workflow_params: { "assembler": "stub" }
+  email_notification: false
+  update_samples: false

--- a/test/fixtures/automated_workflow_executions.yml
+++ b/test/fixtures/automated_workflow_executions.yml
@@ -16,10 +16,18 @@ invalid_metadata_automated_workflow_execution:
   email_notification: true
   update_samples: false
 
-projectA_automated_workflow_execution:
+projectA_automated_workflow_execution_one:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   metadata: { "workflow_name": "phac-nml/iridanextexample", "workflow_version": "1.0.2" }
+  workflow_params: { "assembler": "stub" }
+  email_notification: false
+  update_samples: false
+
+projectA_automated_workflow_execution_two:
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
+  metadata: { "workflow_name": "phac-nml/iridanextexample", "workflow_version": "1.0.1" }
   workflow_params: { "assembler": "stub" }
   email_notification: false
   update_samples: false

--- a/test/fixtures/automated_workflow_executions.yml
+++ b/test/fixtures/automated_workflow_executions.yml
@@ -31,3 +31,11 @@ projectA_automated_workflow_execution_two:
   workflow_params: { "assembler": "stub" }
   email_notification: false
   update_samples: false
+
+projectA_invalid_automated_workflow_execution:
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
+  metadata: { "workflow_name": "phac-nml/iridanextexample", "workflow_version": "invalid" }
+  workflow_params: { "assembler": "stub" }
+  email_notification: false
+  update_samples: false

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -104,6 +104,12 @@ project_one_member_user_bot_account:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
   access_level: <%= Member::AccessLevel::UPLOADER %>
 
+project1_member_project_automation_bot:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
+  access_level: <%= Member::AccessLevel::MAINTAINER %>
+
 project_two_member_john_doe:
   user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
@@ -505,3 +511,9 @@ group_one_member_user_bot_account:
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_one, :uuid) %>
   access_level: <%= Member::AccessLevel::UPLOADER %>
+
+projectA_member_project_automation_bot:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:projectA_automation_bot, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
+  access_level: <%= Member::AccessLevel::MAINTAINER %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -164,3 +164,10 @@ user_group_bot_account<%= (n) %>:
   last_name: "Bot #{format('%03d', (n + 1))}"
   user_type: <%= User.user_types[:group_bot] %>
 <% end %>
+
+projectA_automation_bot:
+  email: <%= "inxt_prj_aaaaaaaaa5_automation_bot@localhost" %>
+  encrypted_password: <%= User.new.send :password_digest, "password1" %>
+  first_name: INXT_PRJ_AAAAAAAAA5
+  last_name: Automation Bot
+  user_type: <%= User.user_types[:project_automation_bot] %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -165,6 +165,13 @@ user_group_bot_account<%= (n) %>:
   user_type: <%= User.user_types[:group_bot] %>
 <% end %>
 
+project1_automation_bot:
+  email: <%= "inxt_prj_aaaaaaaaaa_automation_bot@localhost" %>
+  encrypted_password: <%= User.new.send :password_digest, "password1" %>
+  first_name: INXT_PRJ_AAAAAAAAAA
+  last_name: Automation Bot
+  user_type: <%= User.user_types[:project_automation_bot] %>
+
 projectA_automation_bot:
   email: <%= "inxt_prj_aaaaaaaaa5_automation_bot@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>

--- a/test/jobs/automated_workflow_executions/launch_job_test.rb
+++ b/test/jobs/automated_workflow_executions/launch_job_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/autorun'
+
+module AutomatedWorkflowExecutions
+  class LaunchJobTest < ActiveJob::TestCase
+    def setup
+      @user = users(:jeff_doe)
+      @sample = samples(:sampleB)
+      @pe_attachment_pair = { 'forward' => attachments(:attachmentPEFWD1), 'reverse' => attachments(:attachmentPEREV1) }
+    end
+
+    test 'calls AutomatedWorkflowExecutions::LaunchService for each configured AutomatedWorkflowExecution' do
+      count = 0
+      mock = Minitest::Mock.new
+      def mock.execute(*) = true
+
+      AutomatedWorkflowExecutions::LaunchService.stub :new, lambda { |*|
+                                                              count += 1
+                                                              mock
+                                                            } do
+        AutomatedWorkflowExecutions::LaunchJob.perform_now(@sample, @pe_attachment_pair)
+      end
+      assert_equal 2, count
+    end
+
+    test 'doesn\'t call AutomatedWorkflowExecutions::LaunchService when no configured AutomatedWorkflowExecutions' do
+      count = 0
+      mock = Minitest::Mock.new
+      def mock.execute(*) = true
+
+      AutomatedWorkflowExecutions::LaunchService.stub :new, lambda { |*|
+                                                              count += 1
+                                                              mock
+                                                            } do
+        AutomatedWorkflowExecutions::LaunchJob.perform_now(samples(:sample3), nil)
+      end
+      assert_equal 0, count
+    end
+  end
+end

--- a/test/jobs/automated_workflow_executions/launch_job_test.rb
+++ b/test/jobs/automated_workflow_executions/launch_job_test.rb
@@ -22,7 +22,7 @@ module AutomatedWorkflowExecutions
                                                             } do
         AutomatedWorkflowExecutions::LaunchJob.perform_now(@sample, @pe_attachment_pair)
       end
-      assert_equal 2, count
+      assert_equal 3, count
     end
 
     test 'doesn\'t call AutomatedWorkflowExecutions::LaunchService when no configured AutomatedWorkflowExecutions' do

--- a/test/services/attachments/create_service_test.rb
+++ b/test/services/attachments/create_service_test.rb
@@ -206,7 +206,7 @@ module Attachments
       assert_nil @sample.attachments_updated_at
     end
 
-    test 'queues AutomatedWorkflowExecutions::LaunchJob when uploading pair end data to a Sample whose Project has AutomatedWorkflowExections configured' do
+    test 'queues AutomatedWorkflowExecutions::LaunchJob when uploading pair end data to a Sample whose Project has AutomatedWorkflowExections configured' do # rubocop:disable Layout/LineLength
       sample = samples(:sampleA)
       params = { files: [@testsample_illumina_pe_fwd_blob, @testsample_illumina_pe_rev_blob] }
 
@@ -217,7 +217,7 @@ module Attachments
       assert_enqueued_with(job: AutomatedWorkflowExecutions::LaunchJob)
     end
 
-    test 'doesn\'t queue a AutomatedWorkflowExecutions::LaunchJob when uploading single end data to a Sample whose Project has AutomatedWorkflowExections configured' do
+    test 'doesn\'t queue a AutomatedWorkflowExecutions::LaunchJob when uploading single end data to a Sample whose Project has AutomatedWorkflowExections configured' do # rubocop:disable Layout/LineLength
       sample = samples(:sampleA)
       params = { files: [@testsample_illumina_pe_fwd_blob] }
 

--- a/test/services/attachments/create_service_test.rb
+++ b/test/services/attachments/create_service_test.rb
@@ -205,5 +205,27 @@ module Attachments
 
       assert_nil @sample.attachments_updated_at
     end
+
+    test 'queues AutomatedWorkflowExecutions::LaunchJob when uploading pair end data to a Sample whose Project has AutomatedWorkflowExections configured' do
+      sample = samples(:sampleA)
+      params = { files: [@testsample_illumina_pe_fwd_blob, @testsample_illumina_pe_rev_blob] }
+
+      assert_difference -> { Attachment.count } => 2 do
+        Attachments::CreateService.new(users(:jeff_doe), sample, params).execute
+      end
+
+      assert_enqueued_with(job: AutomatedWorkflowExecutions::LaunchJob)
+    end
+
+    test 'doesn\'t queue a AutomatedWorkflowExecutions::LaunchJob when uploading single end data to a Sample whose Project has AutomatedWorkflowExections configured' do
+      sample = samples(:sampleA)
+      params = { files: [@testsample_illumina_pe_fwd_blob] }
+
+      assert_no_enqueued_jobs do
+        assert_difference -> { Attachment.count } => 1 do
+          Attachments::CreateService.new(users(:jeff_doe), sample, params).execute
+        end
+      end
+    end
   end
 end

--- a/test/services/automated_workflow_executions/launch_service_test.rb
+++ b/test/services/automated_workflow_executions/launch_service_test.rb
@@ -19,6 +19,17 @@ module AutomatedWorkflowExecutions
       end
     end
 
+    test 'returns false if workflow is not valid' do
+      assert_no_difference -> { WorkflowExecution.count } do
+        ret_val = AutomatedWorkflowExecutions::LaunchService.new(
+          automated_workflow_executions(:projectA_invalid_automated_workflow_execution), @sample, @pe_attachment_pair,
+          @automation_bot
+        ).execute
+
+        assert ret_val == false
+      end
+    end
+
     test 'doesn\'t create workflow execution with invalid project bot' do
       skip 'enable this test once WorkflowExecutions::CreateService has been updated to perform authorization'
       assert_no_difference -> { WorkflowExecution.count } do

--- a/test/services/automated_workflow_executions/launch_service_test.rb
+++ b/test/services/automated_workflow_executions/launch_service_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module AutomatedWorkflowExecutions
+  class LaunchServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:jeff_doe)
+      @automated_workflow_execution = automated_workflow_executions(:projectA_automated_workflow_execution)
+      @sample = samples(:sampleB)
+      @automation_bot = users(:projectA_automation_bot)
+      @pe_attachment_pair = { 'forward' => attachments(:attachmentPEFWD1), 'reverse' => attachments(:attachmentPEREV1) }
+    end
+
+    test 'creates workflow execution with valid arguments' do
+      assert_difference -> { WorkflowExecution.count } => 1 do
+        AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample, @pe_attachment_pair,
+                                                       @automation_bot).execute
+      end
+    end
+  end
+end

--- a/test/services/automated_workflow_executions/launch_service_test.rb
+++ b/test/services/automated_workflow_executions/launch_service_test.rb
@@ -6,7 +6,7 @@ module AutomatedWorkflowExecutions
   class LaunchServiceTest < ActiveSupport::TestCase
     def setup
       @user = users(:jeff_doe)
-      @automated_workflow_execution = automated_workflow_executions(:projectA_automated_workflow_execution)
+      @automated_workflow_execution = automated_workflow_executions(:projectA_automated_workflow_execution_one)
       @sample = samples(:sampleB)
       @automation_bot = users(:projectA_automation_bot)
       @pe_attachment_pair = { 'forward' => attachments(:attachmentPEFWD1), 'reverse' => attachments(:attachmentPEREV1) }
@@ -16,6 +16,14 @@ module AutomatedWorkflowExecutions
       assert_difference -> { WorkflowExecution.count } => 1 do
         AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample, @pe_attachment_pair,
                                                        @automation_bot).execute
+      end
+    end
+
+    test 'doesn\'t create workflow execution with invalid project bot' do
+      skip 'enable this test once WorkflowExecutions::CreateService has been updated to perform authorization'
+      assert_no_difference -> { WorkflowExecution.count } do
+        AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample, @pe_attachment_pair,
+                                                       users(:project1_automation_bot)).execute
       end
     end
   end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in `AutomatedWorkflowExecution` launching upon upload of pair end data to a Sample in a Project that has `AutomatedWorkflowExecutions` configured.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch server using `bin/dev`
2. Login as `user1@email.com`
3. Create a personal project named `test awe`
4. Launch rails console (`bin/rails c`) and execute the following to add an automated workflow execution:
```irb
AutomatedWorkflowExecutions::CreateService.new(User.find_by(email: 'user1@email.com'), { namespace: Namespaces::ProjectNamespace.find_by_full_path('user1_at_email.com/test-awe'), metadata: { workflow_name: 'phac-nml/iridanextexample', workflow_version: '1.0.2' },
 workflow_params: { assembler: 'stub' }, email_notification: false, update_samples: true }).execute
```
5. In Project `test awe` create a new sample named `test001`
6. Upload pair end data to `test001`
7. Confirm in rails console that 1 `WorfklowExecution` was created
```irb
WorkflowExecution.where(submitter: Project.last.namespace.automation_bot).count
```
8. Upload 2 sets of pair end data to `test001`
9. Confirm in rails console that only 1 `WorkflowExecution` was created
```irb
WorkflowExecution.where(submitter: Project.last.namespace.automation_bot).count
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
