### PR TITLE
Enhancement: Enforce sample sheet required fields

### DIFF
--- a/app/components/nextflow/samplesheet/column_component.rb
+++ b/app/components/nextflow/samplesheet/column_component.rb
@@ -72,7 +72,7 @@ module Nextflow
       end
 
       def render_metadata_cell(sample, name, fields)
-        render(Samplesheet::MetadataCellComponent.new(sample:, name:, form: fields))
+        render(Samplesheet::MetadataCellComponent.new(sample:, name:, form: fields, required: @required))
       end
 
       # rubocop:disable Metrics/ParameterLists
@@ -108,7 +108,8 @@ module Nextflow
       def render_input_cell(property, fields)
         render(Samplesheet::TextCellComponent.new(
                  property,
-                 fields:
+                 fields:,
+                 required: @required
                ))
       end
 

--- a/app/components/nextflow/samplesheet/metadata_cell_component.html.erb
+++ b/app/components/nextflow/samplesheet/metadata_cell_component.html.erb
@@ -1,4 +1,9 @@
-<div class="p-2.5 text-nowrap">
-  <%= form.hidden_field name, value: metadata %>
-  <span class="h-3.5 inline-block"><%= metadata %></span>
-</div>
+<% if metadata.present? %>
+  <div class="p-2.5 text-nowrap">
+    <%= form.hidden_field name, value: metadata %>
+    <span class="h-3.5 inline-block"><%= metadata %></span>
+  </div>
+<% else %>
+  <%= form.label name, class: "sr-only" %>
+  <%= render Nextflow::Samplesheet::TextCellComponent.new(name, fields: form, required:) %>
+<% end %>

--- a/app/components/nextflow/samplesheet/metadata_cell_component.rb
+++ b/app/components/nextflow/samplesheet/metadata_cell_component.rb
@@ -4,12 +4,13 @@ module Nextflow
   module Samplesheet
     # Component to render a cell with sample metadata into the sample sheet
     class MetadataCellComponent < ViewComponent::Base
-      attr_reader :form, :metadata, :name, :sample
+      attr_reader :form, :metadata, :name, :sample, :required
 
-      def initialize(form:, name:, sample:, field: nil)
+      def initialize(form:, name:, sample:, field: nil, required: false)
         @form = form
         @name = name
         @sample = sample
+        @required = required
         @metadata = metadata_value(field || name)
       end
 

--- a/app/components/nextflow/samplesheet/text_cell_component.html.erb
+++ b/app/components/nextflow/samplesheet/text_cell_component.html.erb
@@ -1,6 +1,6 @@
 <%= fields.text_field(
   name,
   class:
-    "bg-slate-50 border border-slate-100 text-slate-900 text-sm focus:ring-primary-500  block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",
+    "bg-slate-50 border-0 text-slate-900 text-sm focus:ring-primary-500  block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",
   :required => @required
     ) %>

--- a/app/components/nextflow/samplesheet/text_cell_component.html.erb
+++ b/app/components/nextflow/samplesheet/text_cell_component.html.erb
@@ -1,5 +1,6 @@
 <%= fields.text_field(
   name,
   class:
-    "bg-slate-50 border border-slate-100 text-slate-900 text-sm focus:ring-primary-500  block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500"
-) %>
+    "bg-slate-50 border border-slate-100 text-slate-900 text-sm focus:ring-primary-500  block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",
+  :required => @required
+    ) %>

--- a/app/components/nextflow/samplesheet/text_cell_component.rb
+++ b/app/components/nextflow/samplesheet/text_cell_component.rb
@@ -4,11 +4,12 @@ module Nextflow
   module Samplesheet
     # Render a single cell of a Nextflow samplesheet for a property that requires a text input
     class TextCellComponent < ViewComponent::Base
-      attr_reader :name, :fields
+      attr_reader :name, :fields, :required
 
-      def initialize(name, fields:)
+      def initialize(name, fields:, required: false)
         @name = name
         @fields = fields
+        @required = required
       end
     end
   end

--- a/test/components/nextflow_samplesheet_component_test.rb
+++ b/test/components/nextflow_samplesheet_component_test.rb
@@ -39,14 +39,15 @@ class NextflowSamplesheetComponentTest < ApplicationSystemTestCase
     visit("/rails/view_components/nextflow_samplesheet_component/default?schema_file=samplesheet_schema_meta.json&sample_ids[]=#{sample1.id}&sample_ids[]=#{sample2.id}") # rubocop:disable Layout/LineLength
 
     assert_selector '.samplesheet-table' do |table|
-      table.assert_selector '.table-header', count: 3
-      table.assert_selector '.table-column:last-of-type .table-header select', count: 1
-      table.assert_selector '.table-column:last-of-type .table-header select', text: 'insdc_accession'
+      table.assert_selector '.table-header', count: 4
+      table.assert_selector '.table-column:nth-of-type(2) .table-header select', count: 1
+      table.assert_selector '.table-column:nth-of-type(2) .table-header select', text: 'insdc_accession'
       table.assert_selector '.table-column:first-of-type .table-td', count: 2
       table.assert_selector '.table-column:first-of-type .table-td:first-of-type', text: sample1.puid
       table.assert_selector '.table-column:last-of-type .table-td:first-of-type', text: 'ERR86724108'
       table.assert_selector '.table-column:first-of-type .table-td:nth-child(2)', text: sample2.puid
       table.assert_selector '.table-column:last-of-type .table-td:last-of-type', text: 'ERR31551163'
+      table.assert_selector '.table-column:nth-of-type(2) .table-td:first-of-type input[required="required"]'
     end
   end
 end

--- a/test/fixtures/files/nextflow/samplesheet_schema_meta.json
+++ b/test/fixtures/files/nextflow/samplesheet_schema_meta.json
@@ -16,6 +16,12 @@
         "unique": true,
         "errorMessage": "Sample name must be provided and cannot contain spaces"
       },
+      "pfge_pattern": {
+        "type": "string",
+        "pattern": "^\\S+$",
+        "errorMessage": "Metadata thing must be provided and cannot contain spaces",
+        "meta": true
+      },
       "country": {
         "type": "string",
         "meta": [
@@ -33,7 +39,8 @@
     },
     "required": [
       "sample",
-      "insdc_accession"
+      "insdc_accession",
+      "pfge_pattern"
     ]
   }
 }


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

If a field does not have a pre-defined value, display a text field (set required if needed) to allow the user to enter a value.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/679efec8-55f8-4a17-af45-589f83e19d66)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

I set it up so it can be easily seen in the LookBook:

1. Go to: http://localhost:3000/rails/lookbook/inspect/nextflow_samplesheet/default?schema_file=samplesheet_schema_meta.json
2. The `PFGE_PATTERN` column has no pre-defined data and is required. 
3. Ensure that the text field is displayed and when inspecting the field, the `required` attribute should be set.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
