### PR TITLE
Groups/Projects layout: Add controller option for fixed layout

### DIFF
--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -2,13 +2,11 @@
   class="layout-body bg-white dark:bg-slate-800"
   data-controller="layout"
   data-layout-target="layoutContainer"
+  data-turbo-prefetch="false"
 >
   <%= sidebar %>
   <div class="relative content">
-    <nav
-      class="flex px-5"
-      style="height: 50px"
-    >
+    <nav class="flex px-5" style="height: 50px">
       <button
         data-layout-target="expandButton"
         data-action="click->layout#expand"
@@ -20,7 +18,13 @@
         <%= breadcrumb %>
       </turbo-frame>
     </nav>
-    <main class="absolute bottom-0 left-0 right-0 p-4 overflow-y-auto top-12 border-t border-slate-200 dark:border-slate-950" tabindex="0">
+    <main
+      class="
+        absolute bottom-0 left-0 right-0 p-4 overflow-y-auto top-12 border-t
+        border-slate-200 dark:border-slate-950
+      "
+      tabindex="0"
+    >
       <div class="<%= @layout %>"><%= body %></div>
     </main>
     <%= render ConfirmationComponent.new %>

--- a/app/components/samples/table_component.rb
+++ b/app/components/samples/table_component.rb
@@ -54,8 +54,7 @@ module Samples
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('table-container flex flex-col shrink min-h-0'),
-        data: { 'turbo-prefetch': false }
+        classes: class_names('table-container flex flex-col shrink min-h-0')
       }
     end
 

--- a/app/controllers/groups/application_controller.rb
+++ b/app/controllers/groups/application_controller.rb
@@ -5,13 +5,13 @@ module Groups
   class ApplicationController < ApplicationController
     include BreadcrumbNavigation
 
-    before_action :fixed
+    before_action :layout_fixed
 
     layout 'groups'
 
     private
 
-    def fixed
+    def layout_fixed
       @fixed = true
     end
 

--- a/app/controllers/groups/application_controller.rb
+++ b/app/controllers/groups/application_controller.rb
@@ -4,9 +4,16 @@ module Groups
   # Base Controller for Groups
   class ApplicationController < ApplicationController
     include BreadcrumbNavigation
+
+    before_action :fixed
+
     layout 'groups'
 
     private
+
+    def fixed
+      @fixed = true
+    end
 
     def context_crumbs
       @context_crumbs = route_to_context_crumbs(@group.route)

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -45,7 +45,7 @@ module Groups
                                                                                                      :route] })
     end
 
-    def fixed
+    def layout_fixed
       super
       return unless action_name == 'index'
 

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -45,6 +45,13 @@ module Groups
                                                                                                      :route] })
     end
 
+    def fixed
+      super
+      return unless action_name == 'index'
+
+      @fixed = false
+    end
+
     def context_crumbs
       super
       case action_name

--- a/app/controllers/projects/application_controller.rb
+++ b/app/controllers/projects/application_controller.rb
@@ -6,7 +6,7 @@ module Projects
     include BreadcrumbNavigation
 
     before_action :project
-    before_action :fixed
+    before_action :layout_fixed
 
     layout 'projects'
 
@@ -17,7 +17,7 @@ module Projects
       @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
     end
 
-    def fixed
+    def layout_fixed
       @fixed = true
     end
 

--- a/app/controllers/projects/application_controller.rb
+++ b/app/controllers/projects/application_controller.rb
@@ -6,6 +6,7 @@ module Projects
     include BreadcrumbNavigation
 
     before_action :project
+    before_action :fixed
 
     layout 'projects'
 
@@ -14,6 +15,10 @@ module Projects
     def project
       path = [params[:namespace_id], params[:project_id]].join('/')
       @project ||= Namespaces::ProjectNamespace.find_by_full_path(path).project # rubocop:disable Rails/DynamicFindBy
+    end
+
+    def fixed
+      @fixed = true
     end
 
     def context_crumbs

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -116,6 +116,13 @@ module Projects
         }]
     end
 
+    def fixed
+      super
+      return unless action_name == 'index'
+
+      @fixed = false
+    end
+
     def current_page
       @current_page = t(:'projects.sidebar.samples')
     end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -116,7 +116,7 @@ module Projects
         }]
     end
 
-    def fixed
+    def layout_fixed
       super
       return unless action_name == 'index'
 

--- a/app/controllers/projects/workflow_executions_controller.rb
+++ b/app/controllers/projects/workflow_executions_controller.rb
@@ -45,6 +45,10 @@ module Projects
 
     protected
 
+    def fixed
+      @fixed = false
+    end
+
     def redirect_path
       namespace_project_workflow_executions_path
     end

--- a/app/controllers/projects/workflow_executions_controller.rb
+++ b/app/controllers/projects/workflow_executions_controller.rb
@@ -45,7 +45,7 @@ module Projects
 
     protected
 
