### PR TITLE
Workflow Execution: Sample Name Cell Component

### DIFF
--- a/app/components/nextflow/samplesheet/column_component.rb
+++ b/app/components/nextflow/samplesheet/column_component.rb
@@ -3,7 +3,7 @@
 module Nextflow
   module Samplesheet
     # Renders a column in the sample sheet table
-    class ColumnComponent < Component
+    class ColumnComponent < Component # ,
       attr_reader :namespace_id, :header, :property, :samples
 
       # rubocop:disable Metrics/ParameterLists
@@ -18,10 +18,12 @@ module Nextflow
 
       # rubocop:enable Metrics/ParameterLists
 
-      def render_cell_type(property, entry, sample, fields, index)
+      def render_cell_type(property, entry, sample, fields, index) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
         case entry['cell_type']
         when 'sample_cell'
           render_sample_cell(sample, fields)
+        when 'sample_name_cell'
+          render_sample_name_cell(sample, fields)
         when 'fastq_cell'
           render_fastq_cell(sample, property, entry, fields, index)
         when 'file_cell'
@@ -69,6 +71,10 @@ module Nextflow
 
       def render_sample_cell(sample, fields)
         render(Samplesheet::SampleCellComponent.new(sample:, fields:))
+      end
+
+      def render_sample_name_cell(sample, fields)
+        render(Samplesheet::SampleNameCellComponent.new(sample:, fields:))
       end
 
       def render_metadata_cell(sample, name, fields)

--- a/app/components/nextflow/samplesheet/column_component.rb
+++ b/app/components/nextflow/samplesheet/column_component.rb
@@ -3,7 +3,7 @@
 module Nextflow
   module Samplesheet
     # Renders a column in the sample sheet table
-    class ColumnComponent < Component # ,
+    class ColumnComponent < Component
       attr_reader :namespace_id, :header, :property, :samples
 
       # rubocop:disable Metrics/ParameterLists

--- a/app/components/nextflow/samplesheet/sample_name_cell_component.html.erb
+++ b/app/components/nextflow/samplesheet/sample_name_cell_component.html.erb
@@ -1,0 +1,4 @@
+<div class="p-2.5 sticky left-0">
+  <%= sample.name %>
+  <%= fields.hidden_field :sample_name, value: sample.name %>
+</div>

--- a/app/components/nextflow/samplesheet/sample_name_cell_component.rb
+++ b/app/components/nextflow/samplesheet/sample_name_cell_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Nextflow
+  module Samplesheet
+    # Component to render a cell with the sample name into the sample sheet
+    class SampleNameCellComponent < Component
+      attr_reader :sample, :fields
+
+      def initialize(sample:, fields:)
+        @sample = sample
+        @fields = fields
+      end
+    end
+  end
+end

--- a/app/components/nextflow/samplesheet_component.rb
+++ b/app/components/nextflow/samplesheet_component.rb
@@ -30,6 +30,8 @@ module Nextflow
     def identify_cell_type(property, entry)
       return 'sample_cell' if property == 'sample'
 
+      return 'sample_name_cell' if property == 'sample_name'
+
       return 'fastq_cell' if property.match(/fastq_\d+/)
 
       return 'file_cell' if check_for_file(entry)

--- a/test/components/nextflow_samplesheet_component_test.rb
+++ b/test/components/nextflow_samplesheet_component_test.rb
@@ -9,7 +9,7 @@ class NextflowSamplesheetComponentTest < ApplicationSystemTestCase
     visit("/rails/view_components/nextflow_samplesheet_component/default?sample_ids[]=#{sample1.id}&sample_ids[]=#{sample2.id}") # rubocop:disable Layout/LineLength
 
     assert_selector '.samplesheet-table' do |table|
-      table.assert_selector '.table-header', count: 4
+      table.assert_selector '.table-header', count: 5
       table.assert_selector '.table-column:last-of-type .table-header', text: 'STRANDEDNESS (REQUIRED)'
       table.assert_selector '.table-column:first-of-type .table-td', count: 2
       table.assert_selector '.table-column:first-of-type .table-td:first-of-type', text: sample1.puid

