### PR TITLE
Graphql - Add ransack filtering and ordering to groups 

### DIFF
--- a/app/graphql/resolvers/groups_resolver.rb
+++ b/app/graphql/resolvers/groups_resolver.rb
@@ -5,8 +5,22 @@ module Resolvers
   class GroupsResolver < BaseResolver
     type Types::GroupType.connection_type, null: true
 
-    def resolve
-      authorized_scope Group, type: :relation
+    argument :filter, Types::GroupFilterType,
+             required: false,
+             description: 'Ransack filter',
+             default_value: nil
+
+    argument :order_by, Types::GroupOrderInputType,
+             required: false,
+             description: 'Order by',
+             default_value: nil
+
+    def resolve(filter:, order_by:)
+      groups = authorized_scope Group, type: :relation
+      ransack_obj = groups.ransack(filter&.to_h)
+      ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?
+
+      ransack_obj.result
     end
   end
 end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -745,68 +745,6 @@ input GroupFilter {
   created_at_start_all: [String!]
   created_at_start_any: [String!]
   created_at_true: String
-  deleted_at_blank: String
-  deleted_at_cont: String
-  deleted_at_cont_all: [String!]
-  deleted_at_cont_any: [String!]
-  deleted_at_does_not_match: String
-  deleted_at_does_not_match_all: [String!]
-  deleted_at_does_not_match_any: [String!]
-  deleted_at_end: String
-  deleted_at_end_all: [String!]
-  deleted_at_end_any: [String!]
-  deleted_at_eq: String
-  deleted_at_eq_all: [String!]
-  deleted_at_eq_any: [String!]
-  deleted_at_false: String
-  deleted_at_gt: String
-  deleted_at_gt_all: [String!]
-  deleted_at_gt_any: [String!]
-  deleted_at_gteq: String
-  deleted_at_gteq_all: [String!]
-  deleted_at_gteq_any: [String!]
-  deleted_at_i_cont: String
-  deleted_at_i_cont_all: [String!]
-  deleted_at_i_cont_any: [String!]
-  deleted_at_in: [String!]
-  deleted_at_in_all: [String!]
-  deleted_at_in_any: [String!]
-  deleted_at_lt: String
-  deleted_at_lt_all: [String!]
-  deleted_at_lt_any: [String!]
-  deleted_at_lteq: String
-  deleted_at_lteq_all: [String!]
-  deleted_at_lteq_any: [String!]
-  deleted_at_matches: String
-  deleted_at_matches_all: [String!]
-  deleted_at_matches_any: [String!]
-  deleted_at_not_cont: String
-  deleted_at_not_cont_all: [String!]
-  deleted_at_not_cont_any: [String!]
-  deleted_at_not_end: String
-  deleted_at_not_end_all: [String!]
-  deleted_at_not_end_any: [String!]
-  deleted_at_not_eq: String
-  deleted_at_not_eq_all: [String!]
-  deleted_at_not_eq_any: [String!]
-  deleted_at_not_false: String
-  deleted_at_not_i_cont: String
-  deleted_at_not_i_cont_all: [String!]
-  deleted_at_not_i_cont_any: [String!]
-  deleted_at_not_in: [String!]
-  deleted_at_not_in_all: [String!]
-  deleted_at_not_in_any: [String!]
-  deleted_at_not_null: String
-  deleted_at_not_start: String
-  deleted_at_not_start_all: [String!]
-  deleted_at_not_start_any: [String!]
-  deleted_at_not_true: String
-  deleted_at_null: String
-  deleted_at_present: String
-  deleted_at_start: String
-  deleted_at_start_all: [String!]
-  deleted_at_start_any: [String!]
-  deleted_at_true: String
   name_blank: String
   name_cont: String
   name_cont_all: [String!]

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -402,6 +402,7 @@ Field to sort the attachments by
 """
 enum AttachmentOrderField {
   created_at
+  filename
   updated_at
 }
 
@@ -744,6 +745,68 @@ input GroupFilter {
   created_at_start_all: [String!]
   created_at_start_any: [String!]
   created_at_true: String
+  deleted_at_blank: String
+  deleted_at_cont: String
+  deleted_at_cont_all: [String!]
+  deleted_at_cont_any: [String!]
+  deleted_at_does_not_match: String
+  deleted_at_does_not_match_all: [String!]
+  deleted_at_does_not_match_any: [String!]
+  deleted_at_end: String
+  deleted_at_end_all: [String!]
+  deleted_at_end_any: [String!]
+  deleted_at_eq: String
+  deleted_at_eq_all: [String!]
+  deleted_at_eq_any: [String!]
+  deleted_at_false: String
+  deleted_at_gt: String
+  deleted_at_gt_all: [String!]
+  deleted_at_gt_any: [String!]
+  deleted_at_gteq: String
+  deleted_at_gteq_all: [String!]
+  deleted_at_gteq_any: [String!]
+  deleted_at_i_cont: String
+  deleted_at_i_cont_all: [String!]
+  deleted_at_i_cont_any: [String!]
+  deleted_at_in: [String!]
+  deleted_at_in_all: [String!]
+  deleted_at_in_any: [String!]
+  deleted_at_lt: String
+  deleted_at_lt_all: [String!]
+  deleted_at_lt_any: [String!]
+  deleted_at_lteq: String
+  deleted_at_lteq_all: [String!]
+  deleted_at_lteq_any: [String!]
+  deleted_at_matches: String
+  deleted_at_matches_all: [String!]
+  deleted_at_matches_any: [String!]
+  deleted_at_not_cont: String
+  deleted_at_not_cont_all: [String!]
+  deleted_at_not_cont_any: [String!]
+  deleted_at_not_end: String
+  deleted_at_not_end_all: [String!]
+  deleted_at_not_end_any: [String!]
+  deleted_at_not_eq: String
+  deleted_at_not_eq_all: [String!]
+  deleted_at_not_eq_any: [String!]
+  deleted_at_not_false: String
+  deleted_at_not_i_cont: String
+  deleted_at_not_i_cont_all: [String!]
+  deleted_at_not_i_cont_any: [String!]
+  deleted_at_not_in: [String!]
+  deleted_at_not_in_all: [String!]
+  deleted_at_not_in_any: [String!]
+  deleted_at_not_null: String
+  deleted_at_not_start: String
+  deleted_at_not_start_all: [String!]
+  deleted_at_not_start_any: [String!]
+  deleted_at_not_true: String
+  deleted_at_null: String
+  deleted_at_present: String
+  deleted_at_start: String
+  deleted_at_start_all: [String!]
+  deleted_at_start_any: [String!]
+  deleted_at_true: String
   name_blank: String
   name_cont: String
   name_cont_all: [String!]
@@ -941,10 +1004,11 @@ input GroupOrder {
 }
 
 """
-Field to sort the samples by
+Field to sort the groups by
 """
 enum GroupOrderField {
   created_at
+  name
   updated_at
 }
 
@@ -1521,6 +1585,7 @@ Field to sort the samples by
 """
 enum ProjectOrderField {
   created_at
+  name
   updated_at
 }
 
@@ -2211,6 +2276,7 @@ Field to sort the samples by
 """
 enum SampleOrderField {
   created_at
+  name
   updated_at
 }
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -681,6 +681,273 @@ type GroupEdge {
   node: Group
 }
 
+input GroupFilter {
+  created_at_blank: String
+  created_at_cont: String
+  created_at_cont_all: [String!]
+  created_at_cont_any: [String!]
+  created_at_does_not_match: String
+  created_at_does_not_match_all: [String!]
+  created_at_does_not_match_any: [String!]
+  created_at_end: String
+  created_at_end_all: [String!]
+  created_at_end_any: [String!]
+  created_at_eq: String
+  created_at_eq_all: [String!]
+  created_at_eq_any: [String!]
+  created_at_false: String
+  created_at_gt: String
+  created_at_gt_all: [String!]
+  created_at_gt_any: [String!]
+  created_at_gteq: String
+  created_at_gteq_all: [String!]
+  created_at_gteq_any: [String!]
+  created_at_i_cont: String
+  created_at_i_cont_all: [String!]
+  created_at_i_cont_any: [String!]
+  created_at_in: [String!]
+  created_at_in_all: [String!]
+  created_at_in_any: [String!]
+  created_at_lt: String
+  created_at_lt_all: [String!]
+  created_at_lt_any: [String!]
+  created_at_lteq: String
+  created_at_lteq_all: [String!]
+  created_at_lteq_any: [String!]
+  created_at_matches: String
+  created_at_matches_all: [String!]
+  created_at_matches_any: [String!]
+  created_at_not_cont: String
+  created_at_not_cont_all: [String!]
+  created_at_not_cont_any: [String!]
+  created_at_not_end: String
+  created_at_not_end_all: [String!]
+  created_at_not_end_any: [String!]
+  created_at_not_eq: String
+  created_at_not_eq_all: [String!]
+  created_at_not_eq_any: [String!]
+  created_at_not_false: String
+  created_at_not_i_cont: String
+  created_at_not_i_cont_all: [String!]
+  created_at_not_i_cont_any: [String!]
+  created_at_not_in: [String!]
+  created_at_not_in_all: [String!]
+  created_at_not_in_any: [String!]
+  created_at_not_null: String
+  created_at_not_start: String
+  created_at_not_start_all: [String!]
+  created_at_not_start_any: [String!]
+  created_at_not_true: String
+  created_at_null: String
+  created_at_present: String
+  created_at_start: String
+  created_at_start_all: [String!]
+  created_at_start_any: [String!]
+  created_at_true: String
+  name_blank: String
+  name_cont: String
+  name_cont_all: [String!]
+  name_cont_any: [String!]
+  name_does_not_match: String
+  name_does_not_match_all: [String!]
+  name_does_not_match_any: [String!]
+  name_end: String
+  name_end_all: [String!]
+  name_end_any: [String!]
+  name_eq: String
+  name_eq_all: [String!]
+  name_eq_any: [String!]
+  name_false: String
+  name_gt: String
+  name_gt_all: [String!]
+  name_gt_any: [String!]
+  name_gteq: String
+  name_gteq_all: [String!]
+  name_gteq_any: [String!]
+  name_i_cont: String
+  name_i_cont_all: [String!]
+  name_i_cont_any: [String!]
+  name_in: [String!]
+  name_in_all: [String!]
+  name_in_any: [String!]
+  name_lt: String
+  name_lt_all: [String!]
+  name_lt_any: [String!]
+  name_lteq: String
+  name_lteq_all: [String!]
+  name_lteq_any: [String!]
+  name_matches: String
+  name_matches_all: [String!]
+  name_matches_any: [String!]
+  name_not_cont: String
+  name_not_cont_all: [String!]
+  name_not_cont_any: [String!]
+  name_not_end: String
+  name_not_end_all: [String!]
+  name_not_end_any: [String!]
+  name_not_eq: String
+  name_not_eq_all: [String!]
+  name_not_eq_any: [String!]
+  name_not_false: String
+  name_not_i_cont: String
+  name_not_i_cont_all: [String!]
+  name_not_i_cont_any: [String!]
+  name_not_in: [String!]
+  name_not_in_all: [String!]
+  name_not_in_any: [String!]
+  name_not_null: String
+  name_not_start: String
+  name_not_start_all: [String!]
+  name_not_start_any: [String!]
+  name_not_true: String
+  name_null: String
+  name_present: String
+  name_start: String
+  name_start_all: [String!]
+  name_start_any: [String!]
+  name_true: String
+  puid_blank: String
+  puid_cont: String
+  puid_cont_all: [String!]
+  puid_cont_any: [String!]
+  puid_does_not_match: String
+  puid_does_not_match_all: [String!]
+  puid_does_not_match_any: [String!]
+  puid_end: String
+  puid_end_all: [String!]
+  puid_end_any: [String!]
+  puid_eq: String
+  puid_eq_all: [String!]
+  puid_eq_any: [String!]
+  puid_false: String
+  puid_gt: String
+  puid_gt_all: [String!]
+  puid_gt_any: [String!]
+  puid_gteq: String
+  puid_gteq_all: [String!]
+  puid_gteq_any: [String!]
+  puid_i_cont: String
+  puid_i_cont_all: [String!]
+  puid_i_cont_any: [String!]
+  puid_in: [String!]
+  puid_in_all: [String!]
+  puid_in_any: [String!]
+  puid_lt: String
+  puid_lt_all: [String!]
+  puid_lt_any: [String!]
+  puid_lteq: String
+  puid_lteq_all: [String!]
+  puid_lteq_any: [String!]
+  puid_matches: String
+  puid_matches_all: [String!]
+  puid_matches_any: [String!]
+  puid_not_cont: String
+  puid_not_cont_all: [String!]
+  puid_not_cont_any: [String!]
+  puid_not_end: String
+  puid_not_end_all: [String!]
+  puid_not_end_any: [String!]
+  puid_not_eq: String
+  puid_not_eq_all: [String!]
+  puid_not_eq_any: [String!]
+  puid_not_false: String
+  puid_not_i_cont: String
+  puid_not_i_cont_all: [String!]
+  puid_not_i_cont_any: [String!]
+  puid_not_in: [String!]
+  puid_not_in_all: [String!]
+  puid_not_in_any: [String!]
+  puid_not_null: String
+  puid_not_start: String
+  puid_not_start_all: [String!]
+  puid_not_start_any: [String!]
+  puid_not_true: String
+  puid_null: String
+  puid_present: String
+  puid_start: String
+  puid_start_all: [String!]
+  puid_start_any: [String!]
+  puid_true: String
+  updated_at_blank: String
+  updated_at_cont: String
+  updated_at_cont_all: [String!]
+  updated_at_cont_any: [String!]
+  updated_at_does_not_match: String
+  updated_at_does_not_match_all: [String!]
+  updated_at_does_not_match_any: [String!]
+  updated_at_end: String
+  updated_at_end_all: [String!]
+  updated_at_end_any: [String!]
+  updated_at_eq: String
+  updated_at_eq_all: [String!]
+  updated_at_eq_any: [String!]
+  updated_at_false: String
+  updated_at_gt: String
+  updated_at_gt_all: [String!]
+  updated_at_gt_any: [String!]
+  updated_at_gteq: String
+  updated_at_gteq_all: [String!]
+  updated_at_gteq_any: [String!]
+  updated_at_i_cont: String
+  updated_at_i_cont_all: [String!]
+  updated_at_i_cont_any: [String!]
+  updated_at_in: [String!]
+  updated_at_in_all: [String!]
+  updated_at_in_any: [String!]
+  updated_at_lt: String
+  updated_at_lt_all: [String!]
+  updated_at_lt_any: [String!]
+  updated_at_lteq: String
+  updated_at_lteq_all: [String!]
+  updated_at_lteq_any: [String!]
+  updated_at_matches: String
+  updated_at_matches_all: [String!]
+  updated_at_matches_any: [String!]
+  updated_at_not_cont: String
+  updated_at_not_cont_all: [String!]
+  updated_at_not_cont_any: [String!]
+  updated_at_not_end: String
+  updated_at_not_end_all: [String!]
+  updated_at_not_end_any: [String!]
+  updated_at_not_eq: String
+  updated_at_not_eq_all: [String!]
+  updated_at_not_eq_any: [String!]
+  updated_at_not_false: String
+  updated_at_not_i_cont: String
+  updated_at_not_i_cont_all: [String!]
+  updated_at_not_i_cont_any: [String!]
+  updated_at_not_in: [String!]
+  updated_at_not_in_all: [String!]
+  updated_at_not_in_any: [String!]
+  updated_at_not_null: String
+  updated_at_not_start: String
+  updated_at_not_start_all: [String!]
+  updated_at_not_start_any: [String!]
+  updated_at_not_true: String
+  updated_at_null: String
+  updated_at_present: String
+  updated_at_start: String
+  updated_at_start_all: [String!]
+  updated_at_start_any: [String!]
+  updated_at_true: String
+}
+
+"""
+Specify a sort for the groups
+"""
+input GroupOrder {
+  direction: OrderDirection
+  field: GroupOrderField!
+}
+
+"""
+Field to sort the samples by
+"""
+enum GroupOrderField {
+  created_at
+  updated_at
+}
+
 """
 An ISO 8601-encoded datetime
 """
@@ -1296,6 +1563,11 @@ type Query {
     before: String
 
     """
+    Ransack filter
+    """
+    filter: GroupFilter = null
+
+    """
     Returns the first _n_ elements from the list.
     """
     first: Int
@@ -1304,6 +1576,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Order by
+    """
+    orderBy: GroupOrder = null
   ): GroupConnection!
 
   """

--- a/app/graphql/types/attachment_order_input_type.rb
+++ b/app/graphql/types/attachment_order_input_type.rb
@@ -6,6 +6,7 @@ module Types
     description 'Field to sort the attachments by'
     value 'created_at'
     value 'updated_at'
+    value 'filename'
   end
 
   class AttachmentOrderInputType < BaseInputObject # rubocop:disable Style/Documentation

--- a/app/graphql/types/group_filter_type.rb
+++ b/app/graphql/types/group_filter_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  # Group Filter Type
+  class GroupFilterType < BaseInputObject # rubocop:disable GraphQL/ObjectDescription
+    Group.ransackable_attributes.excluding('id').each do |attr|
+      Ransack.predicates.keys.map do |key|
+        value_type = Ransack.predicates[key].wants_array ? [String] : String
+        argument :"#{attr}_#{key}".to_sym,
+                 value_type,
+                 required: false,
+                 camelize: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/group_filter_type.rb
+++ b/app/graphql/types/group_filter_type.rb
@@ -3,7 +3,7 @@
 module Types
   # Group Filter Type
   class GroupFilterType < BaseInputObject # rubocop:disable GraphQL/ObjectDescription
-    Group.ransackable_attributes.excluding('id').each do |attr|
+    Group.ransackable_attributes.excluding(%w[id deleted_at]).each do |attr|
       Ransack.predicates.keys.map do |key|
         value_type = Ransack.predicates[key].wants_array ? [String] : String
         argument :"#{attr}_#{key}".to_sym,

--- a/app/graphql/types/group_order_input_type.rb
+++ b/app/graphql/types/group_order_input_type.rb
@@ -3,9 +3,10 @@
 module Types
   class GroupOrderFieldInputType < BaseEnum # rubocop:disable Style/Documentation
     graphql_name 'GroupOrderField'
-    description 'Field to sort the samples by'
+    description 'Field to sort the groups by'
     value 'created_at'
     value 'updated_at'
+    value 'name'
   end
 
   class GroupOrderInputType < BaseInputObject # rubocop:disable Style/Documentation

--- a/app/graphql/types/group_order_input_type.rb
+++ b/app/graphql/types/group_order_input_type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  class GroupOrderFieldInputType < BaseEnum # rubocop:disable Style/Documentation
+    graphql_name 'GroupOrderField'
+    description 'Field to sort the samples by'
+    value 'created_at'
+    value 'updated_at'
+  end
+
+  class GroupOrderInputType < BaseInputObject # rubocop:disable Style/Documentation
+    graphql_name 'GroupOrder'
+    description 'Specify a sort for the groups'
+
+    argument :direction, OrderDirectionType, required: false # rubocop:disable GraphQL/ArgumentDescription
+    argument :field, GroupOrderFieldInputType, required: true # rubocop:disable GraphQL/ArgumentDescription
+  end
+end

--- a/app/graphql/types/project_order_input_type.rb
+++ b/app/graphql/types/project_order_input_type.rb
@@ -6,6 +6,7 @@ module Types
     description 'Field to sort the samples by'
     value 'created_at'
     value 'updated_at'
+    value 'name'
   end
 
   class ProjectOrderInputType < BaseInputObject # rubocop:disable Style/Documentation

--- a/app/graphql/types/sample_order_input_type.rb
+++ b/app/graphql/types/sample_order_input_type.rb
@@ -6,6 +6,7 @@ module Types
     description 'Field to sort the samples by'
     value 'created_at'
     value 'updated_at'
+    value 'name'
   end
 
   class SampleOrderInputType < BaseInputObject # rubocop:disable Style/Documentation

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -60,6 +60,10 @@ class Group < Namespace
   has_many :shared_projects, through: :shared_project_namespaces, class_name: 'Project', source: :project
   has_many :shared_with_groups, through: :shared_with_group_links, source: :group
 
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id name puid created_at updated_at]
+  end
+
   def self.sti_name
     'Group'
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -60,10 +60,6 @@ class Group < Namespace
   has_many :shared_projects, through: :shared_project_namespaces, class_name: 'Project', source: :project
   has_many :shared_with_groups, through: :shared_with_group_links, source: :group
 
-  def self.ransackable_attributes(_auth_object = nil)
-    %w[id name puid created_at updated_at]
-  end
-
   def self.sti_name
     'Group'
   end

--- a/test/graphql/attachments_query_test.rb
+++ b/test/graphql/attachments_query_test.rb
@@ -169,8 +169,8 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
   test 'attachment query should work with order by' do
     result = IridaSchema.execute(ATTACHMENTS_QUERY, context: { current_user: @user },
                                                     variables: { puid: @sample.puid,
-                                                                 attachmentOrderBy: { field: 'created_at',
-                                                                                      direction: 'desc' } })
+                                                                 attachmentOrderBy: { field: 'filename',
+                                                                                      direction: 'asc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
 

--- a/test/graphql/groups_query_ransack_test.rb
+++ b/test/graphql/groups_query_ransack_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GroupsQueryTest < ActiveSupport::TestCase
+  GROUPS_RANSACK_QUERY = <<~GRAPHQL
+    query($filter: GroupFilter, $orderBy: GroupOrder) {
+      groups(filter: $filter, orderBy: $orderBy) {
+        nodes {
+          name
+          id
+          puid
+          updatedAt
+          createdAt
+        }
+        totalCount
+      }
+    }
+  GRAPHQL
+
+  def setup
+    @user = users(:john_doe)
+    @group = groups(:group_one)
+  end
+
+  test 'ransack groups query should work' do
+    original_date = Time.zone.today
+    Timecop.travel(5.days.from_now) do
+      @group.created_at = Time.zone.now
+      @group.save!
+
+      result = IridaSchema.execute(GROUPS_RANSACK_QUERY,
+                                   context: { current_user: @user },
+                                   variables: { filter: { created_at_gt: (original_date + 1.day).to_s } })
+
+      assert_nil result['errors'], 'should work and have no errors.'
+
+      data = result['data']['groups']['nodes']
+
+      assert_equal 1, data.count
+      assert_equal @group.puid, data[0]['puid']
+    end
+  end
+
+  test 'ransack groups query should work with order by' do
+    result = IridaSchema.execute(GROUPS_RANSACK_QUERY,
+                                 context: { current_user: @user },
+                                 variables: { filter: { name_start: 'Group 1' },
+                                              orderBy: { field: 'created_at', direction: 'asc' } })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['groups']['nodes']
+
+    assert_equal 6, data.count # Group 1, Group 10, Group 11, etc
+    assert_equal groups(:group_one).name, data[0]['name']
+    assert_equal groups(:group_one).puid, data[0]['puid']
+  end
+end

--- a/test/graphql/groups_query_ransack_test.rb
+++ b/test/graphql/groups_query_ransack_test.rb
@@ -20,14 +20,14 @@ class GroupsQueryTest < ActiveSupport::TestCase
 
   def setup
     @user = users(:john_doe)
-    @group = groups(:group_one)
   end
 
   test 'ransack groups query should work' do
+    group = groups(:group_one)
     original_date = Time.zone.today
     Timecop.travel(5.days.from_now) do
-      @group.created_at = Time.zone.now
-      @group.save!
+      group.created_at = Time.zone.now
+      group.save!
 
       result = IridaSchema.execute(GROUPS_RANSACK_QUERY,
                                    context: { current_user: @user },
@@ -38,7 +38,7 @@ class GroupsQueryTest < ActiveSupport::TestCase
       data = result['data']['groups']['nodes']
 
       assert_equal 1, data.count
-      assert_equal @group.puid, data[0]['puid']
+      assert_equal group.puid, data[0]['puid']
     end
   end
 

--- a/test/graphql/groups_query_ransack_test.rb
+++ b/test/graphql/groups_query_ransack_test.rb
@@ -46,14 +46,24 @@ class GroupsQueryTest < ActiveSupport::TestCase
     result = IridaSchema.execute(GROUPS_RANSACK_QUERY,
                                  context: { current_user: @user },
                                  variables: { filter: { name_start: 'Group 1' },
-                                              orderBy: { field: 'created_at', direction: 'asc' } })
+                                              orderBy: { field: 'name', direction: 'desc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
 
     data = result['data']['groups']['nodes']
 
     assert_equal 6, data.count # Group 1, Group 10, Group 11, etc
-    assert_equal groups(:group_one).name, data[0]['name']
-    assert_equal groups(:group_one).puid, data[0]['puid']
+
+    assert_equal groups(:group_sixteen).name, data[0]['name']
+    assert_equal groups(:group_sixteen).puid, data[0]['puid']
+
+    assert_equal groups(:group_fifteen).name, data[1]['name']
+    assert_equal groups(:group_fifteen).puid, data[1]['puid']
+
+    assert_equal groups(:group_ten).name, data[4]['name']
+    assert_equal groups(:group_ten).puid, data[4]['puid']
+
+    assert_equal groups(:group_one).name, data[5]['name']
+    assert_equal groups(:group_one).puid, data[5]['puid']
   end
 end

--- a/test/graphql/projects_query_ransack_test.rb
+++ b/test/graphql/projects_query_ransack_test.rb
@@ -62,13 +62,15 @@ class ProjectsQueryRansackTest < ActiveSupport::TestCase
     result = IridaSchema.execute(PROJECTS_RANSACK_QUERY,
                                  context: { current_user: @user },
                                  variables: { filter: { name_cont: 'Project 1' },
-                                              orderBy: { field: 'created_at', direction: 'asc' } })
+                                              orderBy: { field: 'name', direction: 'asc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
     data = result['data']['projects']['nodes']
 
     assert_equal 12, data.count # Project 1, Project 10, Project 11, etc
-    assert_equal @project.puid, data[0]['puid']
+    assert_equal projects(:namespace_group_link_group_one_project1).puid, data[0]['puid']
+    assert_equal projects(:project1).puid, data[1]['puid']
+    assert_equal projects(:project10).puid, data[2]['puid']
   end
 
   test 'ransack projects query with group id should work' do
@@ -94,13 +96,15 @@ class ProjectsQueryRansackTest < ActiveSupport::TestCase
     result = IridaSchema.execute(PROJECTS_RANSACK_WITH_GROUP_QUERY,
                                  context: { current_user: @user },
                                  variables: { group_id: groups(:group_one).to_global_id.to_s,
-                                              orderBy: { field: 'created_at', direction: 'desc' } })
+                                              orderBy: { field: 'name', direction: 'desc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
     data = result['data']['projects']['nodes']
 
     assert_equal 22, data.count
-    assert_equal @project.puid, data[0]['puid']
+    assert_equal projects(:project9).puid, data[0]['puid']
+    assert_equal projects(:project8).puid, data[1]['puid']
+    assert_equal projects(:project7).puid, data[2]['puid']
   end
 
   test 'ransack projects query should throw authorization error' do

--- a/test/graphql/samples_query_ransack_test.rb
+++ b/test/graphql/samples_query_ransack_test.rb
@@ -73,9 +73,16 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
     assert_nil result['errors'], 'should work and have no errors.'
 
     data = result['data']['samples']['nodes']
+    assert_equal 3, data.count
 
     assert_equal samples(:sample2).name, data[0]['name']
     assert_equal samples(:sample2).puid, data[0]['puid']
+
+    assert_equal samples(:sample1).name, data[1]['name']
+    assert_equal samples(:sample1).puid, data[1]['puid']
+
+    assert_equal samples(:sample37).name, data[2]['name']
+    assert_equal samples(:sample37).puid, data[2]['puid']
   end
 
   test 'ransack samples query with group id should work' do
@@ -105,13 +112,21 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
                                  context: { current_user: @user },
                                  variables:
                                  { group_id: groups(:group_one).to_global_id.to_s,
-                                   orderBy: { field: 'created_at', direction: 'desc' } })
+                                   orderBy: { field: 'created_at', direction: 'asc' } })
 
     assert_nil result['errors'], 'should work and have no errors.'
 
     data = result['data']['samples']['nodes']
+    assert_equal 25, data.count
 
-    assert_equal @sample.puid, data[0]['puid']
+    assert_equal samples(:sample30).name, data[0]['name']
+    assert_equal samples(:sample30).puid, data[0]['puid']
+
+    assert_equal samples(:sample29).name, data[1]['name']
+    assert_equal samples(:sample29).puid, data[1]['puid']
+
+    assert_equal samples(:sample28).name, data[2]['name']
+    assert_equal samples(:sample28).puid, data[2]['puid']
   end
 
   test 'ransack group samples query should throw authorization error' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Adds ransack filtering and ordering to the graphql  groups query

Added `name` to order by for projects, samples, and groups
Added `filename` to order by for attachments

Improved tests for order by 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Sign in with user1
2. go to GraphiQL
3. test filtering
```graphql
query get_groups{
  groups(
    filter:{name_cont:"pyogenes"}
  ){
    nodes{
      name
      id
      puid
      updatedAt
      createdAt
    }
  }
}
```
4. test ordering
```graphql
query get_groups{
  groups(
    orderBy:{field:created_at, direction:desc}
  ){
    nodes{
     name
      id
      puid
      updatedAt
      createdAt
    }
  }
}
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
