### PR TITLE
Fix: Metadata Fields retrieval for Shared Groups and Shared Projects [DFCT0010073]

### DIFF
--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -16,6 +16,6 @@ module Metadata
   end
 
   def fields_for_namespace(namespace: nil, show_fields: false)
-    @fields = !show_fields || namespace.nil? ? [] : namespace.metadata_summary.keys
+    @fields = !show_fields || namespace.nil? ? [] : namespace.metadata_fields
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -64,4 +64,18 @@ class Group < Namespace
   def self.model_prefix
     'GRP'
   end
+
+  def metadata_fields
+    metadata_fields = metadata_summary.keys
+
+    shared_groups.each do |shared_group|
+      metadata_fields.concat shared_group.metadata_summary.keys
+    end
+
+    shared_project_namespaces.each do |shared_project_namespace|
+      metadata_fields.concat shared_project_namespace.metadata_summary.keys
+    end
+
+    metadata_fields.uniq
+  end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -245,6 +245,10 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     raise NotImplementedError, 'The underlying class should implement this method to set the model prefix.'
   end
 
+  def metadata_fields
+    metadata_summary.keys
+  end
+
   private
 
   # Method to restore namespace routes when the namespace is restored
@@ -304,9 +308,5 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
         namespace.save
       end
     end
-  end
-
-  def metadata_fields
-    metadata_summary.keys
   end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -305,4 +305,8 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
       end
     end
   end
+
+  def metadata_fields
+    metadata_summary.keys
+  end
 end

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -375,7 +375,7 @@ projectBravo_namespace:
   description: Project Bravo description
   type: Project
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_bravo, :uuid) %>
-  metadata_summary: {}
+  metadata_summary: {'metadatafield1': 1, 'metadatafield2': 1}
   puid: INXT_PRJ_AAAAAAAABF
 
 projectCharlie_namespace:

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -177,6 +177,10 @@ sampleBravo:
   description: Sample Bravo description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:projectBravo, :uuid) %>
   puid: INXT_SAM_AAAAAAAABH
+  metadata: { 'metadatafield1': 'value1', 'metadatafield2': 'value2' }
+  metadata_provenance: { 'metadatafield1': { 'id': 1, 'source': 'analysis',
+  'updated_at': <%= DateTime.new(2000,1,1) %> },
+  'metadatafield2': { 'id': 1, 'source': 'analysis', 'updated_at': <%= DateTime.new(2000,1,1) %> }}
   created_at: <%= 36.week.ago %>
   updated_at: <%= 36.day.ago %>
 

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -194,4 +194,16 @@ class GroupTest < ActiveSupport::TestCase
   test '#model_prefix' do
     assert_equal 'GRP', Group.model_prefix
   end
+
+  test '#metadata_summary' do
+    assert_equal %w[metadatafield1 metadatafield2], @group.metadata_fields
+  end
+
+  test '#metadata_summary incorporates fields from shared groups' do
+    assert_equal %w[metadatafield1 metadatafield2], groups(:david_doe_group_four).metadata_fields
+  end
+
+  test '#metadata_summary incorporates fields from shared projects' do
+    assert_equal %w[metadatafield1 metadatafield2], groups(:group_alpha).metadata_fields
+  end
 end

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -99,6 +99,7 @@ module Groups
     test 'can search the list of samples by name' do
       visit group_samples_url(@group)
 
+      assert_text 'Displaying items 1-20 of 26 in total'
       within '#group_samples_list' do
         assert_selector 'table tbody tr', count: 20
         assert_text @sample1.name
@@ -119,6 +120,7 @@ module Groups
     test 'can sort the list of samples' do
       visit group_samples_url(@group)
 
+      assert_text 'Displaying items 1-20 of 26 in total'
       # Because PUIDs are not always generated the same, issues regarding order have occurred when hard testing
       # the expected ordering of samples based on PUID. To resolve this, we will gather the first 4 PUIDs and ensure
       # they are ordered as expected against one another.
@@ -169,6 +171,7 @@ module Groups
     test 'can filter by name and then sort the list of samples' do
       visit group_samples_url(@group)
 
+      assert_text 'Displaying items 1-20 of 26 in total'
       within '#group_samples_list' do
         assert_selector 'table tbody tr', count: 20
         within first('table tbody tr td') do
@@ -207,6 +210,7 @@ module Groups
     test 'can filter by puid and then sort the list of samples' do
       visit group_samples_url(@group)
 
+      assert_text 'Displaying items 1-20 of 26 in total'
       within '#group_samples_list' do
         assert_selector 'table tbody tr', count: 20
         within first('table tbody tr td') do
@@ -328,6 +332,7 @@ module Groups
 
     test 'can sort samples by metadata column' do
       visit group_samples_url(@group)
+      assert_text 'Displaying items 1-20 of 26 in total'
       assert_selector 'label', text: I18n.t('groups.samples.index.search.metadata'), count: 1
       assert_selector 'table thead tr th', count: 6
       find('label', text: I18n.t('groups.samples.index.search.metadata')).click
@@ -368,6 +373,7 @@ module Groups
 
     test 'filtering samples by list of  sample puids' do
       visit group_samples_url(@group)
+      assert_text 'Displaying items 1-20 of 26 in total'
       within 'tbody#group-samples-table-body' do
         assert_selector 'tr', count: 20
         assert_selector 'tr td', text: @sample1.puid
@@ -405,6 +411,7 @@ module Groups
 
     test 'selecting / deselecting all samples' do
       visit group_samples_url(@group)
+      assert_text 'Displaying items 1-20 of 26 in total'
       within 'tbody' do
         assert_selector 'input[name="sample_ids[]"]', count: 20
         assert_selector 'input[name="sample_ids[]"]:checked', count: 0


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

When launching a Workflow Execution from the Group Samples page when the Samples come from a shared Project or a shared Group. The metadata fields dropdown would not populate. Also when toggling the metadata on the same Group Samples page no metadata would show from the Samples even though they contained it.

This PR adds in a new method `metadata_fields` to Namespace model with override in Group model. The override in the Group model will query the Shared Groups and Shared Projects to include their metadata fields in the result of the method.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Create a new Group
2. Share an existing Group with Samples that have metadata to the new Group
3. Navigate to the new Group Samples page
4. Verify that metadata is displaying when metadata is toggled.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
