### PR TITLE
Localize member & group link mailers

### DIFF
--- a/app/mailers/group_link_mailer.rb
+++ b/app/mailers/group_link_mailer.rb
@@ -2,43 +2,51 @@
 
 # Group Link Mailer
 class GroupLinkMailer < ApplicationMailer
-  def access_granted_user_email(user_emails, group, namespace)
+  def access_granted_user_email(user_emails, group, namespace, locale)
     @group = group
     @namespace = namespace
     subject = t(:'mailers.group_link_mailer.access_granted_user_email.subject',
                 group_name: @group.name,
                 namespace_type: @namespace.type,
                 namespace_name: @namespace.name)
-    mail(bcc: user_emails, subject:)
+    I18n.with_locale(locale) do
+      mail(bcc: user_emails, subject:)
+    end
   end
 
-  def access_revoked_user_email(user_emails, group, namespace)
+  def access_revoked_user_email(user_emails, group, namespace, locale)
     @group = group
     @namespace = namespace
     subject = t(:'mailers.group_link_mailer.access_revoked_user_email.subject',
                 group_name: @group.name,
                 namespace_type: @namespace.type,
                 namespace_name: @namespace.name)
-    mail(bcc: user_emails, subject:)
+    I18n.with_locale(locale) do
+      mail(bcc: user_emails, subject:)
+    end
   end
 
-  def access_granted_manager_email(manager_emails, group, namespace)
+  def access_granted_manager_email(manager_emails, group, namespace, locale)
     @group = group
     @namespace = namespace
     subject = t(:'mailers.group_link_mailer.access_granted_manager_email.subject',
                 group_name: @group.name,
                 namespace_type: @namespace.type,
                 namespace_name: @namespace.name)
-    mail(bcc: manager_emails, subject:)
+    I18n.with_locale(locale) do
+      mail(bcc: manager_emails, subject:)
+    end
   end
 
-  def access_revoked_manager_email(manager_emails, group, namespace)
+  def access_revoked_manager_email(manager_emails, group, namespace, locale)
     @group = group
     @namespace = namespace
     subject = t(:'mailers.group_link_mailer.access_revoked_manager_email.subject',
                 group_name: @group.name,
                 namespace_type: @namespace.type,
                 namespace_name: @namespace.name)
-    mail(bcc: manager_emails, subject:)
+    I18n.with_locale(locale) do
+      mail(bcc: manager_emails, subject:)
+    end
   end
 end

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -8,7 +8,9 @@ class MemberMailer < ApplicationMailer
     subject = t(:'mailers.member_mailer.access_granted_user_email.subject',
                 type: @namespace.type,
                 name: @namespace.name)
-    mail(to: @member.user.email, subject:)
+    I18n.with_locale(@member.user.locale) do
+      mail(to: @member.user.email, subject:)
+    end
   end
 
   def access_revoked_user_email(member, namespace)
@@ -17,10 +19,12 @@ class MemberMailer < ApplicationMailer
     subject = t(:'mailers.member_mailer.access_revoked_user_email.subject',
                 type: @namespace.type,
                 name: @namespace.name)
-    mail(to: @member.user.email, subject:)
+    I18n.with_locale(@member.user.locale) do
+      mail(to: @member.user.email, subject:)
+    end
   end
 
-  def access_granted_manager_email(member, manager_emails, namespace)
+  def access_granted_manager_email(member, manager_emails, namespace, locale)
     @member = member
     @namespace = namespace
     subject = t(:'mailers.member_mailer.access_granted_manager_email.subject',
@@ -29,10 +33,12 @@ class MemberMailer < ApplicationMailer
                 email: @member.user.email,
                 type: @namespace.type,
                 name: @namespace.name)
-    mail(bcc: manager_emails, subject:)
+    I18n.with_locale(locale) do
+      mail(bcc: manager_emails, subject:)
+    end
   end
 
-  def access_revoked_manager_email(member, manager_emails, namespace)
+  def access_revoked_manager_email(member, manager_emails, namespace, locale)
     @member = member
     @namespace = namespace
     subject = t(:'mailers.member_mailer.access_revoked_manager_email.subject',
@@ -41,6 +47,8 @@ class MemberMailer < ApplicationMailer
                 email: @member.user.email,
                 type: @namespace.type,
                 name: @namespace.name)
-    mail(bcc: manager_emails, subject:)
+    I18n.with_locale(locale) do
+      mail(bcc: manager_emails, subject:)
+    end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -152,14 +152,15 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
       users.pluck(:email)
     end
 
-    def manager_emails(namespace, member = nil)
+    # TODO: Remove default value
+    def manager_emails(namespace, locale = :en, member = nil)
       manager_memberships = Member.for_namespace_and_ancestors(namespace).not_expired
                                   .where(access_level: Member::AccessLevel.manageable)
       managers = if member
-                   User.human_users.where(id: manager_memberships.select(:user_id))
+                   User.human_users.where(id: manager_memberships.select(:user_id), locale:)
                        .and(User.where.not(id: member.user.id)).distinct
                  else
-                   User.human_users.where(id: manager_memberships.select(:user_id)).distinct
+                   User.human_users.where(id: manager_memberships.select(:user_id), locale:).distinct
                  end
       managers.pluck(:email)
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -146,14 +146,13 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
       end
     end
 
-    def user_emails(namespace)
+    def user_emails(namespace, locale)
       user_memberships = Member.for_namespace_and_ancestors(namespace).not_expired
-      users = User.human_users.where(id: user_memberships.select(:user_id)).distinct
+      users = User.human_users.where(id: user_memberships.select(:user_id), locale:).distinct
       users.pluck(:email)
     end
 
