### PR TITLE
Enhancement: Data Export Index

### DIFF
--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -63,22 +63,17 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
     end
   end
 
-  def destroy # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  def destroy
     DataExports::DestroyService.new(@data_export, current_user).execute
-    # Destroyed from data export show view
-    if !@data_export.persisted? && params[:redirect]
-      flash[:success] = t('.success', name: @data_export.name || @data_export.id)
-      redirect_to data_exports_path
-    # Destroyed from data exports listing index view
-    else
-      respond_to do |format|
-        format.turbo_stream do
-          if @data_export.persisted?
-            render status: :unprocessable_entity, locals: { type: 'alert', message: t('.error') }
-          else
-            render status: :ok,
-                   locals: { type: 'success', message: t('.success', name: @data_export.name || @data_export.id) }
-          end
+    respond_to do |format|
+      format.turbo_stream do
+        if @data_export.persisted?
+          render status: :unprocessable_entity,
+                 locals: { type: 'alert',
+                           message: t('.error', name: @data_export.name || @data_export.id) }
+        else
+          flash[:success] = t('.success', name: @data_export.name || @data_export.id)
+          redirect_to data_exports_path
         end
       end
     end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -7,6 +7,8 @@ class DataExport < ApplicationRecord
 
   belongs_to :user
 
+  after_commit { broadcast_refresh_to [user, :data_exports] }
+
   has_one_attached :file, dependent: :purge_later
 
   validates :status, presence: true, acceptance: { accept: %w[processing ready] }

--- a/app/services/data_exports/create_service.rb
+++ b/app/services/data_exports/create_service.rb
@@ -15,7 +15,7 @@ module DataExports
       if @data_export.valid?
         @data_export.export_type == 'analysis' ? validate_analysis_ids : validate_sample_ids
         @data_export.save
-        DataExports::CreateJob.set(wait_until: 5.seconds.from_now).perform_later(@data_export)
+        DataExports::CreateJob.set(wait_until: 30.seconds.from_now).perform_later(@data_export)
       end
 
       @data_export

--- a/app/views/data_exports/destroy.turbo_stream.erb
+++ b/app/views/data_exports/destroy.turbo_stream.erb
@@ -2,6 +2,4 @@
   <%= viral_flash(type:, data: message) %>
 <% end %>
 
-<% unless @data_export.persisted? %>
-  <%= turbo_stream.update "data_exports_table", partial: "table" %>
-<% end %>
+<turbo-stream action="refresh"></turbo-stream>

--- a/app/views/data_exports/index.html.erb
+++ b/app/views/data_exports/index.html.erb
@@ -1,5 +1,7 @@
+<%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+
+<%= turbo_stream_from current_user, :data_exports %>
+
 <%= render Viral::PageHeaderComponent.new(title: t(".title")) %>
 
-<%= turbo_frame_tag "data_exports_table" do %>
-    <%= render partial: "table" %>
-<% end %>
+<%= render partial: "table" %>

--- a/app/views/data_exports/show.html.erb
+++ b/app/views/data_exports/show.html.erb
@@ -30,7 +30,7 @@
       <% end %>
         <%= link_to(
           t("data_exports.show.remove_button"),
-          data_export_path(@data_export, redirect: true),
+          data_export_path(@data_export),
           data: {
             turbo_method: :delete,
             turbo_confirm: t("data_exports.show.remove_button_confirmation", name: @data_export.name || @data_export.id)

--- a/test/controllers/data_exports_controller_test.rb
+++ b/test/controllers/data_exports_controller_test.rb
@@ -84,7 +84,7 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
       delete data_export_path(@data_export1),
              as: :turbo_stream
     end
-    assert_response :success
+    assert_response :redirect
   end
 
   test 'should delete export and redirect through destroy action if redirect param present' do

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -94,6 +94,7 @@ module DataExports
                                'manifest.txt']
       actual_simple_manifest = ''
 
+      DataExports::CreateJob.perform_now(@data_export2)
       export_file = ActiveStorage::Blob.service.path_for(@data_export2.file.key)
       Zip::File.open(export_file) do |zip_file|
         zip_file.each do |entry|

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -484,9 +484,10 @@ module DataExports
     end
 
     test 'turbo stream broadcasts' do
-      assert_no_turbo_stream_broadcasts [users(:john_doe), :data_exports]
+      user = users(:john_doe)
+      assert_no_turbo_stream_broadcasts [user, :data_exports]
 
-      assert_turbo_stream_broadcasts [users(:john_doe), :data_exports], count: 3 do
+      assert_turbo_stream_broadcasts [user, :data_exports], count: 3 do
         DataExports::CreateJob.perform_now(@data_export2)
       end
     end

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -94,7 +94,6 @@ module DataExports
                                'manifest.txt']
       actual_simple_manifest = ''
 
