### PR TITLE
PUID: Uniqueness Conflict Recovery and Resolution Increase

### DIFF
--- a/app/models/concerns/has_puid.rb
+++ b/app/models/concerns/has_puid.rb
@@ -21,7 +21,7 @@ module HasPuid
     rescue ActiveRecord::RecordNotUnique => e
       raise e unless e.message.match(/Key \(puid\)=\(.*\) already exists./)
 
-      Rails.logger.info("Puid conflict encountered for #{klass}, regerating Puid and attempting to save again.")
+      Rails.logger.info("Puid conflict encountered for #{self.class}, regerating Puid and attempting to save again.")
       generate_puid(force: true)
       save!
     end

--- a/lib/base32.rb
+++ b/lib/base32.rb
@@ -24,6 +24,16 @@ module Base32
     encoded.join
   end
 
+  def decode32(string)
+    number = 0
+
+    string.reverse.chars.each_with_index do |char, index|
+      number += ALPHABET.index(char) * (32**index)
+    end
+
+    number
+  end
+
   def encodable?(number, length)
     Math.log(number + 1, 32) <= length
   end

--- a/lib/irida/persistent_unique_id.rb
+++ b/lib/irida/persistent_unique_id.rb
@@ -32,7 +32,7 @@ module Irida
       base32_string = Base32.encode32(time.year - 2000, 2)
       base32_string << Base32.encode32(time.month, 1)
       base32_string << Base32.encode32(time.day, 1)
-      base32_string << Base32.encode32(Integer(time.seconds_since_midnight * 1024), 6)
+      base32_string << Base32.encode32(Integer(time.seconds_since_midnight * 12_228), 6)
     end
 
     def valid_puid?(puid, object_class = nil)


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updates PUID resolution from 1024 to 12228 per second.
Updates HasPuid to override `save!` method to rescue from unique constraint violation for PUID, and regenerate and then re save until no conflicts.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Comment out lines 10-15 in `app/models/concerns/has_puid.rb`
2. Launch server with `bin/dev`
3. Clone 1 sample from one project to another.
  * Observe the following in the log output:
  ```
↳ app/models/concerns/has_puid.rb:18:in `save!'
TRANSACTION (0.1ms)  ROLLBACK
```
  * Observe that clone succeeds

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