-    # TODO: Remove default value
-    def manager_emails(namespace, locale = :en, member = nil)
+    def manager_emails(namespace, locale, member = nil)
       manager_memberships = Member.for_namespace_and_ancestors(namespace).not_expired
                                   .where(access_level: Member::AccessLevel.manageable)
       managers = if member

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -29,13 +29,31 @@ class NamespaceGroupLink < ApplicationRecord
                                       }
 
   def send_access_revoked_emails
-    GroupLinkMailer.access_revoked_user_email(Member.user_emails(group), group, namespace).deliver_later
-    GroupLinkMailer.access_revoked_manager_email(Member.manager_emails(namespace), group, namespace).deliver_later
+    I18n.available_locales.each do |locale|
+      user_emails = Member.user_emails(group, locale)
+      unless user_emails.empty?
+        GroupLinkMailer.access_revoked_user_email(user_emails, group, namespace, locale).deliver_later
+      end
+
+      manager_emails = Member.manager_emails(namespace, locale)
+      next if manager_emails.empty?
+
+      GroupLinkMailer.access_revoked_manager_email(manager_emails, group, namespace, locale).deliver_later
+    end
   end
 
   def send_access_granted_emails
-    GroupLinkMailer.access_granted_user_email(Member.user_emails(group), group, namespace).deliver_later
-    GroupLinkMailer.access_granted_manager_email(Member.manager_emails(namespace), group, namespace).deliver_later
+    I18n.available_locales.each do |locale|
+      user_emails = Member.user_emails(group, locale)
+      unless user_emails.empty?
+        GroupLinkMailer.access_granted_user_email(user_emails, group, namespace, locale).deliver_later
+      end
+
+      manager_emails = Member.manager_emails(namespace, locale)
+      next if manager_emails.empty?
+
+      GroupLinkMailer.access_granted_manager_email(manager_emails, group, namespace, locale).deliver_later
+    end
   end
 
   private

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -37,10 +37,13 @@ module Members
 
     def send_emails
       MemberMailer.access_granted_user_email(member, namespace).deliver_later
-      manager_emails = Member.manager_emails(namespace, member)
-      return if manager_emails.empty?
 
-      MemberMailer.access_granted_manager_email(member, manager_emails, namespace).deliver_later
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(namespace, locale, member)
+        next if manager_emails.empty?
+
+        MemberMailer.access_granted_manager_email(member, manager_emails, namespace, locale).deliver_later
+      end
     end
   end
 end

--- a/app/services/members/destroy_service.rb
+++ b/app/services/members/destroy_service.rb
@@ -37,8 +37,13 @@ module Members
       return if Member.can_view?(member.user, namespace, true)
 
       MemberMailer.access_revoked_user_email(member, namespace).deliver_later
-      MemberMailer.access_revoked_manager_email(member, Member.manager_emails(namespace, member),
-                                                namespace).deliver_later
+
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(namespace, locale, member)
+        next if manager_emails.empty?
+
+        MemberMailer.access_revoked_manager_email(member, manager_emails, namespace, locale).deliver_later
+      end
     end
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -318,6 +318,8 @@ fr:
       information_icon: Information icon
     nextflow:
       required: Required
+      update_samples: Update samples with analysis results
+      email_notification: Receive an email notification when your analysis has completed?
     history:
       latest: Latest
       created_by: "%{type} created by %{user}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -639,6 +639,8 @@ fr:
       index:
         title: Samples
         subtitle: These are the samples in %{namespace_type} %{namespace_name}
+        workflows:
+          button_sr: Launch workflow
         search:
           placeholder: Filter by ID or name
           metadata: Metadata

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -5,58 +5,68 @@ john_doe:
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: John
   last_name: Doe
+  locale: en
 
 jane_doe:
   email: jane.doe@localhost
   first_name: Jane
   last_name: Doe
+  locale: en
 
 jean_doe:
   email: jean.doe@localhost
   first_name: Jean
   last_name: Doe
+  locale: en
 
 james_doe:
   email: james.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: James
   last_name: Doe
+  locale: en
 
 joan_doe:
   email: joan.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Joan
   last_name: Doe
+  locale: en
 
 steve_doe:
   email: steve.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Steve
   last_name: Doe
+  locale: en
 
 michelle_doe:
   email: michelle.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Michelle
   last_name: Doe
+  locale: en
 
 micha_doe:
   email: micha.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Micha
   last_name: Doe
+  locale: en
 
 ryan_doe:
   email: ryan.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Ryan
   last_name: Doe
+  locale: en
 
 david_doe:
   email: david.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: David
   last_name: Doe
+  locale: en
 
 jeff_doe:
   email: jeff.doe@localhost
@@ -65,12 +75,14 @@ jeff_doe:
   last_name: Doe
   provider: developer
   uid: jeff.doe@localhost
+  locale: en
 
 alph_abet:
   email: alph.abet@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Alph
   last_name: Abet
+  locale: en
 
 <% 25.times do |n| %>
 user<%= (n) %>:
@@ -78,6 +90,7 @@ user<%= (n) %>:
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: <%= n %>
+  locale: en
 <% end %>
 
 user25:
@@ -85,6 +98,7 @@ user25:
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "25"
+  locale: en
 
 # Do not link this user to anything
 user_no_access:
@@ -92,48 +106,56 @@ user_no_access:
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "No Access"
+  locale: en
 
 user_no_access:
   email: <%= "user_no_access@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "No Access"
+  locale: en
 
 private_ryan:
   email: <%= "private.ryan@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Private
   last_name: Ryan
+  locale: en
 
 user26:
   email: <%= "user26@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "26"
+  locale: en
 
 private_joan:
   email: <%= "private.joan@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Private
   last_name: Joan
