### PR TITLE
File import service enhancements

### DIFF
--- a/app/controllers/projects/samples/metadata/file_imports_controller.rb
+++ b/app/controllers/projects/samples/metadata/file_imports_controller.rb
@@ -7,17 +7,18 @@ module Projects
       class FileImportsController < Projects::ApplicationController
         respond_to :turbo_stream
 
-        def create
+        def create # rubocop:disable Metrics/AbcSize
           authorize! @project, to: :update_sample?
-          @imported_metadata = ::Samples::Metadata::FileImportService.new(@project, current_user,
+          @namespace = @project.namespace
+          @imported_metadata = ::Samples::Metadata::FileImportService.new(@namespace, current_user,
                                                                           file_import_params).execute
-          if @project.errors.empty?
+          if @namespace.errors.empty?
             render status: :ok, locals: { type: :success, message: t('.success') }
-          elsif @project.errors.include?(:sample)
-            errors = @project.errors.messages_for(:sample)
+          elsif @namespace.errors.include?(:sample)
+            errors = @namespace.errors.messages_for(:sample)
             render status: :partial_content, locals: { type: :alert, message: t('.error'), errors: }
           else
-            error = @project.errors.full_messages_for(:base).first
+            error = @namespace.errors.full_messages_for(:base).first
             render status: :unprocessable_entity, locals: { type: :danger, message: error }
           end
         end

--- a/app/controllers/projects/samples/metadata/file_imports_controller.rb
+++ b/app/controllers/projects/samples/metadata/file_imports_controller.rb
@@ -8,8 +8,8 @@ module Projects
         respond_to :turbo_stream
 
         def create # rubocop:disable Metrics/AbcSize
-          authorize! @project, to: :update_sample?
           @namespace = @project.namespace
+          authorize! @namespace, to: :update_sample_metadata?
           @imported_metadata = ::Samples::Metadata::FileImportService.new(@namespace, current_user,
                                                                           file_import_params).execute
           if @namespace.errors.empty?

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -184,6 +184,13 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     false
   end
 
+  def update_sample_metadata?
+    return true if Member.can_modify?(user, record) == true
+
+    details[:name] = record.name
+    false
+  end
+
   scope_for :relation do |relation|
     relation.with(
       user_groups: relation.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -167,5 +167,12 @@ module Namespaces
       details[:name] = record.name
       false
     end
+
+    def update_sample_metadata?
+      return true if Member.can_modify?(user, record) == true
+
+      details[:name] = record.name
+      false
+    end
   end
 end

--- a/app/services/samples/metadata/file_import_service.rb
+++ b/app/services/samples/metadata/file_import_service.rb
@@ -19,7 +19,7 @@ module Samples
       end
 
       def execute
-        # authorize! @project, to: :update_sample?
+        authorize! @namespace, to: :update_sample_metadata?
 
         validate_sample_id_column
 

--- a/app/services/samples/metadata/file_import_service.rb
+++ b/app/services/samples/metadata/file_import_service.rb
@@ -134,7 +134,9 @@ module Samples
       def find_sample(sample_id)
         if @namespace.type == 'Group'
           authorized_scope(Sample, type: :relation, as: :namespace_samples,
-                                   scope_options: { namespace: @namespace }).where(id: sample_ids)
+                                   scope_options: { namespace: @namespace,
+                                                    minimum_access_level: Member::AccessLevel::MAINTAINER })
+            .find_by!(puid: sample_id)
         else
           project = @namespace.project
           if Irida::PersistentUniqueId.valid_puid?(sample_id, Sample)

--- a/app/views/projects/samples/metadata/file_imports/create.turbo_stream.erb
+++ b/app/views/projects/samples/metadata/file_imports/create.turbo_stream.erb
@@ -1,11 +1,11 @@
-<% if @project.errors.empty? %>
+<% if @project.namespace.errors.empty? %>
   <%= turbo_stream.replace "import_metadata_dialog_content", partial: "success" %>
-<% elsif @project.errors.include?(:sample) %>
+<% elsif @project.namespace.errors.include?(:sample) %>
   <%= turbo_stream.replace "import_metadata_dialog_content",
                        partial: "errors",
                        locals: {
                          type: type,
-                         errors: errors
+                         errors: errors,
                        } %>
 <% else %>
   <%= turbo_stream.update "import_metadata_dialog_alert", viral_alert(type:, message:) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
         create_bot_accounts?: You are not authorized to create bot accounts for group %{name} on this server.
         destroy_bot_accounts?: You are not authorized to destroy bot accounts for group %{name} on this server.
         export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        update_sample_metadata?: You are not authorized to update sample metadata for group %{name} on this server.
       project:
         activity?: You are not authorized to view the activity for project %{name} on this server.
         destroy?: You are not authorized to remove project %{name} from this server.
@@ -109,6 +110,7 @@ en:
         submit_workflow?: You are not authorized to submit workflows for samples within project %{name} on this server.
         view_workflow_executions?: You are not authorized to view workflow executions for project %{name} on this server.
         export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        update_sample_metadata?: You are not authorized to update sample metadata for project %{name} on this server.
       namespaces/user_namespace:
         create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -73,6 +73,7 @@ fr:
         create_bot_accounts?: You are not authorized to create bot accounts for group %{name} on this server.
         destroy_bot_accounts?: You are not authorized to destroy bot accounts for group %{name} on this server.
         export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        update_sample_metadata?: You are not authorized to update sample metadata for group %{name} on this server.
       project:
         activity?: You are not authorized to view the activity for project %{name} on this server.
         destroy?: You are not authorized to remove project %{name} from this server.
@@ -109,6 +110,7 @@ fr:
         submit_workflow?: You are not authorized to submit workflows for samples within project %{name} on this server.
         view_workflow_executions?: You are not authorized to view workflow executions for project %{name} on this server.
         export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        update_sample_metadata?: You are not authorized to update sample metadata for project %{name} on this server.
       namespaces/user_namespace:
         create?: You are not authorized to create a project under the %{name} namespace
         transfer_into_namespace?: You are not authorized to transfer to the user %{name} namespace

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -81,6 +81,10 @@ class GroupPolicyTest < ActiveSupport::TestCase
     assert @policy.submit_workflow?
   end
 
+  test '#update_sample_metadata?' do
+    assert @policy.update_sample_metadata?
+  end
+
   test 'scope' do
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 

--- a/test/policies/namespaces/project_namespace_policy_test.rb
+++ b/test/policies/namespaces/project_namespace_policy_test.rb
@@ -61,5 +61,9 @@ module Namespaces
     test '#view_workflow_executions?' do
       assert @policy.view_automated_workflow_executions?
     end
+
+    test '#update_sample_metadata?' do
+      assert @policy.update_sample_metadata?
+    end
   end
 end

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -19,27 +19,27 @@ module Samples
                              with: ProjectPolicy,
                              context: { user: @john_doe }) do
           params = { file: @csv, sample_id_column: 'sample_name' }
