### PR TITLE
GraphQL: Add Preauthorized types which skip authorizations

### DIFF
--- a/app/graphql/resolvers/attachment_metadata_resolver.rb
+++ b/app/graphql/resolvers/attachment_metadata_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Attachment Metadata Resolver
   class AttachmentMetadataResolver < BaseResolver
-    type GraphQL::Types::JSON, null: false
-
     argument :keys, [GraphQL::Types::String],
              required: false,
              description: 'Optional array of keys to limit metadata result to.',

--- a/app/graphql/resolvers/group_resolver.rb
+++ b/app/graphql/resolvers/group_resolver.rb
@@ -11,8 +11,6 @@ module Resolvers
              description: 'Persistent Unique Identifer of the group. For example, `INXT_GRP_GGGGGGGGGG.`'
     validates required: { one_of: %i[full_path puid] }
 
-    type Types::GroupType, null: true
-
     def resolve(args)
       if args[:full_path]
         Group.find_by_full_path(args[:full_path]) # rubocop:disable Rails/DynamicFindBy

--- a/app/graphql/resolvers/groups_resolver.rb
+++ b/app/graphql/resolvers/groups_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Groups Resolver
   class GroupsResolver < BaseResolver
-    type Types::GroupType.connection_type, null: true
-
     argument :filter, Types::GroupFilterType,
              required: false,
              description: 'Ransack filter',

--- a/app/graphql/resolvers/namespace_projects_resolver.rb
+++ b/app/graphql/resolvers/namespace_projects_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Namespace Resolver
   class NamespaceProjectsResolver < BaseResolver
-    type Types::ProjectType, null: true
-
     argument :include_sub_groups, GraphQL::Types::Boolean,
              required: false,
              description: 'Include projects from subgroups.',

--- a/app/graphql/resolvers/namespace_resolver.rb
+++ b/app/graphql/resolvers/namespace_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
                            For example a group namespace, `INXT_GRP_GGGGGGGGGG.`'
     validates required: { one_of: %i[full_path puid] }
 
-    type Types::NamespaceType, null: true
-
     def resolve(args)
       if args[:full_path]
         # Resolve Group or Namespaces::UserNamespace by full path

--- a/app/graphql/resolvers/nested_groups_resolver.rb
+++ b/app/graphql/resolvers/nested_groups_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Nested Groups Resolver
   class NestedGroupsResolver < BaseResolver
-    type Types::GroupType, null: true
-
     argument :include_parent_descendants, GraphQL::Types::Boolean,
              required: false,
              description: 'List of descendant groups of the parent group.',

--- a/app/graphql/resolvers/project_metadata_summary_resolver.rb
+++ b/app/graphql/resolvers/project_metadata_summary_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Project Metadata Summary Resolver
   class ProjectMetadataSummaryResolver < BaseResolver
-    type GraphQL::Types::JSON, null: false
-
     argument :keys, [GraphQL::Types::String],
              required: false,
              description: 'Optional array of keys to limit metadata summary result to.',

--- a/app/graphql/resolvers/project_resolver.rb
+++ b/app/graphql/resolvers/project_resolver.rb
@@ -11,8 +11,6 @@ module Resolvers
              description: 'Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.'
     validates required: { one_of: %i[full_path puid] }
 
-    type Types::ProjectType, null: true
-
     def resolve(args)
       if args[:full_path]
         Namespaces::ProjectNamespace.find_by_full_path(args[:full_path])&.project # rubocop:disable Rails/DynamicFindBy

--- a/app/graphql/resolvers/project_sample_resolver.rb
+++ b/app/graphql/resolvers/project_sample_resolver.rb
@@ -14,8 +14,6 @@ module Resolvers
              description: 'Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAA`.'
     validates required: { one_of: %i[sample_name sample_puid] }
 
-    type Types::SampleType, null: true
-
     def resolve(args)
       project = Namespaces::ProjectNamespace.find_by(puid: args[:project_puid])&.project
       if args[:sample_puid]

--- a/app/graphql/resolvers/projects_resolver.rb
+++ b/app/graphql/resolvers/projects_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Projects Resolver
   class ProjectsResolver < BaseResolver
