### PR TITLE
Data exports table empty fix

### DIFF
--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -1,4 +1,4 @@
-<% if @data_exports.any? && @pagy.vars[:size].positive? %>
+<% if @has_data_exports %>
   <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
     <%= render Viral::BaseComponent.new(**system_arguments) do %>
       <table

--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -4,13 +4,13 @@
       <table
         class="
           w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
-          dark:divide-slate-600 whitespace-nowrap
+          whitespace-nowrap
         "
       >
         <thead
           class="
-            text-xs text-slate-700 uppercase bg-slate-50 dark:bg-slate-700
-            dark:text-slate-400
+            sticky top-0 z-10 text-xs uppercase text-slate-700 bg-slate-50 dark:bg-slate-700
+            dark:text-slate-300
           "
         >
           <tr>
@@ -40,7 +40,12 @@
             <% end %>
           </tr>
         </thead>
-        <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+        <tbody
+          class="
+            overflow-y-auto bg-white divide-y divide-slate-200 dark:bg-slate-800
+            dark:divide-slate-700
+          "
+        >
           <% @data_exports.each do |data_export| %>
             <%= render Viral::BaseComponent.new(**row_arguments(data_export)) do %>
               <td class="px-3 py-3">

--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -1,96 +1,121 @@
-<%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
-  <%= render Viral::BaseComponent.new(**system_arguments) do %>
-    <table
-      class="
-        w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
-        dark:divide-slate-600 whitespace-nowrap
-      "
-    >
-      <thead
+<% if @data_exports.any? && @pagy.vars[:size].positive? %>
+  <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
+    <%= render Viral::BaseComponent.new(**system_arguments) do %>
+      <table
         class="
-          text-xs text-slate-700 uppercase bg-slate-50 dark:bg-slate-700
-          dark:text-slate-400
+          w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
+          dark:divide-slate-600 whitespace-nowrap
         "
       >
-        <tr>
-          <% @columns.each_with_index do |column, index| %>
+        <thead
+          class="
+            text-xs text-slate-700 uppercase bg-slate-50 dark:bg-slate-700
+            dark:text-slate-400
+          "
+        >
+          <tr>
+            <% @columns.each_with_index do |column, index| %>
+              <%= render_cell(
+              tag: 'th',
+              scope: 'col',
+              classes: class_names('px-3 py-3')
+            ) do %>
+                <%= render Ransack::SortComponent.new(
+                  ransack_obj: @q,
+                  label: t("data_exports.index.table_header.#{column}"),
+                  url: helpers.sorting_url(@q, column),
+                  field: column,
+                  data: {
+                    turbo_action: "replace",
+                  },
+                ) %>
+              <% end %>
+            <% end %>
             <%= render_cell(
               tag: 'th',
               scope: 'col',
               classes: class_names('px-3 py-3')
             ) do %>
-              <%= render Ransack::SortComponent.new(
-                ransack_obj: @q,
-                label: t("data_exports.index.table_header.#{column}"),
-                url: helpers.sorting_url(@q, column),
-                field: column,
-                data: {
-                  turbo_action: "replace",
-                },
-              ) %>
+              <%= t("data_exports.index.table_header.action") %>
             <% end %>
-          <% end %>
-          <%= render_cell(
-              tag: 'th',
-              scope: 'col',
-              classes: class_names('px-3 py-3')
-            ) do %>
-            <%= t("data_exports.index.table_header.action") %>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-        <% @data_exports.each do |data_export| %>
-          <%= render Viral::BaseComponent.new(**row_arguments(data_export)) do %>
-            <td class="px-3 py-3">
-              <%= link_to data_export.id,
-              data_export_path(data_export),
-              data: {
-                turbo: false,
-              },
-              class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
-            </td>
-            <td class="px-3 py-3">
-              <% unless data_export.name.nil? %>
-                <%= link_to data_export.name,
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+          <% @data_exports.each do |data_export| %>
+            <%= render Viral::BaseComponent.new(**row_arguments(data_export)) do %>
+              <td class="px-3 py-3">
+                <%= link_to data_export.id,
                 data_export_path(data_export),
                 data: {
                   turbo: false,
                 },
                 class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
