### PR TITLE
Automated Workflow Executions: Launch Service auto naming

### DIFF
--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -27,6 +27,7 @@ module AutomatedWorkflowExecutions
 
     def workflow_execution_params # rubocop:disable Metrics/MethodLength
       {
+        name:,
         metadata: @automated_workflow_execution.metadata,
         workflow_params: @automated_workflow_execution.workflow_params,
         workflow_type: @workflow.type,
@@ -49,6 +50,14 @@ module AutomatedWorkflowExecutions
           }
         ]
       }.with_indifferent_access
+    end
+
+    def name
+      if @automated_workflow_execution.name.blank?
+        @sample.puid
+      else
+        [@automated_workflow_execution.name, @sample.puid].join(' ')
+      end
     end
   end
 end

--- a/test/services/automated_workflow_executions/launch_service_test.rb
+++ b/test/services/automated_workflow_executions/launch_service_test.rb
@@ -39,7 +39,8 @@ module AutomatedWorkflowExecutions
     end
 
     test 'sets the name in the created workflow execution to samples puid if automated workflow execution doesn\'t have a name' do # rubocop:disable Layout/LineLength
-      workflow_execution = AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample, @pe_attachment_pair,
+      workflow_execution = AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample,
+                                                                          @pe_attachment_pair,
                                                                           @automation_bot).execute
       assert_equal @sample.puid, workflow_execution.name
     end

--- a/test/services/automated_workflow_executions/launch_service_test.rb
+++ b/test/services/automated_workflow_executions/launch_service_test.rb
@@ -37,5 +37,19 @@ module AutomatedWorkflowExecutions
                                                        users(:project1_automation_bot)).execute
       end
     end
+
+    test 'sets the name in the created workflow execution to samples puid if automated workflow execution doesn\'t have a name' do # rubocop:disable Layout/LineLength
+      workflow_execution = AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample, @pe_attachment_pair,
+                                                                          @automation_bot).execute
+      assert_equal @sample.puid, workflow_execution.name
+    end
+
+    test 'sets the name in the created workflow execution to automated workflow execution name plus samples puid if automated workflow execution has a name' do # rubocop:disable Layout/LineLength
+      @automated_workflow_execution.name = 'Prefix'
+      workflow_execution = AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample,
+                                                                          @pe_attachment_pair,
+                                                                          @automation_bot).execute
+      assert_equal "Prefix #{@sample.puid}", workflow_execution.name
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

When a WorkflowExecution is launched by an AutomatedWorkflowExecution, set the name to be the name of the AutomatedWorkflowExecution if present plus the Samples PUID.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Verify tests pass

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
