### PR TITLE
Samples table enhancements followup

### DIFF
--- a/app/components/viral/dialog_component.html.erb
+++ b/app/components/viral/dialog_component.html.erb
@@ -1,6 +1,7 @@
 <%= render Viral::BaseComponent.new(tag: :span, data: {
   controller: "viral--dialog",
   "viral--dialog-open-value": open,
+  "turbo-permanent": true
 }) do %>
 
   <% if trigger.present? %>

--- a/app/components/viral/flash_component.html.erb
+++ b/app/components/viral/flash_component.html.erb
@@ -7,7 +7,7 @@
     shadow dark:text-slate-400 dark:bg-slate-800
   "
   role="alert"
-  data-turbo-permanent
+  data-turbo-permanent="true"
 >
   <% case type.to_s %>
   <% when "success" %>

--- a/app/components/viral/flash_component.html.erb
+++ b/app/components/viral/flash_component.html.erb
@@ -2,33 +2,68 @@
   data-controller="viral--flash"
   data-viral--flash-timeout-value="<%= timeout %>"
   data-viral--flash-type-value="<%= type %>"
-  class="flex items-center w-full max-w-xs p-4 mb-4 text-slate-500 bg-white rounded-lg shadow dark:text-slate-400 dark:bg-slate-800"
+  class="
+    flex items-center w-full max-w-xs p-4 mb-4 text-slate-500 bg-white rounded-lg
+    shadow dark:text-slate-400 dark:bg-slate-800
+  "
   role="alert"
+  data-turbo-permanent
 >
   <% case type.to_s %>
   <% when "success" %>
-    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-green-500 bg-green-100 rounded-lg dark:bg-green-800 dark:text-green-200">
+    <div
+      class="
+        inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-green-500
+        bg-green-100 rounded-lg dark:bg-green-800 dark:text-green-200
+      "
+    >
       <%= viral_icon(name: "check_circle_solid", classes: "w-5 h-5") %>
       <span class="sr-only"><%= t("components.flash.success_icon") %></span>
     </div>
   <% when "error" %>
-    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-red-500 bg-red-100 rounded-lg dark:bg-red-800 dark:text-red-200">
+    <div
+      class="
+        inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-red-500
+        bg-red-100 rounded-lg dark:bg-red-800 dark:text-red-200
+      "
+    >
       <%= viral_icon(name: "x_circle_solid", classes: "w-5 h-5") %>
       <span class="sr-only"><%= t("components.flash.error_icon") %></span>
     </div>
   <% when "warning" %>
-    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-orange-500 bg-orange-100 rounded-lg dark:bg-orange-700 dark:text-orange-200">
+    <div
+      class="
+        inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-orange-500
+        bg-orange-100 rounded-lg dark:bg-orange-700 dark:text-orange-200
+      "
+    >
       <%= viral_icon(name: "exclamation_circle_solid", classes: "w-5 h-5") %>
       <span class="sr-only"><%= t("components.flash.warning_icon") %></span>
     </div>
   <% when "info" %>
-    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-blue-500 bg-blue-100 rounded-lg dark:bg-blue-800 dark:text-blue-200">
+    <div
+      class="
+        inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-blue-500
+        bg-blue-100 rounded-lg dark:bg-blue-800 dark:text-blue-200
+      "
+    >
       <%= viral_icon(name: "information_circle_solid", classes: "w-5 h-5") %>
       <span class="sr-only"><%= t("components.flash.information_icon") %></span>
     </div>
   <% end %>
   <div class="ml-3 text-sm font-normal"><%= data %></div>
-  <button type="button" data-action="viral--flash#dismiss" class="ml-auto -mx-1.5 -my-1.5 bg-white text-slate-400 hover:text-slate-900 rounded-lg focus:ring-2 focus:ring-slate-300 p-1.5 hover:bg-slate-100 inline-flex items-center justify-center h-8 w-8 dark:text-slate-500 dark:hover:text-white dark:bg-slate-800 dark:hover:bg-slate-700" data-dismiss-target="#toast-success" aria-label="Close">
+  <button
+    type="button"
+    data-action="viral--flash#dismiss"
+    class="
+      ml-auto -mx-1.5 -my-1.5 bg-white text-slate-400 hover:text-slate-900 rounded-lg
+      focus:ring-2 focus:ring-slate-300 p-1.5 hover:bg-slate-100 inline-flex
+      items-center justify-center h-8 w-8 dark:text-slate-500 dark:hover:text-white
+      dark:bg-slate-800 dark:hover:bg-slate-700
+    "
+    data-dismiss-target="#toast-success"
+    aria-label="Close"
+  >
     <%= viral_icon(name: "x_mark", classes: "w-5 h-5") %>
     <span class="sr-only"><%= t(:"general.screen_reader.close") %></span>
   </button>

--- a/app/javascript/controllers/form/hidden_inputs_controller.js
+++ b/app/javascript/controllers/form/hidden_inputs_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus";
+import { createHiddenInput } from "utilities/form";
+
+export default class extends Controller {
+    static outlets = ["selection"];
+    static values = {
+        fieldName: String,
+    };
+
+    connect() {
+        this.allIds = this.selectionOutlet.getStoredItems();
+        this.#appendHiddenInputs();
+    }
+
+    clearSelection() {
+        this.selectionOutlet.clear();
+    }
+
+    #appendHiddenInputs() {
+        const fragment = document.createDocumentFragment();
+        for (const id of this.allIds) {
+            fragment.appendChild(createHiddenInput(this.fieldNameValue, id));
+        }
+        this.element.appendChild(fragment);
+    }
+}

