### PR TITLE
Fix: Project Attachment Permissions for Bots

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -215,14 +215,20 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
 
     def can_create_attachment?(user, object_namespace, include_group_links = true) # rubocop:disable Style/OptionalBooleanParameter
+      effective_access_level = effective_access_level(object_namespace, user, include_group_links)
+      return true if (effective_access_level == Member::AccessLevel::UPLOADER) && Current.token&.active?
+
       Member::AccessLevel.manageable.include?(
-        effective_access_level(object_namespace, user, include_group_links)
+        effective_access_level
       )
     end
 
     def can_destroy_attachment?(user, object_namespace, include_group_links = true) # rubocop:disable Style/OptionalBooleanParameter
+      effective_access_level = effective_access_level(object_namespace, user, include_group_links)
+      return true if (effective_access_level == Member::AccessLevel::UPLOADER) && Current.token&.active?
+
       Member::AccessLevel.manageable.include?(
-        effective_access_level(object_namespace, user, include_group_links)
+        effective_access_level
       )
     end
 


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes project attachment permissions to allow project bots to create and destroy attachment. This issue is related to the implementation of [PR754](https://github.com/phac-nml/irida-next/pull/754)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Ensure tests pass locally.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
