### PR TITLE
[ENHC0010017] Change  download paths to use rails_blob_path

### DIFF
--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -4,7 +4,7 @@
 class DataExportsController < ApplicationController # rubocop:disable Metrics/ClassLength
   include BreadcrumbNavigation
 
-  before_action :data_export, only: %i[download destroy show]
+  before_action :data_export, only: %i[destroy show]
   before_action :data_exports, only: %i[index destroy]
   before_action :current_page
   before_action :set_default_tab, only: :show

--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -38,12 +38,6 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
     end
   end
 
-  def download
-    authorize! @data_export, to: :download?
-
-    send_data @data_export.file.download, filename: @data_export.file.filename.to_s
-  end
-
   def create
     @data_export = DataExports::CreateService.new(current_user, data_export_params).execute
 

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -60,12 +60,6 @@ module Projects
         end
       end
 
-      def download
-        authorize! @project, to: :read_sample?
-
-        send_data @attachment.file.download, filename: @attachment.file.filename.to_s
-      end
-
       private
 
       def attachment_params

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -4,7 +4,7 @@ module Projects
   module Samples
     # Controller actions for Project Samples Attachments
     class AttachmentsController < Projects::Samples::ApplicationController
-      before_action :attachment, only: %i[destroy download]
+      before_action :attachment, only: %i[destroy]
 
       def new
         authorize! @project, to: :update_sample?

--- a/app/policies/data_export_policy.rb
+++ b/app/policies/data_export_policy.rb
@@ -6,10 +6,6 @@ class DataExportPolicy < ApplicationPolicy
     true if record.user_id == user.id
   end
 
-  def download?
-    true if record.user_id == user.id
-  end
-
   def read_export?
     true if record.user_id == user.id
   end

--- a/app/views/data_exports/_data_export.html.erb
+++ b/app/views/data_exports/_data_export.html.erb
@@ -39,10 +39,10 @@
     <% end %>
   </td>
   <td class="px-6 py-3 space-x-2">
-    <% if data_export.status == 'ready' %>
+    <% if data_export.status == 'ready' && allowed_to?(:download?, data_export) %>
       <%= link_to(
         t(:"data_exports.index.actions.download"),
-        download_data_export_path(data_export),
+        rails_blob_path(data_export.file),
         data: {
           turbo: false,
         },

--- a/app/views/data_exports/_data_export.html.erb
+++ b/app/views/data_exports/_data_export.html.erb
@@ -39,7 +39,7 @@
     <% end %>
   </td>
   <td class="px-6 py-3 space-x-2">
-    <% if data_export.status == 'ready' && allowed_to?(:download?, data_export) %>
+    <% if data_export.status == 'ready' %>
       <%= link_to(
         t(:"data_exports.index.actions.download"),
         rails_blob_path(data_export.file),

--- a/app/views/data_exports/show.html.erb
+++ b/app/views/data_exports/show.html.erb
@@ -2,31 +2,29 @@
   title: @data_export.name || @data_export.id, id: @data_export.name.nil? ? nil : @data_export.id) do |component| %>
   <%= component.with_buttons do %>
     <div class="flex flex-row">
-      <% if allowed_to?(:download?, @data_export) %>
-        <% if @data_export.status == 'ready' %>
-          <%= link_to(
-            t("data_exports.show.download"),
-            rails_blob_path(@data_export.file),
-            class: "button button--state-primary button--size-default"
-          ) %>
-        <% else %>
-          <button
-              class="
-              button
-              button--size-default
-              button--state-default
-              pointer-events-none
-              cursor-not-allowed
-              bg-slate-100
-              text-slate-600
-              dark:bg-slate-600
-              dark:text-slate-300
-              border-slate-100
-              dark:border-slate-600
-            "
-            ><%= t("data_exports.show.download")%>
-            </button>
-        <% end %>
+      <% if @data_export.status == 'ready' %>
+        <%= link_to(
+          t("data_exports.show.download"),
+          rails_blob_path(@data_export.file),
+          class: "button button--state-primary button--size-default"
+        ) %>
+      <% else %>
+        <button
+            class="
+            button
+            button--size-default
+            button--state-default
+            pointer-events-none
+            cursor-not-allowed
+            bg-slate-100
+            text-slate-600
+            dark:bg-slate-600
+            dark:text-slate-300
+            border-slate-100
+            dark:border-slate-600
+          "
+          ><%= t("data_exports.show.download")%>
+          </button>
       <% end %>
         <%= link_to(
           t("data_exports.show.remove_button"),

--- a/app/views/data_exports/show.html.erb
+++ b/app/views/data_exports/show.html.erb
@@ -2,30 +2,31 @@
   title: @data_export.name || @data_export.id, id: @data_export.name.nil? ? nil : @data_export.id) do |component| %>
   <%= component.with_buttons do %>
     <div class="flex flex-row">
-      <% if @data_export.status == 'ready' %>
-        <%= link_to(
-          t("data_exports.show.download"),
-          download_data_export_path(@data_export),
-          class: "button button--state-primary button--size-default"
-        ) %>
-      <% else %>
-        <%= link_to(
-          t("data_exports.show.download"),
-          download_data_export_path(@data_export),
-          class:"
-            button
-            button--size-default
-            button--state-default
-            pointer-events-none
-            cursor-not-allowed
-            bg-slate-100
-            text-slate-600
-            dark:bg-slate-600
-            dark:text-slate-300
-            border-slate-100
-            dark:border-slate-600
-          "
-        ) %>
+      <% if allowed_to?(:download?, @data_export) %>
+        <% if @data_export.status == 'ready' %>
+          <%= link_to(
+            t("data_exports.show.download"),
+            rails_blob_path(@data_export.file),
+            class: "button button--state-primary button--size-default"
+          ) %>
+        <% else %>
+          <button
+              class="
+              button
+              button--size-default
+              button--state-default
+              pointer-events-none
+              cursor-not-allowed
+              bg-slate-100
+              text-slate-600
+              dark:bg-slate-600
+              dark:text-slate-300
+              border-slate-100
+              dark:border-slate-600
+            "
+            ><%= t("data_exports.show.download")%>
+            </button>
+        <% end %>
       <% end %>
         <%= link_to(
           t("data_exports.show.remove_button"),

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -33,26 +33,22 @@
           <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
           <span>
             <%= link_to attachment.file.filename,
-            download_namespace_project_sample_attachment_path(
-              sample_id: @sample.id,
-              id: attachment.id
-            ),
+            rails_blob_path(attachment.file),
             data: {
               turbo: false
-            } %>
+            },
+            class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
           </span>
         </div>
         <div class="flex items-center">
           <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
           <span>
             <%= link_to attachment.associated_attachment.file.filename,
-            download_namespace_project_sample_attachment_path(
-              sample_id: @sample.id,
-              id: attachment.metadata["associated_attachment_id"]
-            ),
+            rails_blob_path(attachment.associated_attachment.file),
             data: {
               turbo: false
-            } %>
+            },
+            class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
           </span>
         </div>
       </div>
