### PR TITLE
GraphQL: Use scoped context to skip queries and authorization

### DIFF
--- a/app/graphql/resolvers/project_attachments_resolver.rb
+++ b/app/graphql/resolvers/project_attachments_resolver.rb
@@ -16,6 +16,7 @@ module Resolvers
     alias project object
 
     def resolve(filter:, order_by:)
+      context.scoped_set!(:attachments_preauthorized, true)
       ransack_obj = project.namespace.attachments.joins(:file_blob).ransack(filter&.to_h)
       ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?
 

--- a/app/graphql/resolvers/project_sample_resolver.rb
+++ b/app/graphql/resolvers/project_sample_resolver.rb
@@ -18,6 +18,7 @@ module Resolvers
 
     def resolve(args)
       project = Namespaces::ProjectNamespace.find_by(puid: args[:project_puid])&.project
+      context.scoped_set!(:project, project)
       if args[:sample_puid]
         Sample.find_by(puid: args[:sample_puid], project:)
       else

--- a/app/graphql/resolvers/project_samples_resolver.rb
+++ b/app/graphql/resolvers/project_samples_resolver.rb
@@ -16,6 +16,8 @@ module Resolvers
              default_value: nil
 
     def resolve(filter:, order_by:)
+      context.scoped_set!(:project, project)
+      context.scoped_set!(:samples_preauthorized, true)
       ransack_obj = project.samples.ransack(filter&.to_h)
       ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?
 

--- a/app/graphql/resolvers/projects_resolver.rb
+++ b/app/graphql/resolvers/projects_resolver.rb
@@ -21,6 +21,7 @@ module Resolvers
              default_value: nil
 
     def resolve(group_id:, filter:, order_by:)
+      context.scoped_set!(:projects_preauthorized, true)
       projects = group_id ? projects_by_group_scope(group_id:) : projects_by_scope
       ransack_obj = projects.ransack(filter&.to_h)
       ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?

--- a/app/graphql/resolvers/sample_attachments_resolver.rb
+++ b/app/graphql/resolvers/sample_attachments_resolver.rb
@@ -16,6 +16,7 @@ module Resolvers
     alias sample object
 
     def resolve(filter:, order_by:)
+      context.scoped_set!(:attachments_preauthorized, true)
       ransack_obj = sample.attachments.joins(:file_blob).ransack(filter&.to_h)
       ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?
 

--- a/app/graphql/resolvers/samples_resolver.rb
+++ b/app/graphql/resolvers/samples_resolver.rb
@@ -21,6 +21,7 @@ module Resolvers
              default_value: nil
 
     def resolve(group_id:, filter:, order_by:)
+      context.scoped_set!(:samples_preauthorized, true)
       samples = group_id ? samples_by_group_scope(group_id:) : samples_by_project_scope
       ransack_obj = samples.ransack(filter&.to_h)
       ransack_obj.sorts = ["#{order_by.field} #{order_by.direction}"] if order_by.present?

--- a/app/graphql/types/attachment_type.rb
+++ b/app/graphql/types/attachment_type.rb
@@ -26,12 +26,12 @@ module Types
     end
 
     def self.authorized?(object, context)
-      super &&
+      super && (context[:attachments_preauthorized] ||
         allowed_to?(
           :read?,
           object.attachable.project,
           context: { user: context[:current_user], token: context[:token] }
-        )
+        ))
     end
   end
 end

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -35,12 +35,12 @@ module Types
     field :parent, NamespaceType, null: false, description: 'Parent namespace'
 
     def self.authorized?(object, context)
-      super &&
+      super && (context[:projects_preauthorized] ||
         allowed_to?(
           :read?,
           object,
           context: { user: context[:current_user], token: context[:token] }
-        )
+        ))
     end
   end
 end

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -30,7 +30,7 @@ module Types
 
     def project
       context.scoped_set!(:projects_preauthorized, true)
-      context[:project] || sample.project
+      context[:project] || object.project
     end
 
     def self.authorized?(object, context)

--- a/app/graphql/types/sample_type.rb
+++ b/app/graphql/types/sample_type.rb
@@ -28,13 +28,18 @@ module Types
           null: true,
           description: 'Datetime when associated attachments were last updated.'
 
+    def project
+      context.scoped_set!(:projects_preauthorized, true)
+      context[:project] || sample.project
+    end
+
     def self.authorized?(object, context)