+  locale: en
 
 private_micha:
   email: <%= "private.micha@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Private
   last_name: Micha
+  locale: en
 
 user27:
   email: <%= "user27@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "27"
+  locale: en
 
 user28:
   email: <%= "user28@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "28"
+  locale: en
 
 <% 22.times do |n| %>
 user_bot_account<%= (n) %>:
@@ -142,6 +164,7 @@ user_bot_account<%= (n) %>:
   first_name: Project
   last_name: "Bot #{format('%03d', (n + 1))}"
   user_type: <%= User.user_types[:project_bot] %>
+  locale: en
 <% end %>
 
 user29:
@@ -149,12 +172,14 @@ user29:
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "29"
+  locale: en
 
 user30:
   email: <%= "user30@localhost" %>
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: User
   last_name: "30"
+  locale: en
 
 <% 22.times do |n| %>
 user_group_bot_account<%= (n) %>:
@@ -163,6 +188,7 @@ user_group_bot_account<%= (n) %>:
   first_name: Group
   last_name: "Bot #{format('%03d', (n + 1))}"
   user_type: <%= User.user_types[:group_bot] %>
+  locale: en
 <% end %>
 
 project1_automation_bot:

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -24,14 +24,14 @@ james_doe:
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: James
   last_name: Doe
-  locale: en
+  locale: fr
 
 joan_doe:
   email: joan.doe@localhost
   encrypted_password: <%= User.new.send :password_digest, "password1" %>
   first_name: Joan
   last_name: Doe
-  locale: en
+  locale: fr
 
 steve_doe:
   email: steve.doe@localhost

--- a/test/mailers/group_link_mailer_test.rb
+++ b/test/mailers/group_link_mailer_test.rb
@@ -6,59 +6,77 @@ class GroupLinkMailerTest < ActionMailer::TestCase
   def setup
     @group = groups(:group_five)
     @namespace = groups(:group_one)
-    @user_emails = Member.user_emails(@group)
-    @manager_emails = Member.manager_emails(@group)
   end
 
-  def test_access_granted_user_email
-    email = GroupLinkMailer.access_granted_user_email(@user_emails, @group, @namespace)
-    assert_equal @user_emails, email.bcc
-    assert_equal I18n.t(:'mailers.group_link_mailer.access_granted_user_email.subject',
-                        group_name: @group.name,
-                        namespace_type: @namespace.type,
-                        namespace_name: @namespace.name), email.subject
-    assert_match(/#{I18n.t(:'mailers.group_link_mailer.access_granted_user_email.body_html',
-                           group_name: @group.name,
-                           namespace_type: @namespace.type,
-                           namespace_name: @namespace.name)}/, email.body.to_s)
+  def test_localized_access_granted_user_email
+    I18n.available_locales.each do |locale|
+      user_emails = Member.user_emails(@group, locale)
+      email = GroupLinkMailer.access_granted_user_email(user_emails, @group, @namespace, locale)
+      assert_equal user_emails, email.bcc
+      assert_equal I18n.t(:'mailers.group_link_mailer.access_granted_user_email.subject',
+                          group_name: @group.name,
+                          namespace_type: @namespace.type,
+                          namespace_name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{I18n.t(:'mailers.group_link_mailer.access_granted_user_email.body_html',
+                             group_name: @group.name,
+                             namespace_type: @namespace.type,
+                             namespace_name: @namespace.name,
+                             locale:)}/, email.body.to_s)
+    end
   end
 
-  def test_access_revoked_user_email
-    email = GroupLinkMailer.access_revoked_user_email(@user_emails, @group, @namespace)
-    assert_equal @user_emails, email.bcc
-    assert_equal I18n.t(:'mailers.group_link_mailer.access_revoked_user_email.subject',
-                        group_name: @group.name,
-                        namespace_type: @namespace.type,
-                        namespace_name: @namespace.name), email.subject
-    assert_match(/#{I18n.t(:'mailers.group_link_mailer.access_revoked_user_email.body_html',
-                           group_name: @group.name,
-                           namespace_type: @namespace.type,
-                           namespace_name: @namespace.name)}/, email.body.to_s)
+  def test_localized_access_revoked_user_email
+    I18n.available_locales.each do |locale|
+      user_emails = Member.user_emails(@group, locale)
+      email = GroupLinkMailer.access_revoked_user_email(user_emails, @group, @namespace, locale)
+      assert_equal user_emails, email.bcc
+      assert_equal I18n.t(:'mailers.group_link_mailer.access_revoked_user_email.subject',
+                          group_name: @group.name,
+                          namespace_type: @namespace.type,
+                          namespace_name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{I18n.t(:'mailers.group_link_mailer.access_revoked_user_email.body_html',
+                             group_name: @group.name,
+                             namespace_type: @namespace.type,
+                             namespace_name: @namespace.name,
+                             locale:)}/, email.body.to_s)
+    end
   end
 
