### PR TITLE
Fix: URL Helpers in Prod missing default url options (DFCT0010104)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,9 +2,6 @@
 
 require 'active_support/core_ext/integer/time'
 
-# Sets default routing host/port, useful for active storage blobs when running locally
-Rails.application.routes.default_url_options = { host: 'localhost', port: 3000 }
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,8 +7,6 @@ require 'active_support/core_ext/integer/time'
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
 
-Rails.application.routes.default_url_options[:host] = 'localhost'
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  default_url_options protocol: ENV.fetch('RAILS_PROTOCOL', 'http'),
+                      host: ENV.fetch('RAILS_HOST', 'localhost')
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates routes to set default_url_options in all environments (prod was missing).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Test that `attachment_url` in `attachment` type still work in graphql.
```
query {
  sample(puid: "SAMPLE_PUID") {
    attachments {
      nodes {
        attachmentUrl
      }
    }
  }
}
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
