### PR TITLE
Graphql - Add ransack filtering and ordering to projects

### DIFF
--- a/app/graphql/resolvers/projects_resolver.rb
+++ b/app/graphql/resolvers/projects_resolver.rb
@@ -10,18 +10,38 @@ module Resolvers
              description: 'Optional group identifier to return list of projects for (includes direct, indirect, and shared projects).', # rubocop:disable Layout/LineLength
              default_value: nil
 
-    def resolve(group_id:)
-      if group_id
-        group = IridaSchema.object_from_id(group_id, { expected_type: Group })
-        authorize!(group, to: :read?, with: GroupPolicy)
-        authorized_scope(Project, type: :relation, as: :group_projects, scope_options: { group: })
-      else
-        authorized_scope Project, type: :relation
-      end
+    argument :filter, Types::ProjectFilterType,
+             required: false,
+             description: 'Ransack filter',
+             default_value: nil
+
+    argument :order_by, Types::ProjectOrderInputType,
+             required: false,
+             description: 'Order by',
+             default_value: nil
+
+    def resolve(group_id:, filter:, order_by:)
+      projects = group_id ? projects_by_group_scope(group_id:) : projects_by_scope
+      ransack_obj = projects.ransack(filter&.to_h)
+      ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?
+
+      ransack_obj.result
     end
 
     def ready?(**_args)
       authorize!(to: :query?, with: GraphqlPolicy, context: { token: context[:token] })
