### PR TITLE
GraphQL: Samples filtering and ordering

### DIFF
--- a/app/graphql/resolvers/project_samples_resolver.rb
+++ b/app/graphql/resolvers/project_samples_resolver.rb
@@ -5,9 +5,21 @@ module Resolvers
   class ProjectSamplesResolver < BaseResolver
     alias project object
 
-    def resolve
-      scope = project
-      scope.samples
+    argument :filter, Types::SampleFilterType,
+             required: false,
+             description: 'Ransack filter',
+             default_value: nil
+
+    argument :order_by, Types::SampleOrderInputType,
+             required: false,
+             description: 'Order by',
+             default_value: nil
+
+    def resolve(filter:, order_by:)
+      ransack_obj = project.samples.ransack(filter&.to_h)
+      ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?
+
+      ransack_obj.result
     end
   end
 end

--- a/app/graphql/resolvers/samples_resolver.rb
+++ b/app/graphql/resolvers/samples_resolver.rb
@@ -15,9 +15,17 @@ module Resolvers
              description: 'Ransack filter',
              default_value: nil
 
-    def resolve(group_id:, filter:)
+    argument :order_by, Types::SampleOrderInputType,
+             required: false,
+             description: 'Order by',
+             default_value: nil
+
+    def resolve(group_id:, filter:, order_by:)
       samples = group_id ? samples_by_group_scope(group_id:) : samples_by_project_scope