-    def fixed
+    def layout_fixed
       @fixed = false
     end
 

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -2,33 +2,33 @@
 <html class="light" lang="<%= locale %>">
   <%= render "layouts/partials/head" %>
   <body class="bg-white dark:bg-slate-900">
-    <%= render LayoutComponent.new(user: current_user) do |layout| %>
-    <% layout.with_sidebar(label: turbo_frame_tag("sidebar_group_name") { @group.name }, icon_name: "squares_2x2", pipelines_enabled: @pipelines_enabled) do |navigation| %>
+    <%= render LayoutComponent.new(user: current_user, fixed: @fixed) do |layout| %>
+      <% layout.with_sidebar(label: turbo_frame_tag("sidebar_group_name") { @group.name }, icon_name: "squares_2x2", pipelines_enabled: @pipelines_enabled) do |navigation| %>
         <%= navigation.with_section do |section| %>
           <%= render section.with_item(
             url: group_path(@group),
             icon: "squares_2x2",
             label: t(:"groups.sidebar.details"),
-            selected: @current_page == t(:"groups.sidebar.details")
+            selected: @current_page == t(:"groups.sidebar.details"),
           ) %>
           <%= render section.with_item(
             url: group_samples_path(@group),
             icon: "beaker",
             label: t(:"groups.sidebar.samples"),
-            selected: @current_page == t(:"groups.sidebar.samples")
+            selected: @current_page == t(:"groups.sidebar.samples"),
           ) %>
           <%= render section.with_item(
             url: group_members_path(@group),
             icon: "users",
             label: t(:"groups.sidebar.members"),
-            selected: @current_page == t(:"groups.sidebar.members")
+            selected: @current_page == t(:"groups.sidebar.members"),
           ) %>
           <% if allowed_to?(:view_history?, @group) %>
             <%= render section.with_item(
               url: group_history_path(@group),
               icon: "list_bullet",
               label: t(:"groups.sidebar.history"),
-              selected: @current_page == t(:"groups.sidebar.history")
+              selected: @current_page == t(:"groups.sidebar.history"),
             ) %>
           <% end %>
           <% if allowed_to?(:update?, @group) %>

--- a/app/views/layouts/projects.html.erb
+++ b/app/views/layouts/projects.html.erb
@@ -2,8 +2,8 @@
 <html class="light" lang="<%= locale %>">
   <%= render "layouts/partials/head" %>
   <body class="bg-white dark:bg-slate-900">
-    <%= render LayoutComponent.new(user: current_user) do |layout| %>
-    <% layout.with_sidebar(label: turbo_frame_tag("sidebar_project_name") { @project.name }, icon_name: "rectangle_stack", pipelines_enabled: @pipelines_enabled) do |navigation| %>
+    <%= render LayoutComponent.new(user: current_user, fixed: @fixed) do |layout| %>
+      <% layout.with_sidebar(label: turbo_frame_tag("sidebar_project_name") { @project.name }, icon_name: "rectangle_stack", pipelines_enabled: @pipelines_enabled) do |navigation| %>
         <%= navigation.with_section do |section| %>
           <%= render section.with_item(
             url: project_path(@project),
@@ -31,7 +31,7 @@
               selected: @current_page == t(:"projects.sidebar.history"),
             ) %>
           <% end %>
-        <% if allowed_to?(:view_workflow_executions?, @project.namespace) && @pipelines_enabled %>
+          <% if allowed_to?(:view_workflow_executions?, @project.namespace) && @pipelines_enabled %>
             <%= render section.with_item(
               url: project_workflow_executions_path(@project),
               icon: "command_line",
@@ -60,13 +60,14 @@
                 label: t(:"projects.sidebar.bot_accounts"),
                 selected: @current_page == t(:"projects.sidebar.bot_accounts"),
               ) %>
-            <% if @pipelines_enabled %>
-              <% multi_level_menu.with_menu_item(
-                url: project_automated_workflow_executions_path(@project),
-                label: t(:"projects.sidebar.automated_workflow_executions"),
-                selected: @current_page == t(:"projects.sidebar.automated_workflow_executions"),
-              ) %>
-            <% end %>
+              <% if @pipelines_enabled %>
+                <% multi_level_menu.with_menu_item(
+                  url: project_automated_workflow_executions_path(@project),
+                  label: t(:"projects.sidebar.automated_workflow_executions"),
+                  selected:
+                    @current_page == t(:"projects.sidebar.automated_workflow_executions"),
+                ) %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/projects/automated_workflow_executions/_automated_workflow_execution.html.erb
+++ b/app/views/projects/automated_workflow_executions/_automated_workflow_execution.html.erb
@@ -7,24 +7,14 @@
   </td>
   <td
     class="
-      px-6
-      py-4
-      font-medium
-      text-slate-900
-      whitespace-nowrap
-      dark:text-white
+      px-6 py-4 font-medium text-slate-900 whitespace-nowrap dark:text-white
     "
   >
     <%= automated_workflow_execution["name"] %>
   </td>
   <td
     class="
