### PR TITLE
GraphQL: Projects query add group_id arg

### DIFF
--- a/app/graphql/resolvers/projects_resolver.rb
+++ b/app/graphql/resolvers/projects_resolver.rb
@@ -14,7 +14,7 @@ module Resolvers
       if group_id
         group = IridaSchema.object_from_id(group_id, { expected_type: Group })
         authorize!(group, to: :read?, with: GroupPolicy)
-        authorized_scope(Group, type: :relation, as: :group_projects, scope_options: { group: })
+        authorized_scope(Project, type: :relation, as: :group_projects, scope_options: { group: })
       else
         authorized_scope Project, type: :relation
       end

--- a/app/graphql/resolvers/projects_resolver.rb
+++ b/app/graphql/resolvers/projects_resolver.rb
@@ -20,7 +20,7 @@ module Resolvers
       end
     end
 
-    def ready?(**args)
+    def ready?(**_args)
       authorize!(to: :query?, with: GraphqlPolicy, context: { token: context[:token] })
     end
   end

--- a/app/graphql/resolvers/projects_resolver.rb
+++ b/app/graphql/resolvers/projects_resolver.rb
@@ -5,8 +5,23 @@ module Resolvers
   class ProjectsResolver < BaseResolver
     type Types::ProjectType.connection_type, null: true
 
-    def resolve
-      authorized_scope Project, type: :relation
+    argument :group_id, GraphQL::Types::ID,
+             required: false,
+             description: 'Optional group identifier to return list of projects for (includes direct, indirect, and shared projects).', # rubocop:disable Layout/LineLength
+             default_value: nil
+
+    def resolve(group_id:)
+      if group_id
+        group = IridaSchema.object_from_id(group_id, { expected_type: Group })
+        authorize!(group, to: :read?, with: GroupPolicy)
+        authorized_scope(Group, type: :relation, as: :group_projects, scope_options: { group: })
+      else
+        authorized_scope Project, type: :relation
+      end
+    end
+
+    def ready?(**args)
+      authorize!(to: :query?, with: GraphqlPolicy, context: { token: context[:token] })
     end
   end
 end

--- a/app/graphql/resolvers/samples_resolver.rb
+++ b/app/graphql/resolvers/samples_resolver.rb
@@ -21,7 +21,7 @@ module Resolvers
       end
     end
 
-    def ready?(**args)
+    def ready?(**_args)
       authorize!(to: :query?, with: GraphqlPolicy, context: { token: context[:token] })
     end
   end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -855,6 +855,11 @@ type Query {
     first: Int
 
     """
+    Optional group identifier to return list of projects for (includes direct, indirect, and shared projects).
+    """
+    groupId: ID = null
+
+    """
     Returns the last _n_ elements from the list.
     """
     last: Int

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -31,5 +31,13 @@ module Types
           context: { user: context[:current_user], token: context[:token] }
         )
     end
+
+    def self.scope_items(items, context)
+      scope = authorized_scope Project, type: :relation,
+                                        context: { user: context[:current_user], token: context[:token] }
+      scope.where(id: items.select(:id))
+    end
+
+    reauthorize_scoped_objects(false)
   end
 end

--- a/app/policies/graphql_policy.rb
+++ b/app/policies/graphql_policy.rb
@@ -5,15 +5,15 @@ class GraphqlPolicy < ApplicationPolicy
   # nil is allowed as a user accessing the api through graphiql while logged into the website would not have a token
   authorize :token, allow_nil: true
 
-  def query?
-    return true if token.present? && token.scopes.to_set.intersect?(%w[api read_api].to_set)
+  def query? # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    return true if token&.active? && token&.scopes&.to_set&.intersect?(%w[api read_api].to_set)
     return true if token.nil? && !user.nil? # allow users with a session to query the api
 
     false
   end
 
