### PR TITLE
[ENHC0010029] Add TSV support for Metadata imports

### DIFF
--- a/app/services/samples/metadata/file_import_service.rb
+++ b/app/services/samples/metadata/file_import_service.rb
@@ -86,7 +86,7 @@ module Samples
         @spreadsheet = if extension.eql? '.tsv'
                          Roo::CSV.new(@file, csv_options: { col_sep: "\t" })
                        else
-                         Roo::Spreadsheet.open(@file, extension:)
+                         Roo::Spreadsheet.open(@file)
                        end
 
         @headers = @spreadsheet.row(1).collect(&:strip)

--- a/app/views/projects/samples/metadata/file_imports/_dialog.html.erb
+++ b/app/views/projects/samples/metadata/file_imports/_dialog.html.erb
@@ -19,7 +19,7 @@
                             required: true,
                             accept:
                               # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
-                              "text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                              "text/csv,.tsv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                             data: {
                               action:
                                 "change->projects--samples--metadata--file-import#readFile"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1231,7 +1231,7 @@ en:
           dialog:
             title: Upload Sample Metadata
             file: File
-            file_help: CSV, XLS or XLSX.
+            file_help: CSV, TSV, XLS or XLSX.
             sample_id_column: Sample ID Column
             select_sample_id_column: Select a Sample ID Column
             submit_button: Import Metadata

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1229,7 +1229,7 @@ fr:
           dialog:
             title: Upload Sample Metadata
             file: File
-            file_help: CSV, XLS or XLSX.
+            file_help: CSV, TSV, XLS or XLSX.
             sample_id_column: Sample ID Column
             select_sample_id_column: Select a Sample ID Column
             submit_button: Import Metadata

--- a/test/fixtures/files/metadata/valid.tsv
+++ b/test/fixtures/files/metadata/valid.tsv
@@ -1,0 +1,3 @@
+sample_name	metadatafield1	metadatafield2	metadatafield3
+Project 1 Sample 1	10	20	30
+Project 1 Sample 2	15	25	35

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -108,6 +108,23 @@ module Samples
                      @sample2.reload.metadata)
       end
 
+      test 'import sample metadata via tsv file' do
+        assert_equal({}, @sample1.metadata)
+        assert_equal({}, @sample2.metadata)
+        params = { file: File.new('test/fixtures/files/metadata/valid.tsv', 'r'),
+                   sample_id_column: 'sample_name' }
+        response = Samples::Metadata::FileImportService.new(@project, @john_doe,
+                                                            params).execute
+        assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
+                                          updated: [], deleted: [], not_updated: [] },
+                       @sample2.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
+                                          updated: [], deleted: [], not_updated: [] } }, response)
+        assert_equal({ 'metadatafield1' => '10', 'metadatafield2' => '20', 'metadatafield3' => '30' },
+                     @sample1.reload.metadata)
+        assert_equal({ 'metadatafield1' => '15', 'metadatafield2' => '25', 'metadatafield3' => '35' },
+                     @sample2.reload.metadata)
+      end
+
       test 'import sample metadata via other file' do
         other = File.new('test/fixtures/files/metadata/invalid.txt', 'r')
         params = { file: other, sample_id_column: 'sample_name' }


### PR DESCRIPTION
## What does this PR do and why?

Adds tab-delimited csv files (.tsv) to supported file types for metadata importing.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. In the web interface, go to a projects samples page and click the `Import Metadata` button
2. See that the Upload Sample Metadata pop up indicates that TSV files are an option
3. Click `Browse...` to open a file picker, and see that `*.tsv` files are supported
4. Select a TSV file (example: `test/fixtures/files/metadata/valid.tsv`) and see that the `Sample ID Column` drop down selector shows the parsed column headers.
5. If your TSV file matches the samples you should be able to import the metadata from the file.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