--- a/app/javascript/controllers/form/hidden_inputs_controller.js
+++ b/app/javascript/controllers/form/hidden_inputs_controller.js
@@ -8,7 +8,6 @@ export default class extends Controller {
     };
 
     connect() {
-        this.allIds = this.selectionOutlet.getStoredItems();
         this.#appendHiddenInputs();
     }
 
@@ -18,7 +17,7 @@ export default class extends Controller {
 
     #appendHiddenInputs() {
         const fragment = document.createDocumentFragment();
-        for (const id of this.allIds) {
+        for (const id of this.selectionOutlet.getStoredItems()) {
             fragment.appendChild(createHiddenInput(this.fieldNameValue, id));
         }
         this.element.appendChild(fragment);

--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -11,7 +11,6 @@ export default class extends Controller {
     "summary",
   ];
   static values = {
-    fieldName: String,
     pagedFieldName: String,
     singular: String,
     plural: String,
@@ -20,9 +19,8 @@ export default class extends Controller {
   #page = 1;
 
   connect() {
-    this.allIds = this.selectionOutlet.getStoredSamples();
+    this.allIds = this.selectionOutlet.getStoredItems();
     this.#makePagedHiddenInputs();
-    this.#makeAllHiddenInputs();
     this.#replaceCountPlaceholder();
   }
 
@@ -61,23 +59,10 @@ export default class extends Controller {
         fragment.appendChild(createHiddenInput(this.pagedFieldNameValue, id));
       }
       fragment.appendChild(createHiddenInput("page", this.#page));
-      fragment.appendChild(createHiddenInput("format", "turbo_stream"));
       this.pageFormContentTarget.innerHTML = "";
       this.pageFormContentTarget.appendChild(fragment);
       this.#page++;
       this.pageFormTarget.requestSubmit();
     }
-  }
-
-  #makeAllHiddenInputs() {
-    const fragment = document.createDocumentFragment();
-    for (const id of this.allIds) {
-      fragment.appendChild(createHiddenInput(this.fieldNameValue, id));
-    }
-    this.allTarget.appendChild(fragment);
-  }
-
-  clear() {
-    this.selectionOutlet.clear();
   }
 }

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
 
     this.element.setAttribute("data-controller-connected", "true");
 
-    const storageValue = this.getStoredSamples();
+    const storageValue = this.getStoredItems();
 
     if (storageValue) {
       this.#updateUI(storageValue);
@@ -49,6 +49,7 @@ export default class extends Controller {
 
   clear() {
     sessionStorage.removeItem(this.#storageKey);
+    this.#updateUI([]);
   }
 
   save(storageValue) {
@@ -65,12 +66,12 @@ export default class extends Controller {
     return this.#numSelected;
   }
 
-  getStoredSamples() {
+  getStoredItems() {
     return JSON.parse(sessionStorage.getItem(this.#storageKey)) || [];
   }
 
   #addOrRemove(add, storageValue) {
-    const newStorageValue = this.getStoredSamples();
+    const newStorageValue = this.getStoredItems();
 
     if (add) {
       newStorageValue.push(storageValue);
@@ -82,9 +83,7 @@ export default class extends Controller {
     }
 
     this.save(newStorageValue);
-    this.#updateActionLinks(newStorageValue.length);
-    this.#setSelectAllCheckboxValue(newStorageValue.length);
-    this.#updateCounts(newStorageValue.length);
+    this.#updateUI(newStorageValue);
   }
 
   #updateUI(ids) {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,8 @@
 class Project < ApplicationRecord
   acts_as_paranoid
 
+  broadcasts_refreshes
+
   before_restore :restore_namespace
   after_destroy :destroy_namespace
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -3,15 +3,15 @@
 # entity class for Sample
 class Sample < ApplicationRecord
   include MetadataSortable
-
+  include HasPuid
   include History
 
   has_logidze
   acts_as_paranoid
 
-  include HasPuid
-
   belongs_to :project
+
+  broadcasts_refreshes_to :project
 
   has_many :attachments, as: :attachable, dependent: :destroy
 

--- a/app/services/samples/transfer_service.rb
+++ b/app/services/samples/transfer_service.rb
@@ -33,8 +33,7 @@ module Samples
 
       return unless @project.id == new_project_id
 
-      raise TransferError,
-            I18n.t('services.samples.transfer.same_project')
+      raise TransferError, I18n.t('services.samples.transfer.same_project')
     end
 
     def validate_maintainer_sample_transfer

--- a/app/views/data_exports/_new_linelist_export_dialog.html.erb
+++ b/app/views/data_exports/_new_linelist_export_dialog.html.erb
@@ -4,10 +4,9 @@
     <%= turbo_frame_tag "sample_export_dialog_content" do %>
       <div
         data-controller="infinite-scroll data-exports--metadata-selection"
-        data-data-exports--metadata-selection-selected-list-value=<%= t(".selected") %>
-        data-data-exports--metadata-selection-available-list-value=<%= t(".available") %>
+        data-data-exports--metadata-selection-selected-list-value="<%= t(".selected") %>"
+        data-data-exports--metadata-selection-available-list-value="<%= t(".available") %>"
         data-infinite-scroll-selection-outlet='#samples-table'
-        data-infinite-scroll-field-name-value="data_export[export_parameters][ids][]"
         data-infinite-scroll-paged-field-name-value="sample_ids[]"
         data-infinite-scroll-singular-value="<%= t(".description.singular") %>"
         data-infinite-scroll-plural-value="<%= t(".description.plural") %>"
@@ -34,22 +33,9 @@
               <button
                 type="button"
                 class="
-                  flex
-                  items-center
-                  justify-between
-                  w-full
-                  p-3
-                  font-medium
-                  rtl:text-right
-                  text-black
-                  dark:text-white
-                  border
-                  border-slate-200
-                  dark:border-slate-700
-                  hover:bg-slate-100
-                  dark:hover:bg-slate-800
-                  gap-3
-                  rounded-t
+                  flex items-center justify-between w-full p-3 font-medium rtl:text-right
+                  text-black dark:text-white border border-slate-200 dark:border-slate-700
+                  hover:bg-slate-100 dark:hover:bg-slate-800 gap-3 rounded-t
                 "
                 data-action="collapsible#toggle"
                 aria-expanded="true"
@@ -59,7 +45,7 @@
                 <%= viral_icon(
                   name: "chevron_down",
                   classes: "mr-0 w-4 h-4 rotate-0",
-                  "data-collapsible-target": "icon"
+                  "data-collapsible-target": "icon",
                 ) %>
               </button>
             </h2>
@@ -71,12 +57,12 @@
               aria-labelledby="<%= "accordion-collapse-heading-samples" %>"
             >
               <div
-              class="
-                overflow-y-auto max-h-[200px] border border-t-0 border-slate-300 rounded-b block w-full
-                p-2.5 dark:bg-slate-800 dark:border-slate-600
-              "
-              data-action="scroll->infinite-scroll#scroll"
-              data-infinite-scroll-target="scrollable"
+                class="
+                  overflow-y-auto max-h-[200px] border border-t-0 border-slate-300 rounded-b block
+                  w-full p-2.5 dark:bg-slate-800 dark:border-slate-600
+                "
+                data-action="scroll->infinite-scroll#scroll"
+                data-infinite-scroll-target="scrollable"
               >
                 <%= turbo_frame_tag "list_select_samples" do %>
                   <%= render partial: "shared/loading/samples_list_skeleton" %>
@@ -93,50 +79,92 @@
             <%= sortable_lists.with_list(
               id: t(".available"),
               title: t(".available"),
-              list_items: @namespace.metadata_fields.sort_by{|metadata_field| metadata_field.downcase},
-              group: 'metadata_selection',
-              container_classes: 'block mb-1 pr-2 text-sm font-medium',
-              list_classes: 'overflow-y-auto max-w-[356px] min-w-[356px] w-full'
-              ) %>
+              list_items:
+                @namespace.metadata_fields.sort_by do |metadata_field|
+                  metadata_field.downcase
+                end,
+              group: "metadata_selection",
+              container_classes: "block mb-1 pr-2 text-sm font-medium",
+              list_classes: "overflow-y-auto max-w-[356px] min-w-[356px] w-full",
+            ) %>
             <%= sortable_lists.with_list(
               id: t(".selected"),
               title: t(".selected"),
-              group: 'metadata_selection',
-              container_classes: 'block mb-1 text-sm font-medium',
-              list_classes: 'overflow-y-auto max-w-[356px] min-w-[356px] w-full'
-              ) %>
+              group: "metadata_selection",
+              container_classes: "block mb-1 text-sm font-medium",
+              list_classes: "overflow-y-auto max-w-[356px] min-w-[356px] w-full",
+            ) %>
           <% end %>
           <div class="flex -mt-3 font-medium text-slate-900 dark:text-white">
             <button
               class="mr-2 underline text-sm hover:no-underline"
               data-action="click->data-exports--metadata-selection#addAll"
               data-data-exports--metadata-selection-target="addAll"
-              >
+            >
               <%= t(".add_all") %>
             </button>
             <button
               aria-disabled="true"
-              class="ml-2 text-sm text-slate-300 dark:text-slate-700 pointer-events-none cursor-not-allowed"
+              class="
+                ml-2 text-sm text-slate-300 dark:text-slate-700 pointer-events-none
+                cursor-not-allowed
+              "
               data-action="click->data-exports--metadata-selection#removeAll"
               data-data-exports--metadata-selection-target="removeAll"
-              >
+            >
               <%= t(".remove_all") %>
             </button>
           </div>
-          <%= form_for(:data_export, url: data_exports_path, method: :post) do |form| %>
+          <%= form_for(:data_export, url: data_exports_path, method: :post,
+              data: {
+                controller: "spinner form--hidden-inputs",
+                "form--hidden-inputs-selection-outlet": '#samples-table',
+                "form--hidden-inputs-field-name-value": "data_export[export_parameters][ids][]",
+                action: "turbo:submit-start->spinner#submitStart turbo:submit-end->spinner#submitEnd"
+              }
+            ) do |form| %>
             <div class="grid gap-4">
               <div class="form-field mt-1">
                 <%= form.label :name, t(".format") %>
                 <div class="flex">
                   <div class="flex items-center">
-                    <input id="csv-format" type="radio" value="csv" name="data_export[export_parameters][linelist_format]"
-                          checked="true" class="w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600">
-                    <label for="csv-format" class="ml-1 mr-2 text-sm font-medium text-slate-900 dark:text-slate-300"><%= t(".csv") %></label>
+                    <input
+                      id="csv-format"
+                      type="radio"
+                      value="csv"
+                      name="data_export[export_parameters][linelist_format]"
+                      checked="true"
+                      class="
+                        w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 focus:ring-primary-500
+                        dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2
+                        dark:bg-slate-700 dark:border-slate-600
+                      "
+                    >
+                    <label
+                      for="csv-format"
+                      class="
+                        ml-1 mr-2 text-sm font-medium text-slate-900 dark:text-slate-300
+                      "
+                    ><%= t(".csv") %></label>
                   </div>
                   <div class="flex items-center">
-                    <input id="xlsx-format" type="radio" value="xlsx" name="data_export[export_parameters][linelist_format]"
-                          class="w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600">
-                    <label for="xlsx-format" class="ml-1 text-sm font-medium text-slate-900 dark:text-slate-300"><%= t(".xlsx") %></label>
+                    <input
+                      id="xlsx-format"
+                      type="radio"
+                      value="xlsx"
+                      name="data_export[export_parameters][linelist_format]"
+                      class="
+                        w-4 h-4 text-primary-600 bg-slate-100 border-slate-300 focus:ring-primary-500
+                        dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2
+                        dark:bg-slate-700 dark:border-slate-600
+                      "
+                    >
+                    <label
+                      for="xlsx-format"
+                      class="
+                        ml-1 text-sm font-medium text-slate-900 dark:text-slate-300
+                      "
+                    ><%= t(".xlsx") %></label>
                   </div>
                 </div>
               </div>
@@ -150,9 +178,9 @@
                                  checked: false,
                                  class:
                                    "w-4 h-4 mr-2.5 text-primary-600 bg-slate-100 border-slate-300 rounded
-                                    focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800
-                                    focus:ring-2 dark:bg-slate-700 dark:border-slate-600
-                                    ",
+                                                                                                    focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800
+                                                                                                    focus:ring-2 dark:bg-slate-700 dark:border-slate-600
+                                                                                                    ",
                                },
                                true,
                                false %>
@@ -162,16 +190,18 @@
               </div>
               <div>
                 <%= form.hidden_field :export_type, value: "linelist" %>
-                <input type="hidden" aria-hidden="true" name="data_export[export_parameters][namespace_id]", value=<%= namespace_id %>>
+                <input type="hidden" aria-hidden="true"
+                name="data_export[export_parameters][namespace_id]", value=<%= namespace_id %>>
               </div>
-              <div class="hidden" data-infinite-scroll-target="all"></div>
               <div class="hidden" data-data-exports--metadata-selection-target="field"></div>
               <div>
                 <%= form.submit t(".submit_button"),
                             data: {
                               turbo_frame: "_top",
-                              action: %(click->infinite-scroll#clear click->data-exports--metadata-selection#constructMetadataParams),
-                              "data-exports--metadata-selection-target": "submitBtn"
+                              action:
+                                "click->form--hidden-inputs#clearSelection click->data-exports--metadata-selection#constructMetadataParams",
+                              "data-exports--metadata-selection-target": "submitBtn",
+                              "spinner-target": "submit",
                             },
                             class: "button button--state-primary button--size-default",
                             disabled: true %>

--- a/app/views/data_exports/_new_sample_export_dialog.html.erb
+++ b/app/views/data_exports/_new_sample_export_dialog.html.erb
@@ -5,7 +5,6 @@
       <div
         data-controller="infinite-scroll"
         data-infinite-scroll-selection-outlet='#samples-table'
-        data-infinite-scroll-field-name-value="data_export[export_parameters][ids][]"
         data-infinite-scroll-paged-field-name-value="sample_ids[]"
         data-infinite-scroll-singular-value="<%= t(".description.singular") %>"
         data-infinite-scroll-plural-value="<%= t(".description.plural") %>"
@@ -46,7 +45,14 @@
             </div>
           </div>
 
-          <%= form_for(:data_export, url: data_exports_path, method: :post) do |form| %>
+          <%= form_for(:data_export, url: data_exports_path, method: :post,
+              data: {
+                controller: "spinner form--hidden-inputs",
+                "form--hidden-inputs-selection-outlet": '#samples-table',
+                "form--hidden-inputs-field-name-value": "data_export[export_parameters][ids][]",
+                action: "turbo:submit-start->spinner#submitStart turbo:submit-end->spinner#submitEnd"
+              }
+            ) do |form| %>
             <div class="grid gap-4">
               <div class="form-field mt-2">
                 <%= form.label :name, t(".name_label") %>
@@ -58,9 +64,9 @@
                                  checked: false,
                                  class:
                                    "w-4 h-4 mr-2.5 text-primary-600 bg-slate-100 border-slate-300 rounded
-                                    focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800
-                                    focus:ring-2 dark:bg-slate-700 dark:border-slate-600
-                                    ",
+                                                                                    focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800
+                                                                                    focus:ring-2 dark:bg-slate-700 dark:border-slate-600
+                                                                                    ",
                                },
                                true,
                                false %>
@@ -70,14 +76,14 @@
               </div>
               <div>
                 <%= form.hidden_field :export_type, value: "sample" %>
-                <input type="hidden" aria-hidden="true" name="data_export[export_parameters][namespace_id]", value=<%= namespace_id %>>
+                <input type="hidden" aria-hidden="true"
+                name="data_export[export_parameters][namespace_id]", value=<%= namespace_id %>>
               </div>
-              <div class="hidden" data-infinite-scroll-target="all"></div>
               <div>
                 <%= form.submit t(".submit_button"),
                             data: {
                               turbo_frame: "_top",
-                              action: "click->infinite-scroll#clear",
+                              action: "click->form--hidden-inputs#clearSelection",
                             },
                             class: "button button--state-primary button--size-default" %>
               </div>

--- a/app/views/projects/samples/clones/_dialog.html.erb
+++ b/app/views/projects/samples/clones/_dialog.html.erb
@@ -5,7 +5,6 @@
       <div
         data-controller="infinite-scroll"
         data-infinite-scroll-selection-outlet='#samples-table'
-        data-infinite-scroll-field-name-value="clone[sample_ids][]"
         data-infinite-scroll-paged-field-name-value="sample_ids[]"
         data-infinite-scroll-singular-value="<%= t(".description.singular") %>"
         data-infinite-scroll-plural-value="<%= t(".description.plural") %>"
@@ -46,7 +45,9 @@
 
           <%= form_for(:clone, url: namespace_project_samples_clone_path, method: :post,
           data: {
-            controller: "spinner",
+            controller: "spinner form--hidden-inputs",
+            "form--hidden-inputs-selection-outlet": '#samples-table',
+            "form--hidden-inputs-field-name-value": "clone[sample_ids][]",
             action:"turbo:submit-start->spinner#submitStart turbo:submit-end->spinner#submitEnd"
           }
         ) do |form| %>
@@ -55,13 +56,12 @@
                 <%= form.label :new_project_id, t(".new_project_id") %>
                 <%= form.collection_select(:new_project_id, @projects, :id, :full_path) %>
               </div>
-              <div class="hidden" data-infinite-scroll-target="all"></div>
               <div>
                 <%= form.submit t(".submit_button"),
                             class: "button button--size-default button--state-primary",
                             disabled: @projects.count.zero?,
                             data: {
-                              action: "click->infinite-scroll#clear",
+                              action: "click->form--hidden-inputs#clearSelection",
                               "spinner-target": "submit",
                             } %>
               </div>

--- a/app/views/projects/samples/clones/create.turbo_stream.erb
+++ b/app/views/projects/samples/clones/create.turbo_stream.erb
@@ -12,3 +12,5 @@
                          errors: errors,
                        } %>
 <% end %>
+
+<turbo-stream action="refresh"></turbo-stream>

--- a/app/views/projects/samples/deletions/_new_deletion_dialog.html.erb
+++ b/app/views/projects/samples/deletions/_new_deletion_dialog.html.erb
@@ -7,33 +7,42 @@
     <div
       data-controller="selection"
       data-selection-delete-id-param="<%= @sample.id %>"
-      class="mb-4 font-normal text-slate-500 dark:text-slate-400 overflow-x-visible">
+      class="
+        mb-4 font-normal text-slate-500 dark:text-slate-400 overflow-x-visible
+      "
+    >
       <p class="mb-4">
         <%= t(".description", sample_name: @sample.name) %>
       </p>
-      <%= form_for(:deletion, url: namespace_project_samples_deletion_path(sample_id: @sample.id), method: :delete, data: { turbo_frame: "_top" }) do |form| %>
+      <%= form_for(:deletion, url: namespace_project_samples_deletion_path(sample_id: @sample.id), method: :delete,
+            data: {
+              turbo_frame: "_top",
+              controller: "spinner",
+              action:"turbo:submit-start->spinner#submitStart turbo:submit-end->viral--dialog#close"
+            }
+          ) do |form| %>
         <%= form.submit t(".submit_button"),
-                    class: "
-                      button
-                      text-sm
-                      px-5
-                      py-2.5
-                      text-white
-                      bg-red-700
-                      border-red-800
-                      focus:outline-none
-                      hover:bg-red-800
-                      focus:ring-red-300
-                      dark:focus:ring-red-700
-                      dark:bg-red-600
-                      dark:text-white
-                      dark:border-red-600
-                      dark:hover:bg-red-700",
+                    class:
+                      "
+                                              button
+                                              text-sm
+                                              px-5
+                                              py-2.5
+                                              text-white
+                                              bg-red-700
+                                              border-red-800
+                                              focus:outline-none
+                                              hover:bg-red-800
+                                              focus:ring-red-300
+                                              dark:focus:ring-red-700
+                                              dark:bg-red-600
+                                              dark:text-white
+                                              dark:border-red-600
+                                              dark:hover:bg-red-700",
                     data: {
                       action: "click->selection#remove",
-                      "selection-id-param": @sample.id
+                      "selection-id-param": @sample.id,
                     } %>
-        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/projects/samples/deletions/_new_multiple_deletions_dialog.html.erb
+++ b/app/views/projects/samples/deletions/_new_multiple_deletions_dialog.html.erb
@@ -4,7 +4,6 @@
     <div
       data-controller="infinite-scroll"
       data-infinite-scroll-selection-outlet='#samples-table'
-      data-infinite-scroll-field-name-value="multiple_deletion[sample_ids][]"
       data-infinite-scroll-paged-field-name-value="sample_ids[]"
       data-infinite-scroll-singular-value="<%= t(".description.singular") %>"
       data-infinite-scroll-plural-value="<%= t(".description.plural") %>"
@@ -43,13 +42,14 @@
 
       <%= form_for(:deletion, url: destroy_multiple_namespace_project_samples_deletion_path, method: :delete,
             data: {
-              controller: "spinner",
+              controller: "spinner form--hidden-inputs",
+              "form--hidden-inputs-selection-outlet": '#samples-table',
+              "form--hidden-inputs-field-name-value": "multiple_deletion[sample_ids][]",
               action:"turbo:submit-start->spinner#submitStart turbo:submit-end->spinner#submitEnd",
               turbo_frame: "_top"
             }
           ) do |form| %>
         <div class="grid gap-4">
-          <div class="hidden" data-infinite-scroll-target="all"></div>
           <div>
             <%= form.submit t(".submit_button"),
                         class: "
@@ -69,7 +69,7 @@
                         dark:border-red-600
                         dark:hover:bg-red-700",
                         data: {
-                          action: "click->infinite-scroll#clear",
+                          action: "click->form--hidden-inputs#clearSelection",
                           "spinner-target": "submit",
                           "turbo-submits-with": t(:".loading"),
                         } %>

--- a/app/views/projects/samples/deletions/_new_multiple_deletions_dialog.html.erb
+++ b/app/views/projects/samples/deletions/_new_multiple_deletions_dialog.html.erb
@@ -16,66 +16,66 @@
       <% end %>
 
       <div class="grid gap-4">
-          <p
-            data-infinite-scroll-target="summary"
-            class="
-              text-base leading-relaxed text-slate-500 dark:text-slate-400
-            "
-          ><%= t(".description.zero") %></p>
-          <div>
-            <div class="block mb-1 text-sm font-medium text-slate-900 dark:text-white">
-              <%= t(".samples") %>
-            </div>
-            <div
-              class="
-                overflow-y-auto max-h-[300px] border border-slate-300 rounded-md block w-full
-                p-2.5 dark:bg-slate-800 dark:border-slate-600
-              "
-              data-action="scroll->infinite-scroll#scroll"
-              data-infinite-scroll-target="scrollable"
-            >
-              <%= turbo_frame_tag "list_select_samples" do %>
-                <%= render partial: "shared/loading/samples_list_skeleton" %>
-              <% end %>
-            </div>
+        <p
+          data-infinite-scroll-target="summary"
+          class="text-base leading-relaxed text-slate-500 dark:text-slate-400"
+        ><%= t(".description.zero") %></p>
+        <div>
+          <div class="block mb-1 text-sm font-medium text-slate-900 dark:text-white">
+            <%= t(".samples") %>
           </div>
+          <div
+            class="
+              overflow-y-auto max-h-[300px] border border-slate-300 rounded-md block w-full
+              p-2.5 dark:bg-slate-800 dark:border-slate-600
+            "
+            data-action="scroll->infinite-scroll#scroll"
+            data-infinite-scroll-target="scrollable"
+          >
+            <%= turbo_frame_tag "list_select_samples" do %>
+              <%= render partial: "shared/loading/samples_list_skeleton" %>
+            <% end %>
+          </div>
+        </div>
 
-      <%= form_for(:deletion, url: destroy_multiple_namespace_project_samples_deletion_path, method: :delete,
+        <%= form_for(:deletion, url: destroy_multiple_namespace_project_samples_deletion_path, method: :delete,
             data: {
               controller: "spinner form--hidden-inputs",
               "form--hidden-inputs-selection-outlet": '#samples-table',
               "form--hidden-inputs-field-name-value": "multiple_deletion[sample_ids][]",
-              action:"turbo:submit-start->spinner#submitStart turbo:submit-end->spinner#submitEnd",
+              action:"turbo:submit-start->spinner#submitStart turbo:submit-end->viral--dialog#close",
               turbo_frame: "_top"
             }
           ) do |form| %>
-        <div class="grid gap-4">
-          <div>
-            <%= form.submit t(".submit_button"),
-                        class: "
-                        button
-                        text-sm
-                        px-5
-                        py-2.5
-                        text-white
-                        bg-red-700
-                        border-red-800
-                        focus:outline-none
-                        hover:bg-red-800
-                        focus:ring-red-300
-                        dark:focus:ring-red-700
-                        dark:bg-red-600
-                        dark:text-white
-                        dark:border-red-600
-                        dark:hover:bg-red-700",
-                        data: {
-                          action: "click->form--hidden-inputs#clearSelection",
-                          "spinner-target": "submit",
-                          "turbo-submits-with": t(:".loading"),
-                        } %>
+          <div class="grid gap-4">
+            <div>
+              <%= form.submit t(".submit_button"),
+                          class:
+                            "
+                                                                button
+                                                                text-sm
+                                                                px-5
+                                                                py-2.5
+                                                                text-white
+                                                                bg-red-700
+                                                                border-red-800
+                                                                focus:outline-none
+                                                                hover:bg-red-800
+                                                                focus:ring-red-300
+                                                                dark:focus:ring-red-700
+                                                                dark:bg-red-600
+                                                                dark:text-white
+                                                                dark:border-red-600
+                                                                dark:hover:bg-red-700",
+                          data: {
+                            action: "click->form--hidden-inputs#clearSelection",
+                            "spinner-target": "submit",
+                            "turbo-submits-with": t(:".loading"),
+                          } %>
+            </div>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
 
     <div

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -4,6 +4,8 @@
 <%= turbo_frame_tag "samples_alert" %>
 <%= turbo_frame_tag "selected" %>
 
+<%= turbo_stream_from @project %>
+
 <%= render Viral::PageHeaderComponent.new(title: t('.title')) do |component| %>
   <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
@@ -44,22 +46,42 @@
           <% if @project.namespace.metadata_fields.empty? %>
             <% dropdown.with_item(
               label: t(".create_export_button.linelist_export"),
-              url: new_data_export_path(export_type: "linelist", namespace_id: @project.namespace.id),
+              url:
+                new_data_export_path(
+                  export_type: "linelist",
+                  namespace_id: @project.namespace.id,
+                ),
               data: {
-                turbo_stream: true
-                },
-              class: "flex items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300
-                border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed") %>
+                turbo_stream: true,
+              },
+              class:
+                "flex items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300
+                            border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
+            ) %>
           <% else %>
             <% dropdown.with_item(
               label: t(".create_export_button.linelist_export"),
-              url: new_data_export_path(export_type: "linelist", namespace_id: @project.namespace.id),
+              url:
+                new_data_export_path(
+                  export_type: "linelist",
+                  namespace_id: @project.namespace.id,
+                ),
               data: {
-                turbo_stream: true
-                }
-              ) %>
+                turbo_stream: true,
+              },
+            ) %>
           <% end %>
-          <% dropdown.with_item(label: t(".create_export_button.sample_export"), url: new_data_export_path(export_type: "sample", namespace_id: @project.namespace.id), data: { turbo_stream: true }) %>
+          <% dropdown.with_item(
+            label: t(".create_export_button.sample_export"),
+            url:
+              new_data_export_path(
+                export_type: "sample",
+                namespace_id: @project.namespace.id,
+              ),
+            data: {
+              turbo_stream: true,
+            },
+          ) %>
         <% end %>
       <% end %>
       <% if allowed_to?(:update_sample?, @project) && @has_samples %>

--- a/app/views/projects/samples/transfers/_dialog.html.erb
+++ b/app/views/projects/samples/transfers/_dialog.html.erb
@@ -5,7 +5,6 @@
       <div
         data-controller="infinite-scroll"
         data-infinite-scroll-selection-outlet='#samples-table'
-        data-infinite-scroll-field-name-value="transfer[sample_ids][]"
         data-infinite-scroll-paged-field-name-value="sample_ids[]"
         data-infinite-scroll-singular-value="<%= t(".description.singular") %>"
         data-infinite-scroll-plural-value="<%= t(".description.plural") %>"
@@ -14,6 +13,7 @@
         url: list_namespace_project_samples_path,
         data: { "infinite-scroll-target": "pageForm" }
       ) do %>
+          <input type="hidden" name="format" value="turbo_stream"/>
           <div data-infinite-scroll-target="pageFormContent"></div>
         <% end %>
 
@@ -46,8 +46,10 @@
 
           <%= form_for(:transfer, url: namespace_project_samples_transfer_path, method: :post,
               data: {
-                controller: "spinner",
-                action:"turbo:submit-start->spinner#submitStart turbo:submit-end->spinner#submitEnd"
+                controller: "spinner form--hidden-inputs",
+                "form--hidden-inputs-selection-outlet": '#samples-table',
+                "form--hidden-inputs-field-name-value": "transfer[sample_ids][]",
+                action: "turbo:submit-start->spinner#submitStart turbo:submit-end->spinner#submitEnd"
               }
             ) do |form| %>
             <div class="grid gap-4">
@@ -55,13 +57,12 @@
                 <%= form.label :new_project_id, t(".new_project_id") %>
                 <%= form.collection_select(:new_project_id, @projects, :id, :full_path) %>
               </div>
-              <div class="hidden" data-infinite-scroll-target="all"></div>
               <div>
                 <%= form.submit t(".submit_button"),
                             class: "button button--size-default button--state-primary",
                             disabled: @projects.count.zero?,
                             data: {
-                              action: "click->infinite-scroll#clear",
+                              action: "click->form--hidden-inputs#clearSelection",
                               "spinner-target": "submit",
                             } %>
               </div>

--- a/app/views/projects/samples/transfers/create.turbo_stream.erb
+++ b/app/views/projects/samples/transfers/create.turbo_stream.erb
@@ -12,3 +12,5 @@
                          errors: errors,
                        } %>
 <% end %>
+
+<turbo-stream action="refresh"></turbo-stream>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,13 @@
 development:
-  adapter: async
+  adapter: postgresql
 
 test:
-  adapter: test
+  adapter: postgresql
+
+staging:
+  adapter: postgresql
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: irida_production
+  adapter: postgresql
+  url: <%= ENV['DATABASE_URL'] %>
+  channel_prefix:

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,10 +2,7 @@ development:
   adapter: postgresql
 
 test:
-  adapter: postgresql
-
-staging:
-  adapter: postgresql
+  adapter: test
 
 production:
   adapter: postgresql

--- a/test/jobs/workflow_execution_cancelation_job_test.rb
+++ b/test/jobs/workflow_execution_cancelation_job_test.rb
@@ -33,7 +33,7 @@ class WorkflowExecutionCancelationJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCleanupJob)
-    assert_performed_jobs 1
+    assert_performed_jobs(1, only: WorkflowExecutionCancelationJob)
     assert @workflow_execution.reload.canceled?
   end
 
