### PR TITLE
Analysis Exports: Backend - Accept multiple workflow IDs

### DIFF
--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -83,7 +83,7 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
 
   def data_export_params
     params.require(:data_export).permit(:name, :export_type, :email_notification,
-                                        export_parameters: [:linelist_format, :namespace_id,
+                                        export_parameters: [:linelist_format, :namespace_id, :analysis_type,
                                                             { ids: [], metadata_fields: [], attachment_formats: [] }])
   end
 

--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -133,7 +133,8 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
   def locals
     case params[:export_type]
     when 'analysis'
-      { open: true, workflow_execution_id: params[:workflow_execution_id] }
+      { open: true, workflow_execution_id: params[:workflow_execution_id], analysis_type: params['analysis_type'],
+        namespace_id: params['analysis_type'] == 'project' ? params[:namespace_id] : nil }
     when 'sample'
       { open: true, namespace_id: params[:namespace_id], formats: Attachment::FORMAT_REGEX.keys.sort }
     when 'linelist'

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -22,10 +22,20 @@ class DataExport < ApplicationRecord
                  I18n.t('activerecord.errors.models.data_export.attributes.export_parameters.missing_ids'))
     end
 
-    validate_attachment_formats if export_type == 'sample'
-    validate_analysis_type if export_type == 'analysis'
+    validate_export_type_specific_params
+
     validate_namespace_id unless export_type == 'analysis' && export_parameters['analysis_type'] == 'user'
-    validate_linelist_export_parameters if export_type == 'linelist'
+  end
+
+  def validate_export_type_specific_params
+    case export_type
+    when 'sample'
+      validate_attachment_formats
+    when 'analysis'
+      validate_analysis_type
+    when 'linelist'
+      validate_linelist_export_parameters
+    end
   end
 
   def validate_attachment_formats

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -21,9 +21,9 @@ class DataExport < ApplicationRecord
       errors.add(:export_parameters,
                  I18n.t('activerecord.errors.models.data_export.attributes.export_parameters.missing_ids'))
     end
-
+    puts 'in validate start'
     validate_attachment_formats if export_type == 'sample'
-    validate_namespace_id unless export_type == 'analysis'
+    validate_namespace_id unless export_type == 'analysis' && export_parameters['analysis_type'] == 'user'
     validate_linelist_export_parameters if export_type == 'linelist'
   end
 

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -17,7 +17,7 @@ class DataExport < ApplicationRecord
   private
 
   def validate_export_parameters
-    unless export_parameters.key?('ids')
+    if !export_parameters.key?('ids') || (export_parameters.key?('ids') && export_parameters['ids'].empty?)
       errors.add(:export_parameters,
                  I18n.t('activerecord.errors.models.data_export.attributes.export_parameters.missing_ids'))
     end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -21,8 +21,9 @@ class DataExport < ApplicationRecord
       errors.add(:export_parameters,
                  I18n.t('activerecord.errors.models.data_export.attributes.export_parameters.missing_ids'))
     end
-    puts 'in validate start'
+
     validate_attachment_formats if export_type == 'sample'
+    validate_analysis_type if export_type == 'analysis'
     validate_namespace_id unless export_type == 'analysis' && export_parameters['analysis_type'] == 'user'
     validate_linelist_export_parameters if export_type == 'linelist'
   end
@@ -41,6 +42,18 @@ class DataExport < ApplicationRecord
                  I18n.t(
                    'activerecord.errors.models.data_export.attributes.export_parameters.missing_attachment_formats'
                  ))
+    end
+  end
+
+  def validate_analysis_type
+    if export_parameters.key?('analysis_type')
+      unless %w[project user].include?(export_parameters['analysis_type'])
+        errors.add(:export_parameters,
+                   I18n.t('activerecord.errors.models.data_export.attributes.export_parameters.invalid_analysis_type'))
+      end
+    else
+      errors.add(:export_parameters,
+                 I18n.t('activerecord.errors.models.data_export.attributes.export_parameters.missing_analysis_type'))
     end
   end
 

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -135,7 +135,7 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     false
   end
 
-  def export_sample_data?
+  def export_data?
     return true if Member.can_export_data?(user, record) == true
 
     details[:name] = record.name

--- a/app/policies/namespaces/project_namespace_policy.rb
+++ b/app/policies/namespaces/project_namespace_policy.rb
@@ -161,7 +161,7 @@ module Namespaces
       false
     end
 