-      super &&
+      super && (context[:samples_preauthorized] ||
         allowed_to?(
           :read_sample?,
           object.project,
           context: { user: context[:current_user], token: context[:token] }
-        )
+        ))
     end
   end
 end

--- a/test/controllers/projects/samples/attachments_controller_test.rb
+++ b/test/controllers/projects/samples/attachments_controller_test.rb
@@ -55,7 +55,7 @@ module Projects
           post namespace_project_sample_attachments_url(@namespace, @project, @sample1),
                params: { attachment: {
                  files: [fixture_file_upload('test_file_1.fastq', 'text/plain'),
-                         fixture_file_upload('test_file.fastq', 'text/plain')]
+                         fixture_file_upload('test_file_A.fastq', 'text/plain')]
                } },
                as: :turbo_stream
         end
@@ -65,7 +65,7 @@ module Projects
         assert_no_difference('Attachment.count') do
           post namespace_project_sample_attachments_url(@namespace, @project, @sample1),
                params: { attachment: {
-                 files: [fixture_file_upload('test_file.fastq', 'text/plain')]
+                 files: [fixture_file_upload('test_file_A.fastq', 'text/plain')]
                } },
                as: :turbo_stream
         end

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,12 +1,12 @@
-attachment1_file_test_file_fastq:
+attachment1_file_test_file_A_fastq:
   name: file
   record: attachment1 (Attachment)
-  blob: attachment1_file_test_file_fastq_blob
+  blob: attachment1_file_test_file_A_fastq_blob
 
-attachment2_file_test_file_A_fastq:
+attachment2_file_test_file_B_fastq:
   name: file
   record: attachment2 (Attachment)
-  blob: attachment2_file_test_file_A_fastq_blob
+  blob: attachment2_file_test_file_B_fastq_blob
 
 attachmentA_file_test_file_fastq:
   name: file

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,8 +1,10 @@
-attachment1_file_test_file_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file.fastq", service_name: "test" %>
+attachment1_file_test_file_A_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_A.fastq", service_name: "test" %>
 
-attachment2_file_test_file_A_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_A.fastq", service_name: "test" %>
+attachment2_file_test_file_B_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_B.fastq", service_name: "test" %>
 
 test_file_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file.fastq", service_name: "test" %>
+
+test_file_A_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_A.fastq", service_name: "test" %>
 
 testsample_illumina_pe_forward_blob: <%= ActiveStorage::FixtureSet.blob filename: "TestSample_S1_L001_R1_001.fastq", service_name: "test" %>
 testsample_illumina_pe_reverse_blob: <%= ActiveStorage::FixtureSet.blob filename: "TestSample_S1_L001_R2_001.fastq", service_name: "test" %>

--- a/test/fixtures/data_exports.yml
+++ b/test/fixtures/data_exports.yml
@@ -13,7 +13,7 @@ data_export_one:
   created_at: <%= 1.week.ago %>
   updated_at: <%= 1.day.ago %>
   user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
-  manifest: '{"type":"Samples Export","date": "2024-01-01","children":[{"name":"INXT_PRJ_AAAAAAAAAA","type":"folder","irida-next-type":"project","irida-next-name":"Project 1","children":[{"name":"INXT_SAM_AAAAAAAAAA","type":"folder","irida-next-type":"sample","irida-next-name":"Project 1 Sample 1","children":[{"name":"INXT_ATT_AAAAAAAAAA","type":"folder","irida-next-type":"attachment","children":[{"name":"test_file.fastq","type":"file","metadata":{"format":"fastq"}}]},{"name":"INXT_ATT_AAAAAAAAAB","type":"folder","irida-next-type":"attachment","children":[{"name":"test_file_A.fastq","type":"file","metadata":{"format":"fastq"}}]}]}]}]}'
+  manifest: '{"type":"Samples Export","date": "2024-01-01","children":[{"name":"INXT_PRJ_AAAAAAAAAA","type":"folder","irida-next-type":"project","irida-next-name":"Project 1","children":[{"name":"INXT_SAM_AAAAAAAAAA","type":"folder","irida-next-type":"sample","irida-next-name":"Project 1 Sample 1","children":[{"name":"INXT_ATT_AAAAAAAAAA","type":"folder","irida-next-type":"attachment","children":[{"name":"test_file_A.fastq","type":"file","metadata":{"format":"fastq"}}]},{"name":"INXT_ATT_AAAAAAAAAB","type":"folder","irida-next-type":"attachment","children":[{"name":"test_file_B.fastq","type":"file","metadata":{"format":"fastq"}}]}]}]}]}'
 
 data_export_two:
   export_type: sample

