### PR TITLE
Sample filtering when manually entering samples results in cursor moving to next sample entry if there is a pause (DFCT0010081)

### DIFF
--- a/app/components/list_filter_component.html.erb
+++ b/app/components/list_filter_component.html.erb
@@ -56,7 +56,7 @@
         >
           <input
             type="text"
-            name="filter-text"
+            name="q[name_or_puid_in][]"
             class="
               focus:outline-none focus:ring-0 border-none bg-transparent grow
             "

--- a/app/javascript/controllers/list_filter_controller.js
+++ b/app/javascript/controllers/list_filter_controller.js
@@ -10,9 +10,6 @@ export default class extends Controller {
 
   handleInput(event) {
     const value = event.target.value.trim();
-
-    console.log(value);
-
     if (event.keyCode === BACKSPACE && value.length === 0) {
       // Handle backspace event when input is empty, otherwise just let
       this.#handleBackspace(event);

--- a/app/javascript/controllers/list_filter_controller.js
+++ b/app/javascript/controllers/list_filter_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 const BACKSPACE = 8;
+const SPACE = 32;
 const COMMA = 188;
 
 export default class extends Controller {
@@ -15,7 +16,7 @@ export default class extends Controller {
     if (event.keyCode === BACKSPACE && value.length === 0) {
       // Handle backspace event when input is empty, otherwise just let
       this.#handleBackspace(event);
-    } else if (value.length === 0 && event.keyCode === COMMA) {
+    } else if (value.length === 0 && (event.keyCode === COMMA || event.keyCode === SPACE)) {
       // Handle when a `,` is entered alone, that is do nothing
       event.preventDefault();
     } else if (event.keyCode === COMMA) {

--- a/app/javascript/controllers/list_filter_controller.js
+++ b/app/javascript/controllers/list_filter_controller.js
@@ -1,5 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
-import _ from "lodash";
+
+const BACKSPACE = 8;
+const COMMA = 188;
 
 export default class extends Controller {
   static targets = ["tags", "template", "input", "count"];
@@ -8,24 +10,19 @@ export default class extends Controller {
   handleInput(event) {
     const value = event.target.value.trim();
 
-    if (event.keyCode === 8 && value.length === 0) {
-      // Handle backspace event
+    console.log(value);
+
+    if (event.keyCode === BACKSPACE && value.length === 0) {
+      // Handle backspace event when input is empty, otherwise just let
       this.#handleBackspace(event);
-    } else if (value.length === 0 && event.keyCode === 188) {
-      // Handle when a `,` is entered alone
+    } else if (value.length === 0 && event.keyCode === COMMA) {
+      // Handle when a `,` is entered alone, that is do nothing
       event.preventDefault();
-    } else if (event.keyCode === 86 && event.ctrlKey === true) {
-      // Skip handling paste, this gets handled by the paste event
-      return;
-    } else if (event.keyCode === 188) {
+    } else if (event.keyCode === COMMA) {
       // If string ends with a coma, directly add the tag without debounce
       event.preventDefault();
       this.#clearAndFocus();
-      this.#addDelayed.cancel();
       this.tagsTarget.insertBefore(this.#formatTag(value), this.inputTarget);
-    } else {
-      // Just text entered so debounce the value incase user adds more text
-      this.#addDelayed();
     }
   }
 
@@ -68,7 +65,6 @@ export default class extends Controller {
     const text = last.querySelector(".label").innerText;
     this.tagsTarget.removeChild(last);
     this.inputTarget.value = text;
-    this.#addDelayed();
   }
 
   #getNamesAndPUID(value) {
@@ -90,14 +86,6 @@ export default class extends Controller {
     clone.querySelector("input").id = Date.now().toString(36);
     return clone;
   }
-
-  #addDelayed = _.debounce(() => {
-    const value = this.inputTarget.value.trim();
-    if (value.length > 0 && value !== ",") {
-      this.tagsTarget.insertBefore(this.#formatTag(value), this.inputTarget);
-      this.#clearAndFocus();
-    }
-  }, 1000);
 
   #updateCount() {
     const count = this.tagsTarget.querySelectorAll(".search-tag").length;

--- a/app/javascript/controllers/list_filter_controller.js
+++ b/app/javascript/controllers/list_filter_controller.js
@@ -13,7 +13,10 @@ export default class extends Controller {
     if (event.keyCode === BACKSPACE && value.length === 0) {
       // Handle backspace event when input is empty, otherwise just let
       this.#handleBackspace(event);
-    } else if (value.length === 0 && (event.keyCode === COMMA || event.keyCode === SPACE)) {
+    } else if (
+      value.length === 0 &&
+      (event.keyCode === COMMA || event.keyCode === SPACE)
+    ) {
       // Handle when a `,` is entered alone, that is do nothing
       event.preventDefault();
     } else if (event.keyCode === COMMA) {
@@ -52,6 +55,14 @@ export default class extends Controller {
   afterSubmit() {
     if (this.hasSelectionOutlet) {
       this.selectionOutlet.clear();
+    }
+    // check to see if there is any text in the input
+    if (this.inputTarget.value.length > 0) {
+      this.tagsTarget.insertBefore(
+        this.#formatTag(this.inputTarget.value),
+        this.inputTarget,
+      );
+      this.inputTarget.value = "";
     }
     this.#updateCount();
   }

--- a/test/components/viral/system/list_filter_component_test.rb
+++ b/test/components/viral/system/list_filter_component_test.rb
@@ -14,9 +14,9 @@ module System
         within 'dialog' do
           assert_selector 'h1', text: I18n.t(:'components.list_filter.title')
           fill_in I18n.t(:'components.list_filter.description'), with: "#{puid1}, #{puid2}"
-          assert_selector 'span.label', count: 2
+          assert_selector 'span.label', count: 1
           assert_selector 'span.label', text: puid1
-          assert_selector 'span.label', text: puid2
+          find('input').text puid2
           click_button I18n.t(:'components.list_filter.apply')
         end
         assert_selector 'div[data-list-filter-target="count"]', text: '2'
@@ -24,7 +24,11 @@ module System
         click_button I18n.t(:'components.list_filter.title')
         within 'dialog' do
           assert_selector 'h1', text: I18n.t(:'components.list_filter.title')
+          assert_selector 'span.label', count: 2
+          assert_selector 'span.label', text: puid1
+          assert_selector 'span.label', text: puid2
           click_button I18n.t(:'components.list_filter.clear')
+          assert_selector 'span.label', count: 0
           click_button I18n.t(:'components.list_filter.apply')
         end
         assert_no_selector 'div[data-list-filter-target="count"]'

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -358,10 +358,10 @@ module Groups
       find("button[aria-label='#{I18n.t(:'components.list_filter.title')}").click
       within 'dialog' do
         assert_selector 'h1', text: I18n.t(:'components.list_filter.title')
-        find("input[type='text']").send_keys "#{@sample1.puid}, #{@sample2.puid}"
-        assert_selector 'span.label', count: 2
+        find("input[name='q[name_or_puid_in][]']").send_keys "#{@sample1.puid}, #{@sample2.puid}"
+        assert_selector 'span.label', count: 1
         assert_selector 'span.label', text: @sample1.puid
-        assert_selector 'span.label', text: @sample2.puid
+        find("input[name='q[name_or_puid_in][]']").text @sample2.puid
         click_button I18n.t(:'components.list_filter.apply')
       end
 

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -1975,9 +1975,9 @@ module Projects
       within '#list-filter-dialog' do
         assert_selector 'h1', text: I18n.t(:'components.list_filter.title')
         fill_in I18n.t(:'components.list_filter.description'), with: "#{@sample1.puid}, #{@sample2.puid}"
-        assert_selector 'span.label', count: 2
+        assert_selector 'span.label', count: 1
         assert_selector 'span.label', text: @sample1.puid
-        assert_selector 'span.label', text: @sample2.puid
+        find("input[name='q[name_or_puid_in][]']").text @sample2.puid
         click_button I18n.t(:'components.list_filter.apply')
       end
       within '#samples-table table tbody' do

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -681,6 +681,7 @@ module Projects
       end
 
       click_on I18n.t('projects.samples.table.sample')
+      assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
       click_on I18n.t('projects.samples.table.sample')
 
       assert_selector '#samples-table table tbody tr', count: 3


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Fixes #647 Addresses issue when using lodash debounce to automatically create tags was confusing to users.  In this update the user must add a coma.  The final name does not need a coma, but will be converted into a tag when the user presses the submit button.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/phac-nml/irida-next/assets/11295750/ddbb8672-7bff-43bf-a64b-b29906e5e5d9)

![image](https://github.com/phac-nml/irida-next/assets/11295750/7680ec00-0069-4809-b60c-04481e1a35dd)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Go to any project that has samples.
2. Open the filter by name or puid dialog
3. Start typing sample names, and enter a comma, the name should be converted into a tag.
4. Add another sample name and press enter, dialog should close, count on button should be updated to the correct amount, and table should update.
5. Re-open the filter dialog and there should be a tag for each sample name given

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