-      DataExports::CreateJob.perform_now(@data_export2)
       export_file = ActiveStorage::Blob.service.path_for(@data_export2.file.key)
       Zip::File.open(export_file) do |zip_file|
         zip_file.each do |entry|
@@ -481,6 +480,14 @@ module DataExports
       end
       assert expected_files_in_zip.empty?
       assert_equal expected_manifest.to_json, data_export.manifest
+    end
+
+    test 'turbo stream broadcasts' do
+      assert_no_turbo_stream_broadcasts [users(:john_doe), :data_exports]
+
+      assert_turbo_stream_broadcasts [users(:john_doe), :data_exports], count: 3 do
+        DataExports::CreateJob.perform_now(@data_export2)
+      end
     end
   end
 end

--- a/test/models/data_export_test.rb
+++ b/test/models/data_export_test.rb
@@ -213,13 +213,14 @@ class DataExportTest < ActiveSupport::TestCase
   end
 
   test 'turbo stream broadcasts' do
+    user = users(:john_doe)
     data_export = DataExport.new(user: @user, status: 'processing', export_type: 'sample',
                                  export_parameters: { ids: [@sample1.id], namespace_id: @project1.namespace.id,
                                                       attachment_formats: Attachment::FORMAT_REGEX.keys })
 
-    assert_no_turbo_stream_broadcasts [users(:john_doe), :data_exports]
+    assert_no_turbo_stream_broadcasts [user, :data_exports]
 
-    assert_turbo_stream_broadcasts [users(:john_doe), :data_exports], count: 1 do
+    assert_turbo_stream_broadcasts [user, :data_exports], count: 1 do
       data_export.save
     end
   end

--- a/test/models/data_export_test.rb
+++ b/test/models/data_export_test.rb
@@ -213,14 +213,13 @@ class DataExportTest < ActiveSupport::TestCase
   end
 
   test 'turbo stream broadcasts' do
-    user = users(:john_doe)
     data_export = DataExport.new(user: @user, status: 'processing', export_type: 'sample',
                                  export_parameters: { ids: [@sample1.id], namespace_id: @project1.namespace.id,
                                                       attachment_formats: Attachment::FORMAT_REGEX.keys })
 
-    assert_no_turbo_stream_broadcasts [user, :data_exports]
+    assert_no_turbo_stream_broadcasts [@user, :data_exports]
 
-    assert_turbo_stream_broadcasts [user, :data_exports], count: 1 do
+    assert_turbo_stream_broadcasts [@user, :data_exports], count: 1 do
       data_export.save
     end
   end

--- a/test/models/data_export_test.rb
+++ b/test/models/data_export_test.rb
@@ -3,13 +3,6 @@
 require 'test_helper'
 
 class DataExportTest < ActiveSupport::TestCase
-  extend ActiveSupport::Concern
-
-  included do
-    include ActionCable::TestHelper
-
-    include Turbo::Streams::StreamName
-  end
   def setup
     @export1 = data_exports(:data_export_one)
     @project1 = projects(:project1)
@@ -224,8 +217,7 @@ class DataExportTest < ActiveSupport::TestCase
                                  export_parameters: { ids: [@sample1.id], namespace_id: @project1.namespace.id,
                                                       attachment_formats: Attachment::FORMAT_REGEX.keys })
 
-    assert_no_turbo_stream_broadcasts [users(:john_doe),
-                                       :data_exports]
+    assert_no_turbo_stream_broadcasts [users(:john_doe), :data_exports]
 
     assert_turbo_stream_broadcasts [users(:john_doe), :data_exports], count: 1 do
       data_export.save


### PR DESCRIPTION
## What does this PR do and why?
This PR adds enhancements to the Data Exports `index` page, where the page will automatically refresh when export statuses change from `processing` to `ready`.

## Screenshots or screen recordings
[Screencast from 2024-08-22 12:38:18 PM.webm](https://github.com/user-attachments/assets/a724667b-cfa9-4ea9-8bd4-924cb985840b)

## How to set up and validate locally
1. Through the UI, create an export
2. After redirection to the `show` page, navigate to the `index` page.
3. After 30s, the page should refresh on its own and the export status should now be `ready` with the available `download` link.

Other tests:
4. Logic for data export deletion was changed. Delete exports from both the `index` and `show` page. Ensure on the `index` page that the table updates upon deletion with the expected success flash message. On the `show` page, ensure you are redirected back to the `index` page, the proper flash message appears, and the export no longer exists in the table.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