-    def export_sample_data?
+    def export_data?
       return true if Member.can_export_data?(user, record) == true
 
       details[:name] = record.name

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -136,7 +136,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     false
   end
 
-  def export_sample_data?
+  def export_data?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
     return true if Member.can_export_data?(user, record.namespace) == true
 

--- a/app/policies/workflow_execution_policy.rb
+++ b/app/policies/workflow_execution_policy.rb
@@ -2,14 +2,6 @@
 
 # Policy for workflow execution authorization
 class WorkflowExecutionPolicy < ApplicationPolicy
-  def export_workflow_execution_data?
-    return true if record.submitter.id == user.id
-    return true if Member.can_create_export?(user, record.namespace) == true
-
-    details[:id] = record.id
-    false
-  end
-
   def destroy? # rubocop:disable Metrics/AbcSize
     return true if record.submitter.id == user.id
     return true if Member.can_modify?(user, record.namespace) == true

--- a/app/policies/workflow_execution_policy.rb
+++ b/app/policies/workflow_execution_policy.rb
@@ -62,6 +62,7 @@ class WorkflowExecutionPolicy < ApplicationPolicy
 
   scope_for :relation, :user do |relation, options|
     user = options[:user]
+
     relation.where(submitter_id: user.id)
   end
 end

--- a/app/policies/workflow_execution_policy.rb
+++ b/app/policies/workflow_execution_policy.rb
@@ -70,7 +70,6 @@ class WorkflowExecutionPolicy < ApplicationPolicy
 
   scope_for :relation, :user do |relation, options|
     user = options[:user]
-
     relation.where(submitter_id: user.id)
   end
 end

--- a/app/services/data_exports/create_service.rb
+++ b/app/services/data_exports/create_service.rb
@@ -42,12 +42,14 @@ module DataExports
     end
 
     def validate_analysis_ids
-      workflow_executions = if params['export_parameters']['analysis_type'] == 'automated'
-                              authorized_export_automated_workflows
+      puts params
+      workflow_executions = if params['export_parameters']['analysis_type'] == 'project'
+                              authorized_export_project_workflows
                             else
                               authorized_export_user_workflows
                             end
-
+      puts 'after scope'
+      puts workflow_executions.count
       return unless workflow_executions.count != params['export_parameters']['ids'].count
 
       raise DataExportCreateError,
@@ -66,7 +68,8 @@ module DataExports
         .where(id: sample_ids)
     end
 