-          Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
+          Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
         end
       end
 
       test 'import sample metadata without permission' do
         assert_raises(ActionPolicy::Unauthorized) do
           params = { file: @csv, sample_id_column: 'sample_name' }
-          Samples::Metadata::FileImportService.new(@project, @jane_doe, params).execute
+          Samples::Metadata::FileImportService.new(@project.namespace, @jane_doe, params).execute
         end
       end
 
       test 'import sample metadata with empty params' do
-        assert_empty Samples::Metadata::FileImportService.new(@project, @john_doe, {}).execute
-        assert_equal(@project.errors.full_messages_for(:base).first,
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, {}).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
                      I18n.t('services.samples.metadata.import_file.empty_sample_id_column'))
       end
 
       test 'import sample metadata with no file' do
         params = { sample_id_column: 'sample_name' }
-        assert_empty Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
-        assert_equal(@project.errors.full_messages_for(:base).first,
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
                      I18n.t('services.samples.metadata.import_file.empty_file'))
       end
 
@@ -47,7 +47,7 @@ module Samples
         assert_equal({}, @sample1.metadata)
         assert_equal({}, @sample2.metadata)
         params = { file: @csv, sample_id_column: 'sample_name' }
-        response = Samples::Metadata::FileImportService.new(@project, @john_doe,
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe,
                                                             params).execute
         assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
                                           updated: [], deleted: [], not_updated: [] },
@@ -64,7 +64,7 @@ module Samples
         assert_equal({}, @sample2.metadata)
         params = { file: File.new('test/fixtures/files/metadata/valid_with_puid.csv', 'r'),
                    sample_id_column: 'sample_puid' }
-        response = Samples::Metadata::FileImportService.new(@project, @john_doe,
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe,
                                                             params).execute
         assert_equal({ @sample1.puid => { added: %w[metadatafield1 metadatafield2 metadatafield3],
                                           updated: [], deleted: [], not_updated: [] },
@@ -81,7 +81,7 @@ module Samples
         assert_equal({}, @sample2.metadata)
         xls = File.new('test/fixtures/files/metadata/valid.xls', 'r')
         params = { file: xls, sample_id_column: 'sample_name' }
-        response = Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
         assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
                                           updated: [], deleted: [], not_updated: [] },
                        @sample2.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
@@ -97,7 +97,7 @@ module Samples
         assert_equal({}, @sample2.metadata)
         xlsx = File.new('test/fixtures/files/metadata/valid.xlsx', 'r')
         params = { file: xlsx, sample_id_column: 'sample_name' }
-        response = Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
         assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
                                           updated: [], deleted: [], not_updated: [] },
                        @sample2.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