-    type Types::ProjectType.connection_type, null: true
-
     argument :group_id, GraphQL::Types::ID,
              required: false,
              description: 'Optional group identifier to return list of projects for (includes direct, indirect, and shared projects).', # rubocop:disable Layout/LineLength

--- a/app/graphql/resolvers/sample_metadata_resolver.rb
+++ b/app/graphql/resolvers/sample_metadata_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Sample Metadata Resolver
   class SampleMetadataResolver < BaseResolver
-    type GraphQL::Types::JSON, null: false
-
     argument :keys, [GraphQL::Types::String],
              required: false,
              description: 'Optional array of keys to limit metadata result to.',

--- a/app/graphql/resolvers/sample_resolver.rb
+++ b/app/graphql/resolvers/sample_resolver.rb
@@ -7,8 +7,6 @@ module Resolvers
              required: true,
              description: 'Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAA`.'
 
-    type Types::SampleType, null: true
-
     def resolve(puid:)
       Sample.find_by(puid:)
     end

--- a/app/graphql/resolvers/samples_resolver.rb
+++ b/app/graphql/resolvers/samples_resolver.rb
@@ -3,8 +3,6 @@
 module Resolvers
   # Samples Resolver
   class SamplesResolver < BaseResolver
-    type Types::SampleType.connection_type, null: true
-
     argument :group_id, GraphQL::Types::ID,
              required: false,
              description: 'Optional group identifier to return list of samples for.',

--- a/app/graphql/types/group_type.rb
+++ b/app/graphql/types/group_type.rb
@@ -6,7 +6,7 @@ module Types
     implements GraphQL::Types::Relay::Node
     description 'A group'
 
-    field :descendant_groups, PreauthorizedGroupType.connection_type,
+    field :descendant_groups, Types::PreauthorizedGroupType.connection_type,
           null: true,
           description: 'List of descendant groups of this group.',
           complexity: 5,

--- a/app/graphql/types/group_type.rb
+++ b/app/graphql/types/group_type.rb
@@ -6,7 +6,7 @@ module Types
     implements GraphQL::Types::Relay::Node
     description 'A group'
 
-    field :descendant_groups, connection_type,
+    field :descendant_groups, PreauthorizedGroupType.connection_type,
           null: true,
           description: 'List of descendant groups of this group.',
           complexity: 5,

--- a/app/graphql/types/namespace_type.rb
+++ b/app/graphql/types/namespace_type.rb
@@ -15,7 +15,7 @@ module Types
                      description: 'Persistent Unique Identifier of the namespace. For example for a group,
                                   `INXT_GRP_AAAAAAAAAA`.'
 
-    field :projects, ProjectType.connection_type,
+    field :projects, PreauthorizedProjectType.connection_type,
           null: true,
           description: 'Projects within this namespace',
           complexity: 5,

--- a/app/graphql/types/namespace_type.rb
+++ b/app/graphql/types/namespace_type.rb
@@ -15,7 +15,7 @@ module Types
                      description: 'Persistent Unique Identifier of the namespace. For example for a group,
                                   `INXT_GRP_AAAAAAAAAA`.'
 
-    field :projects, PreauthorizedProjectType.connection_type,
+    field :projects, Types::PreauthorizedProjectType.connection_type,
           null: true,
           description: 'Projects within this namespace',
           complexity: 5,

--- a/app/graphql/types/preauthorized_attachment_type.rb
+++ b/app/graphql/types/preauthorized_attachment_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  # Preauthorized Attachment Type
+  # Only to be used as a return type on fields that are connections and
+  # are either scoped or come from an authorized object
+  class PreauthorizedAttachmentType < Types::AttachmentType # rubocop:disable GraphQL/ObjectDescription
+    def self.authorized?(_object, _context)
+      true
+    end
+  end
+end

--- a/app/graphql/types/preauthorized_group_type.rb
+++ b/app/graphql/types/preauthorized_group_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  # Preuthorized Group Type
+  # Only to be used as a return type on fields that are connections and
+  # are either scoped or come from an authorized object
+  class PreuthorizedGroupType < Types::GroupType # rubocop:disable GraphQL/ObjectDescription
+    def self.authorized?(_object, _context)
+      true
+    end
+  end
+end