@@ -61,7 +61,7 @@ class WorkflowExecutionCancelationJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCleanupJob)
-    assert_performed_jobs 6
+    assert_performed_jobs(6, only: WorkflowExecutionCancelationJob)
     assert @workflow_execution.reload.canceled?
   end
 
@@ -87,7 +87,7 @@ class WorkflowExecutionCancelationJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCleanupJob)
-    assert_performed_jobs 3
+    assert_performed_jobs(3, only: WorkflowExecutionCancelationJob)
     @workflow_execution.reload
     assert @workflow_execution.error?
     assert @workflow_execution.http_error_code == 400
@@ -113,7 +113,7 @@ class WorkflowExecutionCancelationJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCleanupJob)
-    assert_performed_jobs 2
+    assert_performed_jobs(2, only: WorkflowExecutionCancelationJob)
     assert @workflow_execution.reload.canceled?
   end
 end

--- a/test/jobs/workflow_execution_cleanup_job_test.rb
+++ b/test/jobs/workflow_execution_cleanup_job_test.rb
@@ -13,7 +13,7 @@ class WorkflowExecutionCleanupJobTest < ActiveJobTestCase
       WorkflowExecutionCleanupJob.perform_later(workflow_execution)
     end
 
-    assert_performed_jobs 1
+    assert_performed_jobs(1, only: WorkflowExecutionCleanupJob)
     assert workflow_execution.reload.cleaned?
   end
 
