### PR TITLE
Group Attachments: Index and Upload

### DIFF
--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -177,9 +177,7 @@
                 <% if @row_actions[:destroy] %>
                   <%= link_to(
                    t(".delete"),
-                      namespace_project_attachment_new_destroy_path(
-                        attachment_id: attachment.id,
-                      ),
+                      destroy_path(attachment),
                       data: {
                         turbo_stream: true,
                       },

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -69,8 +69,8 @@ module Attachments
           id: attachment.id
         )
       else
-        namespace_project_attachment_path(
-          id: attachment.id
+        namespace_project_attachment_new_destroy_path(
+          attachment_id: attachment.id
         )
       end
     end

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -12,8 +12,7 @@ module Attachments
       attachments,
       pagy,
       q,
-      group,
-      project: nil,
+      namespace,
       row_actions: false,
       abilities: {},
       empty: {},
@@ -22,8 +21,7 @@ module Attachments
       @attachments = attachments
       @pagy = pagy
       @q = q
-      @project = project
-      @group = group
+      @namespace = namespace
       @abilities = abilities
       @row_actions = row_actions
       @empty = empty
@@ -66,7 +64,7 @@ module Attachments
     end
 
     def destroy_path(attachment)
-      if @project.nil?
+      if @namespace.type == 'Group'
         group_attachment_path(
           id: attachment.id
         )

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -12,7 +12,8 @@ module Attachments
       attachments,
       pagy,
       q,
-      project,
+      group,
+      project: nil,
       row_actions: false,
       abilities: {},
       empty: {},
@@ -22,6 +23,7 @@ module Attachments
       @pagy = pagy
       @q = q
       @project = project
+      @group = group
       @abilities = abilities
       @row_actions = row_actions
       @empty = empty
@@ -61,6 +63,18 @@ module Attachments
 
     def render_cell(**arguments, &)
       render(Viral::BaseComponent.new(**arguments), &)
+    end
+
+    def destroy_path(attachment)
+      if @project.nil?
+        group_attachment_path(
+          id: attachment.id
+        )
+      else
+        namespace_project_attachment_path(
+          id: attachment.id
+        )
+      end
     end
 
     private

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Groups
+  # Controller actions for Project Attachments
+  class AttachmentsController < Groups::ApplicationController
+    include Metadata
+    before_action :group, :current_page
+
+    def index
+      @q = @group.attachments.ransack(params[:q])
+      set_default_sort
+      @pagy, @attachments = pagy_with_metadata_sort(@q.result)
+    end
+
+    def new
+      authorize! @group, to: :create_attachment?
+
+      render turbo_stream: turbo_stream.update('attachment_modal',
+                                               partial: 'new_attachment_modal',
+                                               locals: {
+                                                 open: true,
+                                                 attachment: Attachment.new(attachable: @group)
+                                               }), status: :ok
+    end
+
+    def create
+      authorize! @group, to: :create_attachment?
+
+      @attachments = ::Attachments::CreateService.new(current_user, @group, attachment_params).execute
+
+      status = if !@attachments.count.positive?
+                 :unprocessable_entity
+               elsif @attachments.count(&:persisted?) == @attachments.count
+                 :ok
+               else
+                 :multi_status
+               end
+
+      respond_to do |format|
+        format.turbo_stream do
+          render status:, locals: { attachment: Attachment.new(attachable: @group),
+                                    attachments: @attachments }
+        end
+      end
+    end
+
+    private
+
+    def group
+      @group = Group.find_by_full_path(params[:group_id]) # rubocop:disable Rails/DynamicFindBy
+    end
+
+    def current_page
+      @current_page = t(:'groups.sidebar.files')
+    end
+
+    def context_crumbs
+      super
+      @context_crumbs +=
+        [{
+          name: t(:'groups.sidebar.files'),
+          path: group_attachments_path(@group)
+        }]
+    end
+
+    def layout_fixed
+      super
+      return unless action_name == 'index'
+
+      @fixed = false
+    end
+
+    def set_default_sort
+      @q.sorts = 'updated_at desc' if @q.sorts.empty?
+    end
+
+    def attachment_params
+      params.require(:attachment).permit(:attachable_id, :attachable_type, files: [])
+    end
+  end
+end

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module Groups
-  # Controller actions for Project Attachments
+  # Controller actions for Group Attachments
   class AttachmentsController < Groups::ApplicationController
     include Metadata
     before_action :group, :current_page
 
     def index
+      authorize! @group, to: :view_attachments?
+
       @q = @group.attachments.ransack(params[:q])
       set_default_sort
       @pagy, @attachments = pagy_with_metadata_sort(@q.result)
@@ -24,8 +26,6 @@ module Groups
     end
 
     def create
-      authorize! @group, to: :create_attachment?
-
       @attachments = ::Attachments::CreateService.new(current_user, @group, attachment_params).execute
 
       status = if !@attachments.count.positive?

--- a/app/views/groups/attachments/_form.html.erb
+++ b/app/views/groups/attachments/_form.html.erb
@@ -1,0 +1,49 @@
+<%= form_with(model: attachment, url: group_attachments_path(id: @group.id)) do |form| %>
+  <%= form.hidden_field :attachable_id %>
+  <%= form.hidden_field :attachable_type %>
+
+  <div
+    class="grid gap-4"
+    data-controller="attachment-upload"
+    data-attachment-upload-button-text-value='<%=t(".uploading") %>'
+  >
+
+    <div
+      class="form-field"
+      data-controller="file-upload"
+      data-file-upload-ignore-value='[".fasta", ".fna", ".fa", ".fastq", ".fq"]'
+      data-file-upload-error-value="<%= t('.files_ignored') %>"
+    >
+      <%= form.label :files,
+                 t(".files"),
+                 class:
+                   "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+      <%= form.file_field :files,
+                      multiple: true,
+                      direct_upload: true,
+                      required: true,
+                      data: {
+                        "file-input-target": "input",
+                        "attachment-upload-target": "attachmentsInput",
+                        action: "change->file-upload#handleFileChange",
+                      },
+                      class:
+                        "block w-full mb-5 text-xs text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400" %>
+
+      <%= viral_alert(message: t('.files_ignored'), type: :info, data: { "file-upload-target": "alert" }, classes: "hidden") do %>
+        <ul
+          class="max-w-md mt-4 space-y-1 list-disc list-inside"
+          data-file-upload-target="error"
+        >REPLACE</ul>
+      <% end %>
+    </div>
+
+    <div>
+      <%= form.submit t(".upload"),
+                  class: "button button--state-primary button--size-default",
+                  data: {
+                    "attachment-upload-target": "submitButton",
+                  } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/groups/attachments/_form.html.erb
+++ b/app/views/groups/attachments/_form.html.erb
@@ -40,7 +40,31 @@
 
     <div>
       <%= form.submit t(".upload"),
-                  class: "button button--state-primary button--size-default",
+                  class: "
+                    inline-flex
+                    items-center
+                    justify-center
+                    w-1/2
+                    text-sm
+                    border
+                    rounded-md
+                    cursor-pointer
+                    sm:w-auto
+                    focus:z-10
+                    px-5
+                    py-2.5
+                    text-white
+                    border-primary-800
+                    bg-primary-700
+                    focus:outline-none
+                    hover:bg-primary-800
+                    focus:ring-primary-300
+                    dark:focus:ring-primary-700
+                    dark:bg-primary-800
+                    dark:text-white
+                    dark:border-primary-900
+                    dark:hover:bg-primary-700
+                  ",
                   data: {
                     "attachment-upload-target": "submitButton",
                   } %>

--- a/app/views/groups/attachments/_new_attachment_modal.html.erb
+++ b/app/views/groups/attachments/_new_attachment_modal.html.erb
@@ -1,0 +1,9 @@
+<%= viral_dialog(open: open) do |dialog| %>
+  <% dialog.with_header(title: t(".upload_files")) %>
+  <% dialog.with_section do %>
+    <%= render partial: "form",
+    locals: {
+      attachment: attachment
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/groups/attachments/_table.html.erb
+++ b/app/views/groups/attachments/_table.html.erb
@@ -1,0 +1,19 @@
+<%# locals: (group:, pagy:, q:, attachments:) -%>
+<%= render Attachments::TableComponent.new(
+  attachments,
+  pagy,
+  q,
+  group,
+  abilities: {
+    # Uncomment when ready to use multi-select functionality
+    # select_attachments: allowed_to?(:destroy_attachment?, project)
+  },
+  row_actions: {
+    # Uncomment when ready to use destroy
+    # destroy: allowed_to?(:destroy_attachment?, project),
+  },
+  empty: {
+    title: t(:".empty.title"),
+    description: t(:".empty.description"),
+  },
+) %>

--- a/app/views/groups/attachments/_table.html.erb
+++ b/app/views/groups/attachments/_table.html.erb
@@ -1,9 +1,9 @@
-<%# locals: (group:, pagy:, q:, attachments:) -%>
+<%# locals: (namespace:, pagy:, q:, attachments:) -%>
 <%= render Attachments::TableComponent.new(
   attachments,
   pagy,
   q,
-  group,
+  namespace,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, project)

--- a/app/views/groups/attachments/_table.html.erb
+++ b/app/views/groups/attachments/_table.html.erb
@@ -6,11 +6,11 @@
   namespace,
   abilities: {
     # Uncomment when ready to use multi-select functionality
-    # select_attachments: allowed_to?(:destroy_attachment?, project)
+    # select_attachments: allowed_to?(:destroy_attachment?, namespace)
   },
   row_actions: {
     # Uncomment when ready to use destroy
-    # destroy: allowed_to?(:destroy_attachment?, project),
+    # destroy: allowed_to?(:destroy_attachment?, namespace),
   },
   empty: {
     title: t(:".empty.title"),

--- a/app/views/groups/attachments/create.turbo_stream.erb
+++ b/app/views/groups/attachments/create.turbo_stream.erb
@@ -1,0 +1,30 @@
+<% attachments&.each do |attachment| %>
+  <% if attachment.persisted? %>
+    <%= turbo_stream.append "flashes" do %>
+      <%= viral_flash(
+        type: :success,
+        data: t(".success", filename: attachment.file.filename),
+      ) %>
+    <% end %>
+  <% else %>
+    <%= turbo_stream.append "flashes" do %>
+      <%= viral_flash(
+        type: :error,
+        data:
+          t(
+            ".failure",
+            filename: attachment.file.filename,
+            errors: attachment.errors.full_messages.join("."),
+          ),
+      ) %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= turbo_stream.update "attachment_modal",
+                    partial: "new_attachment_modal",
+                    locals: {
+                      open: false,
+                      attachment: attachment,
+                    } %>
+
+<turbo-stream action="refresh"></turbo-stream>

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -1,0 +1,55 @@
+<%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+
+<%= turbo_frame_tag "attachment_modal" %>
+
+<div class="fixed-table-component">
+  <%= render Viral::PageHeaderComponent.new(
+    title: t(".title"),
+    subtitle: t(".subtitle", group_name: @group.name),
+  ) do |component| %>
+    <%= component.with_buttons do %>
+    <% if allowed_to?(:create_attachment?, @group) %>
+      <%= link_to t(".upload_files"),
+          new_group_attachment_path(id: @group.id),
+          data: {
+            turbo_frame: "attachment_modal",
+            turbo_stream: true,
+          },
+          class: "button button--size-default button--state-default" %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <div class="flow-root">
+    <div class="flex flex-row-reverse items-center mb-4 space-x-2">
+      <%= search_form_for @q, url: group_attachments_path(@group), html: { "data-controller": "filters" } do |f| %>
+        <%= hidden_field_tag :limit, @pagy.limit %>
+        <%= f.hidden_field :s, value: "#{@q.sorts[0].name} #{@q.sorts[0].dir}" %>
+        <%= f.hidden_field :format, value: "turbo_stream" %>
+
+        <%= f.label :name_cont, "SEARCH", class: "sr-only" %>
+        <div class="relative lg:w-72">
+          <div
+            class="
+              absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none
+            "
+          >
+            <%= viral_icon(name: "magnifying_glass", classes: "h-5 w-5") %>
+          </div>
+          <%= f.search_field :puid_or_file_blob_filename_cont,
+                         "data-action": "filters#submit",
+                         class:
+                           "block w-full p-2.5 pl-10 text-sm text-slate-900 border border-slate-300 rounded-lg bg-slate-50 focus:ring-primary-500 focus:border-primary-500 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",
+                         placeholder: t(:".search.placeholder") %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <%= render partial: "table",
+  locals: {
+    attachments: @attachments,
+    pagy: @pagy,
+    q: @q,
+    group: @group
+  } %>
+</div>

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -50,6 +50,6 @@
     attachments: @attachments,
     pagy: @pagy,
     q: @q,
-    group: @group
+    namespace: @group
   } %>
 </div>

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -15,7 +15,33 @@
             turbo_frame: "attachment_modal",
             turbo_stream: true,
           },
-          class: "button button--size-default button--state-default" %>
+          class: "
+            inline-flex
+            items-center
+            justify-center
+            w-1/2
+            text-sm
+            border
+            rounded-md
+            cursor-pointer
+            sm:w-auto
+            focus:z-10
+            px-5
+            py-2.5
+            bg-white
+            text-slate-900
+            border-slate-200
+            focus:outline-none
+            hover:bg-slate-100
+            hover:text-slate-950
+            focus:ring-slate-200
+            dark:focus:ring-slate-700
+            dark:bg-slate-800
+            dark:text-slate-400
+            dark:border-slate-600
+            dark:hover:text-white
+            dark:hover:bg-slate-700
+          " %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -51,8 +51,6 @@
       <%= search_form_for @q, url: group_attachments_path(@group), html: { "data-controller": "filters" } do |f| %>
         <%= hidden_field_tag :limit, @pagy.limit %>
         <%= f.hidden_field :s, value: "#{@q.sorts[0].name} #{@q.sorts[0].dir}" %>
-        <%= f.hidden_field :format, value: "turbo_stream" %>
-
         <%= f.label :name_cont, "SEARCH", class: "sr-only" %>
         <div class="relative lg:w-72">
           <div

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -17,12 +17,14 @@
             label: t(:"groups.sidebar.samples"),
             selected: @current_page == t(:"groups.sidebar.samples"),
           ) %>
