### PR TITLE
Namespace attachments: Index attachment query change

### DIFF
--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -116,10 +116,16 @@
                 <% if column == :id %>
                   <%= attachment.puid %>
                 <% elsif column == :filename %>
-                  <% if attachment.associated_attachment %>
+                  <% if @render_individual_attachments %>
                     <div>
-                      <div class="flex mb-4 items-center">
-                        <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                      <div class="flex items-center">
+                        <% if attachment.associated_attachment && attachment.metadata['direction'] == 'forward' %>
+                          <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                        <% elsif attachment.associated_attachment %>
+                          <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                        <% else %>
+                          <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                        <% end %>
                         <span>
                           <%= link_to attachment.file.filename,
                           rails_blob_path(attachment.file),
@@ -129,19 +135,34 @@
                           class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
                         </span>
                       </div>
-                      <div class="flex items-center">
-                        <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
-                        <span>
-                          <%= link_to attachment.associated_attachment.file.filename,
-                          rails_blob_path(attachment.associated_attachment.file),
-                          data: {
-                            turbo: false,
-                          },
-                          class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
-                        </span>
-                      </div>
                     </div>
-                <% else %>
+                  <% else %>
+                    <% if attachment.associated_attachment %>
+                      <div>
+                        <div class="flex mb-4 items-center">
+                          <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                          <span>
+                            <%= link_to attachment.file.filename,
+                            rails_blob_path(attachment.file),
+                            data: {
+                              turbo: false,
+                            },
+                            class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
+                          </span>
+                        </div>
+                        <div class="flex items-center">
+                          <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                          <span>
+                            <%= link_to attachment.associated_attachment.file.filename,
+                            rails_blob_path(attachment.associated_attachment.file),
+                            data: {
+                              turbo: false,
+                            },
+                            class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
+                          </span>
+                        </div>
+                      </div>
+                  <% else %>
                     <div>
                       <div class="flex items-center">
                         <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
@@ -155,6 +176,7 @@
                         </span>
                       </div>
                     </div>
+                  <% end %>
                 <% end %>
                 <% elsif column == :format || column == :type %>
                   <%= viral_pill(

--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -93,7 +93,6 @@
         '
       >
         <% @attachments.each do |attachment| %>
-          <% next if attachment.associated_attachment && attachment.metadata['direction'] == 'reverse' %>
           <%= render Viral::BaseComponent.new(**row_arguments(attachment)) do %>
             <% @columns.each_with_index do |column, index| %>
               <%= render_cell(
@@ -117,7 +116,7 @@
                 <% if column == :id %>
                   <%= attachment.puid %>
                 <% elsif column == :filename %>
-                  <% if attachment.associated_attachment && attachment.metadata['direction'] == 'forward' %>
+                  <% if attachment.associated_attachment %>
                     <div>
                       <div class="flex mb-4 items-center">
                         <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -13,6 +13,7 @@ module Attachments
       pagy,
       q,
       namespace,
+      render_individual_attachments,
       row_actions: false,
       abilities: {},
       empty: {},
@@ -24,6 +25,7 @@ module Attachments
       @namespace = namespace
       @abilities = abilities
       @row_actions = row_actions
+      @render_individual_attachments = render_individual_attachments
       @empty = empty
       @renders_row_actions = @row_actions.select { |_key, value| value }.count.positive?
       @system_arguments = system_arguments

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -11,7 +11,9 @@ module Groups
     def index
       authorize! @group, to: :view_attachments?
 
-      @q = @group.attachments.ransack(params[:q])
+      @q = @group.attachments
+                 .where.not(Attachment.arel_table[:metadata].contains({ direction: 'reverse' }))
+                 .ransack(params[:q])
       set_default_sort
       @pagy, @attachments = pagy_with_metadata_sort(@q.result)
     end

--- a/app/controllers/projects/attachments_controller.rb
+++ b/app/controllers/projects/attachments_controller.rb
@@ -2,7 +2,7 @@
 
 module Projects
   # Controller actions for Project Attachments
-  class AttachmentsController < Projects::ApplicationController
+  class AttachmentsController < Projects::ApplicationController # rubocop:disable Metrics/ClassLength
     include Metadata
     before_action :current_page
     before_action :new_destroy_params, only: %i[new_destroy]
@@ -11,9 +11,8 @@ module Projects
     def index
       authorize! @project, to: :view_attachments?
 
-      @q = @project.namespace.attachments
-                   .where.not(Attachment.arel_table[:metadata].contains({ direction: 'reverse' }))
-                   .ransack(params[:q])
+      @render_individual_attachments = filter_requested?
+      @q = build_ransack_query
       set_default_sort
       @pagy, @attachments = pagy_with_metadata_sort(@q.result)
     end
@@ -91,6 +90,20 @@ module Projects
           name: t(:'projects.sidebar.files'),
           path: namespace_project_attachments_path(@project.parent, @project)
         }]
