### PR TITLE
Fix flakey project filter test

### DIFF
--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -101,6 +101,7 @@ module Dashboard
       end
       fill_in I18n.t(:'dashboard.projects.index.search.placeholder'), with: projects(:project1).name
 
+      sleep 1
       assert_selector 'tr', count: 12
       assert_no_selector 'a', text: /\A#{I18n.t(:'components.pagination.next')}\Z/
       assert_no_selector 'a', text: I18n.t(:'components.pagination.previous')


### PR DESCRIPTION
## What does this PR do and why?

The test fills in the search filter and then immediately checks the projects that match. Sometimes this fails because the filter has not resolved yet. 

This PR adds a 1 second sleep statement just like is done later in the test for similar reasons.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
