### PR TITLE
[DFCT0010089] Fix groups being able to recursively share to themselves

### DIFF
--- a/app/controllers/concerns/share_actions.rb
+++ b/app/controllers/concerns/share_actions.rb
@@ -29,30 +29,26 @@ module ShareActions # rubocop:disable Metrics/ModuleLength
                                                                      group_link_params).execute
     @pagy, @namespace_group_links = pagy(load_namespace_group_links)
 
-    respond_to do |format|
-      if @created_namespace_group_link
-        if @created_namespace_group_link.errors.full_messages.count.positive?
-          format.turbo_stream do
-            render status: :conflict,
-                   locals: { namespace_group_link: @created_namespace_group_link, type: 'alert',
-                             message: @created_namespace_group_link.errors.full_messages.first }
-          end
-        else
-          @group_invited = true
-          format.turbo_stream do
-            render status: :ok, locals: { namespace_group_link: @created_namespace_group_link,
-                                          access_levels: @access_levels,
-                                          type: 'success',
-                                          message: t('.success',
-                                                     namespace_name: @created_namespace_group_link.namespace.human_name,
-                                                     group_name: @created_namespace_group_link.group.human_name) }
-          end
-        end
-      else
+    if @created_namespace_group_link.persisted?
+      respond_to do |format|
+        @group_invited = true
         format.turbo_stream do
-          render status: :bad_request,
-                 locals: { type: 'alert',
-                           message: t('.error') }
+          render status: :ok,
+                 locals: { namespace_group_link: @created_namespace_group_link,
+                           access_levels: @access_levels,
+                           type: 'success',
+                           message: t('.success',
+                                      namespace_name: @created_namespace_group_link.namespace.human_name,
+                                      group_name: @created_namespace_group_link.group.human_name) }
+        end
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream do
+          render status: :unprocessable_entity,
+                 locals: { namespace_group_link: @created_namespace_group_link,
+                           type: 'alert',
+                           message: @created_namespace_group_link.errors.full_messages.first }
         end
       end
     end

--- a/app/controllers/concerns/share_actions.rb
+++ b/app/controllers/concerns/share_actions.rb
@@ -136,7 +136,9 @@ module ShareActions # rubocop:disable Metrics/ModuleLength
   end
 
   def namespace_linkable_groups
-    @namespace_linkable_groups = Group.where.not(id: NamespaceGroupLink.where(namespace:).select(:group_id))
+    @namespace_linkable_groups = Group.where.not(
+      id: NamespaceGroupLink.where(namespace:).select(:group_id) + Group.where(id: namespace.id).select(:id)
+    )
   end
 
   def load_namespace_group_links

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -12,6 +12,8 @@ class NamespaceGroupLink < ApplicationRecord
 
   validates :group_id, uniqueness: { scope: [:namespace_id] }
 
+  validates :group_id, comparison: { other_than: :namespace_id }
+
   validates :group_access_level, inclusion: { in: Member::AccessLevel.all_values_with_owner },
                                  presence: true
 

--- a/app/services/group_links/group_link_service.rb
+++ b/app/services/group_links/group_link_service.rb
@@ -33,8 +33,8 @@ module GroupLinks
 
       namespace_group_link
     rescue GroupLinks::GroupLinkService::NamespaceGroupLinkError => e
-      @namespace.errors.add(:base, e.message)
-      false
+      @namespace_group_link.errors.add(:base, e.message)
+      @namespace_group_link
     end
   end
 end

--- a/app/services/group_links/group_link_service.rb
+++ b/app/services/group_links/group_link_service.rb
@@ -24,7 +24,7 @@ module GroupLinks
 
       raise NamespaceGroupLinkError, I18n.t('services.groups.share.group_not_found', group_id:) if group.nil?
 
-      namespace_group_link.save
+      namespace_group_link.save!
 
       namespace_group_link
     rescue GroupLinks::GroupLinkService::NamespaceGroupLinkError => e

--- a/app/services/group_links/group_link_service.rb
+++ b/app/services/group_links/group_link_service.rb
@@ -20,11 +20,16 @@ module GroupLinks
 
       authorize! namespace, to: :link_namespace_with_group?
 
+      if group_id == namespace.id
+        raise NamespaceGroupLinkError,
+              I18n.t('services.groups.share.group_self_reference', group_id:)
+      end
+
       group = Group.find_by(id: group_id)
 
       raise NamespaceGroupLinkError, I18n.t('services.groups.share.group_not_found', group_id:) if group.nil?
 
