### PR TITLE
Enhancement: Attachment Checksum Validation

### DIFF
--- a/app/validators/attachment_checksum_validator.rb
+++ b/app/validators/attachment_checksum_validator.rb
@@ -2,7 +2,7 @@
 
 # Validator for Attachment checksum
 class AttachmentChecksumValidator < ActiveModel::Validator
-  def validate(record) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def validate(record)
     return if record.file.checksum.blank?
 
     klass = record.class

--- a/app/validators/attachment_checksum_validator.rb
+++ b/app/validators/attachment_checksum_validator.rb
@@ -8,21 +8,13 @@ class AttachmentChecksumValidator < ActiveModel::Validator
     klass = record.class
 
     # add error if another Attachment associated with the Attachable exists with the same checksum
-
-    # checks if file has same checksum and name (no error if same contents but different name)
+    # no error occurs if the files have same name but different checksum or same checksum but different filenames
     if klass.joins(:file_blob)
             .where.not(id: record.id)
             .exists?(attachable_id: record.attachable_id,
                      attachable_type: record.attachable_type,
                      deleted_at: nil,
-                     file_blob: { checksum: record.file.checksum, filename: record.file.filename.to_s }) ||
-       #  checks for same filename
-       klass.joins(:file_blob)
-            .where.not(id: record.id)
-            .exists?(attachable_id: record.attachable_id,
-                     attachable_type: record.attachable_type,
-                     deleted_at: nil,
-                     file_blob: { filename: record.file.filename.to_s })
+                     file_blob: { checksum: record.file.checksum, filename: record.file.filename.to_s })
 
       record.errors.add(:file, :checksum_uniqueness)
     end

--- a/app/validators/attachment_checksum_validator.rb
+++ b/app/validators/attachment_checksum_validator.rb
@@ -2,18 +2,29 @@
 
 # Validator for Attachment checksum
 class AttachmentChecksumValidator < ActiveModel::Validator
-  def validate(record)
+  def validate(record) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     return if record.file.checksum.blank?
 
     klass = record.class
 
     # add error if another Attachment associated with the Attachable exists with the same checksum
+
+    # checks if file has same checksum and name (no error if same contents but different name)
     if klass.joins(:file_blob)
             .where.not(id: record.id)
             .exists?(attachable_id: record.attachable_id,
                      attachable_type: record.attachable_type,
                      deleted_at: nil,
-                     file_blob: { checksum: record.file.checksum })
+                     file_blob: { checksum: record.file.checksum, filename: record.file.filename.to_s })
+            #  checks for same filename
+            .or(
+              klass.joins(:file_blob)
+                   .where.not(id: record.id)
+                   .exists?(attachable_id: record.attachable_id,
+                            attachable_type: record.attachable_type,
+                            deleted_at: nil,
+                            file_blob: { filename: record.file.filename.to_s })
+            )
       record.errors.add(:file, :checksum_uniqueness)
     end
   end

--- a/app/validators/attachment_checksum_validator.rb
+++ b/app/validators/attachment_checksum_validator.rb
@@ -17,7 +17,6 @@ class AttachmentChecksumValidator < ActiveModel::Validator
                      deleted_at: nil,
                      file_blob: { checksum: record.file.checksum, filename: record.file.filename.to_s }) ||
        #  checks for same filename
-
        klass.joins(:file_blob)
             .where.not(id: record.id)
             .exists?(attachable_id: record.attachable_id,

--- a/app/validators/attachment_checksum_validator.rb
+++ b/app/validators/attachment_checksum_validator.rb
@@ -15,16 +15,16 @@ class AttachmentChecksumValidator < ActiveModel::Validator
             .exists?(attachable_id: record.attachable_id,
                      attachable_type: record.attachable_type,
                      deleted_at: nil,
-                     file_blob: { checksum: record.file.checksum, filename: record.file.filename.to_s })
-            #  checks for same filename
-            .or(
-              klass.joins(:file_blob)
-                   .where.not(id: record.id)
-                   .exists?(attachable_id: record.attachable_id,
-                            attachable_type: record.attachable_type,
-                            deleted_at: nil,
-                            file_blob: { filename: record.file.filename.to_s })
-            )
+                     file_blob: { checksum: record.file.checksum, filename: record.file.filename.to_s }) ||
+       #  checks for same filename
+
+       klass.joins(:file_blob)
+            .where.not(id: record.id)
+            .exists?(attachable_id: record.attachable_id,
+                     attachable_type: record.attachable_type,
+                     deleted_at: nil,
+                     file_blob: { filename: record.file.filename.to_s })
+
       record.errors.add(:file, :checksum_uniqueness)
     end
   end