-      filter ? samples.ransack(filter.to_h).result : samples
+      ransack_obj = samples.ransack(filter&.to_h)
+      ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?
+
+      ransack_obj.result
     end
 
     def ready?(**_args)

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -924,6 +924,11 @@ type Project implements Node {
     before: String
 
     """
+    Ransack filter
+    """
+    filter: SampleFilter = null
+
+    """
     Returns the first _n_ elements from the list.
     """
     first: Int
@@ -932,6 +937,11 @@ type Project implements Node {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Order by
+    """
+    orderBy: SampleOrder = null
   ): SampleConnection
 
   """
@@ -1183,6 +1193,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Order by
+    """
+    orderBy: SampleOrder = null
   ): SampleConnection
 }
 
@@ -1627,6 +1642,22 @@ input SampleFilter {
   updated_at_start_all: [String!]
   updated_at_start_any: [String!]
   updated_at_true: String
+}
+
+"""
+Specify a sort for the samples
+"""
+input SampleOrder {
+  direction: OrderDirection
+  field: SampleOrderField!
+}
+
+"""
+Field to sort the samples by
+"""
+enum SampleOrderField {
+  created_at
+  updated_at
 }
 
 """

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -34,7 +34,8 @@ module Types
     def self.scope_items(items, context)
       scope = authorized_scope Project, type: :relation,
                                         context: { user: context[:current_user], token: context[:token] }
-      scope.where(id: items.select(:id))
+      project_ids = items.pluck(:id)
+      scope.where(id: project_ids).in_order_of(:id, project_ids)
     end
 
     reauthorize_scoped_objects(false)

--- a/app/graphql/types/sample_order_input_type.rb
+++ b/app/graphql/types/sample_order_input_type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  class SampleOrderFieldInputType < BaseEnum # rubocop:disable Style/Documentation
+    graphql_name 'SampleOrderField'
+    description 'Field to sort the samples by'
+    value 'created_at'
+    value 'updated_at'
+  end
+
+  class SampleOrderInputType < BaseInputObject # rubocop:disable Style/Documentation
+    graphql_name 'SampleOrder'
+    description 'Specify a sort for the samples'
+
+    argument :direction, OrderDirectionType, required: false # rubocop:disable GraphQL/ArgumentDescription
+    argument :field, SampleOrderFieldInputType, required: true # rubocop:disable GraphQL/ArgumentDescription
+  end
+end

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -40,7 +40,8 @@ module Types
     def self.scope_items(items, context)
       scope = authorized_scope Project, type: :relation,
                                         context: { user: context[:current_user], token: context[:token] }
-      Sample.where(id: items.select(:id), project_id: scope.select(:id))
+      sample_ids = items.pluck(:id)
+      Sample.where(id: sample_ids, project_id: scope.select(:id)).in_order_of(:id, sample_ids)
     end
 
     reauthorize_scoped_objects(false)

--- a/test/graphql/project_samples_query_test.rb
+++ b/test/graphql/project_samples_query_test.rb
@@ -98,7 +98,7 @@ class ProjectSamplesQueryTest < ActiveSupport::TestCase
 
     result = IridaSchema.execute(PROJECT_QUERY, context: { current_user: @user },
                                                 variables: { projectPath: project.full_path,
-                                                             sampleFilter: { name_cont: "Sample 2"} })
+                                                             sampleFilter: { name_cont: 'Sample 2' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
 
@@ -123,7 +123,7 @@ class ProjectSamplesQueryTest < ActiveSupport::TestCase
 
     result = IridaSchema.execute(PROJECT_QUERY, context: { current_user: @user },
                                                 variables: { projectPath: project.full_path,
-                                                             sampleOrderBy: { field: 'created_at', direction: 'asc'} })
+                                                             sampleOrderBy: { field: 'created_at', direction: 'asc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
 

--- a/test/graphql/project_samples_query_test.rb
+++ b/test/graphql/project_samples_query_test.rb
@@ -4,12 +4,12 @@ require 'test_helper'
 
 class ProjectSamplesQueryTest < ActiveSupport::TestCase
   PROJECT_QUERY = <<~GRAPHQL
-    query($projectPath: ID!) {
+    query($projectPath: ID!, $sampleFilter: SampleFilter, $sampleOrderBy: SampleOrder) {
       project(fullPath: $projectPath) {
         name
         path
         id
-        samples(first:10) {
+        samples(first:10, filter: $sampleFilter, orderBy: $sampleOrderBy) {
           nodes {
             id
             name
@@ -44,9 +44,9 @@ class ProjectSamplesQueryTest < ActiveSupport::TestCase
 
     # verify fetched sample data matches data on project
     project.samples.each_with_index do |sample, index|
-      assert_equal data['samples']['nodes'][index]['id'], sample.to_global_id.to_s
-      assert_equal data['samples']['nodes'][index]['name'], sample.name
-      assert_equal data['samples']['nodes'][index]['project']['id'], project.to_global_id.to_s
+      assert_equal sample.name, data['samples']['nodes'][index]['name']
+      assert_equal sample.to_global_id.to_s, data['samples']['nodes'][index]['id']
+      assert_equal project.to_global_id.to_s, data['samples']['nodes'][index]['project']['id']
     end
   end
 
@@ -70,9 +70,9 @@ class ProjectSamplesQueryTest < ActiveSupport::TestCase
 
     # verify fetched sample data matches data on project
     project.samples.each_with_index do |sample, index|
-      assert_equal data['samples']['nodes'][index]['id'], sample.to_global_id.to_s
-      assert_equal data['samples']['nodes'][index]['name'], sample.name
-      assert_equal data['samples']['nodes'][index]['project']['id'], project.to_global_id.to_s
+      assert_equal sample.name, data['samples']['nodes'][index]['name']
+      assert_equal sample.to_global_id.to_s, data['samples']['nodes'][index]['id']
+      assert_equal project.to_global_id.to_s, data['samples']['nodes'][index]['project']['id']
     end
   end
 
@@ -91,5 +91,55 @@ class ProjectSamplesQueryTest < ActiveSupport::TestCase
     error_message = result['errors'][0]['message']
 
     assert_equal I18n.t('action_policy.policy.project.read?', name: project.name), error_message
+  end
+
+  test 'project with sample query should work with filter' do
+    project = projects(:project1)
+
+    result = IridaSchema.execute(PROJECT_QUERY, context: { current_user: @user },
+                                                variables: { projectPath: project.full_path,
+                                                             sampleFilter: { name_cont: "Sample 2"} })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['project']
+
+    assert_not_empty data, 'project type should work'
+    assert_equal project.name, data['name']
+
+    assert_equal project.to_global_id.to_s, data['id'], 'id should be GlobalID'
+    assert_equal 2, data['samples']['nodes'].count
+
+    # verify fetched sample data only includes ones with `Sample 2` in the name
+    project.samples.where('name ILIKE \'%Sample 2%\'').each_with_index do |sample, index|
+      assert_equal sample.name, data['samples']['nodes'][index]['name']
+      assert_equal sample.to_global_id.to_s, data['samples']['nodes'][index]['id']
+      assert_equal project.to_global_id.to_s, data['samples']['nodes'][index]['project']['id']
+    end
+  end
+
+  test 'project with sample query should work with order by' do
+    project = projects(:project1)
+
+    result = IridaSchema.execute(PROJECT_QUERY, context: { current_user: @user },
+                                                variables: { projectPath: project.full_path,
+                                                             sampleOrderBy: { field: 'created_at', direction: 'asc'} })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['project']
+
+    assert_not_empty data, 'project type should work'
+    assert_equal project.name, data['name']
+
+    assert_equal project.to_global_id.to_s, data['id'], 'id should be GlobalID'
+    assert_equal project.samples.count, data['samples']['nodes'].count
+
+    # verify fetched sample data matches data on project
+    project.samples.order(created_at: :asc).each_with_index do |sample, index|
+      assert_equal sample.name, data['samples']['nodes'][index]['name']
+      assert_equal sample.to_global_id.to_s, data['samples']['nodes'][index]['id']
+      assert_equal project.to_global_id.to_s, data['samples']['nodes'][index]['project']['id']
+    end
   end
 end

--- a/test/graphql/samples_query_ransack_test.rb
+++ b/test/graphql/samples_query_ransack_test.rb
@@ -65,16 +65,17 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
   end
 
   test 'samples query should work with order by' do
-      result = IridaSchema.execute(SAMPLES_RANSACK_QUERY,
-                                   context: { current_user: @user },
-                                   variables: { filter: { name_start: 'Project 1'}, orderBy: { field: 'created_at', direction: 'asc' } })
+    result = IridaSchema.execute(SAMPLES_RANSACK_QUERY,
+                                  context: { current_user: @user },
+                                  variables: { filter: { name_start: 'Project 1'},
+                                              orderBy: { field: 'created_at', direction: 'asc' } })
 
-      assert_nil result['errors'], 'should work and have no errors.'
+    assert_nil result['errors'], 'should work and have no errors.'
 
-      data = result['data']['samples']['nodes']
+    data = result['data']['samples']['nodes']
 
-      assert_equal samples(:sample2).name, data[0]['name']
-      assert_equal samples(:sample2).puid, data[0]['puid']
+    assert_equal samples(:sample2).name, data[0]['name']
+    assert_equal samples(:sample2).puid, data[0]['puid']
   end
 
   test 'ransack samples query with group id should work' do

--- a/test/graphql/samples_query_ransack_test.rb
+++ b/test/graphql/samples_query_ransack_test.rb
@@ -67,7 +67,7 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
   test 'samples query should work with order by' do
     result = IridaSchema.execute(SAMPLES_RANSACK_QUERY,
                                  context: { current_user: @user },
-                                 variables: { filter: { name_start: 'Project 1'},
+                                 variables: { filter: { name_start: 'Project 1' },
                                               orderBy: { field: 'created_at', direction: 'asc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'

--- a/test/graphql/samples_query_ransack_test.rb
+++ b/test/graphql/samples_query_ransack_test.rb
@@ -66,8 +66,8 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
 
   test 'samples query should work with order by' do
     result = IridaSchema.execute(SAMPLES_RANSACK_QUERY,
-                                  context: { current_user: @user },
-                                  variables: { filter: { name_start: 'Project 1'},
+                                 context: { current_user: @user },
+                                 variables: { filter: { name_start: 'Project 1'},
                                               orderBy: { field: 'created_at', direction: 'asc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
@@ -101,8 +101,6 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
   end
 
   test 'ransack samples query with group id should work with order by' do
-    original_date = Time.zone.today
-
     Timecop.travel(5.days.from_now) do
       @sample.created_at = Time.zone.now
       @sample.save!


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Adds in ordering to samples query, and adds in filtering and ordering to project samples query.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Create a new Group
2. Create a new Project under the new group
3. Create 2 samples in the project.
4. Upload pair end `fastq.gz` attachments to one of the samples
5. Execute the following query to get the Groups ID for querying the samples.
```graphql
query groupId {
  group(puid: puid: "GROUP PUID") {
    id
  }
}
```
6. Execute the following query to only retrieve the sample with `fastq.gz` files from the project:
```graphql
query fastqSamples {
  project(puid: "PROJECT PUID") {
    samples(filter: { attachments_updated_at_not_null: "1" }) {
      nodes {
        id
        name
        puid
      }
    }
  }
}
```
7. Execute the following query to order the samples from the project:
```graphql
query orderedProjectSamples {
  project(puid: "PROJECT PUID") {
    samples(orderBy: { field: created_at, direction: asc }) {
      nodes {
        id
        name
        puid
      }
    }
  }
}
```
8. Execute the following query to order the samples from the group:
```graphql
query orderedGroupSamples {
  samples(groupId: "GROUP ID", orderBy: { field: created_at, direction: asc }) {
    nodes {
      id
      name
      puid
    }
  }
}
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