@@ -26,7 +26,7 @@ class WorkflowExecutionCleanupJobTest < ActiveJobTestCase
       WorkflowExecutionCleanupJob.perform_later(workflow_execution)
     end
 
-    assert_performed_jobs 1
+    assert_performed_jobs(1, only: WorkflowExecutionCleanupJob)
     assert workflow_execution.reload.cleaned?
   end
 
@@ -39,7 +39,7 @@ class WorkflowExecutionCleanupJobTest < ActiveJobTestCase
       WorkflowExecutionCleanupJob.perform_later(workflow_execution)
     end
 
-    assert_performed_jobs 1
+    assert_performed_jobs(1, only: WorkflowExecutionCleanupJob)
     assert workflow_execution.reload.cleaned?
   end
 
@@ -52,7 +52,7 @@ class WorkflowExecutionCleanupJobTest < ActiveJobTestCase
       WorkflowExecutionCleanupJob.perform_later(workflow_execution)
     end
 
-    assert_performed_jobs 1
+    assert_performed_jobs(1, only: WorkflowExecutionCleanupJob)
     assert_not workflow_execution.reload.cleaned?
   end
 end

--- a/test/jobs/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_execution_status_job_test.rb
@@ -66,7 +66,7 @@ class WorkflowExecutionStatusJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCompletionJob)
-    assert_performed_jobs 6
+    assert_performed_jobs(6, only: WorkflowExecutionStatusJob)
     assert @workflow_execution.reload.completing?
   end
 