--- a/test/graphql/attach_files_to_sample_test.rb
+++ b/test/graphql/attach_files_to_sample_test.rb
@@ -167,7 +167,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
   test 'attachFilesToSample mutation attach file with same content but different names' do
     sample = samples(:sampleJeff)
-    # These files have the same md5 sum
+
     blob_file_a = active_storage_blobs(:attachment_md5_a_test_blob)
     blob_file_b = active_storage_blobs(:attachment_md5_b_test_blob)
 
@@ -210,7 +210,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
   test 'attachFilesToSample mutation attach file with same checksum and same names' do
     sample = samples(:sampleJeff)
-    # These files have the same md5 sum
+
     blob_file_a = active_storage_blobs(:attachment_md5_a_test_blob)
     blob_file_a2 = active_storage_blobs(:attachment_md5_a_test_blob)
 
@@ -253,10 +253,11 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
 
   test 'attachFilesToSample mutation attach file with different checksum and same names' do
     sample = samples(:sampleJeff)
-    # These files have the same md5 sum
+
     blob_file_a = active_storage_blobs(:attachment_md5_a_test_blob)
     blob_file_b = active_storage_blobs(:attachment_attach_files_to_sample_test_blob)
 
+    # match blob_file_b.filename to blob_file_a.filename
     blob_file_b.filename = 'md5_a'
     blob_file_b.save
     assert_equal 0, sample.attachments.count

--- a/test/graphql/attach_files_to_sample_test.rb
+++ b/test/graphql/attach_files_to_sample_test.rb
@@ -165,7 +165,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     assert_equal :error, data['status'][blob_file.signed_id]
   end
 
-  test 'attachFilesToSample mutation attach file with same content but different names' do
+  test 'attachFilesToSample mutation attach file with same checksum but different names' do
     sample = samples(:sampleJeff)
 
     blob_file_a = active_storage_blobs(:attachment_md5_a_test_blob)
@@ -289,12 +289,12 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     data = result['data']['attachFilesToSample']
 
     assert_not_empty data, 'attachFilesToSample should be populated when no authorization errors'
-    expected_status = { blob_file_b.signed_id => :error }
+    expected_status = { blob_file_b.signed_id => :success }
     assert_equal expected_status, data['status']
     assert_not_empty data['sample']
-    expected_error = { blob_file_b.signed_id => ['File checksum matches existing file'] }
-    assert_equal expected_error, data['errors']
-    assert_equal 1, sample.attachments.count
+    sample.reload
+    assert_equal 2, sample.attachments.count
+    assert_equal 'md5_a', sample.attachments[1].filename.to_s
   end
 
   test 'attachFilesToSample mutation attach 2 files at once' do

--- a/test/graphql/attach_files_to_sample_test.rb
+++ b/test/graphql/attach_files_to_sample_test.rb
@@ -203,9 +203,7 @@ class AttachFilesToSampleTest < ActiveSupport::TestCase
     expected_status = { blob_file_b.signed_id => :success }
     assert_equal expected_status, data['status']
     assert_not_empty data['sample']
-    sample.reload
     assert_equal 2, sample.attachments.count
-    assert_equal 'md5_b', sample.attachments[1].filename.to_s
   end
 
   test 'attachFilesToSample mutation attach file with same checksum and same names' do

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -25,7 +25,7 @@ class AttachmentTest < ActiveSupport::TestCase
     assert new_attachment.errors.added?(:file, :checksum_uniqueness)
   end
 