@@ -113,7 +113,7 @@ module Samples
         assert_equal({}, @sample2.metadata)
         params = { file: File.new('test/fixtures/files/metadata/valid.tsv', 'r'),
                    sample_id_column: 'sample_name' }
-        response = Samples::Metadata::FileImportService.new(@project, @john_doe,
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe,
                                                             params).execute
         assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
                                           updated: [], deleted: [], not_updated: [] },
@@ -128,40 +128,40 @@ module Samples
       test 'import sample metadata via other file' do
         other = File.new('test/fixtures/files/metadata/invalid.txt', 'r')
         params = { file: other, sample_id_column: 'sample_name' }
-        assert_empty Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
-        assert_equal(@project.errors.full_messages_for(:base).first,
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
                      I18n.t('services.samples.metadata.import_file.invalid_file_extension'))
       end
 
       test 'import sample metadata with no sample_id_column' do
         csv = File.new('test/fixtures/files/metadata/missing_sample_id_column.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name' }
-        assert_empty Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
-        assert_equal(@project.errors.full_messages_for(:base).first,
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
                      I18n.t('services.samples.metadata.import_file.missing_sample_id_column'))
       end
 
       test 'import sample metadata with duplicate column names' do
         csv = File.new('test/fixtures/files/metadata/duplicate_headers.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name' }
-        assert_empty Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
-        assert_equal(@project.errors.full_messages_for(:base).first,
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
                      I18n.t('services.samples.metadata.import_file.duplicate_column_names'))
       end
 
       test 'import sample metadata with no metadata columns' do
         csv = File.new('test/fixtures/files/metadata/missing_metadata_columns.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name' }
-        assert_empty Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
-        assert_equal(@project.errors.full_messages_for(:base).first,
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
                      I18n.t('services.samples.metadata.import_file.missing_metadata_column'))
       end
 
       test 'import sample metadata with no metadata rows' do
         csv = File.new('test/fixtures/files/metadata/missing_metadata_rows.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name' }
-        assert_empty Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
-        assert_equal(@project.errors.full_messages_for(:base).first,
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
                      I18n.t('services.samples.metadata.import_file.missing_metadata_row'))
       end
 
@@ -171,7 +171,7 @@ module Samples
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, sample32.metadata)
         csv = File.new('test/fixtures/files/metadata/contains_empty_values.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name', ignore_empty_values: true }
-        response = Samples::Metadata::FileImportService.new(project29, @john_doe, params).execute
+        response = Samples::Metadata::FileImportService.new(project29.namespace, @john_doe, params).execute
         assert_equal({ sample32.name => { added: ['metadatafield3'], updated: ['metadatafield2'],
                                           deleted: [], not_updated: [] } }, response)
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => '20', 'metadatafield3' => '30' },
@@ -189,10 +189,10 @@ module Samples
                      sample34.metadata_provenance)
         csv = File.new('test/fixtures/files/metadata/contains_analysis_values.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name' }
-        response = Samples::Metadata::FileImportService.new(project31, @john_doe, params).execute
+        response = Samples::Metadata::FileImportService.new(project31.namespace, @john_doe, params).execute
         assert_empty response
         assert_equal("Sample 'Sample 34' with field(s) 'metadatafield1' cannot be updated.",
-                     project31.errors.messages_for(:sample).first)
+                     project31.namespace.errors.messages_for(:sample).first)
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2', 'metadatafield3' => '20' },
                      sample34.reload.metadata)
       end
@@ -203,7 +203,7 @@ module Samples
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, sample32.metadata)
         csv = File.new('test/fixtures/files/metadata/contains_empty_values.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name', ignore_empty_values: false }
-        response = Samples::Metadata::FileImportService.new(project29, @john_doe, params).execute
+        response = Samples::Metadata::FileImportService.new(project29.namespace, @john_doe, params).execute
         assert_equal({ sample32.name => { added: ['metadatafield3'], updated: ['metadatafield2'],
                                           deleted: ['metadatafield1'], not_updated: [] } }, response)
         assert_equal({ 'metadatafield2' => '20', 'metadatafield3' => '30' }, sample32.reload.metadata)
@@ -214,11 +214,11 @@ module Samples
         assert_equal({}, @sample2.metadata)
         csv = File.new('test/fixtures/files/metadata/mixed_project_samples.csv', 'r')
         params = { file: csv, sample_id_column: 'sample_name' }
-        response = Samples::Metadata::FileImportService.new(@project, @john_doe, params).execute
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute
         assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield2 metadatafield3],
                                           updated: [], deleted: [], not_updated: [] } }, response)
         assert_equal("Sample 'Project 2 Sample 1' is not found within this project",
-                     @project.errors.messages_for(:sample).first)
+                     @project.namespace.errors.messages_for(:sample).first)
         assert_equal({ 'metadatafield1' => '10', 'metadatafield2' => '20', 'metadatafield3' => '30' },
                      @sample1.reload.metadata)
         assert_equal({}, @sample2.reload.metadata)

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -15,8 +15,8 @@ module Samples
       end
 
       test 'import sample metadata with permission' do
