### PR TITLE
Fix: Metadata selection in nextflow samplesheet

### DIFF
--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -13,7 +13,7 @@
     <%= text_for(@workflow.description) %>
   </p>
   <%= form_with url: url, method: (instance.nil? ? :post : :patch),
-                data: { turbo_frame: "_top", action: "turbo:submit-end->viral--dialog#close" } do |form| %>
+                data: { turbo_frame: "_top" } do |form| %>
     <input id="submission_turbo" type="hidden" name="format" value="turbo_stream"/>
 
     <%= fields_for :workflow_execution do |workflow| %>
@@ -94,18 +94,18 @@
                                checked: instance.present? && instance["update_samples"],
                                class:
                                  "w-4
-                                                                                                                            h-4
-                                                                                                                            mr-2.5
-                                                                                                                            text-primary-600
-                                                                                                                            bg-slate-100
-                                                                                                                            border-slate-300
-                                                                                                                            rounded
-                                                                                                                            focus:ring-primary-500
-                                                                                                                            dark:focus:ring-primary-600
-                                                                                                                            dark:ring-offset-slate-800
-                                                                                                                            focus:ring-2
-                                                                                                                            dark:bg-slate-700
-                                                                                                                            dark:border-slate-600",
+                                                                                                                                                h-4
+                                                                                                                                                mr-2.5
+                                                                                                                                                text-primary-600
+                                                                                                                                                bg-slate-100
+                                                                                                                                                border-slate-300
+                                                                                                                                                rounded
+                                                                                                                                                focus:ring-primary-500
+                                                                                                                                                dark:focus:ring-primary-600
+                                                                                                                                                dark:ring-offset-slate-800
+                                                                                                                                                focus:ring-2
+                                                                                                                                                dark:bg-slate-700
+                                                                                                                                                dark:border-slate-600",
                              } %>
           <%= workflow.label :update_samples,
                          t(:"components.nextflow.update_samples"),
@@ -119,18 +119,18 @@
                                instance.present? && instance["email_notification"],
                              class:
                                "w-4
-                                                                                                        h-4
-                                                                                                        mr-2.5
-                                                                                                        text-primary-600
-                                                                                                        bg-slate-100
-                                                                                                        border-slate-300
-                                                                                                        rounded
-                                                                                                        focus:ring-primary-500
-                                                                                                        dark:focus:ring-primary-600
-                                                                                                        dark:ring-offset-slate-800
-                                                                                                        focus:ring-2
-                                                                                                        dark:bg-slate-700
-                                                                                                        dark:border-slate-600",
+                                                                                                                        h-4
+                                                                                                                        mr-2.5
+                                                                                                                        text-primary-600
+                                                                                                                        bg-slate-100
+                                                                                                                        border-slate-300
+                                                                                                                        rounded
+                                                                                                                        focus:ring-primary-500
+                                                                                                                        dark:focus:ring-primary-600
+                                                                                                                        dark:ring-offset-slate-800
+                                                                                                                        focus:ring-2
+                                                                                                                        dark:bg-slate-700
+                                                                                                                        dark:border-slate-600",
                            } %>
         <%= workflow.label :email_notification,
                        t(:"components.nextflow.email_notification"),

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -6,12 +6,16 @@ export default class extends Controller {
   connect() {
     this.element.addEventListener("turbo:submit-start", (event) => {
       this.submitTarget.disabled = true;
-      this.tableTarget.appendChild(this.loadingTarget.content.cloneNode(true));
+      if (this.hasTableTarget) {
+        this.tableTarget.appendChild(this.loadingTarget.content.cloneNode(true));
+      }
     });
 
     this.element.addEventListener("turbo:submit-end", (event) => {
       this.submitTarget.disabled = false;
-      this.tableTarget.removeChild(this.tableTarget.lastElementChild);
+      if (this.hasTableTarget) {
+        this.tableTarget.removeChild(this.tableTarget.lastElementChild);
+      }
     });
   }
 

--- a/app/views/projects/automated_workflow_executions/update.turbo_stream.erb
+++ b/app/views/projects/automated_workflow_executions/update.turbo_stream.erb
@@ -1,1 +1,3 @@
 <%= turbo_stream.update "automated_workflow_executions_table", partial: "table" %>
+
+<%= turbo_stream.update "automated_workflow_execution_modal" %>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

When selecting a metadata column in the samplesheet for a pipeline, the dialog would close after retrieving the metadata.

This bug was accidentally introduced when fixing editing automated workflow executions where we wanted the dialog to close on update.

Update action for automated workflow execution has been updated to close the dialog after update instead of using turbo hook.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
