### PR TITLE
GraphQL: Add timestamps

### DIFF
--- a/app/graphql/irida_schema.rb
+++ b/app/graphql/irida_schema.rb
@@ -10,6 +10,7 @@ class IridaSchema < GraphQL::Schema # rubocop:disable GraphQL/ObjectDescription
 
   max_depth 15
   max_complexity 550
+  default_page_size 25
   default_max_page_size 100
 
   # GraphQL-Ruby calls this when something goes wrong while running a query:

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -63,9 +63,9 @@ type Attachment implements Node {
   byteSize: Int!
 
   """
-  Attachment creation date
+  Datetime of creation.
   """
-  createdAt: String!
+  createdAt: ISO8601DateTime!
 
   """
   Attachment file name
@@ -91,6 +91,11 @@ type Attachment implements Node {
   Persistent Unique Identifier of the attachment. For example, `INXT_ATT_AAAAAAAAAAAA`.
   """
   puid: ID!
+
+  """
+  Datetime of last update.
+  """
+  updatedAt: ISO8601DateTime!
 }
 
 """
@@ -258,6 +263,11 @@ A group
 """
 type Group implements Node {
   """
+  Datetime of creation.
+  """
+  createdAt: ISO8601DateTime!
+
+  """
   List of descendant groups of this group.
   """
   descendantGroups(
@@ -357,6 +367,11 @@ type Group implements Node {
                                     `INXT_GRP_AAAAAAAAAA`.
   """
   puid: ID!
+
+  """
+  Datetime of last update.
+  """
+  updatedAt: ISO8601DateTime!
 }
 
 """
@@ -398,6 +413,11 @@ type GroupEdge {
   """
   node: Group
 }
+
+"""
+An ISO 8601-encoded datetime
+"""
+scalar ISO8601DateTime @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")
 
 """
 Represents untyped JSON
@@ -453,6 +473,11 @@ type Mutation {
 A namespace
 """
 type Namespace implements Node {
+  """
+  Datetime of creation.
+  """
+  createdAt: ISO8601DateTime!
+
   """
   Description of the namespace.
   """
@@ -518,6 +543,11 @@ type Namespace implements Node {
                                     `INXT_GRP_AAAAAAAAAA`.
   """
   puid: ID!
+
+  """
+  Datetime of last update.
+  """
+  updatedAt: ISO8601DateTime!
 }
 
 """
@@ -559,6 +589,11 @@ type PageInfo {
 A project
 """
 type Project implements Node {
+  """
+  Datetime of creation.
+  """
+  createdAt: ISO8601DateTime!
+
   """
   Description of the project.
   """
@@ -623,6 +658,11 @@ type Project implements Node {
     """
     last: Int
   ): SampleConnection
+
+  """
+  Datetime of last update.
+  """
+  updatedAt: ISO8601DateTime!
 }
 
 """
@@ -891,6 +931,16 @@ type Sample implements Node {
   ): AttachmentConnection
 
   """
+  Datetime when associated attachments were last updated.
+  """
+  attachmentsUpdatedAt: ISO8601DateTime
+
+  """
+  Datetime of creation.
+  """
+  createdAt: ISO8601DateTime!
+
+  """
   Description of the sample.
   """
   description: String
@@ -924,6 +974,11 @@ type Sample implements Node {
   Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAAAA`.
   """
   puid: ID!
+
+  """
+  Datetime of last update.
+  """
+  updatedAt: ISO8601DateTime!
 }
 
 """
@@ -1021,6 +1076,11 @@ A user
 """
 type User {
   """
+  Datetime of creation.
+  """
+  createdAt: ISO8601DateTime!
+
+  """
   User email.
   """
   email: String!
@@ -1029,4 +1089,9 @@ type User {
   ID of the user.
   """
   id: ID!
+
+  """
+  Datetime of last update.
+  """
+  updatedAt: ISO8601DateTime!
 }

--- a/app/graphql/types/attachment_type.rb
+++ b/app/graphql/types/attachment_type.rb
@@ -2,12 +2,11 @@
 
 module Types
   # Attachment Type
-  class AttachmentType < Types::BaseObject
+  class AttachmentType < Types::BaseType
     implements GraphQL::Types::Relay::Node
     description 'An attachment'
 
     field :byte_size, Integer, null: false, description: 'Attachment file size'
-    field :created_at, String, null: false, description: 'Attachment creation date'
     field :filename, String, null: false, description: 'Attachment file name'
     field :puid,
           ID,

--- a/app/graphql/types/base_type.rb
+++ b/app/graphql/types/base_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  # Base Type
+  class BaseType < Types::BaseObject
+    # ISO8601DateTime field
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'Datetime of creation.'
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'Datetime of last update.'
+  end
+end

--- a/app/graphql/types/namespace_type.rb
+++ b/app/graphql/types/namespace_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   # Namespace Type
-  class NamespaceType < Types::BaseObject
+  class NamespaceType < Types::BaseType
     implements GraphQL::Types::Relay::Node
     description 'A namespace'
 

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   # Project Type
-  class ProjectType < Types::BaseObject
+  class ProjectType < Types::BaseType
     implements GraphQL::Types::Relay::Node
     description 'A project'
 

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   # Sample Type
-  class SampleType < Types::BaseObject
+  class SampleType < Types::BaseType
     implements GraphQL::Types::Relay::Node
     description 'A sample'
 
@@ -24,6 +24,10 @@ module Types
           description: 'Attachments on the sample',
           complexity: 5,
           resolver: Resolvers::SampleAttachmentsResolver
+
+    field :attachments_updated_at, GraphQL::Types::ISO8601DateTime,
+          null: true,
+          description: 'Datetime when associated attachments were last updated.'
 
     def self.authorized?(object, context)
       super &&

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   # User Type
-  class UserType < Types::BaseObject
+  class UserType < Types::BaseType
     description 'A user'
 
     field :email, String, null: false, description: 'User email.'

--- a/test/graphql/attachments_query_test.rb
+++ b/test/graphql/attachments_query_test.rb
@@ -13,7 +13,9 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
               id,
               metadata,
               filename,
-              byteSize
+              byteSize,
+              createdAt,
+              updatedAt
             }
           }
         }
@@ -30,7 +32,9 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
             node {
               id,
               filename,
-              attachmentUrl
+              attachmentUrl,
+              createdAt,
+              updatedAt
             }
           }
         }

--- a/test/graphql/group_query_test.rb
+++ b/test/graphql/group_query_test.rb
@@ -12,6 +12,8 @@ class GroupQueryTest < ActiveSupport::TestCase
         id
         fullName
         fullPath
+        createdAt
+        updatedAt
         descendantGroups(includeParentDescendants: $includeParentDescendants) {
           nodes {
             name
@@ -32,6 +34,8 @@ class GroupQueryTest < ActiveSupport::TestCase
         id
         fullName
         fullPath
+        createdAt
+        updatedAt
         descendantGroups(includeParentDescendants: $includeParentDescendants) {
           nodes {
             name

--- a/test/graphql/groups_query_test.rb
+++ b/test/graphql/groups_query_test.rb
@@ -11,6 +11,8 @@ class GroupsQueryTest < ActiveSupport::TestCase
           path
           description
           id
+          createdAt
+          updatedAt
         }
         totalCount
       }

--- a/test/graphql/namespace_query_test.rb
+++ b/test/graphql/namespace_query_test.rb
@@ -12,6 +12,8 @@ class NamespaceQueryTest < ActiveSupport::TestCase
         id
         fullName
         fullPath
+        createdAt
+        updatedAt
       }
     }
   GRAPHQL

--- a/test/graphql/project_query_test.rb
+++ b/test/graphql/project_query_test.rb
@@ -12,6 +12,8 @@ class ProjectQueryTest < ActiveSupport::TestCase
         id
         fullName
         fullPath
+        createdAt
+        updatedAt
       }
     }
   GRAPHQL
@@ -25,6 +27,8 @@ class ProjectQueryTest < ActiveSupport::TestCase
         id
         fullName
         fullPath
+        createdAt
+        updatedAt
       }
     }
   GRAPHQL

--- a/test/graphql/sample_query_test.rb
+++ b/test/graphql/sample_query_test.rb
@@ -9,6 +9,9 @@ class SampleQueryTest < ActiveSupport::TestCase
         name
         description
         id
+        createdAt
+        updatedAt
+        attachmentsUpdatedAt
       }
     }
   GRAPHQL


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds `createdAt` and `updatedAt` to all types in GraphQL API by adding a new `BaseType` which adds these fields. In addition `attachmentsUpdateAt` has been added to Sample type.

This also updates the GraphQL api to have a default page size of 25.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Start server and navigate to GraphIQL interface (e.g. http://localhost:3000/graphiql)
2. In Docs view, verify that `Attachment`, `Group`, `Namespace`, `Project`, `User` types have `createdAt` and `updatedAt` fields
3. In Docs view, verify that `Sample` type has `createdAt`, `updatedAt` and `attachmentsUpdatedAt` fields
4. Execute queries and request the fields above and verify that no errors are raised.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
