### PR TITLE
GraphQL: Add isPuid query 

### DIFF
--- a/app/graphql/resolvers/is_puid_resolver.rb
+++ b/app/graphql/resolvers/is_puid_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  # Project Resolver
+  # IsPuid Resolver
   class IsPuidResolver < BaseResolver
     argument :id, GraphQL::Types::ID,
              required: true,

--- a/app/graphql/resolvers/is_puid_resolver.rb
+++ b/app/graphql/resolvers/is_puid_resolver.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Resolvers
+  # Project Resolver
+  class IsPuidResolver < BaseResolver
+    argument :id, GraphQL::Types::ID,
+             required: true,
+             description: 'ID to compare to puid format'
+
+    type Boolean, null: false
+
+    def resolve(id:)
+      id_sections = id.split('_')
+      model_prefix = id_sections[1]
+      return false unless id_sections.length == 3
+
+      case model_prefix
+      when 'SAM'
+        Irida::PersistentUniqueId.valid_puid?(id, Sample)
+      when 'ATT'
+        Irida::PersistentUniqueId.valid_puid?(id, Attachment)
+      when 'GRP'
+        Irida::PersistentUniqueId.valid_puid?(id, Group)
+      when 'PRJ'
+        Irida::PersistentUniqueId.valid_puid?(id, Namespaces::ProjectNamespace)
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -715,6 +715,16 @@ type Query {
   ): GroupConnection!
 
   """
+  Boolean
+  """
+  isPuid(
+    """
+    ID to compare to puid format
+    """
+    id: ID!
+  ): Boolean!
+
+  """
   Find a namespace.
   """
   namespace(

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -38,8 +38,19 @@ module Types
     field :project_sample, Types::SampleType, null: true, resolver: Resolvers::ProjectSampleResolver,
                                               description: 'Find a sample within a project.'
 
+    field :is_puid, Boolean, null: false, description: 'Check if id is in puid format' do
+      argument :id, GraphQL::Types::ID, 'ID to compare to puid format'
+    end
+
     def current_user
       context[:current_user]
+    end
+
+    def is_puid(id:)
+      Irida::PersistentUniqueId.valid_puid?(id, Sample) ||
+        Irida::PersistentUniqueId.valid_puid?(id, Attachment) ||
+        Irida::PersistentUniqueId.valid_puid?(id, Group) ||
+        Irida::PersistentUniqueId.valid_puid?(id, Namespaces::ProjectNamespace)
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -38,19 +38,11 @@ module Types
     field :project_sample, Types::SampleType, null: true, resolver: Resolvers::ProjectSampleResolver,
                                               description: 'Find a sample within a project.'
 
-    field :is_puid, Boolean, null: false, description: 'Check if id is in puid format' do
-      argument :id, GraphQL::Types::ID, 'ID to compare to puid format'
-    end
+    field :is_puid, Boolean, null: false, resolver: Resolvers::IsPuidResolver,
+                             description: 'Check if id is in puid format'
 
     def current_user
       context[:current_user]
-    end
-
-    def is_puid(id:)
-      Irida::PersistentUniqueId.valid_puid?(id, Sample) ||
-        Irida::PersistentUniqueId.valid_puid?(id, Attachment) ||
-        Irida::PersistentUniqueId.valid_puid?(id, Group) ||
-        Irida::PersistentUniqueId.valid_puid?(id, Namespaces::ProjectNamespace)
     end
   end
 end

--- a/lib/irida/persistent_unique_id.rb
+++ b/lib/irida/persistent_unique_id.rb
@@ -36,7 +36,7 @@ module Irida
     end
 
     def valid_puid?(puid, object_class = nil)
-      re = /#{app_prefix}_#{object_class.model_prefix}_([A-Z]|[2-7]){10}/
+      re = /\A#{app_prefix}_#{object_class.model_prefix}_([A-Z]|[2-7]){10}\z/
       re.match?(puid)
     end
   end

--- a/test/graphql/is_puid_query_test.rb
+++ b/test/graphql/is_puid_query_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PuidQueryTest < ActiveSupport::TestCase
+  PUID_QUERY_TRUE = <<~GRAPHQL
+    query {
+      isPuid(id: "INXT_SAM_23F24BP6A7")
+    }
+  GRAPHQL
+
+  PUID_QUERY_FALSE = <<~GRAPHQL
+    query {
+      isPuid(id: "INXT_SAM_23D56SE3M8")
+    }
+  GRAPHQL
+
+  def setup
+    @user = users(:john_doe)
+  end
+
+  test 'is puid query should return true' do
+    user = users(:john_doe)
+
+    result = IridaSchema.execute(PUID_QUERY_TRUE, context: { current_user: @user }, variables: {})
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']
+
+    assert_not_empty data, 'puid type should work'
+    assert data['isPuid']
+  end
+
+  test 'is puid query should return false' do
+    user = users(:john_doe)
+
+    result = IridaSchema.execute(PUID_QUERY_FALSE, context: { current_user: @user }, variables: {})
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']
+
+    assert_not_empty data, 'puid type should work'
+    assert_not data['isPuid']
+  end
+end

--- a/test/graphql/is_puid_query_test.rb
+++ b/test/graphql/is_puid_query_test.rb
@@ -20,8 +20,6 @@ class PuidQueryTest < ActiveSupport::TestCase
   end
 
   test 'is puid query should return true' do
-    user = users(:john_doe)
-
     result = IridaSchema.execute(PUID_QUERY_TRUE, context: { current_user: @user }, variables: {})
 
     assert_nil result['errors'], 'should work and have no errors.'
@@ -33,8 +31,6 @@ class PuidQueryTest < ActiveSupport::TestCase
   end
 
   test 'is puid query should return false' do
-    user = users(:john_doe)
-
     result = IridaSchema.execute(PUID_QUERY_FALSE, context: { current_user: @user }, variables: {})
 
     assert_nil result['errors'], 'should work and have no errors.'


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in a new query named `isPuid` which returns `True` if the `id` given is in `puid` format. The query determines this from the `id` argument given.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch server and login as your preferred user
2. Navigate to `GraphiQL` endpoint (e.g. `http://localhost:3000/graphiql`)
3. Try the `isPuid` query using sample id
```
{
  isPuid(id: "INXT_SAM_245HANDHG5")
}
```
4. Try the `isPuid` query using sample id
```
{
  isPuid(id: "INXT_SAM_245HANDHG865")
}
```
5. Try querying an id for either a `Sample`, `Attachment`, `Group`, or `Namespace::ProjectNamespace`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