-  def test_access_granted_manager_email
-    email = GroupLinkMailer.access_granted_manager_email(@manager_emails, @group, @namespace)
-    assert_equal @manager_emails, email.bcc
-    assert_equal I18n.t(:'mailers.group_link_mailer.access_granted_manager_email.subject',
-                        group_name: @group.name,
-                        namespace_type: @namespace.type,
-                        namespace_name: @namespace.name), email.subject
-    assert_match(/#{Regexp.escape(I18n.t(:'mailers.group_link_mailer.access_granted_manager_email.body_html',
-                                         group_name: @group.name,
-                                         namespace_type: @namespace.type,
-                                         namespace_name: @namespace.name))}/, email.body.to_s)
+  def test_localized_access_granted_manager_email # rubocop:disable Metrics/AbcSize
+    I18n.available_locales.each do |locale|
+      manager_emails = Member.manager_emails(@group, locale)
+      email = GroupLinkMailer.access_granted_manager_email(manager_emails, @group, @namespace, locale)
+      assert_equal manager_emails, email.bcc
+      assert_equal I18n.t(:'mailers.group_link_mailer.access_granted_manager_email.subject',
+                          group_name: @group.name,
+                          namespace_type: @namespace.type,
+                          namespace_name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{Regexp.escape(I18n.t(:'mailers.group_link_mailer.access_granted_manager_email.body_html',
+                                           group_name: @group.name,
+                                           namespace_type: @namespace.type,
+                                           namespace_name: @namespace.name,
+                                           locale:))}/, email.body.to_s)
+    end
   end
 
-  def test_access_revoked_manager_email
-    email = GroupLinkMailer.access_revoked_manager_email(@manager_emails, @group, @namespace)
-    assert_equal @manager_emails, email.bcc
-    assert_equal I18n.t(:'mailers.group_link_mailer.access_revoked_manager_email.subject',
-                        group_name: @group.name,
-                        namespace_type: @namespace.type,
-                        namespace_name: @namespace.name), email.subject
-    assert_match(/#{Regexp.escape(I18n.t(:'mailers.group_link_mailer.access_revoked_manager_email.body_html',
-                                         group_name: @group.name,
-                                         namespace_type: @namespace.type,
-                                         namespace_name: @namespace.name))}/, email.body.to_s)
+  def test_localized_access_revoked_manager_email # rubocop:disable Metrics/AbcSize
+    I18n.available_locales.each do |locale|
+      manager_emails = Member.manager_emails(@group, locale)
+      email = GroupLinkMailer.access_revoked_manager_email(manager_emails, @group, @namespace, locale)
+      assert_equal manager_emails, email.bcc
+      assert_equal I18n.t(:'mailers.group_link_mailer.access_revoked_manager_email.subject',
+                          group_name: @group.name,
+                          namespace_type: @namespace.type,
+                          namespace_name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{Regexp.escape(I18n.t(:'mailers.group_link_mailer.access_revoked_manager_email.body_html',
+                                           group_name: @group.name,
+                                           namespace_type: @namespace.type,
+                                           namespace_name: @namespace.name,
+                                           locale:))}/, email.body.to_s)
+    end
   end
 end

--- a/test/mailers/member_mailer_test.rb
+++ b/test/mailers/member_mailer_test.rb
@@ -6,62 +6,81 @@ class MemberMailerTest < ActionMailer::TestCase
   def setup
     @member = members(:group_one_member_john_doe)
     @namespace = @member.namespace
-    @manager_emails = Member.manager_emails(@namespace, @member)
   end
 
-  def test_access_granted_user_email
-    email = MemberMailer.access_granted_user_email(@member, @namespace)
-    assert_equal [@member.user.email], email.to
-    assert_equal I18n.t(:'mailers.member_mailer.access_granted_user_email.subject',
-                        type: @namespace.type,
-                        name: @namespace.name), email.subject
-    assert_match(/#{I18n.t(:'mailers.member_mailer.access_granted_user_email.body_html',
-                           type: @namespace.type,
-                           name: @namespace.name)}/, email.body.to_s)
+  def test_localized_access_granted_user_email # rubocop:disable Metrics/AbcSize
+    I18n.available_locales.each do |locale|
+      @member.user.locale = locale
+      email = MemberMailer.access_granted_user_email(@member, @namespace)
+      assert_equal [@member.user.email], email.to
+      assert_equal I18n.t(:'mailers.member_mailer.access_granted_user_email.subject',
+                          type: @namespace.type,
+                          name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{I18n.t(:'mailers.member_mailer.access_granted_user_email.body_html',
+                             type: @namespace.type,
+                             name: @namespace.name,
+                             locale:)}/, email.body.to_s)
+    end
   end
 
-  def test_access_revoked_user_email
-    email = MemberMailer.access_revoked_user_email(@member, @namespace)
-    assert_equal [@member.user.email], email.to
-    assert_equal I18n.t(:'mailers.member_mailer.access_revoked_user_email.subject',
-                        type: @namespace.type,
-                        name: @namespace.name), email.subject
-    assert_match(/#{I18n.t(:'mailers.member_mailer.access_revoked_user_email.body_html',
-                           type: @namespace.type,
-                           name: @namespace.name)}/, email.body.to_s)
+  def test_localized_access_revoked_user_email # rubocop:disable Metrics/AbcSize
+    I18n.available_locales.each do |locale|
+      @member.user.locale = locale
+      email = MemberMailer.access_revoked_user_email(@member, @namespace)
+      assert_equal [@member.user.email], email.to
+      assert_equal I18n.t(:'mailers.member_mailer.access_revoked_user_email.subject',
+                          type: @namespace.type,
+                          name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{I18n.t(:'mailers.member_mailer.access_revoked_user_email.body_html',
+                             type: @namespace.type,
+                             name: @namespace.name,
+                             locale:)}/, email.body.to_s)
+    end
   end
 