-          <%= render section.with_item(
-            url: group_attachments_path(@group),
-            icon: "document_text",
-            label: t(:"groups.sidebar.files"),
-            selected: @current_page == t(:"groups.sidebar.files"),
-          ) %>
+          <% if allowed_to?(:view_attachments?, @group) %>
+            <%= render section.with_item(
+              url: group_attachments_path(@group),
+              icon: "document_text",
+              label: t(:"groups.sidebar.files"),
+              selected: @current_page == t(:"groups.sidebar.files"),
+            ) %>
+          <% end %>
           <%= render section.with_item(
             url: group_members_path(@group),
             icon: "users",

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -18,6 +18,12 @@
             selected: @current_page == t(:"groups.sidebar.samples"),
           ) %>
           <%= render section.with_item(
+            url: group_attachments_path(@group),
+            icon: "document_text",
+            label: t(:"groups.sidebar.files"),
+            selected: @current_page == t(:"groups.sidebar.files"),
+          ) %>
+          <%= render section.with_item(
             url: group_members_path(@group),
             icon: "users",
             label: t(:"groups.sidebar.members"),

--- a/app/views/projects/attachments/_form.html.erb
+++ b/app/views/projects/attachments/_form.html.erb
@@ -40,7 +40,31 @@
 
     <div>
       <%= form.submit t(".upload"),
-                  class: "button button--state-primary button--size-default",
+                  class: "
+                    inline-flex
+                    items-center
+                    justify-center
+                    w-1/2
+                    text-sm
+                    border
+                    rounded-md
+                    cursor-pointer
+                    sm:w-auto
+                    focus:z-10
+                    px-5
+                    py-2.5
+                    text-white
+                    border-primary-800
+                    bg-primary-700
+                    focus:outline-none
+                    hover:bg-primary-800
+                    focus:ring-primary-300
+                    dark:focus:ring-primary-700
+                    dark:bg-primary-800
+                    dark:text-white
+                    dark:border-primary-900
+                    dark:hover:bg-primary-700
+                    ",
                   data: {
                     "attachment-upload-target": "submitButton",
                   } %>

--- a/app/views/projects/attachments/_table.html.erb
+++ b/app/views/projects/attachments/_table.html.erb
@@ -1,9 +1,9 @@
-<%# locals: (project:, pagy:, q:, attachments:) -%>
+<%# locals: (namespace:, pagy:, q:, attachments:) -%>
 <%= render Attachments::TableComponent.new(
   attachments,
   pagy,
   q,
-  project,
+  namespace,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, project)

--- a/app/views/projects/attachments/_table.html.erb
+++ b/app/views/projects/attachments/_table.html.erb
@@ -6,10 +6,10 @@
   namespace,
   abilities: {
     # Uncomment when ready to use multi-select functionality
-    # select_attachments: allowed_to?(:destroy_attachment?, project)
+    # select_attachments: allowed_to?(:destroy_attachment?, namespace.project)
   },
   row_actions: {
-    destroy: allowed_to?(:destroy_attachment?, project),
+    destroy: allowed_to?(:destroy_attachment?, namespace.project),
   },
   empty: {
     title: t(:".empty.title"),

--- a/app/views/projects/attachments/index.html.erb
+++ b/app/views/projects/attachments/index.html.erb
@@ -8,14 +8,40 @@
     subtitle: t(".subtitle", project_name: @project.name),
   ) do |component| %>
     <%= component.with_buttons do %>
-      <% if allowed_to?(:create_attachment?, @project) %>
-        <%= link_to t(".upload_files"),
-        new_namespace_project_attachment_path(id: @project.id),
-        data: {
-          turbo_frame: "attachment_modal",
-          turbo_stream: true,
-        },
-        class: "button button--size-default button--state-default" %>
+    <% if allowed_to?(:create_attachment?, @project) %>
+      <%= link_to t(".upload_files"),
+          new_namespace_project_attachment_path(id: @project.id),
+          data: {
+            turbo_frame: "attachment_modal",
+            turbo_stream: true,
+          },
+          class: "
+            inline-flex
+            items-center
+            justify-center
+            w-1/2
+            text-sm
+            border
+            rounded-md
+            cursor-pointer
+            sm:w-auto
+            focus:z-10
+            px-5
+            py-2.5
+            bg-white
+            text-slate-900
+            border-slate-200
+            focus:outline-none
+            hover:bg-slate-100
+            hover:text-slate-950
+            focus:ring-slate-200
+            dark:focus:ring-slate-700
+            dark:bg-slate-800
+            dark:text-slate-400
+            dark:border-slate-600
+            dark:hover:text-white
+            dark:hover:bg-slate-700
+          " %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/projects/attachments/index.html.erb
+++ b/app/views/projects/attachments/index.html.erb
@@ -51,8 +51,6 @@
       <%= search_form_for @q, url: namespace_project_attachments_path(@project.parent, @project), html: { "data-controller": "filters" } do |f| %>
         <%= hidden_field_tag :limit, @pagy.limit %>
         <%= f.hidden_field :s, value: "#{@q.sorts[0].name} #{@q.sorts[0].dir}" %>
-        <%= f.hidden_field :format, value: "turbo_stream" %>
-
         <%= f.label :puid_or_file_blob_filename_cont, "SEARCH", class: "sr-only" %>
         <div class="relative lg:w-72">
           <div

--- a/app/views/projects/attachments/index.html.erb
+++ b/app/views/projects/attachments/index.html.erb
@@ -50,6 +50,6 @@
     attachments: @attachments,
     pagy: @pagy,
     q: @q,
-    project: @project,
+    namespace: @project.namespace
   } %>
 </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -34,7 +34,7 @@ jobs: &jobs
 development:
   primary:
     <<: *default