--- a/test/graphql/attachments_query_test.rb
+++ b/test/graphql/attachments_query_test.rb
@@ -8,15 +8,13 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
       sample(puid: $puid) {
         id
         attachments(filter: $attachmentFilter, orderBy: $attachmentOrderBy) {
-          edges {
-            node {
-              id,
-              metadata,
-              filename,
-              byteSize,
-              createdAt,
-              updatedAt
-            }
+          nodes {
+            id,
+            metadata,
+            filename,
+            byteSize,
+            createdAt,
+            updatedAt
           }
         }
       }
@@ -28,15 +26,13 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
       project(puid: $puid) {
         id
         attachments(filter: $attachmentFilter, orderBy: $attachmentOrderBy) {
-          edges {
-            node {
-              id,
-              metadata,
-              filename,
-              byteSize,
-              createdAt,
-              updatedAt
-            }
+          nodes {
+            id,
+            metadata,
+            filename,
+            byteSize,
+            createdAt,
+            updatedAt
           }
         }
       }
@@ -48,16 +44,14 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
       sample(puid: $puid) {
         id
         attachments {
-          edges {
-            node {
-              id,
-              filename,
-              attachmentUrl,
-              createdAt,
-              updatedAt
-            }
+          nodes {
+            id,
+             filename,
+            attachmentUrl,
+             createdAt,
+            updatedAt
           }
-        }
+         }
       }
     }
   GRAPHQL
@@ -67,13 +61,11 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
       sample(puid: $puid) {
         id
         attachments {
-          edges {
-            node {
-              id,
-              metadata(
-                keys: ["format"]
-              )
-            }
+          nodes {
+            id,
+            metadata(
+              keys: ["format"]
+            )
           }
         }
       }
@@ -85,11 +77,9 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
       sample(puid: $samp_puid) {
         id
         attachments(first: $first) {
-          edges {
-            node {
-              id,
-              metadata
-            }
+          nodes {
+            id,
+            metadata
           }
         }
       }
@@ -114,21 +104,21 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     assert_not_empty data, 'sample type should work'
 
     assert_not_empty data['attachments']
-    assert_not_empty data['attachments']['edges']
+    assert_not_empty data['attachments']['nodes']
 
-    attachments = data['attachments']['edges']
+    attachments = data['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file.fastq', attachments[0]['node']['filename']
-    assert_equal 'test_file_A.fastq', attachments[1]['node']['filename']
+    assert_equal 'test_file.fastq', attachments[0]['filename']
+    assert_equal 'test_file_A.fastq', attachments[1]['filename']
 
-    assert_equal 2102, attachments[0]['node']['byteSize']
-    assert_equal 2101, attachments[1]['node']['byteSize']
+    assert_equal 2102, attachments[0]['byteSize']
+    assert_equal 2101, attachments[1]['byteSize']
 
-    assert_equal 'fastq', attachments[0]['node']['metadata']['format']
-    assert_equal 'none', attachments[0]['node']['metadata']['compression']
-    assert_equal 'fastq', attachments[1]['node']['metadata']['format']
-    assert_equal 'none', attachments[1]['node']['metadata']['compression']
+    assert_equal 'fastq', attachments[0]['metadata']['format']
+    assert_equal 'none', attachments[0]['metadata']['compression']
+    assert_equal 'fastq', attachments[1]['metadata']['format']
+    assert_equal 'none', attachments[1]['metadata']['compression']
   end
 
   test 'attachment query on project should work' do
@@ -143,21 +133,21 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     assert_not_empty data, 'project type should work'
 
     assert_not_empty data['attachments']
-    assert_not_empty data['attachments']['edges']
+    assert_not_empty data['attachments']['nodes']
 
-    attachments = data['attachments']['edges']
+    attachments = data['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file.fastq', attachments[0]['node']['filename']
-    assert_equal 'data_export_8.csv', attachments[1]['node']['filename']
+    assert_equal 'test_file.fastq', attachments[0]['filename']
+    assert_equal 'data_export_8.csv', attachments[1]['filename']
 
-    assert_equal 2102, attachments[0]['node']['byteSize']
-    assert_equal 84, attachments[1]['node']['byteSize']
+    assert_equal 2102, attachments[0]['byteSize']
+    assert_equal 84, attachments[1]['byteSize']
 
-    assert_equal 'fastq', attachments[0]['node']['metadata']['format']
-    assert_equal 'none', attachments[0]['node']['metadata']['compression']
-    assert_equal 'csv', attachments[1]['node']['metadata']['format']
-    assert_equal 'none', attachments[1]['node']['metadata']['compression']
+    assert_equal 'fastq', attachments[0]['metadata']['format']
+    assert_equal 'none', attachments[0]['metadata']['compression']
+    assert_equal 'csv', attachments[1]['metadata']['format']
+    assert_equal 'none', attachments[1]['metadata']['compression']
   end
 
   test 'attachment query should work for uploader access level' do
@@ -173,21 +163,21 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     assert_not_empty data, 'sample type should work'
 
     assert_not_empty data['attachments']
-    assert_not_empty data['attachments']['edges']
+    assert_not_empty data['attachments']['nodes']
 
-    attachments = data['attachments']['edges']
+    attachments = data['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file.fastq', attachments[0]['node']['filename']
-    assert_equal 'test_file_A.fastq', attachments[1]['node']['filename']
+    assert_equal 'test_file.fastq', attachments[0]['filename']
+    assert_equal 'test_file_A.fastq', attachments[1]['filename']
 
-    assert_equal 2102, attachments[0]['node']['byteSize']
-    assert_equal 2101, attachments[1]['node']['byteSize']
+    assert_equal 2102, attachments[0]['byteSize']
+    assert_equal 2101, attachments[1]['byteSize']
 
-    assert_equal 'fastq', attachments[0]['node']['metadata']['format']
-    assert_equal 'none', attachments[0]['node']['metadata']['compression']
-    assert_equal 'fastq', attachments[1]['node']['metadata']['format']
-    assert_equal 'none', attachments[1]['node']['metadata']['compression']
+    assert_equal 'fastq', attachments[0]['metadata']['format']
+    assert_equal 'none', attachments[0]['metadata']['compression']
+    assert_equal 'fastq', attachments[1]['metadata']['format']
+    assert_equal 'none', attachments[1]['metadata']['compression']
   end
 
   test 'attachment query should work with filter' do
@@ -202,17 +192,17 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     assert_not_empty data, 'sample type should work'
 
     assert_not_empty data['attachments']
-    assert_not_empty data['attachments']['edges']
+    assert_not_empty data['attachments']['nodes']
 
-    attachments = data['attachments']['edges']
+    attachments = data['attachments']['nodes']
     assert_equal 1, attachments.count
 
-    assert_equal 'test_file_A.fastq', attachments[0]['node']['filename']
+    assert_equal 'test_file_A.fastq', attachments[0]['filename']
 
-    assert_equal 2101, attachments[0]['node']['byteSize']
+    assert_equal 2101, attachments[0]['byteSize']
 
-    assert_equal 'fastq', attachments[0]['node']['metadata']['format']
-    assert_equal 'none', attachments[0]['node']['metadata']['compression']
+    assert_equal 'fastq', attachments[0]['metadata']['format']
+    assert_equal 'none', attachments[0]['metadata']['compression']
   end
 
   test 'attachment query should work with order by' do
@@ -228,21 +218,21 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     assert_not_empty data, 'sample type should work'
 
     assert_not_empty data['attachments']
-    assert_not_empty data['attachments']['edges']
+    assert_not_empty data['attachments']['nodes']
 
-    attachments = data['attachments']['edges']
+    attachments = data['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file.fastq', attachments[0]['node']['filename']
-    assert_equal 'test_file_A.fastq', attachments[1]['node']['filename']
+    assert_equal 'test_file.fastq', attachments[0]['filename']
+    assert_equal 'test_file_A.fastq', attachments[1]['filename']
 
-    assert_equal 2102, attachments[0]['node']['byteSize']
-    assert_equal 2101, attachments[1]['node']['byteSize']
+    assert_equal 2102, attachments[0]['byteSize']
+    assert_equal 2101, attachments[1]['byteSize']
 
-    assert_equal 'fastq', attachments[0]['node']['metadata']['format']
-    assert_equal 'none', attachments[0]['node']['metadata']['compression']
-    assert_equal 'fastq', attachments[1]['node']['metadata']['format']
-    assert_equal 'none', attachments[1]['node']['metadata']['compression']
+    assert_equal 'fastq', attachments[0]['metadata']['format']
+    assert_equal 'none', attachments[0]['metadata']['compression']
+    assert_equal 'fastq', attachments[1]['metadata']['format']
+    assert_equal 'none', attachments[1]['metadata']['compression']
   end
 
   test 'attachment url query should work' do
@@ -257,11 +247,11 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
 
     assert_nil result['errors'], 'should work and have no errors.'
 
-    attachments = result['data']['sample']['attachments']['edges']
+    attachments = result['data']['sample']['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal file_url1, attachments[0]['node']['attachmentUrl']
-    assert_equal file_url2, attachments[1]['node']['attachmentUrl']
+    assert_equal file_url1, attachments[0]['attachmentUrl']
+    assert_equal file_url2, attachments[1]['attachmentUrl']
   end
 
   test 'attachment url query should not work due to expired token for uploader access level' do
@@ -283,9 +273,9 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
 
     assert_nil result['errors'], 'should work and have no errors.'
 
-    attachments = result['data']['sample']['attachments']['edges']
-    metadata1 = attachments[0]['node']['metadata']
-    metadata2 = attachments[1]['node']['metadata']
+    attachments = result['data']['sample']['attachments']['nodes']
+    metadata1 = attachments[0]['metadata']
+    metadata2 = attachments[1]['metadata']
 
     assert_equal 'fastq', metadata1['format'], "should have requested 'format'"
     assert_equal 'fastq', metadata2['format'], "should have requested 'format'"
@@ -303,10 +293,10 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
 
     assert_nil result['errors'], 'should work and have no errors.'
 
-    attachment1 = result['data']['sample']['attachments']['edges'][0]
-    attachment2 = result['data']['sample']['attachments']['edges'][1]
-    metadata1 = attachment1['node']['metadata']
-    metadata2 = attachment2['node']['metadata']
+    attachment1 = result['data']['sample']['attachments']['nodes'][0]
+    attachment2 = result['data']['sample']['attachments']['nodes'][1]
+    metadata1 = attachment1['metadata']
+    metadata2 = attachment2['metadata']
 
     assert_equal 'forward', metadata1['direction']
     assert_equal 'reverse', metadata2['direction']
@@ -315,7 +305,7 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     assert_equal 'pe', metadata2['type']
 
     # check they reference each other
-    assert_equal attachment1['node']['id'], "gid://irida/Attachment/#{metadata2['associated_attachment_id']}"
-    assert_equal attachment2['node']['id'], "gid://irida/Attachment/#{metadata1['associated_attachment_id']}"
+    assert_equal attachment1['id'], "gid://irida/Attachment/#{metadata2['associated_attachment_id']}"
+    assert_equal attachment2['id'], "gid://irida/Attachment/#{metadata1['associated_attachment_id']}"
   end
 end

--- a/test/graphql/attachments_query_test.rb
+++ b/test/graphql/attachments_query_test.rb
@@ -233,11 +233,11 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     attachments = data['attachments']['edges']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file_A.fastq', attachments[0]['node']['filename']
-    assert_equal 'test_file.fastq', attachments[1]['node']['filename']
+    assert_equal 'test_file.fastq', attachments[0]['node']['filename']
+    assert_equal 'test_file_A.fastq', attachments[1]['node']['filename']
 
-    assert_equal 2101, attachments[0]['node']['byteSize']
-    assert_equal 2102, attachments[1]['node']['byteSize']
+    assert_equal 2102, attachments[0]['node']['byteSize']
+    assert_equal 2101, attachments[1]['node']['byteSize']
 
     assert_equal 'fastq', attachments[0]['node']['metadata']['format']
     assert_equal 'none', attachments[0]['node']['metadata']['compression']

--- a/test/graphql/attachments_query_test.rb
+++ b/test/graphql/attachments_query_test.rb
@@ -109,10 +109,10 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     attachments = data['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file.fastq', attachments[0]['filename']
-    assert_equal 'test_file_A.fastq', attachments[1]['filename']
+    assert_equal 'test_file_A.fastq', attachments[0]['filename']
+    assert_equal 'test_file_B.fastq', attachments[1]['filename']
 
-    assert_equal 2102, attachments[0]['byteSize']
+    assert_equal 2101, attachments[0]['byteSize']
     assert_equal 2101, attachments[1]['byteSize']
 
     assert_equal 'fastq', attachments[0]['metadata']['format']
@@ -168,10 +168,10 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     attachments = data['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file.fastq', attachments[0]['filename']
-    assert_equal 'test_file_A.fastq', attachments[1]['filename']
+    assert_equal 'test_file_A.fastq', attachments[0]['filename']
+    assert_equal 'test_file_B.fastq', attachments[1]['filename']
 
-    assert_equal 2102, attachments[0]['byteSize']
+    assert_equal 2101, attachments[0]['byteSize']
     assert_equal 2101, attachments[1]['byteSize']
 
     assert_equal 'fastq', attachments[0]['metadata']['format']
@@ -223,10 +223,10 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     attachments = data['attachments']['nodes']
     assert_equal 2, attachments.count
 
-    assert_equal 'test_file.fastq', attachments[0]['filename']
-    assert_equal 'test_file_A.fastq', attachments[1]['filename']
+    assert_equal 'test_file_A.fastq', attachments[0]['filename']
+    assert_equal 'test_file_B.fastq', attachments[1]['filename']
 
-    assert_equal 2102, attachments[0]['byteSize']
+    assert_equal 2101, attachments[0]['byteSize']
     assert_equal 2101, attachments[1]['byteSize']
 
     assert_equal 'fastq', attachments[0]['metadata']['format']

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -61,7 +61,7 @@ module DataExports
               'irida-next-type' => 'attachment',
               'children' =>
               [{
-                'name' => 'test_file.fastq',
+                'name' => 'test_file_A.fastq',
                 'type' => 'file',
                 'metadata' => { 'format' => 'fastq' }
               }]
@@ -71,7 +71,7 @@ module DataExports
                'type' => 'folder',
                'irida-next-type' => 'attachment',
                'children' => [{
-                 'name' => 'test_file_A.fastq',
+                 'name' => 'test_file_B.fastq',
                  'type' => 'file',
                  'metadata' => { 'format' => 'fastq' }
                }]
@@ -114,9 +114,9 @@ module DataExports
         '└─ INXT_PRJ_AAAAAAAAAA/ (Project 1)',
         '   └─ INXT_SAM_AAAAAAAAAA/ (Project 1 Sample 1)',
         '      ├─ INXT_ATT_AAAAAAAAAA/',
-        '      │  └─ test_file.fastq',
+        '      │  └─ test_file_A.fastq',
         '      └─ INXT_ATT_AAAAAAAAAB/',
-        '         └─ test_file_A.fastq',
+        '         └─ test_file_B.fastq',
         ''
       ].join("\n")
 

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -19,8 +19,10 @@ class AttachmentTest < ActiveSupport::TestCase
   end
 
   test 'invalid when file checksum matches another Attachment associated with the Attachable' do
-    new_attachment = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_A.fastq').open,
-                                                       filename: 'test_file_A.fastq' })
+    new_attachment = @sample.attachments.build(
+      file: { io: Rails.root.join('test/fixtures/files/test_file_A.fastq').open,
+              filename: 'test_file_A.fastq' }
+    )
     assert_not new_attachment.valid?
     assert new_attachment.errors.added?(:file, :checksum_uniqueness)
   end

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -19,8 +19,8 @@ class AttachmentTest < ActiveSupport::TestCase
   end
 
   test 'invalid when file checksum matches another Attachment associated with the Attachable' do
-    new_attachment = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file.fastq').open,
-                                                       filename: 'test_file.fastq' })
+    new_attachment = @sample.attachments.build(file: { io: Rails.root.join('test/fixtures/files/test_file_A.fastq').open,
+                                                       filename: 'test_file_A.fastq' })
     assert_not new_attachment.valid?
     assert new_attachment.errors.added?(:file, :checksum_uniqueness)
   end
@@ -28,8 +28,8 @@ class AttachmentTest < ActiveSupport::TestCase
   test 'file checksum matches another Attachment associated with the Attachable but with different filename' do
     assert_equal 2, @sample.attachments.count
     new_attachment = @sample.attachments.build(file:
-      { io: Rails.root.join('test/fixtures/files/test_file.fastq').open,
-        filename: 'copy_of_test_file.fastq' })
+      { io: Rails.root.join('test/fixtures/files/test_file_A.fastq').open,
+        filename: 'copy_of_test_file_A.fastq' })
     assert new_attachment.valid?
     @sample.save
     assert_equal 3, @sample.attachments.count
@@ -38,7 +38,7 @@ class AttachmentTest < ActiveSupport::TestCase
   test 'file checksum differs from another Attachment associated with the Attachable but with same filename' do
     new_attachment = @sample.attachments.build(file:
       { io: Rails.root.join('test/fixtures/files/test_file_C.fastq').open,
-        filename: 'test_file.fastq' })
+        filename: 'test_file_A.fastq' })
     assert new_attachment.valid?
     @sample.save
     assert_equal 3, @sample.attachments.count

--- a/test/services/attachments/create_service_test.rb
+++ b/test/services/attachments/create_service_test.rb
@@ -10,7 +10,7 @@ module Attachments
       @sample1 = samples(:sample1)
       @project1 = projects(:project1)
       @group1 = groups(:group_one)
-      @fastq_se_blob = active_storage_blobs(:test_file_fastq_blob)
+      @fastq_se_blob = active_storage_blobs(:test_file_A_fastq_blob)
       @attachment_b_blob = active_storage_blobs(:attachmentB_file_test_file_fastq_blob)
       @testsample_illumina_pe_fwd_blob = active_storage_blobs(:testsample_illumina_pe_forward_blob)
       @testsample_illumina_pe_rev_blob = active_storage_blobs(:testsample_illumina_pe_reverse_blob)

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -162,9 +162,9 @@ module Projects
         click_button I18n.t('projects.samples.attachments.delete_attachment_modal.submit_button')
       end
 
-      assert_text I18n.t('projects.samples.attachments.destroy.success', filename: 'test_file.fastq')
+      assert_text I18n.t('projects.samples.attachments.destroy.success', filename: 'test_file_A.fastq')
       within('#table-listing') do
-        assert_no_text 'test_file.fastq'
+        assert_no_text 'test_file_A.fastq'
       end
     end
 
@@ -908,8 +908,8 @@ module Projects
       end
       click_link I18n.t('projects.samples.show.concatenate_button'), match: :first
       within('span[data-controller-connected="true"] dialog') do
-        assert_text 'test_file.fastq'
         assert_text 'test_file_A.fastq'
+        assert_text 'test_file_B.fastq'
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
         assert_html5_inputs_valid
@@ -958,8 +958,8 @@ module Projects
       end
       click_link I18n.t('projects.samples.show.concatenate_button'), match: :first
       within('span[data-controller-connected="true"] dialog') do
-        assert_text 'test_file.fastq'
         assert_text 'test_file_A.fastq'
+        assert_text 'test_file_B.fastq'
         fill_in I18n.t('projects.samples.attachments.concatenations.modal.basename'), with: 'concatenated_file'
         check 'Delete originals'
         click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
@@ -1132,21 +1132,21 @@ module Projects
       visit namespace_project_sample_url(@namespace, @project, @sample1)
       within %(turbo-frame[id="table-listing"]) do
         assert_selector 'table #attachments-table-body tr', count: 2
-        find('table #attachments-table-body tr', text: 'test_file.fastq').find('input').click
         find('table #attachments-table-body tr', text: 'test_file_A.fastq').find('input').click
+        find('table #attachments-table-body tr', text: 'test_file_B.fastq').find('input').click
       end
       click_link I18n.t('projects.samples.show.delete_files_button'), match: :first
       within('span[data-controller-connected="true"] dialog') do
-        assert_text 'test_file.fastq'
         assert_text 'test_file_A.fastq'
+        assert_text 'test_file_B.fastq'
         click_on I18n.t('projects.samples.attachments.deletions.modal.submit_button')
         assert_html5_inputs_valid
       end
       assert_text I18n.t('projects.samples.attachments.deletions.destroy.success')
       within %(turbo-frame[id="table-listing"]) do
         assert_selector 'table #attachments-table-body tr', count: 0
-        assert_no_text 'test_file.fastq'
         assert_no_text 'test_file_A.fastq'
+        assert_no_text 'test_file_B.fastq'
         assert_text I18n.t('projects.samples.show.no_files')
         assert_text I18n.t('projects.samples.show.no_associated_files')
       end
@@ -2536,23 +2536,23 @@ module Projects
         click_button I18n.t('projects.samples.attachments.delete_attachment_modal.submit_button')
       end
 
-      assert_text I18n.t('projects.samples.attachments.destroy.success', filename: 'test_file.fastq')
+      assert_text I18n.t('projects.samples.attachments.destroy.success', filename: 'test_file_A.fastq')
       within('#table-listing') do
-        assert_no_text 'test_file.fastq'
-        assert_text 'test_file_A.fastq'
+        assert_no_text 'test_file_A.fastq'
+        assert_text 'test_file_B.fastq'
       end
 
       click_link I18n.t('projects.samples.show.delete_files_button'), match: :first
 
       within('dialog') do
-        assert_text 'test_file_A.fastq'
-        assert_no_text 'test_file.fastq'
+        assert_text 'test_file_B.fastq'
+        assert_no_text 'test_file_A.fastq'
         click_button I18n.t('projects.samples.attachments.deletions.modal.submit_button')
       end
 
       assert_text I18n.t('projects.samples.attachments.deletions.destroy.success')
       assert_no_text 'test_file_A.fastq'
-      assert_no_text 'test_file.fastq'
+      assert_no_text 'test_file_B.fastq'
       assert_text I18n.t('projects.samples.show.no_files')
       assert_selector 'a.cursor-not-allowed.pointer-events-none', count: 2
     end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -340,7 +340,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'table tbody tr', count: 1
     assert_text 'INXT_SAM_AAAAAAAAAA'
     assert_text 'INXT_ATT_AAAAAAAAAA'
-    assert_text 'test_file.fastq'
+    assert_text 'test_file_A.fastq'
   end
 
   test 'can view workflow execution with samplesheet with multiple files' do
@@ -353,7 +353,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'table tbody tr', count: 1
     assert_text 'INXT_SAM_AAAAAAAAAA'
     assert_text 'INXT_ATT_AAAAAAAAAA'
-    assert_text 'test_file.fastq'
+    assert_text 'test_file_A.fastq'
     assert_text 'INXT_ATT_AAAAAAAAAB'
     assert_text 'test_file_A.fastq'
   end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR utilizes scoped context to mark in resolvers that the items are already authorized.

https://graphql-ruby.org/queries/executing_queries.html#scoped-context

It also uses the scoped context to set project in project samples resolver, so that if those samples want to retrieve project info we don't need to perform a second query or authorization.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

1. Querying Projects:
```graphql
query myProjects {
  projects(first: 100) {
    nodes {
      id
      name
      updatedAt
      puid
    }
    pageInfo {
      endCursor
      hasNextPage
    }
  }
}
```
before:
![image](https://github.com/user-attachments/assets/3b22c1cd-d0df-4355-b085-3ae5a3792a7f)

after:
![image](https://github.com/user-attachments/assets/f3f687b3-a08f-44a8-9187-6fef921902df)

2. Querying Project Samples:
```graphql
query projectSamples{
  project(fullPath: "streptococcus/streptococcus-pyogenes/streptococcus-pyogenes-m92/outbreak-2023") {
    metadataSummary
    samples(first: 100) {
      nodes {
        puid
        name
        metadata
      }
      pageInfo {
        endCursor
        hasNextPage
      }
    }
  }
}
```
before:
![image](https://github.com/user-attachments/assets/04e2683a-3384-41fb-ad9b-9d0fd1ef9603)

after:
![image](https://github.com/user-attachments/assets/eaab25e5-62e9-40eb-9dcc-524eba9594f7)

4. Querying Sample Attachments:
```graphql
query sampleAttachments{
  projectSample(projectPuid: "INXT_PRJ_AYJRS2PC2S", sampleName: "Streptococcus pyogenes M92/Outbreak 2023 Sample 1") {
    attachments(first: 100) {
      nodes {
        filename
      }
    }
  }
}
```
before:
![image](https://github.com/user-attachments/assets/0704a415-129c-4918-921a-9baa7bab99a8)

after:
![image](https://github.com/user-attachments/assets/357ff83f-68f9-4d08-b9be-5969d8668038)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