-        assert_authorized_to(:update_sample?, @project,
-                             with: ProjectPolicy,
+        assert_authorized_to(:update_sample_metadata?, @project.namespace,
+                             with: Namespaces::ProjectNamespacePolicy,
                              context: { user: @john_doe }) do
           params = { file: @csv, sample_id_column: 'sample_name' }
           Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, params).execute

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -34,17 +34,27 @@ module Samples
       end
 
       test 'import sample metadata without permission for project namespace' do
-        assert_raises(ActionPolicy::Unauthorized) do
+        exception = assert_raises(ActionPolicy::Unauthorized) do
           params = { file: @csv, sample_id_column: 'sample_name' }
           Samples::Metadata::FileImportService.new(@project.namespace, @jane_doe, params).execute
         end
+        assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
+        assert_equal :update_sample_metadata?, exception.rule
+        assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+        assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.update_sample_metadata?',
+                            name: @project.name), exception.result.message
       end
 
       test 'import sample metadata without permission for group' do
-        assert_raises(ActionPolicy::Unauthorized) do
+        exception = assert_raises(ActionPolicy::Unauthorized) do
           params = { file: @csv, sample_id_column: 'sample_puid' }
           Samples::Metadata::FileImportService.new(@group, @jane_doe, params).execute
         end
+        assert_equal GroupPolicy, exception.policy
+        assert_equal :update_sample_metadata?, exception.rule
+        assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+        assert_equal I18n.t(:'action_policy.policy.group.update_sample_metadata?',
+                            name: @group.name), exception.result.message
       end
 
       test 'import sample metadata with empty params' do


### PR DESCRIPTION
## What does this PR do and why?
The `Samples::Metadata::FileImportService` has been updated to accept a namespace instead of a project, because users want the ability to import from the Group Samples Page.

The existing project sample metadata import should work as usual.

Fixes #696.

## Screenshots or screen recordings
N/A

## How to set up and validate locally
- Test via running the service tests:
1. Run tests within `test/services/samples/metadata/file_import_service_test.rb`
- Test via console:
1. Create a new csv file and copy the following into it:
```
SAMPLE ID,AGE,FOOD,GENDER,NEW
INXT_SAM_AYIJB6262K,43,Pork Belly Buns,Female,TRUE
INXT_SAM_AYIJB6266D,49,Fish and Chips,Female,TRUE
INXT_SAM_AYIJB627B5,6,Vegetable Soup,Female,TRUE
INXT_SAM_AYIJB627FZ,59,Pizza,Female,TRUE
INXT_SAM_AYIJB627KC,24,Chilli con Carne,Male,TRUE
INXT_SAM_AYIJB627N5,47,Teriyaki Chicken Donburi,Female,TRUE
INXT_SAM_AYIJB627SB,46,Chicken Milanese,Male,TRUE
INXT_SAM_AYIJB627V2,83,Pork Belly Buns,Female,TRUE
INXT_SAM_AYIJB627ZX,85,Salmon Nigiri,Male,TRUE
INXT_SAM_AYIJB62755,98,Chicken Milanese,Female,TRUE
INXT_SAM_AYIJB625O7,88,Ricotta Stuffed Ravioli,Male,TRUE
INXT_SAM_AYIJB625SW,60,Linguine with Clams,Female,TRUE
INXT_SAM_AYIJB625WN,77,Stinky Tofu,Male,TRUE
INXT_SAM_AYIJB6252R,79,Sushi,Female,TRUE
INXT_SAM_AYIJB626AA,58,Chicken Parm,Female,TRUE
INXT_SAM_AYIJB626D4,61,Pappardelle alla Bolognese,Male,TRUE
INXT_SAM_AYIJB626IE,99,French Fries with Sausages,Female,TRUE
INXT_SAM_AYIJB626MC,68,Chicken Milanese,Male,TRUE
INXT_SAM_AYIJB626PR,85,Meatballs with Sauce,Female,TRUE
INXT_SAM_AYIJB626TI,28,Pierogi,Female,TRUE

```  
3. Open a console
4. Run the following commands: 
```
user = User.find_by(email: "admin@email.com")
group = Group.find_by(name: "Bacillus cereus")
response = Samples::Metadata::FileImportService.new(group, user, { file: File.new(<path of the csv file>, 'r'), sample_id_column: 'SAMPLE ID' }).execute
```
5. Navigate to `http://localhost:3000/-/groups/bacillus/bacillus-cereus/-/samples` and verify the sample metadata has the `New` key.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