-    database: irida_next_development
+    database: irida_next_test
   jobs:
     <<: *jobs
     database: irida_next_jobs_development

--- a/config/database.yml
+++ b/config/database.yml
@@ -34,7 +34,7 @@ jobs: &jobs
 development:
   primary:
     <<: *default
-    database: irida_next_test
+    database: irida_next_development
   jobs:
     <<: *jobs
     database: irida_next_jobs_development

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -563,14 +563,14 @@ en:
       index:
         search:
           placeholder: Filter by ID or Filename
-        subtitle: These are the files that belong to Project %{group_name}
+        subtitle: These are the files that belong to Group %{group_name}
         title: Files
         upload_files: Upload Files
       new_attachment_modal:
         upload_files: Upload Files
       table:
         empty:
-          description: There are no files associated with this project.
+          description: There are no files associated with this group.
           title: No Files
     bots:
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -551,6 +551,27 @@ en:
   groups:
     activity:
       title: Group activity
+    attachments:
+      create:
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        success: File %{filename} was successfully uploaded.
+      form:
+        files: Files
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        upload: Upload
+        uploading: Uploading
+      index:
+        search:
+          placeholder: Filter by ID or Filename
+        subtitle: These are the files that belong to Project %{group_name}
+        title: Files
+        upload_files: Upload Files
+      new_attachment_modal:
+        upload_files: Upload Files
+      table:
+        empty:
+          description: There are no files associated with this project.
+          title: No Files
     bots:
       index:
         access_level:
@@ -757,6 +778,7 @@ en:
       activity: Activity
       bot_accounts: Bot Accounts
       details: Details
+      files: Files
       general: General
       history: History
       members: Members

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -778,8 +778,8 @@ fr:
       activity: Activity
       bot_accounts: Bot Accounts
       details: Details
-      general: General
       files: Files
+      general: General
       history: History
       members: Members
       samples: Samples

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -551,6 +551,27 @@ fr:
   groups:
     activity:
       title: Group activity
+    attachments:
+      create:
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        success: File %{filename} was successfully uploaded.
+      form:
+        files: Files
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        upload: Upload
+        uploading: Uploading
+      index:
+        search:
+          placeholder: Filter by ID or Filename
+        subtitle: These are the files that belong to Project %{group_name}
+        title: Files
+        upload_files: Upload Files
+      new_attachment_modal:
+        upload_files: Upload Files
+      table:
+        empty:
+          description: There are no files associated with this project.
+          title: No Files
     bots:
       index:
         access_level:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -563,14 +563,14 @@ fr:
       index:
         search:
           placeholder: Filter by ID or Filename
-        subtitle: These are the files that belong to Project %{group_name}
+        subtitle: These are the files that belong to Group %{group_name}
         title: Files
         upload_files: Upload Files
       new_attachment_modal:
         upload_files: Upload Files
       table:
         empty:
-          description: There are no files associated with this project.
+          description: There are no files associated with this group.
           title: No Files
     bots:
       index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -779,6 +779,7 @@ fr:
       bot_accounts: Bot Accounts
       details: Details
       general: General
+      files: Files
       history: History
       members: Members
       samples: Samples

--- a/config/routes/group.rb
+++ b/config/routes/group.rb
@@ -25,6 +25,7 @@ constraints(::Constraints::GroupUrlConstrainer.new) do
       end
     end
 
+    resources :attachments, only: %i[create destroy index new]
     resources :group_links, only: %i[create destroy update index new]
     resources :samples, only: %i[index] do
       scope module: :samples, as: :samples do

--- a/test/controllers/groups/attachments_controller_test.rb
+++ b/test/controllers/groups/attachments_controller_test.rb
@@ -7,7 +7,7 @@ module Groups
     setup do
       sign_in users(:john_doe)
       @namespace = groups(:group_one)
-      @attachment1 = attachments(:project1Attachment1)
+      @attachment1 = attachments(:group1Attachment1)
     end
 
     test 'should get index' do

--- a/test/controllers/groups/attachments_controller_test.rb
+++ b/test/controllers/groups/attachments_controller_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Groups
+  class AttachmentsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      sign_in users(:john_doe)
+      @namespace = groups(:group_one)
+      @attachment1 = attachments(:project1Attachment1)
+    end
+
+    test 'should get index' do
+      get group_attachments_url(@namespace)
+      assert_response :success
+    end
+
+    test 'should not get index without proper access' do
+      sign_in users(:ryan_doe)
+      get group_attachments_url(@namespace)
+      assert_response :unauthorized
+    end
+
+    test 'should get new' do
+      get new_group_attachment_url(@namespace)
+      assert_response :success
+    end
+
+    test 'should not get new without proper access' do
+      sign_in users(:ryan_doe)
+      get new_group_attachment_url(@namespace)
+      assert_response :unauthorized
+    end
+
+    test 'should create attachment' do
+      assert_difference('Attachment.count') do
+        post group_attachments_url(@namespace),
+             params: { attachment: {
+               files: [fixture_file_upload('test_file_1.fastq', 'text/plain')]
+             } },
+             as: :turbo_stream
+      end
+    end
+  end
+end

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -216,4 +216,4 @@ group1_attachment1_file_test_file_fastq:
 group1_attachment2_file_test_file_A_fastq:
   name: file
   record: group1Attachment2 (Attachment)