-    def authorized_export_automated_workflows
+    def authorized_export_project_workflows
+      puts 'in project workflow'
       project_namespace = Namespace.find(params['export_parameters']['namespace_id'])
       authorize! project_namespace, to: :export_data?
       authorized_scope(WorkflowExecution, type: :relation, as: :automated,

--- a/app/services/data_exports/create_service.rb
+++ b/app/services/data_exports/create_service.rb
@@ -13,9 +13,9 @@ module DataExports
       assign_initial_export_attributes
 
       if @data_export.valid?
-        @data_export.export_type == 'analysis' ? validate_analysis_id : validate_sample_ids
+        @data_export.export_type == 'analysis' ? validate_analysis_ids : validate_sample_ids
         @data_export.save
-        DataExports::CreateJob.set(wait_until: 30.seconds.from_now).perform_later(@data_export)
+        DataExports::CreateJob.perform_later(@data_export)
       end
 
       @data_export
@@ -31,7 +31,7 @@ module DataExports
     def validate_sample_ids
       namespace = Namespace.find(params['export_parameters']['namespace_id'])
 
-      authorize! namespace, to: :export_sample_data?
+      authorize! namespace, to: :export_data?
 
       samples = authorized_export_samples(namespace, params['export_parameters']['ids'])
 
@@ -41,18 +41,17 @@ module DataExports
             I18n.t('services.data_exports.create.invalid_export_samples')
     end
 
-    def validate_analysis_id
-      unless params['export_parameters']['ids'].count == 1
-        raise DataExportCreateError,
-              I18n.t('services.data_exports.create.invalid_workflow_execution_id_count')
-      end
+    def validate_analysis_ids
+      workflow_executions = if params['export_parameters']['analysis_type'] == 'automated'
+                              authorized_export_automated_workflows
+                            else
+                              authorized_export_user_workflows
+                            end
 
-      workflow_execution = WorkflowExecution.find_by(id: params['export_parameters']['ids'][0])
-      if workflow_execution.nil?
-        raise DataExportCreateError,
-              I18n.t('services.data_exports.create.invalid_workflow_execution_id')
-      end
-      authorize! workflow_execution, to: :export_workflow_execution_data?
+      return unless workflow_executions.count != params['export_parameters']['ids'].count
+
+      raise DataExportCreateError,
+            I18n.t('services.data_exports.create.invalid_export_workflow_executions')
     end
 
     def assign_initial_export_attributes
@@ -65,6 +64,19 @@ module DataExports
       authorized_scope(Sample, type: :relation, as: :namespace_samples,
                                scope_options: { namespace:, minimum_access_level: Member::AccessLevel::ANALYST })
         .where(id: sample_ids)
+    end
+
+    def authorized_export_automated_workflows
+      project_namespace = Namespace.find(params['export_parameters']['namespace_id'])
+      authorize! project_namespace, to: :export_data?
+      authorized_scope(WorkflowExecution, type: :relation, as: :automated,
+                                          scope_options: { project: project_namespace.project })
+        .where(id: params['export_parameters']['ids'])
+    end
+
+    def authorized_export_user_workflows
+      authorized_scope(WorkflowExecution, type: :relation, as: :user, scope_options: { user: current_user })
+        .where(id: params['export_parameters']['ids'])
     end
   end
 end

--- a/app/views/data_exports/_new_analysis_export_dialog.html.erb
+++ b/app/views/data_exports/_new_analysis_export_dialog.html.erb
@@ -43,6 +43,18 @@
           name="data_export[export_parameters][ids][]"
           value="<%= workflow_execution_id %>"
         >
+        <input
+          type="hidden"
+          name="data_export[export_parameters][analysis_type]"
+          value="<%= analysis_type %>"
+        >
+        <% unless namespace_id.nil? %>
+          <input
+            type="hidden"
+            name="data_export[export_parameters][namespace_id]"
+            value="<%= namespace_id %>"
+          >
+        <% end %>
         <div>
           <%= form.submit t(".submit_button"),
                       data: {

--- a/app/views/groups/samples/_table.html.erb
+++ b/app/views/groups/samples/_table.html.erb
@@ -8,7 +8,7 @@
   abilities: {
     select_samples:
       allowed_to?(:submit_workflow?, group) ||
-        allowed_to?(:export_sample_data?, group),
+        allowed_to?(:export_data?, group),
   },
   metadata_fields: @fields,
   search_params: @search_params,

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -16,7 +16,7 @@
           <span class="sr-only"><%= t(".workflows.button_sr") %></span>
         <% end %>
       <% end %>
-      <% if allowed_to?(:export_sample_data?, @group) %>
+      <% if allowed_to?(:export_data?, @group) %>
         <%= viral_dropdown(label: t(".create_export_button.label"), aria: { label: t('.create_export_button.label') }, caret: true, action_link: true, action_link_value: 1, classes: "font-normal button button--size-default button--state-default action-link") do |dropdown| %>
           <% if @group.metadata_fields.empty? %>
             <% dropdown.with_item(
@@ -54,7 +54,7 @@
 <% if @has_samples %>
   <div class="flow-root">
     <div class="float-left inline-flex space-x-2">
-      <% if allowed_to?(:submit_workflow?, @group) || allowed_to?(:export_sample_data?, @group) %>
+      <% if allowed_to?(:submit_workflow?, @group) || allowed_to?(:export_data?, @group) %>
         <%= search_form_for(
                   @q,
                   url: select_group_samples_url(**request.query_parameters),

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -10,7 +10,7 @@
       allowed_to?(:submit_workflow?, project) ||
         allowed_to?(:clone_sample?, project) ||
         allowed_to?(:transfer_sample?, project) ||
-        allowed_to?(:export_sample_data?, project),
+        allowed_to?(:export_data?, project),
   },
   metadata_fields: @fields,
   search_params: @search_params,

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -41,7 +41,7 @@
         },
         class: "button button--size-default button--state-default action-link" %>
       <% end %>
-      <% if allowed_to?(:export_sample_data?, @project) %>
+      <% if allowed_to?(:export_data?, @project) %>
         <%= viral_dropdown(label: t(".create_export_button.label"), aria: { label: t('.create_export_button.label') }, caret: true, action_link: true, action_link_value: 1, classes: "font-normal button button--size-default button--state-default action-link") do |dropdown| %>
           <% if @project.namespace.metadata_fields.empty? %>
             <% dropdown.with_item(
@@ -115,7 +115,7 @@
 
 <div class="flow-root">
   <div class="float-left inline-flex space-x-2">
-    <% if allowed_to?(:submit_workflow?, @project) || allowed_to?(:clone_sample?, @project) || allowed_to?(:transfer_sample?, @project) || allowed_to?(:export_sample_data?, @project) %>
+    <% if allowed_to?(:submit_workflow?, @project) || allowed_to?(:clone_sample?, @project) || allowed_to?(:transfer_sample?, @project) || allowed_to?(:export_data?, @project) %>
       <div class="float-left inline-flex space-x-2">
         <%= search_form_for(
                   @q,

--- a/app/views/projects/workflow_executions/show.html.erb
+++ b/app/views/projects/workflow_executions/show.html.erb
@@ -8,11 +8,13 @@
   <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
   <%= component.with_buttons do %>
     <div class="flex flex-row">
-      <% if allowed_to?(:export_workflow_execution_data?, @workflow_execution) %>
+      <% if allowed_to?(:export_data?, @namespace.project) %>
         <% if @workflow_execution.completed? %>
           <%= link_to t("projects.workflow_executions.show.create_export_button"),
           new_data_export_path(
             export_type: "analysis",
+            analysis_type: "project",
+            namespace_id: @namespace.id,
             workflow_execution_id: @workflow_execution.id,
           ),
           data: {
@@ -23,6 +25,8 @@
           <%= link_to t("projects.workflow_executions.show.create_export_button"),
           new_data_export_path(
             export_type: "analysis",
+            analysis_type: "project",
+            namespace_id: @namespace.id,
             workflow_execution_id: @workflow_execution.id,
           ),
           data: {

--- a/app/views/workflow_executions/show.html.erb
+++ b/app/views/workflow_executions/show.html.erb
@@ -12,6 +12,7 @@
         <%= link_to t(".create_export_button"),
                     new_data_export_path(
                       export_type: "analysis",
+                      analysis_type: "user",
                       workflow_execution_id: @workflow_execution.id
                     ),
                     data: {
@@ -22,6 +23,7 @@
         <%= link_to t(".create_export_button"),
                     new_data_export_path(
                       export_type: "analysis",
+                      analysis_type: "user",
                       workflow_execution_id: @workflow_execution.id
                     ),
                     data: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
         submit_workflow?: You are not authorized to submit workflows for samples within group %{name} on this server.
         create_bot_accounts?: You are not authorized to create bot accounts for group %{name} on this server.
         destroy_bot_accounts?: You are not authorized to destroy bot accounts for group %{name} on this server.
-        export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        export_data?: You are not authorized to export data from project %{name} on this server.
         update_sample_metadata?: You are not authorized to update sample metadata for group %{name} on this server.
       project:
         activity?: You are not authorized to view the activity for project %{name} on this server.
@@ -109,7 +109,7 @@ en:
         view_automated_workflow_executions?: "You are not authorized to view automated workflow executions for project %{name}"
         submit_workflow?: You are not authorized to submit workflows for samples within project %{name} on this server.
         view_workflow_executions?: You are not authorized to view workflow executions for project %{name} on this server.
-        export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        export_data?: You are not authorized to export data from project %{name} on this server.
         update_sample_metadata?: You are not authorized to update sample metadata for project %{name} on this server.
       namespaces/user_namespace:
         create?: You are not authorized to create a project under the %{name} namespace
@@ -182,8 +182,8 @@ en:
               missing_metadata_fields: must contain metadata fields for linelist exports
               missing_file_format: must contain a format for linelist exports
               invalid_file_format: must have either a .xlsx or .csv format for linelist exports
-              missing_namespace_id: must have a namespace id for linelist exports
-              invalid_namespace_id: must have valid namespace for linelist exports
+              missing_namespace_id: must have a namespace id
+              invalid_namespace_id: must have valid namespace
               invalid_attachment_format: "%{invalid_formats} are not valid attachment formats"
               missing_attachment_formats: must have attachment formats for sample exports
         namespace:
@@ -1505,8 +1505,7 @@ en:
     data_exports:
       create:
         invalid_export_samples: Unable to create export due to either sample permissions or not found samples.
-        invalid_workflow_execution_id: A workflow execution selected for export does not exist.
-        invalid_workflow_execution_id_count: An analysis export may only contain one workflow execution.
+        invalid_export_workflow_executions: Unable to create export due to either workflow execution permissions or not found workflow executions.
     members:
       create:
         role_not_allowed: "A maintainer can only add members to the %{namespace_type} %{namespace_name} up to the Maintainer role"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,6 @@ en:
         read?: You are not authorized to view profile for user %{name} on this server.
         update?: You are not authorized to update user %{name} on this server.
       workflow_execution:
-        export_workflow_execution_data?: "You are not authorized to export the workflow execution %{id} on this server."
         index?: "You are not authorized to view workflow executions for %{namespace_type} %{name}"
         destroy?: "You are not authorized to destroy workflow executions for %{namespace_type} %{name}"
         read?: "You are not authorized to view workflow execution %{id}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -72,7 +72,7 @@ fr:
         submit_workflow?: You are not authorized to submit workflows for samples within group %{name} on this server.
         create_bot_accounts?: You are not authorized to create bot accounts for group %{name} on this server.
         destroy_bot_accounts?: You are not authorized to destroy bot accounts for group %{name} on this server.
-        export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        export_data?: You are not authorized to export data from project %{name} on this server.
         update_sample_metadata?: You are not authorized to update sample metadata for group %{name} on this server.
       project:
         activity?: You are not authorized to view the activity for project %{name} on this server.
@@ -109,7 +109,7 @@ fr:
         view_automated_workflow_executions?: "You are not authorized to view automated workflow executions for project %{name}"
         submit_workflow?: You are not authorized to submit workflows for samples within project %{name} on this server.
         view_workflow_executions?: You are not authorized to view workflow executions for project %{name} on this server.
-        export_sample_data?: You are not authorized to export samples from project %{name} on this server.
+        export_data?: You are not authorized to export data from project %{name} on this server.
         update_sample_metadata?: You are not authorized to update sample metadata for project %{name} on this server.
       namespaces/user_namespace:
         create?: You are not authorized to create a project under the %{name} namespace
@@ -182,8 +182,8 @@ fr:
               missing_metadata_fields: must contain metadata fields for linelist exports
               missing_file_format: must contain a format for linelist exports
               invalid_file_format: must have either a .xlsx or .csv format for linelist exports
-              missing_namespace_type: must have a namespace type for linelist exports
-              invalid_namespace_type: must have a namespace type of Group or Project for linelist exports
+              missing_namespace_id: must have a namespace id
+              invalid_namespace_id: must have valid namespace
               invalid_attachment_format: "%{invalid_formats} are not valid attachment formats"
               missing_attachment_formats: must have attachment formats for sample exports
         namespace:
@@ -1504,8 +1504,7 @@ fr:
     data_exports:
       create:
         invalid_export_samples: Unable to create export due to either sample permissions or not found samples.
-        invalid_workflow_execution_id: A workflow execution selected for export does not exist.
-        invalid_workflow_execution_id_count: An analysis export may only contain one workflow execution.
+        invalid_export_workflow_executions: Unable to create export due to either workflow execution permissions or not found workflow executions.
     members:
       create:
         role_not_allowed: "A maintainer can only add members to the %{namespace_type} %{namespace_name} up to the Maintainer role"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -126,7 +126,6 @@ fr:
         read?: You are not authorized to view profile for user %{name} on this server.
         update?: You are not authorized to update user %{name} on this server.
       workflow_execution:
-        export_workflow_execution_data?: "You are not authorized to export the workflow execution %{id} on this server."
         index?: "You are not authorized to view workflow executions for %{namespace_type} %{name}"
         destroy?: "You are not authorized to destroy workflow executions for %{namespace_type} %{name}"
         read?: "You are not authorized to view workflow execution %{id}"

--- a/test/controllers/data_exports_controller_test.rb
+++ b/test/controllers/data_exports_controller_test.rb
@@ -328,4 +328,31 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
          }
     assert_response :unprocessable_entity
   end
+
+  test 'should not create new analysis export with both user and project workflow ids and analysis_type project' do
+    user_workflow = workflow_executions(:workflow_execution_valid)
+    post data_exports_path(format: :turbo_stream),
+         params: {
+           data_export: {
+             export_type: 'analysis',
+             export_parameters: { 'ids' => [@workflow1.id, @workflow2.id, user_workflow.id],
+                                  'namespace_id' => @namespace.id,
+                                  'analysis_type' => 'project' }
+           }
+         }
+    assert_response :unprocessable_entity
+  end
+
+  test 'should not create new analysis export with both user and project workflow ids and analysis_type user' do
+    user_workflow = workflow_executions(:workflow_execution_valid)
+    post data_exports_path(format: :turbo_stream),
+         params: {
+           data_export: {
+             export_type: 'analysis',
+             export_parameters: { 'ids' => [@workflow1.id, @workflow2.id, user_workflow.id],
+                                  'analysis_type' => 'user' }
+           }
+         }
+    assert_response :unprocessable_entity
+  end
 end

--- a/test/controllers/data_exports_controller_test.rb
+++ b/test/controllers/data_exports_controller_test.rb
@@ -8,6 +8,9 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
     @sample1 = samples(:sample1)
     @project1 = projects(:project1)
     @data_export1 = data_exports(:data_export_one)
+    @namespace = namespaces_project_namespaces(:project1_namespace)
+    @workflow1 = workflow_executions(:automated_workflow_execution)
+    @workflow2 = workflow_executions(:automated_example_completed)
   end
 
   test 'should view exports' do
@@ -33,7 +36,7 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
     workflow_execution = workflow_executions(:irida_next_example_completed_with_output)
     params = { 'data_export' => {
                  'export_type' => 'analysis',
-                 'export_parameters' => { 'ids' => [workflow_execution.id] }
+                 'export_parameters' => { 'ids' => [workflow_execution.id], analysis_type: 'user' }
                },
                format: :turbo_stream }
     assert_difference('DataExport.count', 1) do
@@ -287,5 +290,42 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
       sample_ids: [@sample1.id]
     }
     assert_response :success
+  end
+
+  test 'should create new analysis export withmultiple ids' do
+    post data_exports_path(format: :turbo_stream),
+         params: {
+           data_export: {
+             export_type: 'analysis',
+             export_parameters: { 'ids' => [@workflow1.id, @workflow2.id],
+                                  'namespace_id' => @namespace.id,
+                                  'analysis_type' => 'project' }
+           }
+         }
+    assert_response :redirect
+  end
+
+  test 'should not create new analysis export with missing analysis_type' do
+    post data_exports_path(format: :turbo_stream),
+         params: {
+           data_export: {
+             export_type: 'analysis',
+             export_parameters: { 'ids' => [@workflow1.id, @workflow2.id],
+                                  'namespace_id' => @namespace.id }
+           }
+         }
+    assert_response :unprocessable_entity
+  end
+
+  test 'should not create new analysis export with invalid analysis_type' do
+    post data_exports_path(format: :turbo_stream),
+         params: {
+           data_export: {
+             export_type: 'analysis',
+             export_parameters: { 'ids' => [@workflow1.id, @workflow2.id],
+                                  'namespace_id' => 'invalid_id' }
+           }
+         }
+    assert_response :unprocessable_entity
   end
 end

--- a/test/controllers/data_exports_controller_test.rb
+++ b/test/controllers/data_exports_controller_test.rb
@@ -292,7 +292,7 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should create new analysis export withmultiple ids' do
+  test 'should create new analysis export with multiple ids' do
     post data_exports_path(format: :turbo_stream),
          params: {
            data_export: {

--- a/test/fixtures/data_exports.yml
+++ b/test/fixtures/data_exports.yml
@@ -73,7 +73,7 @@ data_export_six:
   name: Data Export 6
   export_type: analysis
   status: processing
-  export_parameters: {ids: [<%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_with_output, :uuid) %>]}
+  export_parameters: {ids: [<%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_with_output, :uuid) %>], analysis_type: 'user'}
   email_notification: true
   created_at: <%= 1.week.ago %>
   updated_at: <%= 1.day.ago %>
@@ -83,7 +83,7 @@ data_export_seven:
   name: Data Export 7
   export_type: analysis
   status: ready
-  export_parameters: {ids: [<%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_with_output, :uuid) %>]}
+  export_parameters: {ids: [<%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_with_output, :uuid) %>], analysis_type: 'user'}
   email_notification: true
   created_at: <%= 1.week.ago %>
   updated_at: <%= 1.day.ago %>

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -297,10 +297,10 @@ module DataExports
       samples_workflow_execution = samples_workflow_executions(:sample46_irida_next_example_completed_with_output)
       sample = samples(:sample46)
 
-      expected_files_in_zip = ["#{sample.puid}/#{samples_workflow_execution.outputs[0].filename}",
+      expected_files_in_zip = ["#{workflow_execution.id}/#{sample.puid}/#{samples_workflow_execution.outputs[0].filename}",
                                'manifest.json',
                                'manifest.txt',
-                               workflow_execution.outputs[0].filename.to_s]
+                               "#{workflow_execution.id}/#{workflow_execution.outputs[0].filename}"]
       DataExports::CreateJob.perform_now(@data_export6)
       export_file = ActiveStorage::Blob.service.path_for(@data_export6.file.key)
       Zip::File.open(export_file) do |zip_file|
@@ -315,23 +315,29 @@ module DataExports
         'date' => Date.current.strftime('%Y-%m-%d'),
         'children' =>
         [
-          {
-            'name' => workflow_execution.outputs[0].filename.to_s,
-            'type' => 'file'
-          },
-          {
-            'name' => sample.puid,
+          { 'name' => workflow_execution.id,
             'type' => 'folder',
-            'irida-next-type' => 'sample',
-            'irida-next-name' => sample.name,
-            'children' =>
-            [
+            'irida-next-type' => 'workflow_execution',
+            'irida-next-name' => workflow_execution.id,
+            'children' => [
               {
-                'name' => samples_workflow_execution.outputs[0].filename.to_s,
+                'name' => workflow_execution.outputs[0].filename.to_s,
                 'type' => 'file'
+              },
+              {
+                'name' => sample.puid,
+                'type' => 'folder',
+                'irida-next-type' => 'sample',
+                'irida-next-name' => sample.name,
+                'children' =>
+                [
+                  {
+                    'name' => samples_workflow_execution.outputs[0].filename.to_s,
+                    'type' => 'file'
+                  }
+                ]
               }
-            ]
-          }
+            ] }
         ]
       }
 

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -297,10 +297,12 @@ module DataExports
       samples_workflow_execution = samples_workflow_executions(:sample46_irida_next_example_completed_with_output)
       sample = samples(:sample46)
 
-      expected_files_in_zip = ["#{workflow_execution.id}/#{sample.puid}/#{samples_workflow_execution.outputs[0].filename}",
-                               'manifest.json',
-                               'manifest.txt',
-                               "#{workflow_execution.id}/#{workflow_execution.outputs[0].filename}"]
+      expected_files_in_zip = [
+        "#{workflow_execution.id}/#{sample.puid}/#{samples_workflow_execution.outputs[0].filename}",
+        'manifest.json',
+        'manifest.txt',
+        "#{workflow_execution.id}/#{workflow_execution.outputs[0].filename}"
+      ]
       DataExports::CreateJob.perform_now(@data_export6)
       export_file = ActiveStorage::Blob.service.path_for(@data_export6.file.key)
       Zip::File.open(export_file) do |zip_file|

--- a/test/models/data_export_test.rb
+++ b/test/models/data_export_test.rb
@@ -8,6 +8,7 @@ class DataExportTest < ActiveSupport::TestCase
     @project1 = projects(:project1)
     @sample1 = samples(:sample1)
     @user = users(:john_doe)
+    @workflow_execution = workflow_executions(:irida_next_example_completed_with_output)
   end
 
   test 'valid sample data export' do
@@ -53,7 +54,7 @@ class DataExportTest < ActiveSupport::TestCase
 
   test 'data export with invalid export_type' do
     data_export = DataExport.new(user: @user, status: 'ready', export_type: 'invalid type',
-                                 export_parameters: { ids: [@sample1.id] })
+                                 export_parameters: { ids: [@workflow_execution.id], analysis_type: 'user' })
     assert_not data_export.valid?
     data_export.export_type = 'analysis'
     assert data_export.valid?
@@ -78,7 +79,7 @@ class DataExportTest < ActiveSupport::TestCase
 
   test 'export with missing ids' do
     data_export = DataExport.new(user: @user, status: 'processing', export_type: 'analysis',
-                                 export_parameters: { not_ids: [@sample1.id] })
+                                 export_parameters: { not_ids: [@workflow_execution.id], analysis_type: 'user' })
     assert_not data_export.valid?
     assert_equal I18n.t('activerecord.errors.models.data_export.attributes.export_parameters.missing_ids'),
                  data_export.errors[:export_parameters].first
