### PR TITLE
Enhancement: Export Show

### DIFF
--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -42,7 +42,7 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
     else
       flash[:success] = t('.success', name: @data_export.name || @data_export.id)
 
-      redirect_to data_export_path(@data_export, format: :html)
+      redirect_to data_export_path(@data_export)
     end
   end
 

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -3,6 +3,7 @@
 # entity class for DataExport
 class DataExport < ApplicationRecord
   has_logidze
+  broadcasts_refreshes
 
   belongs_to :user
 

--- a/app/views/data_exports/show.html.erb
+++ b/app/views/data_exports/show.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+<%= turbo_stream_from @data_export %>
 <%= render Viral::PageHeaderComponent.new(
   title: @data_export.name || @data_export.id, id: @data_export.name.nil? ? nil : @data_export.id) do |component| %>
   <%= component.with_buttons do %>
@@ -70,14 +72,9 @@
       <% end %>
     <% end %>
   </div>
-  <div class="flex flex-col" data-turbo-temporary>
-    <%= turbo_frame_tag "data-export-listing",
-      src: data_export_path(format: :turbo_stream, tab: @tab || 'summary') do %>
-      <% if @tab == "preview" %>
-        <%= render partial: "shared/loading/list" %>
-      <% else %>
-        <%= render partial: "shared/loading/table" %>
-      <% end %>
-    <% end %>
-  </div>
+  <% if @tab == "preview" %>
+    <%= render partial: "preview" %>
+  <% else %>
+    <%= render partial: "summary" %>
+  <% end %>
 </div>

--- a/app/views/data_exports/show.turbo_stream.erb
+++ b/app/views/data_exports/show.turbo_stream.erb
@@ -1,7 +1,0 @@
-<%= turbo_stream.update "data-export-listing" do %>
-  <% if @tab == 'preview' %>
-    <% render partial: "preview" %>
-  <% else %>
-    <% render partial: "summary" %>
-  <% end %>
-<% end %>

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -173,7 +173,7 @@ class DataExportsTest < ApplicationSystemTestCase
     # processing
     visit data_export_path(@data_export2)
 
-    within %(div:nth-child(3) dd) do
+    within %(dl div:nth-child(3) dd) do
       assert_selector 'span.bg-slate-100.text-slate-800.text-xs.font-medium.rounded-full',
                       text: I18n.t(:"data_exports.status.#{@data_export2.status}")
     end
@@ -181,7 +181,7 @@ class DataExportsTest < ApplicationSystemTestCase
     # ready
     visit data_export_path(@data_export1)
 
-    within %(div:nth-child(4) dd) do
+    within %(dl div:nth-child(4) dd) do
       assert_selector 'span.bg-green-100.text-green-800.text-xs.font-medium.rounded-full',
                       text: I18n.t(:"data_exports.status.#{@data_export1.status}")
     end


### PR DESCRIPTION
## What does this PR do and why?
This PR enhances the Data Exports' `show` page to automatically refresh once the export status changes from `processing` to `ready`.

## Screenshots or screen recordings
[Screencast from 2024-08-22 12:36:08 PM.webm](https://github.com/user-attachments/assets/e8a2ead9-e092-4411-b36b-d2ff665eee41)

## How to set up and validate locally
1. Create a sample export
2. Once redirected onto the `show page`, stay on the page for 30s until the export is ready. The page should automatically refresh and the following should change:
- Status changes from `processing` to `ready`
- `Download` button is enabled
- Expiry date is available
- `Preview` tab is added

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