-  blob: group1_attachment2_file_test_file_A_fastq_blob
+  blob: group1_attachment2_file_data_export_8_csv_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -106,4 +106,4 @@ project1_attachment1_file_test_file_fastq_blob: <%= ActiveStorage::FixtureSet.bl
 project1_attachment2_file_data_export_8_csv_blob: <%= ActiveStorage::FixtureSet.blob filename: "data_export_8.csv", service_name: "test" %>
 
 group1_attachment1_file_test_file_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file.fastq", service_name: "test" %>
-group1_attachment2_file_test_file_A_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_A.fastq", service_name: "test" %>
+group1_attachment2_file_data_export_8_csv_blob: <%= ActiveStorage::FixtureSet.blob filename: "data_export_8.csv", service_name: "test" %>

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -369,7 +369,7 @@ group1Attachment1:
   created_at: <%= 3.hours.ago %>
 
 group1Attachment2:
-  metadata: { "compression": "none", "format": "fastq" }
+  metadata: { "compression": "none", "format": "csv" }
   attachable: group_one (Namespace)
   puid: INXT_ATT_ABAAAAAAAM
   created_at: <%= 2.hours.ago %>

--- a/test/graphql/attachments_query_test.rb
+++ b/test/graphql/attachments_query_test.rb
@@ -188,14 +188,14 @@ class AttachmentsQueryTest < ActiveSupport::TestCase
     assert_equal 2, attachments.count
 
     assert_equal 'test_file.fastq', attachments[0]['node']['filename']