-      namespace_group_link.save!
+      namespace_group_link.save
 
       namespace_group_link
     rescue GroupLinks::GroupLinkService::NamespaceGroupLinkError => e

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,6 +194,7 @@ en:
             group_id:
               blank: Group must exist
               taken: has already been shared with this namespace
+              comparison: "Group must be other than %{group_id}"
             namespace_id:
               blank: Namespace must exist
               taken: The namespace has already been shared with this group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1529,6 +1529,7 @@ en:
         namespace_group_exists: A group with the same name/path already exists in the new namespace.
       share:
         group_not_found: Group with id %{group_id} to share namespace with cannot be found.
+        group_self_reference: Group cannot be shared with itself.
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,7 +193,7 @@ en:
           attributes:
             group_id:
               blank: Group must exist
-              taken: The group has already been shared with this namespace
+              taken: has already been shared with this namespace
             namespace_id:
               blank: Namespace must exist
               taken: The namespace has already been shared with this group

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -193,6 +193,7 @@ fr:
             group_id:
               blank: Group must exist
               taken: The group has already been shared with this namespace
+              comparison: "Group must be other than %{group_id}"
             namespace_id:
               blank: Namespace must exist
               taken: The namespace has already been shared with this group

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1522,6 +1522,7 @@ fr:
         namespace_group_exists: A group with the same name/path already exists in the new namespace.
       share:
         group_not_found: Group with id %{group_id} to share namespace with cannot be found.
+        group_self_reference: Group cannot be shared with itself.
     projects:
       transfer:
         namespace_project_exists: Project with the same name or path already exists in the target namespace.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -192,7 +192,7 @@ fr:
           attributes:
             group_id:
               blank: Group must exist
-              taken: The group has already been shared with this namespace
+              taken: has already been shared with this namespace
               comparison: "Group must be other than %{group_id}"
             namespace_id:
               blank: Namespace must exist

--- a/test/controllers/concerns/group_share_actions_concern_test.rb
+++ b/test/controllers/concerns/group_share_actions_concern_test.rb
@@ -43,7 +43,7 @@ class GroupShareActionsConcernTest < ActionDispatch::IntegrationTest
                                   group_access_level: Member::AccessLevel::ANALYST
                                 }, format: :turbo_stream })
 
-    assert_response :conflict
+    assert_response :unprocessable_entity
 
     # failed, so did not increase
     assert_equal 2, namespace.shared_with_group_links.of_ancestors_and_self.count

--- a/test/controllers/concerns/group_share_actions_concern_test.rb
+++ b/test/controllers/concerns/group_share_actions_concern_test.rb
@@ -31,6 +31,24 @@ class GroupShareActionsConcernTest < ActionDispatch::IntegrationTest
     assert_equal 3, namespace.shared_with_group_links.of_ancestors_and_self.count
   end
 
+  test 'group to self group link error' do
+    sign_in users(:john_doe)
+    namespace = groups(:group_one)
+
+    assert_equal 2, namespace.shared_with_group_links.of_ancestors_and_self.count
+
+    post group_group_links_path(namespace,
+                                params: { namespace_group_link: {
+                                  group_id: namespace.id,
+                                  group_access_level: Member::AccessLevel::ANALYST
+                                }, format: :turbo_stream })
+
+    assert_response :conflict
+
+    # failed, so did not increase
+    assert_equal 2, namespace.shared_with_group_links.of_ancestors_and_self.count
+  end
+
   test 'group to group link destroy' do
     sign_in users(:john_doe)
     namespace_group_link = namespace_group_links(:namespace_group_link2)

--- a/test/controllers/groups/group_links_controller_test.rb
+++ b/test/controllers/groups/group_links_controller_test.rb
@@ -31,7 +31,7 @@ module Groups
                                     group_access_level: Member::AccessLevel::ANALYST
                                   }, format: :turbo_stream })
 
-      assert_response :bad_request
+      assert_response :unprocessable_entity
     end
 
     test 'should not share group b with group a as user doesn\'t have correct permissions' do
@@ -67,7 +67,7 @@ module Groups
                                     group_access_level: Member::AccessLevel::ANALYST
                                   }, format: :turbo_stream })
 
-      assert_response :conflict
+      assert_response :unprocessable_entity
     end
 
     test 'unshare group' do