-  def test_access_granted_manager_email # rubocop:disable Metrics/AbcSize
-    email = MemberMailer.access_granted_manager_email(@member, @manager_emails, @namespace)
-    assert_equal @manager_emails, email.bcc
-    assert_equal I18n.t(:'mailers.member_mailer.access_granted_manager_email.subject',
-                        first_name: @member.user.first_name.capitalize,
-                        last_name: @member.user.last_name.capitalize,
-                        email: @member.user.email,
-                        type: @namespace.type,
-                        name: @namespace.name), email.subject
-    assert_match(/#{Regexp.escape(I18n.t(:'mailers.member_mailer.access_granted_manager_email.body_html',
-                                         first_name: @member.user.first_name.capitalize,
-                                         last_name: @member.user.last_name.capitalize,
-                                         email: @member.user.email,
-                                         type: @namespace.type,
-                                         name: @namespace.name))}/, email.body.to_s)
+  def test_localized_access_granted_manager_email # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    I18n.available_locales.each do |locale|
+      manager_emails = Member.manager_emails(@namespace, locale, @member)
+      email = MemberMailer.access_granted_manager_email(@member, manager_emails, @namespace, locale)
+      assert_equal manager_emails, email.bcc
+      assert_equal I18n.t(:'mailers.member_mailer.access_granted_manager_email.subject',
+                          first_name: @member.user.first_name.capitalize,
+                          last_name: @member.user.last_name.capitalize,
+                          email: @member.user.email,
+                          type: @namespace.type,
+                          name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{Regexp.escape(I18n.t(:'mailers.member_mailer.access_granted_manager_email.body_html',
+                                           first_name: @member.user.first_name.capitalize,
+                                           last_name: @member.user.last_name.capitalize,
+                                           email: @member.user.email,
+                                           type: @namespace.type,
+                                           name: @namespace.name,
+                                           locale:))}/, email.body.to_s)
+    end
   end
 
-  def test_access_revoked_manager_email # rubocop:disable Metrics/AbcSize
-    email = MemberMailer.access_revoked_manager_email(@member, @manager_emails, @namespace)
-    assert_equal @manager_emails, email.bcc
-    assert_equal I18n.t(:'mailers.member_mailer.access_revoked_manager_email.subject',
-                        first_name: @member.user.first_name.capitalize,
-                        last_name: @member.user.last_name.capitalize,
-                        email: @member.user.email,
-                        type: @namespace.type,
-                        name: @namespace.name), email.subject
-    assert_match(/#{Regexp.escape(I18n.t(:'mailers.member_mailer.access_revoked_manager_email.body_html',
-                                         first_name: @member.user.first_name.capitalize,
-                                         last_name: @member.user.last_name.capitalize,
-                                         email: @member.user.email,
-                                         type: @namespace.type,
-                                         name: @namespace.name))}/, email.body.to_s)
+  def test_access_revoked_manager_email # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    I18n.available_locales.each do |locale|
+      manager_emails = Member.manager_emails(@namespace, locale, @member)
+      email = MemberMailer.access_revoked_manager_email(@member, manager_emails, @namespace, locale)
+      assert_equal manager_emails, email.bcc
+      assert_equal I18n.t(:'mailers.member_mailer.access_revoked_manager_email.subject',
+                          first_name: @member.user.first_name.capitalize,
+                          last_name: @member.user.last_name.capitalize,
+                          email: @member.user.email,
+                          type: @namespace.type,
+                          name: @namespace.name,
+                          locale:), email.subject
+      assert_match(/#{Regexp.escape(I18n.t(:'mailers.member_mailer.access_revoked_manager_email.body_html',
+                                           first_name: @member.user.first_name.capitalize,
+                                           last_name: @member.user.last_name.capitalize,
+                                           email: @member.user.email,
+                                           type: @namespace.type,
+                                           name: @namespace.name,
+                                           locale:))}/, email.body.to_s)
+    end
   end
 end

--- a/test/mailers/pipeline_mailer_test.rb
+++ b/test/mailers/pipeline_mailer_test.rb
@@ -22,7 +22,7 @@ class PipelineMailerTest < ActionMailer::TestCase
   end
 
   def test_localized_complete_email
-    I18n.available_locales do |locale|
+    I18n.available_locales.each do |locale|
       workflow_execution = workflow_executions(:irida_next_example_completed)
       workflow_execution.submitter.locale = locale
       email = PipelineMailer.complete_email(workflow_execution)
@@ -35,7 +35,7 @@ class PipelineMailerTest < ActionMailer::TestCase
   end
 
   def test_localized_error_email
-    I18n.available_locales do |locale|
+    I18n.available_locales.each do |locale|
       workflow_execution = workflow_executions(:irida_next_example_error)
       workflow_execution.submitter.locale = locale
       email = PipelineMailer.error_email(workflow_execution)

--- a/test/mailers/previews/group_link_mailer_preview.rb
+++ b/test/mailers/previews/group_link_mailer_preview.rb
@@ -4,50 +4,50 @@
 class GroupLinkMailerPreview < ActionMailer::Preview
   def access_granted_to_group_user_email
     setup_group
-    setup_user_emails
-    GroupLinkMailer.access_granted_user_email(@user_emails, @group, @namespace)
+    setup_user_emails(params[:locale])
+    GroupLinkMailer.access_granted_user_email(@user_emails, @group, @namespace, params[:locale])
   end
 
   def access_granted_to_project_user_email
     setup_project
-    setup_user_emails
-    GroupLinkMailer.access_granted_user_email(@user_emails, @group, @namespace)
+    setup_user_emails(params[:locale])
+    GroupLinkMailer.access_granted_user_email(@user_emails, @group, @namespace, params[:locale])
   end
 
   def access_revoked_from_group_user_email
     setup_group
-    setup_user_emails
-    GroupLinkMailer.access_revoked_user_email(@user_emails, @group, @namespace)
+    setup_user_emails(params[:locale])
+    GroupLinkMailer.access_revoked_user_email(@user_emails, @group, @namespace, params[:locale])
   end
 
   def access_revoked_from_project_user_email
     setup_project