-  def mutate?
-    return true if token&.scopes&.include?('api')
+  def mutate? # rubocop:disable Metrics/CyclomaticComplexity
+    return true if token&.active? && token&.scopes&.include?('api')
     return true if token.nil? && !user.nil? # allow users with a session to mutate the api
 
     false

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -154,7 +154,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
   scope_for :relation do |relation| # rubocop:disable Metrics/BlockLength
     relation
       .with(
-        personal_project_namespaces: user.namespace&.project_namespaces&.select(:id),
+        personal_project_namespaces: Namespaces::ProjectNamespace.where(parent_id: user.namespace&.id),
         direct_project_namespaces: user.members.not_expired.joins(:namespace).where(
           namespace: { type: Namespaces::ProjectNamespace.sti_name }
         ).select(:namespace_id),
@@ -217,7 +217,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
 
   scope_for :relation, :manageable do |relation| # rubocop:disable Metrics/BlockLength
     relation.with(
-      personal_project_namespaces: user.namespace&.project_namespaces&.select(:id),
+      personal_project_namespaces: Namespaces::ProjectNamespace.where(parent_id: user.namespace&.id),
       direct_project_namespaces: user.members.not_expired.joins(:namespace).where(
         access_level: Member::AccessLevel.manageable,
         namespace: { type: Namespaces::ProjectNamespace.sti_name }
@@ -260,7 +260,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
   scope_for :relation, :personal do |relation|
     relation
       .with(
-        personal_project_namespaces: user.namespace&.project_namespaces&.select(:id)
+        personal_project_namespaces: Namespaces::ProjectNamespace.where(parent_id: user.namespace&.id)
       )
       .where(
         Arel.sql(

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -163,9 +163,9 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
             type: Group.sti_name
           )).select(:id),
         group_linked_project_namespaces: Namespaces::ProjectNamespace.where(
-          parent_id: Group.where(id: NamespaceGroupLink.where(
-            group: Group.where(id: user.members.not_expired.joins(:namespace).select(:namespace_id)).self_and_descendants
-          ).not_expired.select(:namespace_id)).self_and_descendants
+          parent_id: Group.where(id: NamespaceGroupLink.where(group: Group.where(
+            id: user.members.not_expired.joins(:namespace).select(:namespace_id)
+          ).self_and_descendants).not_expired.select(:namespace_id)).self_and_descendants
         ).select(:id),
         direct_linked_project_namespaces: Namespaces::ProjectNamespace.where(id: NamespaceGroupLink.where(
           group: Group.where(id: user.members.not_expired.joins(:namespace).select(:namespace_id)).self_and_descendants

--- a/app/policies/sample_policy.rb
+++ b/app/policies/sample_policy.rb
@@ -26,14 +26,14 @@ class SamplePolicy < ApplicationPolicy
       relation
         .with(
           direct_group_projects: Project.joins(:namespace)
-                                .where(namespace: { parent_id: namespace.self_and_descendants.select(:id) }).select(:id),
+                                .where(namespace: { parent_id: namespace.self_and_descendant_ids }).select(:id),
           linked_group_projects: Project.where(namespace_id: Namespace
             .where(
               id: NamespaceGroupLink
                       .not_expired
                       .where(group_id: namespace.self_and_descendant_ids, group_access_level: minimum_access_level..)
                       .select(:namespace_id)
-            ).self_and_descendants.select(:id))
+            ).self_and_descendant_ids)
           .select(:id)
         ).where(
           Arel.sql(

--- a/test/graphql/create_sample_mutation_test.rb
+++ b/test/graphql/create_sample_mutation_test.rb
@@ -159,7 +159,7 @@ class CreateSampleMutationTest < ActiveSupport::TestCase
 
     error_message = result['errors'][0]['message']
 
-    assert_equal 'You are not authorized to create samples for project Project 1 on this server.', error_message
+    assert_equal 'You are not authorized to perform this action', error_message
   end
 
   test 'createSample mutation should not work with unauthorized project and valid api scope token' do

--- a/test/graphql/projects_query_test.rb
+++ b/test/graphql/projects_query_test.rb
@@ -17,6 +17,20 @@ class ProjectsQueryTest < ActiveSupport::TestCase
     }
   GRAPHQL
 
+  GROUP_PROJECTS_QUERY = <<~GRAPHQL
+    query($group_id: ID!) {
+      projects(groupId: $group_id) {
+        nodes {
+          name
+          path
+          description
+          id
+        }
+        totalCount
+      }
+    }
+  GRAPHQL
+
   def setup
     @user = users(:john_doe)
   end
@@ -75,5 +89,33 @@ class ProjectsQueryTest < ActiveSupport::TestCase
     error_message = result['errors'][0]['message']
     assert_equal 'An object of type Project was hidden due to permissions',
                  error_message
+  end
+
+  test 'group projects query should work' do
+    result = IridaSchema.execute(GROUP_PROJECTS_QUERY, context: { current_user: @user },
+                                                       variables:
+                                                      { group_id: groups(:group_one).to_global_id.to_s })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['projects']
+
+    assert_not_empty data, 'projects type should work'
+    assert_not_empty data['nodes']
+  end
+
+  test 'group projects query should throw authorization error' do
+    result = IridaSchema.execute(GROUP_PROJECTS_QUERY, context: { current_user: @user },
+                                                       variables:
+                                                      { group_id: groups(:group_a).to_global_id.to_s })
+
+    assert_not_nil result['errors'], 'should not work and have authorization errors.'
+
+    assert_equal "You are not authorized to view group #{groups(:group_a).name} on this server.",
+                 result['errors'].first['message']
+
+    data = result['data']['projects']
+
+    assert_nil data
   end
 end

--- a/test/graphql/projects_query_test.rb
+++ b/test/graphql/projects_query_test.rb
@@ -78,16 +78,16 @@ class ProjectsQueryTest < ActiveSupport::TestCase
     assert_equal projects_count, data['totalCount']
   end
 
-  test 'projects query should work but with errors due to expired token for uploader access level' do
+  test 'projects query should throw authorization error due to expired token for uploader access level' do
     user = users(:user_bot_account0)
     token = personal_access_tokens(:user_bot_account0_expired_pat)
 
     result = IridaSchema.execute(PROJECTS_QUERY, context: { current_user: user, token: },
                                                  variables: { first: 20 })
 
-    assert_not_nil result['errors'], 'should work and have errors.'
+    assert_not_nil result['errors'], 'should not work and have authorization errors.'
     error_message = result['errors'][0]['message']
-    assert_equal 'An object of type Project was hidden due to permissions',
+    assert_equal 'You are not authorized to perform this action',
                  error_message
   end
 

--- a/test/graphql/update_sample_metadata_test.rb
+++ b/test/graphql/update_sample_metadata_test.rb
@@ -198,7 +198,7 @@ class UpdateSampleMetadataMutationTest < ActiveSupport::TestCase
 
     error_message = result['errors'][0]['message']
 
-    assert_equal 'You are not authorized to update samples for project Project 1 on this server.', error_message
+    assert_equal 'You are not authorized to perform this action', error_message
   end
 
   test 'updateSampleMetadata mutation should not work with invalid sample id' do

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -290,4 +290,20 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     assert_equal true, policy.submit_workflow?
   end
+
+  test 'group_projects scope includes linked projects and projects from linked groups' do
+    user = users(:private_ryan)
+    group = groups(:group_alpha)
+    policy = ProjectPolicy.new(group, user:)
+
+    scoped_projects = policy.apply_scope(Project, type: :relation, name: :group_projects,
+                                                  scope_options: { group: })
+
+    assert_equal 4, scoped_projects.count
+
+    assert scoped_projects.include?(projects(:projectAlpha))
+    assert scoped_projects.include?(projects(:projectAlpha1))
+    assert scoped_projects.include?(projects(:projectBravo))
+    assert scoped_projects.include?(projects(:projectCharlie))
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in an optional argument to `projects` query named `groupId`, this can be used to limit the results to `projects` only accessible by members with access to the `Group` specified by `groupId`. This includes direct, indirect (projects from subgroups), and linked projects (projects shared with group or subgroup, or contained within groups and their subgroups that are shared with this group or groups subgroups).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Create a Group hierarchy that has subgroups with projects, and has projects shared to the group or any of the subgroups, along with groups that contain projects, shared with the group or any of its subgroups.
3. Ensure that when querying the projects by the groups id in graphql that all are returned (can use graphiql).
Example query
```graphql
query groupId {
  group(puid: PUID_OF_TOP_LEVEL_GROUP) {
    id
  }
}

query groupProjects {
  projects(groupId: GROUP_ID_RETURNED_FROM_QUERY_ABOVE, first: 100) {
    nodes {
      name
      path
      puid
    }
    totalCount
  }
}
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