-              <% end %>
-            </td>
-            <td class="px-3 py-3">
-              <%= t(:"data_exports.types.#{data_export.export_type}") %>
-            </td>
-            <td class="px-3 py-3">
-              <% if data_export.status == 'ready' %>
-                <%= viral_pill(text: t(:"data_exports.status.#{data_export.status}"), color: :green) %>
-              <% else %>
-                <%= viral_pill(text: t(:"data_exports.status.#{data_export.status}"), color: :slate) %>
-              <% end %>
-            </td>
-            <td class="px-3 py-3">
-              <%= helpers.local_time(data_export.created_at, :full_date) %>
-            </td>
-            <td class="px-3 py-3">
-              <% unless data_export.expires_at.nil? %>
-                <%= helpers.local_time(data_export.expires_at, :full_date) %>
-              <% end %>
-            </td>
-            <td class="px-3 py-3 space-x-2">
-              <% if data_export.status == 'ready' %>
-                <%= link_to(
-                  t(:"data_exports.index.actions.download"),
-                  rails_blob_path(data_export.file),
+              </td>
+              <td class="px-3 py-3">
+                <% unless data_export.name.nil? %>
+                  <%= link_to data_export.name,
+                  data_export_path(data_export),
                   data: {
                     turbo: false,
+                  },
+                  class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
+                <% end %>
+              </td>
+              <td class="px-3 py-3">
+                <%= t(:"data_exports.types.#{data_export.export_type}") %>
+              </td>
+              <td class="px-3 py-3">
+                <% if data_export.status == 'ready' %>
+                  <%= viral_pill(text: t(:"data_exports.status.#{data_export.status}"), color: :green) %>
+                <% else %>
+                  <%= viral_pill(text: t(:"data_exports.status.#{data_export.status}"), color: :slate) %>
+                <% end %>
+              </td>
+              <td class="px-3 py-3">
+                <%= helpers.local_time(data_export.created_at, :full_date) %>
+              </td>
+              <td class="px-3 py-3">
+                <% unless data_export.expires_at.nil? %>
+                  <%= helpers.local_time(data_export.expires_at, :full_date) %>
+                <% end %>
+              </td>
+              <td class="px-3 py-3 space-x-2">
+                <% if data_export.status == 'ready' %>
+                  <%= link_to(
+                    t(:"data_exports.index.actions.download"),
+                    rails_blob_path(data_export.file),
+                    data: {
+                      turbo: false,
+                    },
+                    aria: {
+                      label:
+                        (
+                          t(
+                            :"data_exports.index.actions.download_aria_label",
+                            name: data_export.name || data_export.id,
+                          )
+                        ),
+                    },
+                    class:
+                      "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
+                  ) %>
+                <% end %>
+                <%= link_to(
+                  t(:"data_exports.index.actions.delete"),
+                  data_export_path(data_export),
+                  data: {
+                    turbo_method: :delete,
+                    turbo_confirm:
+                      t(
+                        :"data_exports.index.delete_confirmation",
+                        name: data_export.name || data_export.id,
+                      ),
                   },
                   aria: {
                     label:
                       (
                         t(
-                          :"data_exports.index.actions.download_aria_label",
+                          :"data_exports.index.actions.delete_aria_label",
                           name: data_export.name || data_export.id,
                         )
                       ),
@@ -98,45 +123,18 @@
                   class:
                     "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
                 ) %>
-              <% end %>
-              <%= link_to(
-                t(:"data_exports.index.actions.delete"),
-                data_export_path(data_export),
-                data: {
-                  turbo_method: :delete,
-                  turbo_confirm:
-                    t(
-                      :"data_exports.index.delete_confirmation",
-                      name: data_export.name || data_export.id,
-                    ),
-                },
-                aria: {
-                  label:
-                    (
-                      t(
-                        :"data_exports.index.actions.delete_aria_label",
-                        name: data_export.name || data_export.id,
-                      )
-                    ),
-                },
-                class:
-                  "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
-              ) %>
-            </td>
+              </td>
+            <% end %>
           <% end %>
-        <% end %>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    <% end %>
+    <%= render Viral::Pagy::FullComponent.new(
+      @pagy,
+      item: t("data_exports.index.limit.item"),
+    ) %>
   <% end %>
-  <% if @data_exports.any? %>
-    <div class="flex items-center justify-between">
-      <%= render Viral::Pagy::LimitComponent.new(
-        @pagy,
-        item: t("data_exports.index.limit.item"),
-      ) %>
-      <%= render Viral::Pagy::PaginationComponent.new(@pagy) %>
-    </div>
-  <% end %>
+<% else %>
   <div class="empty_state_message">
     <%= viral_empty(
       title: @empty[:title],

--- a/app/components/data_exports/table_component.rb
+++ b/app/components/data_exports/table_component.rb
@@ -9,12 +9,14 @@ module DataExports
 
     # rubocop:disable Naming/MethodParameterName
     def initialize(
+      has_data_exports,
       data_exports,
       pagy,
       q,
       empty: {},
       **system_arguments
     )
+      @has_data_exports = has_data_exports
       @data_exports = data_exports
       @pagy = pagy
       @q = q

--- a/app/components/data_exports/table_component.rb
+++ b/app/components/data_exports/table_component.rb
@@ -7,7 +7,7 @@ module DataExports
   class TableComponent < Component
     include Ransack::Helpers::FormHelper
 
-    # rubocop:disable Naming/MethodParameterName
+    # rubocop:disable Naming/MethodParameterName, Metrics/ParameterLists
     def initialize(
       has_data_exports,
       data_exports,
@@ -25,7 +25,7 @@ module DataExports
 
       @columns = columns
     end
-    # rubocop:enable Naming/MethodParameterName
+    # rubocop:enable Naming/MethodParameterName, Metrics/ParameterLists
 
     def system_arguments
       { tag: 'div' }.deep_merge(@system_arguments).tap do |args|

--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -14,7 +14,9 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
   TABS = %w[summary preview].freeze
 
   def index
-    @q = load_data_exports.ransack(params[:q])
+    all_data_exports = load_data_exports
+    @has_data_exports = all_data_exports.count.positive?
+    @q = all_data_exports.ransack(params[:q])
     set_default_sort
     @pagy, @data_exports = pagy(@q.result)
   end

--- a/app/views/data_exports/_table.html.erb
+++ b/app/views/data_exports/_table.html.erb
@@ -1,5 +1,6 @@
-<%# locals: (data_exports:, pagy:, q:) -%>
+<%# locals: (has_data_exports:, data_exports:, pagy:, q:) -%>
 <%= render DataExports::TableComponent.new(
+  has_data_exports,
   data_exports,
   pagy,
   q,

--- a/app/views/data_exports/index.html.erb
+++ b/app/views/data_exports/index.html.erb
@@ -28,6 +28,7 @@
 
 <%= render partial: "table",
 locals: {
+  has_data_exports: @has_data_exports,
   data_exports: @data_exports,
   pagy: @pagy,
   q: @q,

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -1110,5 +1110,12 @@ class DataExportsTest < ApplicationSystemTestCase
       assert_text @data_export10.id
       assert_text @data_export10.name
     end
+
+    fill_in placeholder: I18n.t(:'data_exports.index.search.placeholder'),
+            with: 'something that does not exist'
+    within 'div[role="alert"]' do
+      assert_text I18n.t('components.viral.pagy.empty_state.title')
+      assert_text I18n.t('components.viral.pagy.empty_state.description')
+    end
   end
 end

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -140,8 +140,10 @@ class DataExportsTest < ApplicationSystemTestCase
     end
 
     assert_no_selector 'table'
-    assert_text I18n.t('data_exports.index.no_data_exports')
-    assert_text I18n.t('data_exports.index.no_data_exports_message')
+    within 'div[role="alert"]' do
+      assert_text I18n.t('data_exports.index.no_data_exports')
+      assert_text I18n.t('data_exports.index.no_data_exports_message')
+    end
   end
 
   test 'can navigate to individual data export page from data exports page' do


### PR DESCRIPTION
## What does this PR do and why?
Displaying separate messages within the data export table to show empty state and no items found.

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/172fe791-43f1-4709-9649-cb7f71b5d128)
![image](https://github.com/user-attachments/assets/db8b5839-0837-4e0d-b926-b14c5f09b972)

## How to set up and validate locally
1. Navigate to the data exports page.
2. Search for a data export that does not exist.
3. Verify the `No items found` message is displayed.
4. Delete all the data exports within the table.
5. Verify the `No Data Exports` message is displayed.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