-    setup_user_emails
-    GroupLinkMailer.access_revoked_user_email(@user_emails, @group, @namespace)
+    setup_user_emails(params[:locale])
+    GroupLinkMailer.access_revoked_user_email(@user_emails, @group, @namespace, params[:locale])
   end
 
   def access_granted_to_group_manager_email
     setup_group
-    setup_manager_emails
-    GroupLinkMailer.access_granted_manager_email(@manager_emails, @group, @namespace)
+    setup_manager_emails(params[:locale])
+    GroupLinkMailer.access_granted_manager_email(@manager_emails, @group, @namespace, params[:locale])
   end
 
   def access_granted_to_project_manager_email
     setup_project
-    setup_manager_emails
-    GroupLinkMailer.access_granted_manager_email(@manager_emails, @group, @namespace)
+    setup_manager_emails(params[:locale])
+    GroupLinkMailer.access_granted_manager_email(@manager_emails, @group, @namespace, params[:locale])
   end
 
   def access_revoked_from_group_manager_email
     setup_group
-    setup_manager_emails
-    GroupLinkMailer.access_revoked_manager_email(@manager_emails, @group, @namespace)
+    setup_manager_emails(params[:locale])
+    GroupLinkMailer.access_revoked_manager_email(@manager_emails, @group, @namespace, params[:locale])
   end
 
   def access_revoked_from_project_manager_email
     setup_project
-    setup_manager_emails
-    GroupLinkMailer.access_revoked_manager_email(@manager_emails, @group, @namespace)
+    setup_manager_emails(params[:locale])
+    GroupLinkMailer.access_revoked_manager_email(@manager_emails, @group, @namespace, params[:locale])
   end
 
   private
@@ -62,11 +62,11 @@ class GroupLinkMailerPreview < ActionMailer::Preview
     @namespace = Project.first.namespace
   end
 
-  def setup_user_emails
-    @user_emails = Member.user_emails(@namespace)
+  def setup_user_emails(locale)
+    @user_emails = Member.user_emails(@namespace, locale)
   end
 
-  def setup_manager_emails
-    @manager_emails = Member.manager_emails(@namespace)
+  def setup_manager_emails(locale)
+    @manager_emails = Member.manager_emails(@namespace, locale)
   end
 end

--- a/test/mailers/previews/member_mailer_preview.rb
+++ b/test/mailers/previews/member_mailer_preview.rb
@@ -24,22 +24,22 @@ class MemberMailerPreview < ActionMailer::Preview
 
   def access_granted_to_group_manager_email
     setup_group
-    MemberMailer.access_granted_manager_email(@member, @manager_emails, @namespace)
+    MemberMailer.access_granted_manager_email(@member, @manager_emails, @namespace, params[:locale])
   end
 
   def access_granted_to_project_manager_email
     setup_project
-    MemberMailer.access_granted_manager_email(@member, @manager_emails, @namespace)
+    MemberMailer.access_granted_manager_email(@member, @manager_emails, @namespace, params[:locale])
   end
 
   def access_revoked_from_group_manager_email
     setup_group
-    MemberMailer.access_revoked_manager_email(@member, @manager_emails, @namespace)
+    MemberMailer.access_revoked_manager_email(@member, @manager_emails, @namespace, params[:locale])
   end
 
   def access_revoked_from_project_manager_email
     setup_project
-    MemberMailer.access_revoked_manager_email(@member, @manager_emails, @namespace)
+    MemberMailer.access_revoked_manager_email(@member, @manager_emails, @namespace, params[:locale])
   end
 
   private
@@ -56,6 +56,7 @@ class MemberMailerPreview < ActionMailer::Preview
 
   def setup
     @member = Member.first
+    @member.user.locale = params[:locale]
     @manager_emails = Member.manager_emails(@namespace, @member)
   end
 end

--- a/test/services/group_links/group_link_service_test.rb
+++ b/test/services/group_links/group_link_service_test.rb
@@ -17,11 +17,20 @@ module GroupLinks
         GroupLinks::GroupLinkService.new(@user, namespace, params).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