+    end
+
+    def filter_requested?
+      params.dig(:q, :puid_or_file_blob_filename_cont).present?
+    end
+
+    def build_ransack_query
+      if @render_individual_attachments
+        @project.namespace.attachments.all.ransack(params[:q])
+      else
+        @project.namespace.attachments
+                .where.not(Attachment.arel_table[:metadata].contains({ direction: 'reverse' }))
+                .ransack(params[:q])
+      end
     end
 
     def new_destroy_params

--- a/app/controllers/projects/attachments_controller.rb
+++ b/app/controllers/projects/attachments_controller.rb
@@ -11,7 +11,9 @@ module Projects
     def index
       authorize! @project, to: :view_attachments?
 
-      @q = @project.namespace.attachments.ransack(params[:q])
+      @q = @project.namespace.attachments
+                   .where.not(Attachment.arel_table[:metadata].contains({ direction: 'reverse' }))
+                   .ransack(params[:q])
       set_default_sort
       @pagy, @attachments = pagy_with_metadata_sort(@q.result)
     end

--- a/app/views/groups/attachments/_table.html.erb
+++ b/app/views/groups/attachments/_table.html.erb
@@ -1,9 +1,10 @@
-<%# locals: (namespace:, pagy:, q:, attachments:) -%>
+<%# locals: (namespace:, pagy:, q:, attachments:, render_individual_attachments:) -%>
 <%= render Attachments::TableComponent.new(
   attachments,
   pagy,
   q,
   namespace,
+  render_individual_attachments,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, namespace)

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -74,6 +74,7 @@
     attachments: @attachments,
     pagy: @pagy,
     q: @q,
-    namespace: @group
+    namespace: @group,
+    render_individual_attachments: @render_individual_attachments
   } %>
 </div>

--- a/app/views/projects/attachments/_table.html.erb
+++ b/app/views/projects/attachments/_table.html.erb
@@ -1,9 +1,10 @@
-<%# locals: (namespace:, pagy:, q:, attachments:) -%>
+<%# locals: (namespace:, pagy:, q:, attachments:, render_individual_attachments:) -%>
 <%= render Attachments::TableComponent.new(
   attachments,
   pagy,
   q,
   namespace,
+  render_individual_attachments,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, namespace.project)

--- a/app/views/projects/attachments/index.html.erb
+++ b/app/views/projects/attachments/index.html.erb
@@ -74,6 +74,7 @@
     attachments: @attachments,
     pagy: @pagy,
     q: @q,
-    namespace: @project.namespace
+    namespace: @project.namespace,
+    render_individual_attachments: @render_individual_attachments
   } %>
 </div>

--- a/test/system/groups/attachments_test.rb
+++ b/test/system/groups/attachments_test.rb
@@ -278,7 +278,7 @@ module Groups
         click_on I18n.t('groups.attachments.form.upload')
       end
       assert_selector '#attachments-table table tbody tr', count: 3
-      assert_text 'Displaying 1-4 of 4 items'
+      assert_text 'Displaying 1-3 of 3 items'
 
       within('table tbody') do
         assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R2_001.fastq.gz'

--- a/test/system/groups/attachments_test.rb
+++ b/test/system/groups/attachments_test.rb
@@ -305,5 +305,44 @@ module Groups
       assert_text I18n.t('groups.attachments.destroy.success', filename: 'TestSample_S1_L001_R2_001.fastq.gz')
       assert_text I18n.t('groups.attachments.destroy.success', filename: 'TestSample_S1_L001_R1_001.fastq.gz')
     end
+
+    test 'rendering paired end attachments separately when filtering' do
+      visit group_attachments_path(@namespace)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      assert_selector 'table tbody tr', count: 2
+
+      click_on I18n.t('projects.attachments.index.upload_files')
+
+      within('dialog') do
+        attach_file 'attachment[files][]', [Rails.root.join('test/fixtures/files/TestSample_S1_L001_R2_001.fastq.gz'),
+                                            Rails.root.join('test/fixtures/files/TestSample_S1_L001_R1_001.fastq.gz')]
+        click_on I18n.t('projects.attachments.form.upload')
+      end
+      assert_selector '#attachments-table table tbody tr', count: 3
+      assert_text 'Displaying 1-3 of 3 items'
+
+      within('table tbody') do
+        assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R2_001.fastq.gz'
+        assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R1_001.fastq.gz'
+        assert_selector 'tr:first-child td:nth-child(3)', text: 'fastq'
+        assert_selector 'tr:first-child td:nth-child(4)', text: 'illumina_pe'
+      end
+
+      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+              with: 'fastq.gz'
+
+      assert_selector '#attachments-table table tbody tr', count: 2
+      assert_text 'Displaying 1-2 of 2 items'
+
+      within('table tbody') do
+        assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R2_001.fastq.gz'
+        assert_selector 'tr:first-child td:nth-child(3)', text: 'fastq'
+        assert_selector 'tr:first-child td:nth-child(4)', text: 'illumina_pe'
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: 'TestSample_S1_L001_R1_001.fastq.gz'
+        assert_selector 'tr:nth-child(2) td:nth-child(3)', text: 'fastq'
+        assert_selector 'tr:nth-child(2) td:nth-child(4)', text: 'illumina_pe'
+      end
+    end
   end
 end