-      px-6
-      py-4
-      font-medium
-      text-slate-900
-      whitespace-nowrap
-      dark:text-white
+      px-6 py-4 font-medium text-slate-900 whitespace-nowrap dark:text-white
     "
   >
     <%= automated_workflow_execution.metadata["workflow_name"] %>
@@ -35,16 +25,12 @@
   <td class="px-6 py-4 whitespace-nowrap">
     <%= local_time(automated_workflow_execution["created_at"], :full_date) %>
   </td>
+  <td class="px-6 py-4 whitespace-nowrap">
+    <%= local_time_ago(automated_workflow_execution["updated_at"]) %>
+  </td>
   <td
     class="
-      px-6
-      py-4
-      space-x-2
-      whitespace-nowrap
-      sticky
-      right-0
-      bg-white
-      dark:bg-slate-800
+      px-6 py-4 space-x-2 whitespace-nowrap sticky right-0 bg-white dark:bg-slate-800
     "
   >
     <%= link_to(
@@ -52,24 +38,24 @@
       namespace_project_automated_workflow_execution_path(
         @project.parent,
         @project,
-        automated_workflow_execution
+        automated_workflow_execution,
       ),
       data: {
         turbo_method: :delete,
         turbo_confirm:
-          t(:"projects.automated_workflow_executions.actions.delete_confirm")
+          t(:"projects.automated_workflow_executions.actions.delete_confirm"),
       },
       class:
-        "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer"
+        "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
     ) %>
     <%= link_to t(:"projects.automated_workflow_executions.actions.edit_button"),
     edit_namespace_project_automated_workflow_execution_path(
       @project.parent,
       @project,
-      automated_workflow_execution
+      automated_workflow_execution,
     ),
     data: {
-      turbo_stream: true
+      turbo_stream: true,
     },
     class:
       "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer" %>

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -17,7 +17,7 @@
       "aria-label": attachment.file.filename,
       data: {
         selection_target: "rowSelection",
-        action: "input->selection#toggle"
+        action: "input->selection#toggle",
       },
       class:
         "text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
@@ -35,7 +35,7 @@
             <%= link_to attachment.file.filename,
             rails_blob_path(attachment.file),
             data: {
-              turbo: false
+              turbo: false,
             },
             class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
           </span>
@@ -46,7 +46,7 @@
             <%= link_to attachment.associated_attachment.file.filename,
             rails_blob_path(attachment.associated_attachment.file),
             data: {
-              turbo: false
+              turbo: false,
             },
             class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
           </span>
@@ -62,7 +62,7 @@
             <%= link_to attachment.file.filename,
             rails_blob_path(attachment.file),
             data: {
-              turbo: false
+              turbo: false,
             },
             class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
           </span>
@@ -73,11 +73,11 @@
 
   <td class="px-6 py-4"><%= viral_pill(
       text: attachment.metadata["format"],
-      color: find_pill_color_for_attachment(attachment, "format")
+      color: find_pill_color_for_attachment(attachment, "format"),
     ) %></td>
   <td class="px-6 py-4"><%= viral_pill(
       text: attachment.metadata["type"],
-      color: find_pill_color_for_attachment(attachment, "type")
+      color: find_pill_color_for_attachment(attachment, "type"),
     ) %></td>
 
   <% if attachment.associated_attachment %>
@@ -103,13 +103,10 @@
         t(".delete"),
         namespace_project_sample_attachment_new_destroy_path(
           sample_id: @sample.id,
-          attachment_id: attachment.id
+          attachment_id: attachment.id,
         ),
-        data: {
-          "turbo-prefetch": false,
-        },
         class:
-          "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer"
+          "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
       ) %>
     <% end %>
   </td>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Previously both the groups and projects layouts specified that the LayoutComponent was always fixed, now controllers which use either layout can specify if the layout should be fixed or not (e.g. be able to take the full width).

With this change, both the Group and Project Samples index use non fixed layout and Project Workflow Executions uses non fixed layout.

Additionally `data-turbo-prefetch="false"` has been added to LayoutComponent, so now hovering over a link will not preload it anywhere within the application.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/12131997-920f-443b-95b8-130271759604)

![image](https://github.com/user-attachments/assets/98c60925-da56-4bf4-ba96-c37e6d2668ec)

![image](https://github.com/user-attachments/assets/32d108bf-ee18-4d86-bc25-495705114f53)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch server
2. Go to Project Samples Page, make browser full screen and toggle sidebar (observe that the table consumes full width)
3. Go to Group Samples Page, make browser full screen and toggle sidebar (observe that the table consumes full width)
4. Go to a Project, setup an Automated Workflow Execution, add a sample, add pairend data, go to Project Workflow Executions page and toggle sidebar (observe that the table consumes full width)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