--- a/app/graphql/types/preauthorized_group_type.rb
+++ b/app/graphql/types/preauthorized_group_type.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Types
-  # Preuthorized Group Type
+  # Preauthorized Group Type
   # Only to be used as a return type on fields that are connections and
   # are either scoped or come from an authorized object
-  class PreuthorizedGroupType < Types::GroupType # rubocop:disable GraphQL/ObjectDescription
+  class PreauthorizedGroupType < Types::GroupType # rubocop:disable GraphQL/ObjectDescription
     def self.authorized?(_object, _context)
       true
     end

--- a/app/graphql/types/preauthorized_namespace_type.rb
+++ b/app/graphql/types/preauthorized_namespace_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  # Preuthorized Namespace Type
+  # Only to be used as a return type on fields that are connections and
+  # are either scoped or come from an authorized object
+  class PreuthorizedNamespaceType < Types::NamespaceType # rubocop:disable GraphQL/ObjectDescription
+    def self.authorized?(_object, _context)
+      true
+    end
+  end
+end

--- a/app/graphql/types/preauthorized_namespace_type.rb
+++ b/app/graphql/types/preauthorized_namespace_type.rb
@@ -4,7 +4,7 @@ module Types
   # Preuthorized Namespace Type
   # Only to be used as a return type on fields that are connections and
   # are either scoped or come from an authorized object
-  class PreuthorizedNamespaceType < Types::NamespaceType # rubocop:disable GraphQL/ObjectDescription
+  class PreauthorizedNamespaceType < Types::NamespaceType # rubocop:disable GraphQL/ObjectDescription
     def self.authorized?(_object, _context)
       true
     end

--- a/app/graphql/types/preauthorized_project_type.rb
+++ b/app/graphql/types/preauthorized_project_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  # Preauthorized Project Type
+  # Only to be used as a return type on fields that are connections and
+  # are either scoped or come from an authorized object
+  class PreauthorizedProjectType < Types::ProjectType # rubocop:disable GraphQL/ObjectDescription
+    def self.authorized?(_object, _context)
+      true
+    end
+  end
+end

--- a/app/graphql/types/preauthorized_sample_type.rb
+++ b/app/graphql/types/preauthorized_sample_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  # Preauthorized Sample Type
+  # Only to be used as a return type on fields that are connections and
+  # are either scoped or come from an authorized object
+  class PreauthorizedSampleType < Types::SampleType # rubocop:disable GraphQL/ObjectDescription
+    def self.authorized?(_object, _context)
+      true
+    end
+  end
+end

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -7,7 +7,7 @@ module Types
     description 'A project'
 
     field :attachments,
-          PreauthorizedAttachmentType.connection_type,
+          Types::PreauthorizedAttachmentType.connection_type,
           null: true,
           description: 'Attachments on the project',
           resolver: Resolvers::ProjectAttachmentsResolver
@@ -27,12 +27,12 @@ module Types
                      description: 'Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.'
 
     field :samples,
-          PreauthorizedSampleType.connection_type,
+          Types::PreauthorizedSampleType.connection_type,
           null: true,
           description: 'Samples on the project',
           resolver: Resolvers::ProjectSamplesResolver
 
-    field :parent, PreauthorizedNamespaceType, null: false, description: 'Parent namespace'
+    field :parent, Types::PreauthorizedNamespaceType, null: false, description: 'Parent namespace'
 
     def self.authorized?(object, context)
       super &&

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -7,7 +7,7 @@ module Types
     description 'A project'
 
     field :attachments,
-          AttachmentType.connection_type,
+          PreauthorizedAttachmentType.connection_type,
           null: true,
           description: 'Attachments on the project',
           resolver: Resolvers::ProjectAttachmentsResolver
@@ -27,12 +27,12 @@ module Types
                      description: 'Persistent Unique Identifier of the project. For example, `INXT_PRJ_AAAAAAAAAA`.'
 
     field :samples,