@@ -64,13 +60,11 @@
           <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
           <span>
             <%= link_to attachment.file.filename,
-            download_namespace_project_sample_attachment_path(
-              sample_id: @sample.id,
-              id: attachment.id
-            ),
+            rails_blob_path(attachment.file),
             data: {
               turbo: false
-            } %>
+            },
+            class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
           </span>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
     draw :workflow_executions
     resources :data_exports, only: %i[index new create destroy show] do
       member do
-        get :download
         get :redirect_from
       end
     end

--- a/config/routes/project.rb
+++ b/config/routes/project.rb
@@ -48,9 +48,6 @@ constraints(::Constraints::ProjectUrlConstrainer.new) do
           get :select
         end
         resources :attachments, module: :samples, only: %i[new create destroy] do
-          member do
-            get :download
-          end
           scope module: :attachments, as: :attachments do
             collection do
               resource :concatenation, only: %i[create new]

--- a/test/controllers/data_exports_controller_test.rb
+++ b/test/controllers/data_exports_controller_test.rb
@@ -14,17 +14,6 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should download export' do
-    get download_data_export_path(@data_export1)
-    assert_response :success
-  end
-
-  test 'should not download export without authorization' do
-    sign_in users(:jane_doe)
-    get download_data_export_path(@data_export1)
-    assert_response :unauthorized
-  end
-
   test 'should create new export with viable params' do
     params = { 'data_export' => { 'export_type' => 'sample', 'export_parameters' => { 'ids' => [@sample1.id] } },
                format: :turbo_stream }

--- a/test/controllers/projects/samples/attachments_controller_test.rb
+++ b/test/controllers/projects/samples/attachments_controller_test.rb
@@ -113,19 +113,6 @@ module Projects
                  as: :turbo_stream
         end
       end
-
-      test 'user with access can download the attachment' do
-        get download_namespace_project_sample_attachment_url(@namespace, @project, @sample1, @attachment1)
-
-        assert_response :success
-      end
-
-      test 'user without access cannot download the attachment' do
-        sign_in users(:user_no_access)
-        get download_namespace_project_sample_attachment_url(@namespace, @project, @sample1, @attachment1)
-
-        assert_response :unauthorized
-      end
     end
   end
 end

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -180,7 +180,7 @@ class DataExportsTest < ApplicationSystemTestCase
 
     visit data_export_path(@data_export2)
 
-    assert_selector 'a.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t(:'data_exports.show.download')
     assert_no_text I18n.t(:'data_exports.show.tabs.preview')
   end


### PR DESCRIPTION
## What does this PR do and why?
This PR changes from using the download endpoints for sample attachments and data exports to utilizing the Rails helper `rails_blob_path` to download the files.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Ensure you are able to create and download both sample and workflow execution exports
2. Ensure you can download both single and paired-end sample files.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