@@ -190,6 +191,24 @@ class DataExportTest < ActiveSupport::TestCase
     assert_not data_export.valid?
     assert_equal I18n.t(
       'activerecord.errors.models.data_export.attributes.export_parameters.missing_attachment_formats'
+    ), data_export.errors[:export_parameters].first
+  end
+
+  test 'analysis export without analysis_type param' do
+    data_export = DataExport.new(user: @user, status: 'processing', export_type: 'analysis',
+                                 export_parameters: { ids: [@workflow_execution.id] })
+    assert_not data_export.valid?
+    assert_equal I18n.t(
+      'activerecord.errors.models.data_export.attributes.export_parameters.missing_analysis_type'
+    ), data_export.errors[:export_parameters].first
+  end
+
+  test 'analysis export with invalid analysis_type param' do
+    data_export = DataExport.new(user: @user, status: 'processing', export_type: 'analysis',
+                                 export_parameters: { ids: [@workflow_execution.id], analysis_type: 'invalid_type' })
+    assert_not data_export.valid?
+    assert_equal I18n.t(
+      'activerecord.errors.models.data_export.attributes.export_parameters.invalid_analysis_type'
     ), data_export.errors[:export_parameters].first
   end
 end

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -73,8 +73,8 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   test '#clone_sample_into_project?' do
     assert @policy.clone_sample_into_project?
   end
