### PR TITLE
Graphql - Add metadata_summary field to Projects

### DIFF
--- a/app/graphql/resolvers/project_metadata_summary_resolver.rb
+++ b/app/graphql/resolvers/project_metadata_summary_resolver.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Resolvers
+  # Project Metadata Summary Resolver
+  class ProjectMetadataSummaryResolver < BaseResolver
+    type GraphQL::Types::JSON, null: false
+
+    argument :keys, [GraphQL::Types::String],
+             required: false,
+             description: 'Optional array of keys to limit metadata result to.',
+             default_value: nil
+
+    alias project object
+
+    def resolve(args)
+      scope = project
+
+      return scope.metadata_summary unless args[:keys]
+
+      scope.metadata_summary.slice(*args[:keys])
+    end
+  end
+end

--- a/app/graphql/resolvers/project_metadata_summary_resolver.rb
+++ b/app/graphql/resolvers/project_metadata_summary_resolver.rb
@@ -7,7 +7,7 @@ module Resolvers
 
     argument :keys, [GraphQL::Types::String],
              required: false,
-             description: 'Optional array of keys to limit metadata result to.',
+             description: 'Optional array of keys to limit metadata summary result to.',
              default_value: nil
 
     alias project object

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -894,7 +894,7 @@ type Project implements Node {
   """
   metadataSummary(
     """
-    Optional array of keys to limit metadata result to.
+    Optional array of keys to limit metadata summary result to.
     """
     keys: [String!] = null
   ): JSON!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -890,6 +890,16 @@ type Project implements Node {
   id: ID!
 
   """
+  Metadata summary for the project
+  """
+  metadataSummary(
+    """
+    Optional array of keys to limit metadata result to.
+    """
+    keys: [String!] = null
+  ): JSON!
+
+  """
   Name of the project.
   """
   name: String!

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -9,6 +9,12 @@ module Types
     field :description, String, null: true, description: 'Description of the project.'
     field :full_name, String, null: false, description: 'Full name of the project.'
     field :full_path, ID, null: false, description: 'Full path of the project.' # rubocop:disable GraphQL/ExtractType
+    field :metadata_summary,
+          GraphQL::Types::JSON,
+          null: false,
+          description: 'Metadata summary for the project',
+          resolver: Resolvers::ProjectMetadataSummaryResolver
+
     field :name, String, null: false, description: 'Name of the project.'
     field :path, String, null: false, description: 'Path of the project.'
     field :puid, ID, null: false,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,6 +25,7 @@ class Project < ApplicationRecord
   delegate :full_name, to: :namespace
   delegate :parent, to: :namespace
   delegate :puid, to: :namespace
+  delegate :metadata_summary, to: :namespace
 
   ransack_alias :name, :namespace_name
   ransack_alias :puid, :namespace_puid


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Adds the `metadata_summary` field to graphql projects

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Sign in and go to GraphiQL
2. Test the new field
```graphql
query get_projects_metadata{
  projects{
    nodes{
      puid
      name
      metadataSummary
    }
  }
}
```
3. Test with arguments
```graphql
query get_projects_metadata{
  projects{
    nodes{
      puid
      name
      metadataSummary(keys: ["age","gender"])
    }
  }
}
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