--- a/test/controllers/projects/group_links_controller_test.rb
+++ b/test/controllers/projects/group_links_controller_test.rb
@@ -32,7 +32,7 @@ module Projects
                                                 group_access_level: Member::AccessLevel::ANALYST
                                               }, format: :turbo_stream })
 
-      assert_response :bad_request
+      assert_response :unprocessable_entity
     end
 
     test 'shouldn\'t share project namespace with group as user doesn\'t have correct permissions' do
@@ -68,7 +68,7 @@ module Projects
                                                 group_access_level: Member::AccessLevel::ANALYST
                                               }, format: :turbo_stream })
 
-      assert_response :conflict
+      assert_response :unprocessable_entity
     end
 
     test 'unshare project' do

--- a/test/models/namespace_group_link_test.rb
+++ b/test/models/namespace_group_link_test.rb
@@ -25,6 +25,16 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
     )
   end
 
+  test 'cannot create self to self group links' do
+    group_group_link = NamespaceGroupLink.new(group_id: @group_to_share.id, namespace_id: @group_to_share.id,
+                                              group_access_level: Member::AccessLevel::ANALYST)
+
+    assert_not group_group_link.save
+    assert group_group_link.errors.full_messages.include?(
+      "Group must be other than #{@group_to_share.id}"
+    )
+  end
+
   test '#validates access level out of range' do
     group_group_link = NamespaceGroupLink.new(group_id: @group_to_share.id, namespace_id: @group.id,
                                               group_access_level: Member::AccessLevel::ANALYST + 100_000)

--- a/test/models/namespace_group_link_test.rb
+++ b/test/models/namespace_group_link_test.rb
@@ -41,7 +41,7 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
 
     assert_not group_group_link.save
     assert group_group_link.errors.full_messages.include?(
-      "Group access level #{I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_access_level.inclusion')}"
+      "Group access level #{I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_access_level.inclusion')}" # rubocop:disable Layout/LineLength
     )
   end
 

--- a/test/models/namespace_group_link_test.rb
+++ b/test/models/namespace_group_link_test.rb
@@ -20,8 +20,8 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
                                               group_access_level: Member::AccessLevel::ANALYST)
 
     assert_not group_group_link.save
-    group_group_link.errors.full_messages.include?(
-      I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_id.taken')
+    assert group_group_link.errors.full_messages.include?(
+      "Group #{I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_id.taken')}"
     )
   end
 
@@ -40,8 +40,8 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
                                               group_access_level: Member::AccessLevel::ANALYST + 100_000)
 
     assert_not group_group_link.save
-    group_group_link.errors.full_messages.include?(
-      I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_access_level.inclusion')
+    assert group_group_link.errors.full_messages.include?(
+      "Group access level #{I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_access_level.inclusion')}"
     )
   end
 

--- a/test/models/namespace_group_link_test.rb
+++ b/test/models/namespace_group_link_test.rb
@@ -20,8 +20,9 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
                                               group_access_level: Member::AccessLevel::ANALYST)
 
     assert_not group_group_link.save
-    assert group_group_link.errors.full_messages.include?(
-      "Group #{I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_id.taken')}"
+
+    assert group_group_link.errors.full_messages_for(:group_id).first.include?(
+      I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_id.taken')
     )
   end
 
@@ -30,8 +31,9 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
                                               group_access_level: Member::AccessLevel::ANALYST)
 
     assert_not group_group_link.save
-    assert group_group_link.errors.full_messages.include?(
-      "Group must be other than #{@group_to_share.id}"
+    assert group_group_link.errors.full_messages_for(:group_id).include?(
+      I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_id.comparison',
+             group_id: @group_to_share.id)
     )
   end
 
@@ -40,8 +42,9 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
                                               group_access_level: Member::AccessLevel::ANALYST + 100_000)
 
     assert_not group_group_link.save