+    end
+
+    private
+
+    def projects_by_scope
+      authorized_scope Project, type: :relation
+    end
+
+    def projects_by_group_scope(group_id:)
+      group = IridaSchema.object_from_id(group_id, { expected_type: Group })
+      authorize!(group, to: :read?, with: GroupPolicy)
+      authorized_scope(Project, type: :relation, as: :group_projects, scope_options: { group: })
     end
   end
 end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1053,68 +1053,6 @@ input ProjectFilter {
   created_at_start_all: [String!]
   created_at_start_any: [String!]
   created_at_true: String
-  deleted_at_blank: String
-  deleted_at_cont: String
-  deleted_at_cont_all: [String!]
-  deleted_at_cont_any: [String!]
-  deleted_at_does_not_match: String
-  deleted_at_does_not_match_all: [String!]
-  deleted_at_does_not_match_any: [String!]
-  deleted_at_end: String
-  deleted_at_end_all: [String!]
-  deleted_at_end_any: [String!]
-  deleted_at_eq: String
-  deleted_at_eq_all: [String!]
-  deleted_at_eq_any: [String!]
-  deleted_at_false: String
-  deleted_at_gt: String
-  deleted_at_gt_all: [String!]
-  deleted_at_gt_any: [String!]
-  deleted_at_gteq: String
-  deleted_at_gteq_all: [String!]
-  deleted_at_gteq_any: [String!]
-  deleted_at_i_cont: String
-  deleted_at_i_cont_all: [String!]
-  deleted_at_i_cont_any: [String!]
-  deleted_at_in: [String!]
-  deleted_at_in_all: [String!]
-  deleted_at_in_any: [String!]
-  deleted_at_lt: String
-  deleted_at_lt_all: [String!]
-  deleted_at_lt_any: [String!]
-  deleted_at_lteq: String
-  deleted_at_lteq_all: [String!]
-  deleted_at_lteq_any: [String!]
-  deleted_at_matches: String
-  deleted_at_matches_all: [String!]
-  deleted_at_matches_any: [String!]
-  deleted_at_not_cont: String
-  deleted_at_not_cont_all: [String!]
-  deleted_at_not_cont_any: [String!]
-  deleted_at_not_end: String
-  deleted_at_not_end_all: [String!]
-  deleted_at_not_end_any: [String!]
-  deleted_at_not_eq: String
-  deleted_at_not_eq_all: [String!]
-  deleted_at_not_eq_any: [String!]
-  deleted_at_not_false: String
-  deleted_at_not_i_cont: String
-  deleted_at_not_i_cont_all: [String!]
-  deleted_at_not_i_cont_any: [String!]
-  deleted_at_not_in: [String!]
-  deleted_at_not_in_all: [String!]
-  deleted_at_not_in_any: [String!]
-  deleted_at_not_null: String
-  deleted_at_not_start: String
-  deleted_at_not_start_all: [String!]
-  deleted_at_not_start_any: [String!]
-  deleted_at_not_true: String
-  deleted_at_null: String
-  deleted_at_present: String
-  deleted_at_start: String
-  deleted_at_start_all: [String!]
-  deleted_at_start_any: [String!]
-  deleted_at_true: String
   name_blank: String
   name_cont: String
   name_cont_all: [String!]
@@ -1177,6 +1115,68 @@ input ProjectFilter {
   name_start_all: [String!]
   name_start_any: [String!]
   name_true: String
+  puid_blank: String
+  puid_cont: String
+  puid_cont_all: [String!]
+  puid_cont_any: [String!]
+  puid_does_not_match: String
+  puid_does_not_match_all: [String!]
+  puid_does_not_match_any: [String!]
+  puid_end: String
+  puid_end_all: [String!]
+  puid_end_any: [String!]
+  puid_eq: String
+  puid_eq_all: [String!]
+  puid_eq_any: [String!]
+  puid_false: String
+  puid_gt: String
+  puid_gt_all: [String!]
+  puid_gt_any: [String!]
+  puid_gteq: String
+  puid_gteq_all: [String!]
+  puid_gteq_any: [String!]
+  puid_i_cont: String
+  puid_i_cont_all: [String!]
+  puid_i_cont_any: [String!]
+  puid_in: [String!]
+  puid_in_all: [String!]
+  puid_in_any: [String!]
+  puid_lt: String
+  puid_lt_all: [String!]
+  puid_lt_any: [String!]
+  puid_lteq: String
+  puid_lteq_all: [String!]
+  puid_lteq_any: [String!]
+  puid_matches: String
+  puid_matches_all: [String!]
+  puid_matches_any: [String!]
+  puid_not_cont: String
+  puid_not_cont_all: [String!]
+  puid_not_cont_any: [String!]
+  puid_not_end: String
+  puid_not_end_all: [String!]
+  puid_not_end_any: [String!]
+  puid_not_eq: String
+  puid_not_eq_all: [String!]
+  puid_not_eq_any: [String!]
+  puid_not_false: String
+  puid_not_i_cont: String
+  puid_not_i_cont_all: [String!]
+  puid_not_i_cont_any: [String!]
+  puid_not_in: [String!]
+  puid_not_in_all: [String!]
+  puid_not_in_any: [String!]
+  puid_not_null: String
+  puid_not_start: String
+  puid_not_start_all: [String!]
+  puid_not_start_any: [String!]
+  puid_not_true: String
+  puid_null: String
+  puid_present: String
+  puid_start: String
+  puid_start_all: [String!]
+  puid_start_any: [String!]
+  puid_true: String
   updated_at_blank: String
   updated_at_cont: String
   updated_at_cont_all: [String!]

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -990,6 +990,273 @@ type ProjectEdge {
   node: Project
 }
 
+input ProjectFilter {
+  created_at_blank: String
+  created_at_cont: String
+  created_at_cont_all: [String!]
+  created_at_cont_any: [String!]
+  created_at_does_not_match: String
+  created_at_does_not_match_all: [String!]
+  created_at_does_not_match_any: [String!]
+  created_at_end: String
+  created_at_end_all: [String!]
+  created_at_end_any: [String!]
+  created_at_eq: String
+  created_at_eq_all: [String!]
+  created_at_eq_any: [String!]
+  created_at_false: String
+  created_at_gt: String
+  created_at_gt_all: [String!]
+  created_at_gt_any: [String!]
+  created_at_gteq: String
+  created_at_gteq_all: [String!]
+  created_at_gteq_any: [String!]
+  created_at_i_cont: String
+  created_at_i_cont_all: [String!]
+  created_at_i_cont_any: [String!]
+  created_at_in: [String!]
+  created_at_in_all: [String!]
+  created_at_in_any: [String!]
+  created_at_lt: String
+  created_at_lt_all: [String!]
+  created_at_lt_any: [String!]
+  created_at_lteq: String
+  created_at_lteq_all: [String!]
+  created_at_lteq_any: [String!]
+  created_at_matches: String
+  created_at_matches_all: [String!]
+  created_at_matches_any: [String!]
+  created_at_not_cont: String
+  created_at_not_cont_all: [String!]
+  created_at_not_cont_any: [String!]
+  created_at_not_end: String
+  created_at_not_end_all: [String!]
+  created_at_not_end_any: [String!]
+  created_at_not_eq: String
+  created_at_not_eq_all: [String!]
+  created_at_not_eq_any: [String!]
+  created_at_not_false: String
+  created_at_not_i_cont: String
+  created_at_not_i_cont_all: [String!]
+  created_at_not_i_cont_any: [String!]
+  created_at_not_in: [String!]
+  created_at_not_in_all: [String!]
+  created_at_not_in_any: [String!]
+  created_at_not_null: String
+  created_at_not_start: String
+  created_at_not_start_all: [String!]
+  created_at_not_start_any: [String!]
+  created_at_not_true: String
+  created_at_null: String
+  created_at_present: String
+  created_at_start: String
+  created_at_start_all: [String!]
+  created_at_start_any: [String!]
+  created_at_true: String
+  deleted_at_blank: String
+  deleted_at_cont: String
+  deleted_at_cont_all: [String!]
+  deleted_at_cont_any: [String!]
+  deleted_at_does_not_match: String
+  deleted_at_does_not_match_all: [String!]
+  deleted_at_does_not_match_any: [String!]
+  deleted_at_end: String
+  deleted_at_end_all: [String!]
+  deleted_at_end_any: [String!]
+  deleted_at_eq: String
+  deleted_at_eq_all: [String!]
+  deleted_at_eq_any: [String!]
+  deleted_at_false: String
+  deleted_at_gt: String
+  deleted_at_gt_all: [String!]
+  deleted_at_gt_any: [String!]
+  deleted_at_gteq: String
+  deleted_at_gteq_all: [String!]
+  deleted_at_gteq_any: [String!]
+  deleted_at_i_cont: String
+  deleted_at_i_cont_all: [String!]
+  deleted_at_i_cont_any: [String!]
+  deleted_at_in: [String!]
+  deleted_at_in_all: [String!]
+  deleted_at_in_any: [String!]
+  deleted_at_lt: String
+  deleted_at_lt_all: [String!]
+  deleted_at_lt_any: [String!]
+  deleted_at_lteq: String
+  deleted_at_lteq_all: [String!]
+  deleted_at_lteq_any: [String!]
+  deleted_at_matches: String
+  deleted_at_matches_all: [String!]
+  deleted_at_matches_any: [String!]
+  deleted_at_not_cont: String
+  deleted_at_not_cont_all: [String!]
+  deleted_at_not_cont_any: [String!]
+  deleted_at_not_end: String
+  deleted_at_not_end_all: [String!]
+  deleted_at_not_end_any: [String!]
+  deleted_at_not_eq: String
+  deleted_at_not_eq_all: [String!]
+  deleted_at_not_eq_any: [String!]
+  deleted_at_not_false: String
+  deleted_at_not_i_cont: String
+  deleted_at_not_i_cont_all: [String!]
+  deleted_at_not_i_cont_any: [String!]
+  deleted_at_not_in: [String!]
+  deleted_at_not_in_all: [String!]
+  deleted_at_not_in_any: [String!]
+  deleted_at_not_null: String
+  deleted_at_not_start: String
+  deleted_at_not_start_all: [String!]
+  deleted_at_not_start_any: [String!]
+  deleted_at_not_true: String
+  deleted_at_null: String
+  deleted_at_present: String
+  deleted_at_start: String
+  deleted_at_start_all: [String!]
+  deleted_at_start_any: [String!]
+  deleted_at_true: String
+  name_blank: String
+  name_cont: String
+  name_cont_all: [String!]
+  name_cont_any: [String!]
+  name_does_not_match: String
+  name_does_not_match_all: [String!]
+  name_does_not_match_any: [String!]
+  name_end: String
+  name_end_all: [String!]
+  name_end_any: [String!]
+  name_eq: String
+  name_eq_all: [String!]
+  name_eq_any: [String!]
+  name_false: String
+  name_gt: String
+  name_gt_all: [String!]
+  name_gt_any: [String!]
+  name_gteq: String
+  name_gteq_all: [String!]
+  name_gteq_any: [String!]
+  name_i_cont: String
+  name_i_cont_all: [String!]
+  name_i_cont_any: [String!]
+  name_in: [String!]
+  name_in_all: [String!]
+  name_in_any: [String!]
+  name_lt: String
+  name_lt_all: [String!]
+  name_lt_any: [String!]
+  name_lteq: String
+  name_lteq_all: [String!]
+  name_lteq_any: [String!]
+  name_matches: String
+  name_matches_all: [String!]
+  name_matches_any: [String!]
+  name_not_cont: String
+  name_not_cont_all: [String!]
+  name_not_cont_any: [String!]
+  name_not_end: String
+  name_not_end_all: [String!]
+  name_not_end_any: [String!]
+  name_not_eq: String
+  name_not_eq_all: [String!]
+  name_not_eq_any: [String!]
+  name_not_false: String
+  name_not_i_cont: String
+  name_not_i_cont_all: [String!]
+  name_not_i_cont_any: [String!]
+  name_not_in: [String!]
+  name_not_in_all: [String!]
+  name_not_in_any: [String!]
+  name_not_null: String
+  name_not_start: String
+  name_not_start_all: [String!]
+  name_not_start_any: [String!]
+  name_not_true: String
+  name_null: String
+  name_present: String
+  name_start: String
+  name_start_all: [String!]
+  name_start_any: [String!]
+  name_true: String
+  updated_at_blank: String
+  updated_at_cont: String
+  updated_at_cont_all: [String!]
+  updated_at_cont_any: [String!]
+  updated_at_does_not_match: String
+  updated_at_does_not_match_all: [String!]
+  updated_at_does_not_match_any: [String!]
+  updated_at_end: String
+  updated_at_end_all: [String!]
+  updated_at_end_any: [String!]
+  updated_at_eq: String
+  updated_at_eq_all: [String!]
+  updated_at_eq_any: [String!]
+  updated_at_false: String
+  updated_at_gt: String
+  updated_at_gt_all: [String!]
+  updated_at_gt_any: [String!]
+  updated_at_gteq: String
+  updated_at_gteq_all: [String!]
+  updated_at_gteq_any: [String!]
+  updated_at_i_cont: String
+  updated_at_i_cont_all: [String!]
+  updated_at_i_cont_any: [String!]
+  updated_at_in: [String!]
+  updated_at_in_all: [String!]
+  updated_at_in_any: [String!]
+  updated_at_lt: String
+  updated_at_lt_all: [String!]
+  updated_at_lt_any: [String!]
+  updated_at_lteq: String
+  updated_at_lteq_all: [String!]
+  updated_at_lteq_any: [String!]
+  updated_at_matches: String
+  updated_at_matches_all: [String!]
+  updated_at_matches_any: [String!]
+  updated_at_not_cont: String
+  updated_at_not_cont_all: [String!]
+  updated_at_not_cont_any: [String!]
+  updated_at_not_end: String
+  updated_at_not_end_all: [String!]
+  updated_at_not_end_any: [String!]
+  updated_at_not_eq: String
+  updated_at_not_eq_all: [String!]
+  updated_at_not_eq_any: [String!]
+  updated_at_not_false: String
+  updated_at_not_i_cont: String
+  updated_at_not_i_cont_all: [String!]
+  updated_at_not_i_cont_any: [String!]
+  updated_at_not_in: [String!]
+  updated_at_not_in_all: [String!]
+  updated_at_not_in_any: [String!]
+  updated_at_not_null: String
+  updated_at_not_start: String
+  updated_at_not_start_all: [String!]
+  updated_at_not_start_any: [String!]
+  updated_at_not_true: String
+  updated_at_null: String
+  updated_at_present: String
+  updated_at_start: String
+  updated_at_start_all: [String!]
+  updated_at_start_any: [String!]
+  updated_at_true: String
+}
+
+"""
+Specify a sort for the projects
+"""
+input ProjectOrder {
+  direction: OrderDirection
+  field: ProjectOrderField!
+}
+
+"""
+Field to sort the samples by
+"""
+enum ProjectOrderField {
+  created_at
+  updated_at
+}
+
 """
 The query root of this schema
 """
@@ -1135,6 +1402,11 @@ type Query {
     before: String
 
     """
+    Ransack filter
+    """
+    filter: ProjectFilter = null
+
+    """
     Returns the first _n_ elements from the list.
     """
     first: Int
@@ -1148,6 +1420,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Order by
+    """
+    orderBy: ProjectOrder = null
   ): ProjectConnection
 
   """

--- a/app/graphql/types/project_filter_type.rb
+++ b/app/graphql/types/project_filter_type.rb
@@ -3,7 +3,7 @@
 module Types
   # Project Filter Type
   class ProjectFilterType < BaseInputObject # rubocop:disable GraphQL/ObjectDescription
-    Namespaces::ProjectNamespace.ransackable_attributes.excluding('id').each do |attr|
+    Project.ransackable_attributes.excluding('id').each do |attr|
       Ransack.predicates.keys.map do |key|
         value_type = Ransack.predicates[key].wants_array ? [String] : String
         argument :"#{attr}_#{key}".to_sym,

--- a/app/graphql/types/project_filter_type.rb
+++ b/app/graphql/types/project_filter_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  # Project Filter Type
+  class ProjectFilterType < BaseInputObject # rubocop:disable GraphQL/ObjectDescription
+    Namespaces::ProjectNamespace.ransackable_attributes.excluding('id').each do |attr|
+      Ransack.predicates.keys.map do |key|
+        value_type = Ransack.predicates[key].wants_array ? [String] : String
+        argument :"#{attr}_#{key}".to_sym,
+                 value_type,
+                 required: false,
+                 camelize: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/project_order_input_type.rb
+++ b/app/graphql/types/project_order_input_type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  class ProjectOrderFieldInputType < BaseEnum # rubocop:disable Style/Documentation
+    graphql_name 'ProjectOrderField'
+    description 'Field to sort the samples by'
+    value 'created_at'
+    value 'updated_at'
+  end
+
+  class ProjectOrderInputType < BaseInputObject # rubocop:disable Style/Documentation
+    graphql_name 'ProjectOrder'
+    description 'Specify a sort for the projects'
+
+    argument :direction, OrderDirectionType, required: false # rubocop:disable GraphQL/ArgumentDescription
+    argument :field, ProjectOrderFieldInputType, required: true # rubocop:disable GraphQL/ArgumentDescription
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,6 +26,9 @@ class Project < ApplicationRecord
   delegate :parent, to: :namespace
   delegate :puid, to: :namespace
 
+  ransack_alias :name, :namespace_name
+  ransack_alias :puid, :namespace_puid
+
   scope :include_route, -> { includes(namespace: [{ parent: :route }, :route]) }
 
   def to_param
@@ -33,7 +36,7 @@ class Project < ApplicationRecord
   end
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[id puid name created_at updated_at]
+    %w[id created_at updated_at] + _ransack_aliases.keys
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -33,7 +33,7 @@ class Project < ApplicationRecord
   end
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[id created_at updated_at]
+    %w[id puid name created_at updated_at]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/test/graphql/projects_query_ransack_test.rb
+++ b/test/graphql/projects_query_ransack_test.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProjectsQueryRansackTest < ActiveSupport::TestCase
+  PROJECTS_RANSACK_QUERY = <<~GRAPHQL
+    query($filter: ProjectFilter, $orderBy: ProjectOrder) {
+      projects(filter: $filter, orderBy: $orderBy) {
+        nodes {
+          name
+          path
+          description
+          id
+          puid
+          createdAt
+        }
+        totalCount
+      }
+    }
+  GRAPHQL
+
+  PROJECTS_RANSACK_WITH_GROUP_QUERY = <<~GRAPHQL
+    query($filter: ProjectFilter, $group_id: ID!, $orderBy: ProjectOrder) {
+      projects(filter: $filter, groupId: $group_id, orderBy: $orderBy) {
+        nodes {
+          name
+          path
+          description
+          id
+          puid
+          createdAt
+        }
+        totalCount
+      }
+    }
+  GRAPHQL
+
+  def setup
+    @user = users(:john_doe)
+    @project = projects(:project1)
+  end
+
+  test 'ransack projects query should work' do
+    original_date = Time.zone.today
+    Timecop.travel(5.days.from_now) do
+      @project.created_at = Time.zone.now
+      @project.save!
+
+      result = IridaSchema.execute(PROJECTS_RANSACK_QUERY,
+                                   context: { current_user: @user },
+                                   variables: { filter: { created_at_gt: (original_date + 1.day).to_s } })
+
+      assert_nil result['errors'], 'should work and have no errors.'
+      data = result['data']['projects']['nodes']
+
+      assert_equal 1, data.count
+      assert_equal @project.puid, data[0]['puid']
+    end
+  end
+
+  test 'ransack projects query should work with order by' do
+    result = IridaSchema.execute(PROJECTS_RANSACK_QUERY,
+                                 context: { current_user: @user },
+                                 variables: { filter: { name_cont: 'Project 1' },
+                                              orderBy: { field: 'created_at', direction: 'asc' } })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+    data = result['data']['projects']['nodes']
+
+    assert_equal 12, data.count # Project 1, Project 10, Project 11, etc
+    assert_equal @project.puid, data[0]['puid']
+  end
+
+  test 'ransack projects query with group id should work' do
+    original_date = Time.zone.today
+    Timecop.travel(5.days.from_now) do
+      @project.created_at = Time.zone.now
+      @project.save!
+
+      result = IridaSchema.execute(PROJECTS_RANSACK_WITH_GROUP_QUERY,
+                                   context: { current_user: @user },
+                                   variables: { group_id: groups(:group_one).to_global_id.to_s,
+                                                filter: { created_at_gt: (original_date + 1.day).to_s } })
+
+      assert_nil result['errors'], 'should work and have no errors.'
+      data = result['data']['projects']['nodes']
+
+      assert_equal 1, data.count
+      assert_equal @project.puid, data[0]['puid']
+    end
+  end
+
+  test 'ransack projects query with group id should work with order by' do
+    result = IridaSchema.execute(PROJECTS_RANSACK_WITH_GROUP_QUERY,
+                                 context: { current_user: @user },
+                                 variables: { group_id: groups(:group_one).to_global_id.to_s,
+                                              orderBy: { field: 'created_at', direction: 'desc' } })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+    data = result['data']['projects']['nodes']
+
+    assert_equal 22, data.count
+    assert_equal @project.puid, data[0]['puid']
+  end
+
+  test 'ransack projects query should throw authorization error' do
+    original_date = Time.zone.today
+    Timecop.travel(5.days.from_now) do
+      @project.created_at = Time.zone.now
+      @project.save!
+
+      result = IridaSchema.execute(PROJECTS_RANSACK_WITH_GROUP_QUERY,
+                                   context: { current_user: @user },
+                                   variables: { group_id: groups(:group_a).to_global_id.to_s,
+                                                filter: { created_at_gt: (original_date + 1.day).to_s } })
+
+      assert_not_nil result['errors'], 'should not work and have authorization errors.'
+
+      assert_equal "You are not authorized to view group #{groups(:group_a).name} on this server.",
+                   result['errors'].first['message']
+
+      data = result['data']['projects']
+
+      assert_nil data
+    end
+  end
+
+  test 'ransack group projects query should throw authorization error due to expired token for uploader access level' do
+    user = users(:user_bot_account0)
+    token = personal_access_tokens(:user_bot_account0_expired_pat)
+    group = groups(:group_one)
+    original_date = Time.zone.today
+
+    Timecop.travel(5.days.from_now) do
+      @project.created_at = Time.zone.now
+      @project.save!
+
+      result = IridaSchema.execute(PROJECTS_RANSACK_WITH_GROUP_QUERY,
+                                   context: { current_user: user, token: },
+                                   variables: { group_id: group.to_global_id.to_s,
+                                                filter: { created_at_gt: (original_date + 1.day).to_s } })
+
+      assert_not_nil result['errors'], 'should not work and have authorization errors.'
+
+      assert_equal 'You are not authorized to perform this action',
+                   result['errors'].first['message']
+
+      data = result['data']['projects']
+
+      assert_nil data
+    end
+  end
+end

--- a/test/graphql/samples_query_ransack_test.rb
+++ b/test/graphql/samples_query_ransack_test.rb
@@ -101,22 +101,17 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
   end
 
   test 'ransack samples query with group id should work with order by' do
-    Timecop.travel(5.days.from_now) do
-      @sample.created_at = Time.zone.now
-      @sample.save!
+    result = IridaSchema.execute(SAMPLES_RANSACK_WITH_GROUP_QUERY,
+                                 context: { current_user: @user },
+                                 variables:
+                                 { group_id: groups(:group_one).to_global_id.to_s,
+                                   orderBy: { field: 'created_at', direction: 'desc' } })
 
-      result = IridaSchema.execute(SAMPLES_RANSACK_WITH_GROUP_QUERY,
-                                   context: { current_user: @user },
-                                   variables:
-                                   { group_id: groups(:group_one).to_global_id.to_s,
-                                     orderBy: { field: 'created_at', direction: 'desc' } })
+    assert_nil result['errors'], 'should work and have no errors.'
 
-      assert_nil result['errors'], 'should work and have no errors.'
+    data = result['data']['samples']['nodes']
 
-      data = result['data']['samples']['nodes']
-
-      assert_equal @sample.puid, data[0]['puid']
-    end
+    assert_equal @sample.puid, data[0]['puid']
   end
 
   test 'ransack group samples query should throw authorization error' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Adds ransack filtering and ordering to the graphql projects query

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Sign in with user1
2. go to GraphiQL 
3. Test filtering
```graphql
query get_projects_filter{
  projects(filter: { name_cont:"2023"  }
    nodes{
      puid
      name
      createdAt
      updatedAt
    }
  }
}
```
4. test ordering
```graphql
query get_projects_order_by{
  projects(orderBy:{field:updated_at, direction:desc}){
    nodes{
      puid
      name
      createdAt
      updatedAt
    }
  }
}
```
5. verify that queries with group id still work as intended
```graphql
# get a relevant group id
query get_groups{
  groups{
    nodes{
   		name
      id  
    }
  }
}

# do a query with group id
query get_projects_by_group{
  projects(
    	groupId:"gid://irida/Group/ef20539d-23aa-41c4-907c-06f4f6b7d4d3"
    	orderBy:{field:updated_at, direction:desc}){
    nodes{
      puid
      name
      createdAt
      updatedAt
    }
  }
}
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
