### PR TITLE
GraphQL: CreateSample mutation not found Project error handling

### DIFF
--- a/app/graphql/mutations/create_sample.rb
+++ b/app/graphql/mutations/create_sample.rb
@@ -22,7 +22,7 @@ module Mutations
       project = if args[:project_id]
                   IridaSchema.object_from_id(args[:project_id], { expected_type: Project })
                 else
-                  Namespaces::ProjectNamespace.find_by(puid: args[:project_puid])&.project
+                  Namespaces::ProjectNamespace.find_by!(puid: args[:project_puid]).project
                 end
       sample = Samples::CreateService.new(current_user, project,
                                           { name: args[:name], description: args[:description] }).execute
@@ -37,6 +37,11 @@ module Mutations
           errors: sample.errors.full_messages
         }
       end
+    rescue ActiveRecord::RecordNotFound
+      {
+        sample: nil,
+        errors: ['Project not found by provided ID or PUID']
+      }
     end
 
     def ready?(**_args)

--- a/app/services/samples/create_service.rb
+++ b/app/services/samples/create_service.rb
@@ -8,11 +8,11 @@ module Samples
     def initialize(user = nil, project = nil, params = {})
       super(user, params)
       @project = project
-      @sample = Sample.new(params.merge(project_id: project.id))
+      @sample = Sample.new(params.merge(project_id: project&.id))
     end
 
     def execute
-      authorize! @project, to: :create_sample?
+      authorize! @project, to: :create_sample? unless @project.nil?
 
       sample.save
       sample


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updates `CreateSample` mutation to catch `ActiveRecord::NotFound` which would be caused by not found Project and responds accordingly with an appropriate error message.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