--- a/test/components/nextflow_samplesheet_component_test.rb
+++ b/test/components/nextflow_samplesheet_component_test.rb
@@ -13,6 +13,7 @@ class NextflowSamplesheetComponentTest < ApplicationSystemTestCase
       table.assert_selector '.table-column:last-of-type .table-header', text: 'STRANDEDNESS (REQUIRED)'
       table.assert_selector '.table-column:first-of-type .table-td', count: 2
       table.assert_selector '.table-column:first-of-type .table-td:first-of-type', text: sample1.puid
+      table.assert_selector '.table-column:nth-of-type(2) .table-td:first-of-type', text: sample1.name
       table.assert_selector '.table-column:last-of-type .table-td:first-of-type select option', count: 4
       table.assert_selector '.table-column:last-of-type .table-td:first-of-type select option:nth-of-type(2)',
                             text: 'forward'

--- a/test/fixtures/files/nextflow/samplesheet_schema.json
+++ b/test/fixtures/files/nextflow/samplesheet_schema.json
@@ -12,9 +12,8 @@
       },
       "sample_name": {
         "type": "string",
-        "pattern": "^\\S+$",
         "meta": ["name"],
-        "errorMessage": "Sample name must be provided and cannot contain spaces"
+        "errorMessage": "Sample name must be provided"
       },
       "fastq_1": {
         "type": "string",

--- a/test/fixtures/files/nextflow/samplesheet_schema.json
+++ b/test/fixtures/files/nextflow/samplesheet_schema.json
@@ -10,6 +10,12 @@
         "pattern": "^\\S+$",
         "errorMessage": "Sample name must be provided and cannot contain spaces"
       },
+      "sample_name": {
+        "type": "string",
+        "pattern": "^\\S+$",
+        "meta": ["name"],
+        "errorMessage": "Sample name must be provided and cannot contain spaces"
+      },
       "fastq_1": {
         "type": "string",
         "pattern": "^\\S+\\.f(ast)?q\\.gz$",

--- a/test/fixtures/files/nextflow/schema_input.json
+++ b/test/fixtures/files/nextflow/schema_input.json
@@ -12,6 +12,12 @@
         "pattern": "^\\S+$",
         "meta": ["id"],
         "unique": true,
+        "errorMessage": "Sample id must be provided and cannot contain spaces"
+      },
+      "sample_name": {
+        "type": "string",
+        "pattern": "^\\S+$",
+        "meta": ["name"],
         "errorMessage": "Sample name must be provided and cannot contain spaces"
       },
       "fastq_1": {

--- a/test/fixtures/files/nextflow/schema_input.json
+++ b/test/fixtures/files/nextflow/schema_input.json
@@ -16,9 +16,8 @@
       },
       "sample_name": {
         "type": "string",
-        "pattern": "^\\S+$",
         "meta": ["name"],
-        "errorMessage": "Sample name must be provided and cannot contain spaces"
+        "errorMessage": "Sample name must be provided"
       },
       "fastq_1": {
         "type": "string",


### PR DESCRIPTION
## What does this PR do and why?
Updated the `SamplesheetComponent` to include sample names. 
See http://localhost:3000/rails/lookbook/inspect/nextflow_samplesheet/default.
Fixes #670.

## Screenshots or screen recordings
![Screenshot from 2024-07-30 13-47-40](https://github.com/user-attachments/assets/2f9f65f2-df07-4004-815e-c6f7e42dc961)

## How to set up and validate locally
1. Add `add-sample-name` to versions within the `pipelines.json` file. (Reference https://github.com/phac-nml/iridanextexample/tree/add-sample-name)
1. Run sapporo-service.
1. Run irida-next.
1. Execute the newly added pipeline `add-sample-name`.
1. Verify the sample name is displayed within the sample sheet. 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