-    assert group_group_link.errors.full_messages.include?(
-      "Group access level #{I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_access_level.inclusion')}" # rubocop:disable Layout/LineLength
+
+    assert group_group_link.errors.full_messages_for(:group_access_level).first.include?(
+      I18n.t('activerecord.errors.models.namespace_group_link.attributes.group_access_level.inclusion')
     )
   end
 

--- a/test/services/group_links/group_link_service_test.rb
+++ b/test/services/group_links/group_link_service_test.rb
@@ -39,10 +39,9 @@ module GroupLinks
       params = { group_id: group.id, group_access_level: Member::AccessLevel::ANALYST }
 
       assert_difference -> { NamespaceGroupLink.count } => 0 do
-        GroupLinks::GroupLinkService.new(@user, group, params).execute
+        namespace_group_link = GroupLinks::GroupLinkService.new(@user, group, params).execute
+        assert namespace_group_link.errors.full_messages.include? I18n.t('services.groups.share.group_self_reference')
       end
-
-      assert group.errors.full_messages.include? I18n.t('services.groups.share.group_self_reference')
 
       assert_enqueued_emails 0
     end
@@ -60,7 +59,8 @@ module GroupLinks
       assert_equal GroupPolicy, exception.policy
       assert_equal :link_namespace_with_group?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.group.link_namespace_with_group?', name: namespace.name),
+      assert_equal I18n.t(:'action_policy.policy.group.link_namespace_with_group?',
+                          name: namespace.name),
                    exception.result.message
       assert_no_enqueued_emails
     end
@@ -83,10 +83,10 @@ module GroupLinks
       params = { group_id: group.id, group_access_level: Member::AccessLevel::ANALYST }
 
       assert_no_difference ['NamespaceGroupLink.count'] do
-        GroupLinks::GroupLinkService.new(user, namespace, params).execute
+        namespace_group_link = GroupLinks::GroupLinkService.new(user, namespace, params).execute
+        assert namespace_group_link.errors.full_messages.include?(I18n.t('services.groups.share.invalid_namespace_type'))
       end
 
-      assert namespace.errors.full_messages.include?(I18n.t('services.groups.share.invalid_namespace_type'))
       assert_no_enqueued_emails
     end
 

--- a/test/services/group_links/group_link_service_test.rb
+++ b/test/services/group_links/group_link_service_test.rb
@@ -39,10 +39,10 @@ module GroupLinks
       params = { group_id: group.id, group_access_level: Member::AccessLevel::ANALYST }
 
       assert_difference -> { NamespaceGroupLink.count } => 0 do
-        assert_raises(ActiveRecord::RecordInvalid) do
-          GroupLinks::GroupLinkService.new(@user, group, params).execute
-        end
+        GroupLinks::GroupLinkService.new(@user, group, params).execute
       end
+
+      assert group.errors.full_messages.include? I18n.t('services.groups.share.group_self_reference')
 
       assert_enqueued_emails 0
     end

--- a/test/services/group_links/group_link_service_test.rb
+++ b/test/services/group_links/group_link_service_test.rb
@@ -84,7 +84,9 @@ module GroupLinks
 
       assert_no_difference ['NamespaceGroupLink.count'] do
         namespace_group_link = GroupLinks::GroupLinkService.new(user, namespace, params).execute
-        assert namespace_group_link.errors.full_messages.include?(I18n.t('services.groups.share.invalid_namespace_type'))
+        assert namespace_group_link.errors.full_messages.include?(
+          I18n.t('services.groups.share.invalid_namespace_type')
+        )
       end
 
       assert_no_enqueued_emails

--- a/test/services/group_links/group_link_service_test.rb
+++ b/test/services/group_links/group_link_service_test.rb
@@ -33,6 +33,20 @@ module GroupLinks
       end
     end
 
+    test 'share group a with group a error' do
+      group = groups(:group_one)
+      # namespace = groups(:group_six)
+      params = { group_id: group.id, group_access_level: Member::AccessLevel::ANALYST }
+
+      assert_difference -> { NamespaceGroupLink.count } => 0 do
+        assert_raises(ActiveRecord::RecordInvalid) do
+          GroupLinks::GroupLinkService.new(@user, group, params).execute
+        end
+      end
+
+      assert_enqueued_emails 0
+    end
+
     test 'share group b with group a with incorrect permissions' do
       user = users(:ryan_doe)
       group = groups(:group_one)


### PR DESCRIPTION
## What does this PR do and why?

Fixes #642 

Fixes bug where a group could be shared with itself.
* No longer displays own group as an option to share on the `Groups>Members>Groups>Invite Group` form.
* Adds validation to NamespaceGroupLink such that group_id cannot equal namespace_id

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Sign in with a non admin user
2. Create a new group
3. Select `Members` on sidebar, then select `Groups` tab, then click `Invite Group`
4. In the `Group to share namespace with` dropdown, see that the current group is not in the list of groups.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