-  test 'file contents matches another Attachment associated with the Attachable but with different filename' do
+  test 'file checksum matches another Attachment associated with the Attachable but with different filename' do
     assert_equal 2, @sample.attachments.count
     new_attachment = @sample.attachments.build(file:
       { io: Rails.root.join('test/fixtures/files/test_file.fastq').open,
@@ -35,12 +35,13 @@ class AttachmentTest < ActiveSupport::TestCase
     assert_equal 3, @sample.attachments.count
   end
 
-  test 'file contents differ from another Attachment associated with the Attachable but with same filename' do
+  test 'file checksum differs from another Attachment associated with the Attachable but with same filename' do
     new_attachment = @sample.attachments.build(file:
       { io: Rails.root.join('test/fixtures/files/test_file_C.fastq').open,
         filename: 'test_file.fastq' })
-    assert_not new_attachment.valid?
-    assert new_attachment.errors.added?(:file, :checksum_uniqueness)
+    assert new_attachment.valid?
+    @sample.save
+    assert_equal 3, @sample.attachments.count
   end
 
   test 'metadata fastq file types' do

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -25,6 +25,24 @@ class AttachmentTest < ActiveSupport::TestCase
     assert new_attachment.errors.added?(:file, :checksum_uniqueness)
   end
 
+  test 'file contents matches another Attachment associated with the Attachable but with different filename' do
+    assert_equal 2, @sample.attachments.count
+    new_attachment = @sample.attachments.build(file:
+      { io: Rails.root.join('test/fixtures/files/test_file.fastq').open,
+        filename: 'copy_of_test_file.fastq' })
+    assert new_attachment.valid?
+    @sample.save
+    assert_equal 3, @sample.attachments.count
+  end
+
+  test 'file contents differ from another Attachment associated with the Attachable but with same filename' do
+    new_attachment = @sample.attachments.build(file:
+      { io: Rails.root.join('test/fixtures/files/test_file_C.fastq').open,
+        filename: 'test_file.fastq' })
+    assert_not new_attachment.valid?
+    assert new_attachment.errors.added?(:file, :checksum_uniqueness)
+  end
+
   test 'metadata fastq file types' do
     new_fastq_attachment_ext_fastq =
       @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_1.fastq').open,

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -686,7 +686,7 @@ class DataExportsTest < ApplicationSystemTestCase
     assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
-    within %(#samples-table) do
+    within first('tbody') do
       find("input[type='checkbox'][value='#{@sample30.id}']").click
     end
 
@@ -701,9 +701,10 @@ class DataExportsTest < ApplicationSystemTestCase
       click_button I18n.t('data_exports.new_linelist_export_dialog.submit_button')
     end
 
-    assert_selector 'dl', count: 1
-    assert_selector 'div:nth-child(2) dd', text: 'test csv export'
-    assert_selector 'div:nth-child(4) dd', text: 'csv'
+    within first('dl') do
+      assert_selector 'div:nth-child(2) dd', text: 'test csv export'
+      assert_selector 'div:nth-child(4) dd', text: 'csv'
+    end
   end
 
   test 'create xlsx export from group samples page' do
@@ -711,7 +712,7 @@ class DataExportsTest < ApplicationSystemTestCase
     assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
-    within %(#samples-table) do
+    within first('tbody') do
       find("input[type='checkbox'][value='#{@sample1.id}']").click
     end
 
@@ -727,9 +728,10 @@ class DataExportsTest < ApplicationSystemTestCase
       click_button I18n.t('data_exports.new_linelist_export_dialog.submit_button')
     end
 
-    assert_selector 'dl', count: 1
-    assert_selector 'div:nth-child(2) dd', text: 'test xlsx export'
-    assert_selector 'div:nth-child(4) dd', text: 'xlsx'
+    within first('dl') do
+      assert_selector 'div:nth-child(2) dd', text: 'test xlsx export'
+      assert_selector 'div:nth-child(4) dd', text: 'xlsx'
+    end
   end
 
   test 'linelist export with ready status does not have preview tab' do


### PR DESCRIPTION
## What does this PR do and why?
This PR changes the Attachment checksum validation. Previously, samples could not have two attachments with the same checksum attached. With the new validation, samples can have attachments with the same checksum attached, as long as they have different filenames

## Screenshots or screen recordings
Attachments with same checksum but different filenames:
Old Validation:
[Screencast from 2024-08-13 03:53:17 PM.webm](https://github.com/user-attachments/assets/076e033a-00e3-47c2-8cac-0eb23e303aac)

New Validation:
[Screencast from 2024-08-13 03:51:56 PM.webm](https://github.com/user-attachments/assets/9377163f-3a41-4154-a013-660e3e19c052)

## How to set up and validate locally
1. Create two files that are a copy of one another (same checksum) except with different filenames
2. Navigate to any sample files page
3. Upload the above files. They should upload normally.
4. With the above files still attached to the sample, try attaching the files again. They should all fail uploading as the checksum and filenames match already existing attachments.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