-    assert_equal 'test_file_A.fastq', attachments[1]['node']['filename']
+    assert_equal 'data_export_8.csv', attachments[1]['node']['filename']
 
     assert_equal 2102, attachments[0]['node']['byteSize']
-    assert_equal 2101, attachments[1]['node']['byteSize']
+    assert_equal 84, attachments[1]['node']['byteSize']
 
     assert_equal 'fastq', attachments[0]['node']['metadata']['format']
     assert_equal 'none', attachments[0]['node']['metadata']['compression']
-    assert_equal 'fastq', attachments[1]['node']['metadata']['format']
+    assert_equal 'csv', attachments[1]['node']['metadata']['format']
     assert_equal 'none', attachments[1]['node']['metadata']['compression']
   end
 

--- a/test/system/groups/attachments_test.rb
+++ b/test/system/groups/attachments_test.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module Groups
+  class AttachmentsTest < ApplicationSystemTestCase
+    include ActionView::Helpers::SanitizeHelper
+
+    setup do
+      @user = users(:john_doe)
+      login_as @user
+      @namespace = groups(:group_one)
+      @attachment1 = attachments(:group1Attachment1)
+      @attachment2 = attachments(:group1Attachment2)
+    end
+
+    test 'visiting the index' do
+      visit group_path(@namespace)
+      click_on I18n.t('groups.sidebar.files')
+
+      assert_selector 'h1', text: I18n.t('groups.attachments.index.title')
+      assert_selector '#attachments-table table tbody tr', count: 2
+      assert_selector 'tr:first-child th', text: @attachment1.puid
+      assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+      assert_selector 'tr:first-child td:nth-child(3)', text: @attachment1.metadata['format']
+      assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+      assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      assert_selector 'tr:nth-child(2) td:nth-child(3)', text: @attachment2.metadata['format']
+    end
+
+    test 'user with proper access can upload file' do
+      visit group_attachments_path(@namespace)
+      assert_selector '#attachments-table table tbody tr', count: 2
+
+      assert_selector 'a', text: I18n.t('projects.attachments.index.upload_files')
+      click_on I18n.t('projects.attachments.index.upload_files')
+
+      within('dialog') do
+        attach_file 'attachment[files][]', Rails.root.join('test/fixtures/files/test_file_2.fastq.gz')
+        click_on I18n.t('projects.attachments.form.upload')
+      end
+
+      assert_selector '#attachments-table table tbody tr', count: 3
+      within('tbody') do
+        assert_text 'test_file_2.fastq.gz'
+      end
+    end
+
+    test 'user without proper access cannot view upload button' do
+      login_as users(:ryan_doe)
+      visit group_attachments_path(@namespace)
+
+      assert_no_selector 'a', text: I18n.t('groups.attachments.index.upload_files')
+    end
+
+    test 'user without proper access cannot view files link on sidebar' do
+      login_as users(:ryan_doe)
+      visit group_path(@namespace)
+
+      assert_no_selector 'a', text: I18n.t('groups.sidebar.files')
+    end
+
+    test 'should not be able to attach a duplicate file to a group' do
+      visit group_attachments_path(@namespace)
+      assert_selector '#attachments-table table tbody tr', count: 2
+
+      click_on I18n.t('groups.attachments.index.upload_files')
+
+      within('dialog') do
+        attach_file 'attachment[files][]', Rails.root.join('test/fixtures/files/test_file_2.fastq.gz')
+        click_on I18n.t('groups.attachments.form.upload')
+      end
+      assert_selector '#attachments-table table tbody tr', count: 3
+      click_on I18n.t('groups.attachments.index.upload_files')
+
+      within('dialog') do
+        attach_file 'attachment[files][]', Rails.root.join('test/fixtures/files/test_file_2.fastq.gz')
+        click_on I18n.t('groups.attachments.form.upload')
+      end
+
+      assert_text 'checksum matches existing file'
+      assert_selector '#attachments-table table tbody tr', count: 3
+    end
+
+    test 'can sort by column' do
+      visit group_attachments_path(@namespace)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      assert_selector 'table tbody tr', count: 2
+
+      click_on 'ID'
+      assert_selector 'table thead th:first-child svg.icon-arrow_up'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment1.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      end
+
+      click_on 'ID'
+      assert_selector 'table thead th:first-child svg.icon-arrow_down'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment2.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment2.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment1.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment1.file.filename.to_s
+      end
+
+      click_on 'Filename'
+      assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment2.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment2.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment1.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment1.file.filename.to_s
+      end
+
+      click_on 'Filename'
+      assert_selector 'table thead th:nth-child(2) svg.icon-arrow_down'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment1.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      end
+
+      click_on 'format'
+      assert_selector 'table thead th:nth-child(3) svg.icon-arrow_up'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment2.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment2.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment1.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment1.file.filename.to_s
+      end
+
+      click_on 'format'
+      assert_selector 'table thead th:nth-child(3) svg.icon-arrow_down'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment1.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      end
+
+      click_on 'type'
+      assert_selector 'table thead th:nth-child(4) svg.icon-arrow_up'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment1.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      end
+
+      click_on 'type'
+      assert_selector 'table thead th:nth-child(4) svg.icon-arrow_down'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment1.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      end
+
+      click_on 'Size'
+      assert_selector 'table thead th:nth-child(5) svg.icon-arrow_up'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment2.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment2.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment1.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment1.file.filename.to_s
+      end
+
+      click_on 'Size'
+      assert_selector 'table thead th:nth-child(5) svg.icon-arrow_down'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment1.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      end
+
+      click_on 'Uploaded'
+      assert_selector 'table thead th:nth-child(6) svg.icon-arrow_up'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment1.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment1.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment2.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment2.file.filename.to_s
+      end
+
+      click_on 'Uploaded'
+      assert_selector 'table thead th:nth-child(6) svg.icon-arrow_down'
+      within('table tbody') do
+        assert_selector 'tr:first-child th', text: @attachment2.puid
+        assert_selector 'tr:first-child td:nth-child(2)', text: @attachment2.file.filename.to_s
+        assert_selector 'tr:nth-child(2) th', text: @attachment1.puid
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: @attachment1.file.filename.to_s
+      end
+    end
+
+    test 'can filter by filename or puid' do
+      visit group_attachments_path(@namespace)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      assert_selector 'table tbody tr', count: 2
+
+      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+              with: @attachment1.file.filename.to_s
+
+      assert_text 'Displaying 1 item'
+      assert_selector 'table tbody tr', count: 1
+
+      within('table tbody') do
+        assert_text @attachment1.puid
+        assert_text @attachment1.file.filename.to_s
+        assert_no_text @attachment2.puid
+        assert_no_text @attachment2.file.filename.to_s
+      end
+
+      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+              with: @attachment2.puid
+
+      assert_text 'Displaying 1 item'
+      assert_selector 'table tbody tr', count: 1
+
+      within('table tbody') do
+        assert_text @attachment2.puid
+        assert_text @attachment2.file.filename.to_s
+        assert_no_text @attachment1.puid
+        assert_no_text @attachment1.file.filename.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds the attachments UI (for index listing and uploading) to groups

To follow:
Destroy will be added after [project attachments destroy](https://github.com/phac-nml/irida-next/pull/762) is merged.
Possible streamlining between group/project attachments (controller concerns etc.).

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/3106aab0-ad11-4781-b966-6ac2e956aa4b)

## How to set up and validate locally
1. Navigate to a group
3. Click "Files" on the sidebar
4. Verify `No Files` state
5. Verify the upload works by uploading a bunch of files, preferably with different formats and types
6. Verify per page selection, pagination, and sorting/filtering works as expected
7. Click on a filename and ensure it downloads

Other tests:
8. Verify project `guests` cannot see the `Files` sidebar link in groups
9. Verify project `analysts` cannot see the `Upload Files` button on the groups attachments index page
10. After uploading a file, wait ~1 minute to verify the table automatically updates the `Uploaded time_ago`
11. Verify sort, filter, and limit selection work as expected, and work together (ie: sort, then add a filter, then select a limit; all should still be enabled)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