-                                 args: [Member.user_emails(group), group, namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
-                                 args: [Member.manager_emails(namespace), group, namespace]
+      assert_enqueued_emails 3
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
+                                     args: [user_emails, group, namespace, locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
+                                   args: [manager_emails, group, namespace, locale]
+      end
     end
 
     test 'share group b with group a with incorrect permissions' do
@@ -78,11 +87,20 @@ module GroupLinks
         GroupLinks::GroupLinkService.new(@user, namespace, params).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
-                                 args: [Member.user_emails(group), group, namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
-                                 args: [Member.manager_emails(namespace), group, namespace]
+      assert_enqueued_emails 3
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
+                                     args: [user_emails, group, namespace, locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
+                                   args: [manager_emails, group, namespace, locale]
+      end
     end
 
     test 'group a shared with group b is logged using logidze' do
@@ -110,11 +128,20 @@ module GroupLinks
         GroupLinks::GroupLinkService.new(@user, namespace, params).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
-                                 args: [Member.user_emails(group), group, namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
-                                 args: [Member.manager_emails(namespace), group, namespace]
+      assert_enqueued_emails 4
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
+                                     args: [user_emails, group, namespace, locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
+                                   args: [manager_emails, group, namespace, locale]
+      end
     end
 
     test 'share project with group with incorrect permissions' do
@@ -159,11 +186,20 @@ module GroupLinks
                                          params).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
-                                 args: [Member.user_emails(group), group, namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
-                                 args: [Member.manager_emails(namespace), group, namespace]
+      assert_enqueued_emails 4
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
+                                     args: [user_emails, group, namespace, locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
+                                   args: [manager_emails, group, namespace, locale]
+      end
     end
 
     test 'project shared with group is logged using logidze' do

--- a/test/services/group_links/group_unlink_service_test.rb
+++ b/test/services/group_links/group_unlink_service_test.rb
@@ -15,15 +15,27 @@ module GroupLinks
         GroupLinks::GroupUnlinkService.new(@user, namespace_group_link).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
+      assert_enqueued_emails 3
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(namespace_group_link.group, locale)
+
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace_group_link.namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+      end
     end
 
     test 'share group b with group a then unshare' do
@@ -40,23 +52,37 @@ module GroupLinks
         GroupLinks::GroupUnlinkService.new(@user, namespace_group_link).execute
       end
 
-      assert_enqueued_emails 4
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
+      assert_enqueued_emails 6
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(namespace_group_link.group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+          assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace_group_link.namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+
+        assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+      end
     end
 
     test 'unshare group b with group a with invalid permissions' do
@@ -91,15 +117,26 @@ module GroupLinks
         GroupLinks::GroupUnlinkService.new(@user, namespace_group_link).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
+      assert_enqueued_emails 3
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(namespace_group_link.group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace_group_link.namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+      end
     end
 
     test 'unshare project with group' do
@@ -109,15 +146,26 @@ module GroupLinks
         GroupLinks::GroupUnlinkService.new(@user, namespace_group_link).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
+      assert_enqueued_emails 4
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(namespace_group_link.group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace_group_link.namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+      end
     end
 
     test 'share project with group then unshare' do
@@ -134,23 +182,37 @@ module GroupLinks
         GroupLinks::GroupUnlinkService.new(@user, namespace_group_link).execute
       end
 
-      assert_enqueued_emails 4
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
+      assert_enqueued_emails 8
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(namespace_group_link.group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_granted_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+          assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace_group_link.namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_granted_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+
+        assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+      end
     end
 
     test 'unshare project with group with invalid permissions' do
@@ -179,15 +241,26 @@ module GroupLinks
         GroupLinks::GroupUnlinkService.new(@user, namespace_group_link).execute
       end
 
-      assert_enqueued_emails 2
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
-                                 args: [Member.user_emails(namespace_group_link.group),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
-      assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
-                                 args: [Member.manager_emails(namespace_group_link.namespace),
-                                        namespace_group_link.group,
-                                        namespace_group_link.namespace]
+      assert_enqueued_emails 4
+      I18n.available_locales.each do |locale|
+        user_emails = Member.user_emails(namespace_group_link.group, locale)
+        unless user_emails.empty?
+          assert_enqueued_email_with GroupLinkMailer, :access_revoked_user_email,
+                                     args: [user_emails,
+                                            namespace_group_link.group,
+                                            namespace_group_link.namespace,
+                                            locale]
+        end
+
+        manager_emails = Member.manager_emails(namespace_group_link.namespace, locale)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with GroupLinkMailer, :access_revoked_manager_email,
+                                   args: [manager_emails,
+                                          namespace_group_link.group,
+                                          namespace_group_link.namespace,
+                                          locale]
+      end
     end
   end
 end

--- a/test/services/members/create_service_test.rb
+++ b/test/services/members/create_service_test.rb
@@ -21,7 +21,7 @@ module Members
         @new_member = Members::CreateService.new(@user, @group, valid_params, true).execute
       end
 
-      assert_enqueued_emails 2
+      assert_enqueued_emails 3
       assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, @group]
       I18n.available_locales.each do |locale|
         manager_emails = Member.manager_emails(@group, locale, @new_member)
@@ -52,7 +52,7 @@ module Members
         @new_member = Members::CreateService.new(@user, @project_namespace, valid_params, true).execute
       end
 
-      assert_enqueued_emails 2
+      assert_enqueued_emails 3
       assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, @project_namespace]
       I18n.available_locales.each do |locale|
         manager_emails = Member.manager_emails(@project_namespace, locale, @new_member)
@@ -185,7 +185,7 @@ module Members
         @new_member = Members::CreateService.new(@user, group, valid_params, true).execute
       end
 
-      assert_enqueued_emails 2
+      assert_enqueued_emails 3
       assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, group]
       I18n.available_locales.each do |locale|
         manager_emails = Member.manager_emails(group, locale, @new_member)
@@ -207,7 +207,7 @@ module Members
         @new_member = Members::CreateService.new(@user, @project_namespace, valid_params, true).execute
       end
 
-      assert_enqueued_emails 2
+      assert_enqueued_emails 3
       assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, @project_namespace]
       I18n.available_locales.each do |locale|
         manager_emails = Member.manager_emails(@project_namespace, locale, @new_member)

--- a/test/services/members/create_service_test.rb
+++ b/test/services/members/create_service_test.rb
@@ -22,10 +22,14 @@ module Members
       end
 
       assert_enqueued_emails 2
-      assert_enqueued_email_with MemberMailer, :access_granted_user_email,
-                                 args: [@new_member, @group]
-      assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
-                                 args: [@new_member, Member.manager_emails(@group, @new_member), @group]
+      assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, @group]
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(@group, locale, @new_member)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
+                                   args: [@new_member, manager_emails, @group, locale]
+      end
     end
 
     test 'create group member with no email notification' do
@@ -49,12 +53,14 @@ module Members
       end
 
       assert_enqueued_emails 2
-      assert_enqueued_email_with MemberMailer, :access_granted_user_email,
-                                 args: [@new_member, @project_namespace]
-      assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
-                                 args: [@new_member,
-                                        Member.manager_emails(@project_namespace, @new_member),
-                                        @project_namespace]
+      assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, @project_namespace]
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(@project_namespace, locale, @new_member)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
+                                   args: [@new_member, manager_emails, @project_namespace, locale]
+      end
     end
 
     test 'create group member with invalid params' do
@@ -180,10 +186,14 @@ module Members
       end
 
       assert_enqueued_emails 2
-      assert_enqueued_email_with MemberMailer, :access_granted_user_email,
-                                 args: [@new_member, group]
-      assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
-                                 args: [@new_member, Member.manager_emails(group, @new_member), group]
+      assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, group]
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(group, locale, @new_member)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
+                                   args: [@new_member, manager_emails, group, locale]
+      end
     end
 
     test 'valid authorization to create project member' do
@@ -198,12 +208,14 @@ module Members
       end
 
       assert_enqueued_emails 2
-      assert_enqueued_email_with MemberMailer, :access_granted_user_email,
-                                 args: [@new_member, @project_namespace]
-      assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
-                                 args: [@new_member,
-                                        Member.manager_emails(@project_namespace, @new_member),
-                                        @project_namespace]
+      assert_enqueued_email_with MemberMailer, :access_granted_user_email, args: [@new_member, @project_namespace]
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(@project_namespace, locale, @new_member)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with MemberMailer, :access_granted_manager_email,
+                                   args: [@new_member, manager_emails, @project_namespace, locale]
+      end
     end
 
     test 'create group member logged using logidze' do

--- a/test/services/members/destroy_service_test.rb
+++ b/test/services/members/destroy_service_test.rb
@@ -18,7 +18,7 @@ module Members
         Members::DestroyService.new(@group_member, @group, @user).execute
       end
 
-      assert_enqueued_emails 2
+      assert_enqueued_emails 3
       assert_enqueued_email_with MemberMailer, :access_revoked_user_email, args: [@group_member, @group]
       I18n.available_locales.each do |locale|
         manager_emails = Member.manager_emails(@group, locale, @group_member)
@@ -35,7 +35,7 @@ module Members
         Members::DestroyService.new(@group_member, @group, user).execute
       end
 
-      assert_enqueued_emails 2
+      assert_enqueued_emails 3
       assert_enqueued_email_with MemberMailer, :access_revoked_user_email, args: [@group_member, @group]
       I18n.available_locales.each do |locale|
         manager_emails = Member.manager_emails(@group, locale, @group_member)
@@ -77,7 +77,7 @@ module Members
         Members::DestroyService.new(@project_member, @project_namespace, @user).execute
       end
 
-      assert_enqueued_emails 2
+      assert_enqueued_emails 3
       assert_enqueued_email_with MemberMailer, :access_revoked_user_email, args: [@project_member, @project_namespace]
       I18n.available_locales.each do |locale|
         manager_emails = Member.manager_emails(@project_namespace, locale, @project_member)

--- a/test/services/members/destroy_service_test.rb
+++ b/test/services/members/destroy_service_test.rb
@@ -19,10 +19,14 @@ module Members
       end
 
       assert_enqueued_emails 2
-      assert_enqueued_email_with MemberMailer, :access_revoked_user_email,
-                                 args: [@group_member, @group]
-      assert_enqueued_email_with MemberMailer, :access_revoked_manager_email,
-                                 args: [@group_member, Member.manager_emails(@group, @group_member), @group]
+      assert_enqueued_email_with MemberMailer, :access_revoked_user_email, args: [@group_member, @group]
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(@group, locale, @group_member)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with MemberMailer, :access_revoked_manager_email,
+                                   args: [@group_member, manager_emails, @group, locale]
+      end
     end
 
     test 'remove themselves as a group member' do
@@ -32,10 +36,14 @@ module Members
       end
 
       assert_enqueued_emails 2
-      assert_enqueued_email_with MemberMailer, :access_revoked_user_email,
-                                 args: [@group_member, @group]
-      assert_enqueued_email_with MemberMailer, :access_revoked_manager_email,
-                                 args: [@group_member, Member.manager_emails(@group, @group_member), @group]
+      assert_enqueued_email_with MemberMailer, :access_revoked_user_email, args: [@group_member, @group]
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(@group, locale, @group_member)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with MemberMailer, :access_revoked_manager_email,
+                                   args: [@group_member, manager_emails, @group, locale]
+      end
     end
 
     test 'remove group member when user does not have direct or inherited membership' do
@@ -70,12 +78,14 @@ module Members
       end
 
       assert_enqueued_emails 2
-      assert_enqueued_email_with MemberMailer, :access_revoked_user_email,
-                                 args: [@project_member, @project_namespace]
-      assert_enqueued_email_with MemberMailer, :access_revoked_manager_email,
-                                 args: [@project_member,
-                                        Member.manager_emails(@project_namespace, @project_member),
-                                        @project_namespace]
+      assert_enqueued_email_with MemberMailer, :access_revoked_user_email, args: [@project_member, @project_namespace]
+      I18n.available_locales.each do |locale|
+        manager_emails = Member.manager_emails(@project_namespace, locale, @project_member)
+        next if manager_emails.empty?
+
+        assert_enqueued_email_with MemberMailer, :access_revoked_manager_email,
+                                   args: [@project_member, manager_emails, @project_namespace, locale]
+      end
     end
 
     test 'remove project member with incorrect permissions' do


### PR DESCRIPTION
## What does this PR do and why?
Sending member & group link emails to users in the locale set within their account.
A continuation of #571. Fixes #566.

## Screenshots or screen recordings
Please see #542 & #564.

## How to set up and validate locally
Please see #542 & #564.

Verify users & managers received their email in their locale of choice.

Try changing the locale drop-down in the [member](http://localhost:3000/rails/mailers/member_mailer) & [group_link](http://localhost:3000/rails/mailers/group_link_mailer) mailer previews.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