-  test '#export_sample_data?' do
-    assert @policy.export_sample_data?
+  test '#export_data?' do
+    assert @policy.export_data?
   end
 
   test '#submit_workflow?' do

--- a/test/services/data_exports/create_service_test.rb
+++ b/test/services/data_exports/create_service_test.rb
@@ -73,8 +73,8 @@ module DataExports
                                                 'attachment_formats' =>
                                Attachment::FORMAT_REGEX.keys } }
 
-      assert_authorized_to(:export_sample_data?, @project1.namespace, with: Namespaces::ProjectNamespacePolicy,
-                                                                      context: { user: @user }) do
+      assert_authorized_to(:export_data?, @project1.namespace, with: Namespaces::ProjectNamespacePolicy,
+                                                               context: { user: @user }) do
         DataExports::CreateService.new(@user, valid_params).execute
       end
     end
@@ -94,9 +94,9 @@ module DataExports
       end
 
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
-      assert_equal :export_sample_data?, exception.rule
+      assert_equal :export_data?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
-      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.export_sample_data?',
+      assert_equal I18n.t(:'action_policy.policy.namespaces/project_namespace.export_data?',
                           name: @project1.name),
                    exception.result.message
     end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds new logic to accept multiple workflow execution IDs for any analysis export

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Set up the ability to run workflow executions locally as described in [PR 507](https://github.com/phac-nml/irida-next/pull/507)
2. Run a couple workflow executions
3. Once completed, export it with:
```
user = USER YOU MADE WORKFLOW EXECUTION WITH
params_1 = {'export_type' => 'analysis', 'export_parameters' => {'ids' => [FIRST_WORKFLOW_EXECUTION_ID, SECOND_WORKFLOW_EXECUTION_ID], 'analysis_type' => 'user'}, 'email_notification' => true, 'name' => 'test export'}
DataExports::CreateService.new(user, params_1).execute
```
4. After 30s, download the export either through the UI or with (replace `localhost` with `localhost:3000` in the given URL):
```
data_export = DataExport.last
Rails.application.routes.url_helpers.rails_blob_url(data_export.file)
```
5. Ensure the top level directory now contains folders named with the `workflow_execution.id` and that they contain the expected files. Ensure both `manifest.txt` and `manifest.json` contain the accurate folder naming and structure
6. Repeat the above with workflow executions from `Automated Workflow Executions`, The workflows can be set up with the steps described in [PR585](https://github.com/phac-nml/irida-next/pull/585). 
The following will need to be changed in your params:
- Replace `"analysis_type" => "user"` with `"analysis_type" => "project"`
- Add `namespace_id => NAMESPACE_ID OF THE PROJECT YOU'RE EXPORTING FROM` to `params["export_parameters"]`
- Ensure you're using a user that is an `owner or maintainer` of the project. 
- Example params:
```
user = USER WITH CORRECT ACCESS
params_2 = {'export_type' => 'analysis', 'export_parameters' => {'ids' => [FIRST_WORKFLOW_EXECUTION_ID, SECOND_WORKFLOW_EXECUTION_ID], 'analysis_type' => 'project', 'namespace_id' => 'PROJECT.NAMESPACE_ID'}, 'email_notification' => true, 'name' => 'test export'}
DataExports::CreateService.new(user, params_2).execute
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