@@ -95,7 +95,7 @@ class WorkflowExecutionStatusJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCleanupJob)
-    assert_performed_jobs 3
+    assert_performed_jobs(3, only: WorkflowExecutionStatusJob)
     @workflow_execution.reload
     assert @workflow_execution.error?
     assert @workflow_execution.http_error_code == 400
@@ -124,7 +124,7 @@ class WorkflowExecutionStatusJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCompletionJob)
-    assert_performed_jobs 2
+    assert_performed_jobs(2, only: WorkflowExecutionStatusJob)
     assert @workflow_execution.reload.completing?
   end
 end

--- a/test/jobs/workflow_execution_submission_job_test.rb
+++ b/test/jobs/workflow_execution_submission_job_test.rb
@@ -32,7 +32,7 @@ class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionStatusJob)
-    assert_performed_jobs(1, only: WorklowExecutionSubmissionJob)
+    assert_performed_jobs(1, only: WorkflowExecutionSubmissionJob)
     assert @workflow_execution.reload.submitted?
   end
 

--- a/test/jobs/workflow_execution_submission_job_test.rb
+++ b/test/jobs/workflow_execution_submission_job_test.rb
@@ -32,7 +32,7 @@ class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionStatusJob)
-    assert_performed_jobs 1
+    assert_performed_jobs(1, only: WorklowExecutionSubmissionJob)
     assert @workflow_execution.reload.submitted?
   end
 