--- a/test/system/projects/attachments_test.rb
+++ b/test/system/projects/attachments_test.rb
@@ -306,5 +306,44 @@ module Projects
       assert_text I18n.t('projects.attachments.destroy.success', filename: 'TestSample_S1_L001_R2_001.fastq.gz')
       assert_text I18n.t('projects.attachments.destroy.success', filename: 'TestSample_S1_L001_R1_001.fastq.gz')
     end
+
+    test 'rendering paired end attachments separately when filtering' do
+      visit namespace_project_attachments_path(@namespace, @project1)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      assert_selector 'table tbody tr', count: 2
+
+      click_on I18n.t('projects.attachments.index.upload_files')
+
+      within('dialog') do
+        attach_file 'attachment[files][]', [Rails.root.join('test/fixtures/files/TestSample_S1_L001_R2_001.fastq.gz'),
+                                            Rails.root.join('test/fixtures/files/TestSample_S1_L001_R1_001.fastq.gz')]
+        click_on I18n.t('projects.attachments.form.upload')
+      end
+      assert_selector '#attachments-table table tbody tr', count: 3
+      assert_text 'Displaying 1-3 of 3 items'
+
+      within('table tbody') do
+        assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R2_001.fastq.gz'
+        assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R1_001.fastq.gz'
+        assert_selector 'tr:first-child td:nth-child(3)', text: 'fastq'
+        assert_selector 'tr:first-child td:nth-child(4)', text: 'illumina_pe'
+      end
+
+      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+              with: 'fastq.gz'
+
+      assert_selector '#attachments-table table tbody tr', count: 2
+      assert_text 'Displaying 1-2 of 2 items'
+
+      within('table tbody') do
+        assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R2_001.fastq.gz'
+        assert_selector 'tr:first-child td:nth-child(3)', text: 'fastq'
+        assert_selector 'tr:first-child td:nth-child(4)', text: 'illumina_pe'
+        assert_selector 'tr:nth-child(2) td:nth-child(2)', text: 'TestSample_S1_L001_R1_001.fastq.gz'
+        assert_selector 'tr:nth-child(2) td:nth-child(3)', text: 'fastq'
+        assert_selector 'tr:nth-child(2) td:nth-child(4)', text: 'illumina_pe'
+      end
+    end
   end
 end

--- a/test/system/projects/attachments_test.rb
+++ b/test/system/projects/attachments_test.rb
@@ -279,7 +279,7 @@ module Projects
         click_on I18n.t('projects.attachments.form.upload')
       end
       assert_selector '#attachments-table table tbody tr', count: 3
-      assert_text 'Displaying 1-4 of 4 items'
+      assert_text 'Displaying 1-3 of 3 items'
 
       within('table tbody') do
         assert_selector 'tr:first-child td:nth-child(2)', text: 'TestSample_S1_L001_R2_001.fastq.gz'


### PR DESCRIPTION
## What does this PR do and why?
This PR alters the `namespace.attachments` query in `index` to exclude paired-end (PE) reverse attachments. We are doing this because we render the PE attachments together within a single table row, but ransack will count both attachments, so 5 PE attachments would take up 10 'slots' within the attachments table, which is not intuitive with the limit selection.

In addition, when using ransack filter, the list of attachments will render each attachment individually (ie: PE attachments will be separated).

## Screenshots or screen recordings
Currently on main (note limit: 10, but only 6 entries on the table):
![image](https://github.com/user-attachments/assets/115950e5-6cb7-4c89-9ab8-1b506636f3f9)

Now:
![image](https://github.com/user-attachments/assets/81edab50-f59c-4bd1-b01c-83bf658403ab)

Filtering PE:
![image](https://github.com/user-attachments/assets/dafb9762-2009-4063-bdb2-9b105edbe99f)

## How to set up and validate locally
In both project and group attachments:
1. Upload multiple paired-end files
2. Verify that each paired-end entry counts as a single attachment.
3. Test the new filter by filtering by something (`fastq.gz`) that will render both of the PE attachments. Verify they render individually.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