-          SampleType.connection_type,
+          PreauthorizedSampleType.connection_type,
           null: true,
           description: 'Samples on the project',
           resolver: Resolvers::ProjectSamplesResolver
 
-    field :parent, NamespaceType, null: false, description: 'Parent namespace'
+    field :parent, PreauthorizedNamespaceType, null: false, description: 'Parent namespace'
 
     def self.authorized?(object, context)
       super &&

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -16,8 +16,8 @@ module Types
 
     field :group, Types::GroupType, null: true, authorize: { to: :read? }, resolver: Resolvers::GroupResolver,
                                     description: 'Find a group.'
-    field :groups, Types::GroupType.connection_type, null: false, resolver: Resolvers::GroupsResolver,
-                                                     description: 'Find groups.'
+    field :groups, Types::PreauthorizedGroupType.connection_type, null: false, resolver: Resolvers::GroupsResolver,
+                                                                  description: 'Find groups.'
 
     field :namespace, Types::NamespaceType, null: true, authorize: { to: :read? },
                                             resolver: Resolvers::NamespaceResolver,
@@ -26,14 +26,14 @@ module Types
     field :project, Types::ProjectType, null: true, authorize: { to: :read? }, resolver: Resolvers::ProjectResolver,
                                         description: 'Find a project.'
 
-    field :projects, Types::ProjectType.connection_type, null: true, resolver: Resolvers::ProjectsResolver,
-                                                         description: 'Find projects.'
+    field :projects, Types::PreauthorizedProjectType.connection_type, null: true, resolver: Resolvers::ProjectsResolver,
+                                                                      description: 'Find projects.'
 
     field :sample, Types::SampleType, null: true, resolver: Resolvers::SampleResolver,
                                       description: 'Find a sample.'
 
-    field :samples, Types::SampleType.connection_type, null: true, resolver: Resolvers::SamplesResolver,
-                                                       description: 'Find samples.'
+    field :samples, Types::PreauthorizedSampleType.connection_type, null: true, resolver: Resolvers::SamplesResolver,
+                                                                    description: 'Find samples.'
 
     field :project_sample, Types::SampleType, null: true, resolver: Resolvers::ProjectSampleResolver,
                                               description: 'Find a sample within a project.'

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -8,7 +8,7 @@ module Types
 
     field :description, String, null: true, description: 'Description of the sample.'
     field :name, String, null: false, description: 'Name of the sample.'
-    field :project, ProjectType, null: false, description: 'Project the sample is on.'
+    field :project, PreauthorizedProjectType, null: false, description: 'Project the sample is on.'
     field :puid, ID, null: false,
                      description: 'Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAAAA`.'
 
@@ -19,7 +19,7 @@ module Types
           resolver: Resolvers::SampleMetadataResolver
 
     field :attachments,
-          AttachmentType.connection_type,
+          PreauthorizedAttachmentType.connection_type,
           null: true,
           description: 'Attachments on the sample',
           resolver: Resolvers::SampleAttachmentsResolver

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -8,7 +8,7 @@ module Types
 
     field :description, String, null: true, description: 'Description of the sample.'
     field :name, String, null: false, description: 'Name of the sample.'
-    field :project, PreauthorizedProjectType, null: false, description: 'Project the sample is on.'
+    field :project, ProjectType, null: false, description: 'Project the sample is on.'
     field :puid, ID, null: false,
                      description: 'Persistent Unique Identifier of the sample. For example, `INXT_SAM_AAAAAAAAAAAA`.'
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Adds in `Preauthorized` prefixed types, which always return true in `self.authorized?`, these are only to be used in fields of other types that are already authorized or from resolvers that use policy scopes to query the types.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before this change:

Time of request to get up to 100 samples from a project:
![image](https://github.com/user-attachments/assets/a01dd28c-faf6-4d16-9cf5-1d5afc3fdc3f)

After this change:
Time of request to get up to 100 samples from a project:
![image](https://github.com/user-attachments/assets/41abd129-b9a0-4878-8f12-7c924540318d)

As you can see there is reduction in the number of ActiveRecord queries, since we are not authorizing each sample anymore.

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
