### PR TITLE
Linelist Export: Include Project PUID to project.type exports

### DIFF
--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -307,6 +307,7 @@ module DataExports
       csv.each do |row|
         assert_equal sample32.puid, row['SAMPLE ID']
         assert_equal sample32.name, row['SAMPLE NAME']
+        assert_equal sample32.project.puid, row['PROJECT ID']
         assert_equal sample32.metadata['metadatafield1'], row['METADATAFIELD1']
         assert_equal sample32.metadata['metadatafield2'], row['METADATAFIELD2']
       end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds the `Project PUID` to linelist exports created from `projects`. Previously, the `Project PUID` was only included for linelist exports from `groups`

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Navigate to a project with samples that have metadata
2. Create a linelist export.
3. Download the export after it's ready. Verify the `Project PUID` is included.
4. Repeat with the format you did not use above.
5. Repeat the above, exporting from `Groups`. Verify the exports are as expected (sample id, name, project puid and metadata fields).

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