@@ -60,7 +60,7 @@ class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionStatusJob)
-    assert_performed_jobs 6
+    assert_performed_jobs(6, only: WorkflowExecutionSubmissionJob)
     assert @workflow_execution.reload.submitted?
   end
 
@@ -86,7 +86,7 @@ class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionCleanupJob)
-    assert_performed_jobs 3
+    assert_performed_jobs(3, only: WorkflowExecutionSubmissionJob)
     @workflow_execution.reload
     assert @workflow_execution.error?
     assert @workflow_execution.http_error_code == 400
@@ -112,7 +112,7 @@ class WorkflowExecutionSubmissionJobTest < ActiveJobTestCase
     end
 
     assert_enqueued_jobs(1, only: WorkflowExecutionStatusJob)
-    assert_performed_jobs 2
+    assert_performed_jobs(2, only: WorkflowExecutionSubmissionJob)
     assert @workflow_execution.reload.submitted?
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR is a follow up to #679.

* Added in action cable config and updated the Projects Table so that it is now refreshed when a Sample is created, updated, or deleted.
* Moved hidden input handling from `infinite-scroll` controller into a new `form--hidden-inputs` controller.
* Updated `clone` and `transfer` samples response to reload the page
* Added `data-turbo-permanent` to `dialog` and `flash` so that if the page is refreshed they persist.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch server
2. Navigate to Project Samples page for Project of choice
3. Perform actions on the table that require a selection of samples and ensure that each respond as expected

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
