### PR TITLE
Fix: local_time_ago on sample and workflow execution table_components

### DIFF
--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -145,7 +145,9 @@
                   <%= helpers.local_time(sample[column], :full_date) %>
                 <% elsif column == :updated_at || column == :attachments_updated_at %>
                   <% if sample[column].present? %>
-                    <%= helpers.local_time_ago(sample[column]) %>
+                    <div data-turbo-permanent="true">
+                      <%= helpers.local_time_ago(sample[column]) %>
+                    </div>
                   <% end %>
                 <% else %>
                   <%= sample[column.to_sym] %>

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -91,8 +91,11 @@
                 <% elsif column == :created_at %>
                   <%= helpers.local_time(workflow_execution[column], :full_date) %>
                 <% elsif column == :updated_at || column == :attachments_updated_at %>
+
                   <% if workflow_execution[column].present? %>
+                  <div data-turbo-permanent="true">
                     <%= helpers.local_time_ago(workflow_execution[column]) %>
+                  </div>
                   <% end %>
                 <% else %>
                   <%= workflow_execution[column.to_sym] %>

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -91,11 +91,10 @@
                 <% elsif column == :created_at %>
                   <%= helpers.local_time(workflow_execution[column], :full_date) %>
                 <% elsif column == :updated_at || column == :attachments_updated_at %>
-
                   <% if workflow_execution[column].present? %>
-                  <div data-turbo-permanent="true">
-                    <%= helpers.local_time_ago(workflow_execution[column]) %>
-                  </div>
+                    <div data-turbo-permanent="true">
+                      <%= helpers.local_time_ago(workflow_execution[column]) %>
+                    </div>
                   <% end %>
                 <% else %>
                   <%= workflow_execution[column.to_sym] %>


### PR DESCRIPTION
## What does this PR do and why?
This PR is a follow-up to to [PR694](https://github.com/phac-nml/irida-next/pull/694), and adds a workaround to the `Last Updated` column. Before this PR, after table morphing, the `Last Updated` `time_ago` would switch back to UTC time and not using the `local_time_ago`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Start a Workflow Execution
2. Ensure `Last Updated` updates periodically and stays as a `time_ago` reading rather than switching to a UTC timestamp.
3. Create a sample in a project
4. Ensure `Last Updated` updates periodically and stays as a `time_ago` reading rather than switching to a UTC timestamp.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
