### PR TITLE
Namespace Attachments: Empty Search State

### DIFF
--- a/app/components/attachments/dialogs/delete_attachment_component.html.erb
+++ b/app/components/attachments/dialogs/delete_attachment_component.html.erb
@@ -9,10 +9,15 @@
       <p class="mb-4">
         <% if @attachment.associated_attachment %>
           <%= t(".description.paired_end",
-          filenames:
-          "'#{@attachment.file.filename.to_s}', '#{@attachment.associated_attachment.file.filename.to_s}'") %>
+            filenames:
+            "'#{@attachment.file.filename.to_s}', '#{@attachment.associated_attachment.file.filename.to_s}'",
+            attachable_type: @namespace.type.downcase)
+          %>
         <% else %>
-          <%= t(".description.single", filename: @attachment.file.filename.to_s) %>
+          <%= t(".description.single",
+            filename: @attachment.file.filename.to_s,
+            attachable_type: @namespace.type.downcase)
+            %>
         <% end %>
       </p>
       <%= form_for(:deletion, url: destroy_path, method: :delete) do |form| %>

--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -1,146 +1,132 @@
-<%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
-  <%= render Viral::BaseComponent.new(**system_arguments) do %>
-    <table
-      class='
-        w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
-        whitespace-nowrap
-      '
-    >
-      <thead
+<% if @has_attachments %>
+  <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
+    <%= render Viral::BaseComponent.new(**system_arguments) do %>
+      <table
         class='
-          text-xs uppercase text-slate-700 bg-slate-50 dark:bg-slate-700
-          dark:text-slate-300 sticky top-0 z-10
+          w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
+          whitespace-nowrap
         '
       >
-        <tr>
-          <% @columns.each_with_index do |column, index| %>
-            <%= render_cell(
-              tag: 'th',
-              scope: 'col',
-              classes: class_names('px-3 py-3', 'sticky left-0 min-w-56 max-w-56 z-10 bg-slate-50 dark:bg-slate-700': index.zero?, 'sticky left-56 z-10 bg-slate-50 dark:bg-slate-700': index == 1)
-            ) do %>
-              <% if index.zero? and @abilities[:select_attachments] %>
-                <%= check_box_tag "select-page",
-                title: t(:".select_page"),
-                "aria-label": t(:".select_page"),
-                data: {
-                  action: "input->selection#togglePage",
-                  controller: "filters",
-                  selection_target: "selectPage",
-                },
-                class:
-                  "w-4 h-4 mr-2.5 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
-              <% end %>
-              <% if column == :id %>
-                <%= render Ransack::SortComponent.new(
-                  ransack_obj: @q,
-                  label: t(".#{column}"),
-                  url: helpers.sorting_url(@q, "puid"),
-                  field: "puid",
-                  data: {
-                    turbo_action: "replace",
-                  },
-                ) %>
-              <% elsif column == :byte_size || column == :filename %>
-                <%= render Ransack::SortComponent.new(
-                  ransack_obj: @q,
-                  label: t(".#{column}"),
-                  url: helpers.sorting_url(@q, "file_blob_#{column}"),
-                  field: "file_blob_#{column}",
-                  data: {
-                    turbo_action: "replace",
-                  },
-                ) %>
-              <% elsif column == :format || column == :type %>
-                <%= render Ransack::SortComponent.new(
-                  ransack_obj: @q,
-                  label: column,
-                  url:
-                    helpers.sorting_url(@q, URI.encode_www_form_component("metadata_#{column}")),
-                  field: "metadata_#{column}",
-                  data: {
-                    turbo_action: "replace",
-                  },
-                ) %>
-              <% else %>
-                <%= render Ransack::SortComponent.new(
-                  ransack_obj: @q,
-                  label: t(".#{column}"),
-                  url: helpers.sorting_url(@q, column),
-                  field: column,
-                  data: {
-                    turbo_action: "replace",
-                  },
-                ) %>
-              <% end %>
-            <% end %>
-          <% end %>
-          <% if @renders_row_actions %>
-            <%= render_cell(
-              tag: 'th',
-              scope: 'col',
-              classes: class_names('px-3 py-3 bg-slate-50 dark:bg-slate-700 sticky right-0')
-            ) do %>
-              <%= t(".actions") %>
-            <% end %>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody
-        class='
-          overflow-y-auto bg-white divide-y divide-slate-200 dark:bg-slate-800
-          dark:divide-slate-700
-        '
-      >
-        <% @attachments.each do |attachment| %>
-          <%= render Viral::BaseComponent.new(**row_arguments(attachment)) do %>
+        <thead
+          class='
+            text-xs uppercase text-slate-700 bg-slate-50 dark:bg-slate-700
+            dark:text-slate-300 sticky top-0 z-10
+          '
+        >
+          <tr>
             <% @columns.each_with_index do |column, index| %>
               <%= render_cell(
-                tag: index.zero? ? 'th' :'td',
-                scope: index.zero? ? 'row' : nil,
-                classes: class_names('px-3 py-3', 'sticky left-0 min-w-56 max-w-56 bg-slate-50 dark:bg-slate-700': index.zero?, 'sticky left-56 bg-slate-50 dark:bg-slate-700': index == 1)
+                tag: 'th',
+                scope: 'col',
+                classes: class_names('px-3 py-3', 'sticky left-0 min-w-56 max-w-56 z-10 bg-slate-50 dark:bg-slate-700': index.zero?, 'sticky left-56 z-10 bg-slate-50 dark:bg-slate-700': index == 1)
               ) do %>
-                <% if index.zero? && @abilities[:select_attachments] %>
-                  <%= check_box_tag "attachment_ids[]",
-                  attachment.id,
-                  nil,
-                  id: dom_id(attachment),
-                  "aria-label": attachment.file.filename.to_s,
+                <% if index.zero? and @abilities[:select_attachments] %>
+                  <%= check_box_tag "select-page",
+                  title: t(:".select_page"),
+                  "aria-label": t(:".select_page"),
                   data: {
-                    action: "input->selection#toggle",
-                    selection_target: "rowSelection",
+                    action: "input->selection#togglePage",
+                    controller: "filters",
+                    selection_target: "selectPage",
                   },
                   class:
                     "w-4 h-4 mr-2.5 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
                 <% end %>
                 <% if column == :id %>
-                  <%= attachment.puid %>
-                <% elsif column == :filename %>
-                  <% if @render_individual_attachments %>
-                    <div>
-                      <div class="flex items-center">
-                        <% if attachment.associated_attachment && attachment.metadata['direction'] == 'forward' %>
-                          <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
-                        <% elsif attachment.associated_attachment %>
-                          <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
-                        <% else %>
-                          <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
-                        <% end %>
-                        <span>
-                          <%= link_to attachment.file.filename,
-                          rails_blob_path(attachment.file),
-                          data: {
-                            turbo: false,
-                          },
-                          class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
-                        </span>
-                      </div>
-                    </div>
-                  <% else %>
-                    <% if attachment.associated_attachment %>
+                  <%= render Ransack::SortComponent.new(
+                    ransack_obj: @q,
+                    label: t(".#{column}"),
+                    url: helpers.sorting_url(@q, "puid"),
+                    field: "puid",
+                    data: {
+                      turbo_action: "replace",
+                    },
+                  ) %>
+                <% elsif column == :byte_size || column == :filename %>
+                  <%= render Ransack::SortComponent.new(
+                    ransack_obj: @q,
+                    label: t(".#{column}"),
+                    url: helpers.sorting_url(@q, "file_blob_#{column}"),
+                    field: "file_blob_#{column}",
+                    data: {
+                      turbo_action: "replace",
+                    },
+                  ) %>
+                <% elsif column == :format || column == :type %>
+                  <%= render Ransack::SortComponent.new(
+                    ransack_obj: @q,
+                    label: column,
+                    url:
+                      helpers.sorting_url(@q, URI.encode_www_form_component("metadata_#{column}")),
+                    field: "metadata_#{column}",
+                    data: {
+                      turbo_action: "replace",
+                    },
+                  ) %>
+                <% else %>
+                  <%= render Ransack::SortComponent.new(
+                    ransack_obj: @q,
+                    label: t(".#{column}"),
+                    url: helpers.sorting_url(@q, column),
+                    field: column,
+                    data: {
+                      turbo_action: "replace",
+                    },
+                  ) %>
+                <% end %>
+              <% end %>
+            <% end %>
+            <% if @renders_row_actions %>
+              <%= render_cell(
+                tag: 'th',
+                scope: 'col',
+                classes: class_names('px-3 py-3 bg-slate-50 dark:bg-slate-700 sticky right-0')
+              ) do %>
+                <%= t(".actions") %>
+              <% end %>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody
+          class='
+            overflow-y-auto bg-white divide-y divide-slate-200 dark:bg-slate-800
+            dark:divide-slate-700
+          '
+        >
+          <% @attachments.each do |attachment| %>
+            <%= render Viral::BaseComponent.new(**row_arguments(attachment)) do %>
+              <% @columns.each_with_index do |column, index| %>
+                <%= render_cell(
+                  tag: index.zero? ? 'th' :'td',
+                  scope: index.zero? ? 'row' : nil,
+                  classes: class_names('px-3 py-3', 'sticky left-0 min-w-56 max-w-56 bg-slate-50 dark:bg-slate-700': index.zero?, 'sticky left-56 bg-slate-50 dark:bg-slate-700': index == 1)
+                ) do %>
+                  <% if index.zero? && @abilities[:select_attachments] %>
+                    <%= check_box_tag "attachment_ids[]",
+                    attachment.id,
+                    nil,
+                    id: dom_id(attachment),
+                    "aria-label": attachment.file.filename.to_s,
+                    data: {
+                      action: "input->selection#toggle",
+                      selection_target: "rowSelection",
+                    },
+                    class:
+                      "w-4 h-4 mr-2.5 text-primary-600 bg-slate-100 border-slate-300 rounded focus:ring-primary-500 dark:focus:ring-primary-600 dark:ring-offset-slate-800 focus:ring-2 dark:bg-slate-700 dark:border-slate-600" %>
+                  <% end %>
+                  <% if column == :id %>
+                    <%= attachment.puid %>
+                  <% elsif column == :filename %>
+                    <% if @render_individual_attachments %>
                       <div>
-                        <div class="flex mb-4 items-center">
-                          <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                        <div class="flex items-center">
+                          <% if attachment.associated_attachment && attachment.metadata['direction'] == 'forward' %>
+                            <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                          <% elsif attachment.associated_attachment %>
+                            <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                          <% else %>
+                            <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                          <% end %>
                           <span>
                             <%= link_to attachment.file.filename,
                             rails_blob_path(attachment.file),
@@ -150,11 +136,40 @@
                             class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
                           </span>
                         </div>
+                      </div>
+                    <% else %>
+                      <% if attachment.associated_attachment %>
+                        <div>
+                          <div class="flex mb-4 items-center">
+                            <%= viral_icon(name: :arrow_right, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                            <span>
+                              <%= link_to attachment.file.filename,
+                              rails_blob_path(attachment.file),
+                              data: {
+                                turbo: false,
+                              },
+                              class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
+                            </span>
+                          </div>
+                          <div class="flex items-center">
+                            <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                            <span>
+                              <%= link_to attachment.associated_attachment.file.filename,
+                              rails_blob_path(attachment.associated_attachment.file),
+                              data: {
+                                turbo: false,
+                              },
+                              class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
+                            </span>
+                          </div>
+                        </div>
+                    <% else %>
+                      <div>
                         <div class="flex items-center">
-                          <%= viral_icon(name: :arrow_left, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
+                          <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
                           <span>
-                            <%= link_to attachment.associated_attachment.file.filename,
-                            rails_blob_path(attachment.associated_attachment.file),
+                            <%= link_to attachment.file.filename,
+                            rails_blob_path(attachment.file),
                             data: {
                               turbo: false,
                             },
@@ -162,90 +177,77 @@
                           </span>
                         </div>
                       </div>
-                  <% else %>
-                    <div>
-                      <div class="flex items-center">
-                        <%= viral_icon(name: :document_text, color: :subdued, classes: "h-6 w-6 ml-0 mr-2") %>
-                        <span>
-                          <%= link_to attachment.file.filename,
-                          rails_blob_path(attachment.file),
-                          data: {
-                            turbo: false,
-                          },
-                          class: "text-slate-900 dark:text-slate-100 font-semibold hover:underline" %>
-                        </span>
-                      </div>
-                    </div>
+                    <% end %>
+                  <% end %>
+                  <% elsif column == :format || column == :type %>
+                    <%= viral_pill(
+                      text: attachment.metadata[column.to_s],
+                      color: helpers.find_pill_color_for_attachment(attachment, column.to_s),
+                    ) %>
+                  <% elsif column == :byte_size %>
+                    <%= number_to_human_size(attachment.file.blob.byte_size) %>
+                  <% elsif column == :created_at%>
+                    <%= helpers.local_time_ago(attachment.created_at) %>
                   <% end %>
                 <% end %>
-                <% elsif column == :format || column == :type %>
-                  <%= viral_pill(
-                    text: attachment.metadata[column.to_s],
-                    color: helpers.find_pill_color_for_attachment(attachment, column.to_s),
-                  ) %>
-                <% elsif column == :byte_size %>
-                  <%= number_to_human_size(attachment.file.blob.byte_size) %>
-                <% elsif column == :created_at%>
-                  <%= helpers.local_time_ago(attachment.created_at) %>
-                <% end %>
               <% end %>
-            <% end %>
-            <% if @renders_row_actions %>
-              <%= render_cell(
-                tag: 'td',
-                classes: class_names('px-3 py-3 sticky right-0 bg-white dark:bg-slate-800 z-5 space-x-2')
-              ) do %>
-                <% if @row_actions[:destroy] %>
-                  <%= link_to(
-                   t(".delete"),
-                      destroy_path(attachment.id),
-                      data: {
-                        turbo_stream: true,
-                      },
-                      class:
-                        "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
-                    ) %>
+              <% if @renders_row_actions %>
+                <%= render_cell(
+                  tag: 'td',
+                  classes: class_names('px-3 py-3 sticky right-0 bg-white dark:bg-slate-800 z-5 space-x-2')
+                ) do %>
+                  <% if @row_actions[:destroy] %>
+                    <%= link_to(
+                    t(".delete"),
+                        destroy_path(attachment.id),
+                        data: {
+                          turbo_stream: true,
+                        },
+                        class:
+                          "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
+                      ) %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>
           <% end %>
+        </tbody>
+        <% if @abilities[:select_attachments] && !@attachments.empty? %>
+          <tfoot class="sticky bottom-0 z-10">
+            <tr class="border-t dark:border-slate-700 border-slate-200">
+              <td
+                class="
+                  sticky left-0 z-10 px-6 py-3 bg-slate-50 dark:bg-slate-900
+                "
+                colspan="3"
+              >
+                <span>
+                  <%= t(".counts.attachments") %>:
+                  <strong data-action="turbo:morph-element->selection#idempotentConnect"><%= @pagy.count %></strong>
+                </span>
+                <span>
+                  <%= t(".counts.selected") %>:
+                  <strong
+                    data-selection-target="selected"
+                    data-action="
+                      turbo:morph-element->selection#idempotentConnect
+                    "
+                  >0</strong>
+                </span>
+              </td>
+              <td colspan="100%" class="px-3 py-3 bg-slate-50 dark:bg-slate-900"></td>
+            </tr>
+          </tfoot>
         <% end %>
-      </tbody>
-      <% if @abilities[:select_attachments] && !@attachments.empty? %>
-        <tfoot class="sticky bottom-0 z-10">
-          <tr class="border-t dark:border-slate-700 border-slate-200">
-            <td
-              class="
-                sticky left-0 z-10 px-6 py-3 bg-slate-50 dark:bg-slate-900
-              "
-              colspan="3"
-            >
-              <span>
-                <%= t(".counts.attachments") %>:
-                <strong data-action="turbo:morph-element->selection#idempotentConnect"><%= @pagy.count %></strong>
-              </span>
-              <span>
-                <%= t(".counts.selected") %>:
-                <strong
-                  data-selection-target="selected"
-                  data-action="
-                    turbo:morph-element->selection#idempotentConnect
-                  "
-                >0</strong>
-              </span>
-            </td>
-            <td colspan="100%" class="px-3 py-3 bg-slate-50 dark:bg-slate-900"></td>
-          </tr>
-        </tfoot>
-      <% end %>
-    </table>
+      </table>
+    <% end %>
+     <%= render Viral::Pagy::FullComponent.new(
+      @pagy,
+      item: t(".limit.item"),
+    ) %>
+
   <% end %>
-  <% unless @attachments.empty? %>
-    <div class="flex items-center justify-between">
-      <%= render Viral::Pagy::LimitComponent.new(@pagy, item: t(".limit.item")) %>
-      <%= render Viral::Pagy::PaginationComponent.new(@pagy) %>
-    </div>
-  <% end %>
+<% else %>
   <div class="empty_state_message">
     <%= viral_empty(
       title: @empty[:title],

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -14,6 +14,7 @@ module Attachments
       q,
       namespace,
       render_individual_attachments,
+      has_attachments,
       row_actions: false,
       abilities: {},
       empty: {},
@@ -23,9 +24,10 @@ module Attachments
       @pagy = pagy
       @q = q
       @namespace = namespace
+      @render_individual_attachments = render_individual_attachments
+      @has_attachments = has_attachments
       @abilities = abilities
       @row_actions = row_actions
-      @render_individual_attachments = render_individual_attachments
       @empty = empty
       @renders_row_actions = @row_actions.select { |_key, value| value }.count.positive?
       @system_arguments = system_arguments

--- a/app/controllers/concerns/attachment_actions.rb
+++ b/app/controllers/concerns/attachment_actions.rb
@@ -16,7 +16,9 @@ module AttachmentActions # rubocop:disable Metrics/ModuleLength
     authorize! @authorize_object, to: :view_attachments?
 
     @render_individual_attachments = filter_requested?
-    @q = build_ransack_query
+    all_attachments = load_attachments
+    @has_attachments = all_attachments.count.positive?
+    @q = all_attachments.ransack(params[:q])
     set_default_sort
     @pagy, @attachments = pagy_with_metadata_sort(@q.result)
   end
@@ -87,6 +89,15 @@ module AttachmentActions # rubocop:disable Metrics/ModuleLength
 
   def filter_requested?
     params.dig(:q, :puid_or_file_blob_filename_cont).present?
+  end
+
+  def load_attachments
+    if @render_individual_attachments
+      @namespace.attachments.all
+    else
+      @namespace.attachments
+                .where.not(Attachment.arel_table[:metadata].contains({ direction: 'reverse' }))
+    end
   end
 
   def build_ransack_query

--- a/app/controllers/concerns/attachment_actions.rb
+++ b/app/controllers/concerns/attachment_actions.rb
@@ -100,16 +100,6 @@ module AttachmentActions # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  def build_ransack_query
-    if @render_individual_attachments
-      @namespace.attachments.all.ransack(params[:q])
-    else
-      @namespace.attachments
-                .where.not(Attachment.arel_table[:metadata].contains({ direction: 'reverse' }))
-                .ransack(params[:q])
-    end
-  end
-
   def new_destroy_params
     @attachment = Attachment.find_by(id: params[:attachment_id])
   end

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -31,7 +31,7 @@ module Groups
       @context_crumbs +=
         [{
           name: t(:'groups.sidebar.files'),
-          path: group_attachments_path(@namespace)
+          path: group_attachments_path(@group)
         }]
     end
   end

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -31,7 +31,7 @@ module Groups
       @context_crumbs +=
         [{
           name: t(:'groups.sidebar.files'),
-          path: group_attachments_path(@group)
+          path: group_attachments_path(@namespace)
         }]
     end
   end

--- a/app/views/groups/attachments/_table.html.erb
+++ b/app/views/groups/attachments/_table.html.erb
@@ -1,10 +1,11 @@
-<%# locals: (namespace:, pagy:, q:, attachments:, render_individual_attachments:) -%>
+<%# locals: (namespace:, pagy:, q:, attachments:, render_individual_attachments:, has_attachments:) -%>
 <%= render Attachments::TableComponent.new(
   attachments,
   pagy,
   q,
   namespace,
   render_individual_attachments,
+  has_attachments,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, namespace)

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -75,6 +75,7 @@
     pagy: @pagy,
     q: @q,
     namespace: @group,
-    render_individual_attachments: @render_individual_attachments
+    render_individual_attachments: @render_individual_attachments,
+    has_attachments: @has_attachments
   } %>
 </div>

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -48,7 +48,7 @@
 
   <div class="flow-root">
     <div class="flex flex-row-reverse items-center mb-4 space-x-2">
-      <%= search_form_for @q, url: group_attachments_path(@group), html: { "data-controller": "filters" } do |f| %>
+      <%= search_form_for @q, url: group_attachments_path(@group), html: { "data-controller": "filters", "data-turbo-action": "replace" } do |f| %>
         <%= hidden_field_tag :limit, @pagy.limit %>
         <%= f.hidden_field :s, value: "#{@q.sorts[0].name} #{@q.sorts[0].dir}" %>
         <%= f.label :name_cont, "SEARCH", class: "sr-only" %>

--- a/app/views/projects/attachments/_table.html.erb
+++ b/app/views/projects/attachments/_table.html.erb
@@ -1,10 +1,11 @@
-<%# locals: (namespace:, pagy:, q:, attachments:, render_individual_attachments:) -%>
+<%# locals: (namespace:, pagy:, q:, attachments:, render_individual_attachments:, has_attachments:) -%>
 <%= render Attachments::TableComponent.new(
   attachments,
   pagy,
   q,
   namespace,
   render_individual_attachments,
+  has_attachments,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, namespace.project)

--- a/app/views/projects/attachments/index.html.erb
+++ b/app/views/projects/attachments/index.html.erb
@@ -75,6 +75,7 @@
     pagy: @pagy,
     q: @q,
     namespace: @project.namespace,
-    render_individual_attachments: @render_individual_attachments
+    render_individual_attachments: @render_individual_attachments,
+    has_attachments: @has_attachments
   } %>
 </div>

--- a/app/views/projects/attachments/index.html.erb
+++ b/app/views/projects/attachments/index.html.erb
@@ -48,7 +48,7 @@
 
   <div class="flow-root">
     <div class="flex flex-row-reverse items-center mb-4 space-x-2">
-      <%= search_form_for @q, url: namespace_project_attachments_path(@project.parent, @project), html: { "data-controller": "filters" } do |f| %>
+      <%= search_form_for @q, url: namespace_project_attachments_path(@project.parent, @project), html: { "data-controller": "filters", "data-turbo-action": "replace" } do |f| %>
         <%= hidden_field_tag :limit, @pagy.limit %>
         <%= f.hidden_field :s, value: "#{@q.sorts[0].name} #{@q.sorts[0].dir}" %>
         <%= f.label :puid_or_file_blob_filename_cont, "SEARCH", class: "sr-only" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,9 +135,6 @@ en:
         provider: Authentication Provider
         uid: Authentication Provider UID
     concerns:
-      atttachment_actions:
-        destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
       history:
         system: System
       track_activity:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,9 @@ en:
         provider: Authentication Provider
         uid: Authentication Provider UID
     concerns:
+      atttachment_actions:
+        destroy:
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
       history:
         system: System
       track_activity:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,8 +279,8 @@ en:
     dialogs:
       delete_attachment_component:
         description:
-          paired_end: Are you sure that you want to delete files %{filenames} from the group?
-          single: Are you sure that you want to delete file '%{filename}' from the group?
+          paired_end: Are you sure that you want to delete files %{filenames} from the %{attachable_type}?
+          single: Are you sure that you want to delete file '%{filename}' from the %{attachable_type}?
         submit_button: Confirm
         title: Delete File
       new_attachment_component:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -135,6 +135,9 @@ fr:
         provider: Authentication Provider
         uid: Authentication Provider UID
     concerns:
+      attachment_actions:
+        destroy:
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
       history:
         system: System
       track_activity:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -135,9 +135,6 @@ fr:
         provider: Authentication Provider
         uid: Authentication Provider UID
     concerns:
-      attachment_actions:
-        destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
       history:
         system: System
       track_activity:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -279,8 +279,8 @@ fr:
     dialogs:
       delete_attachment_component:
         description:
-          paired_end: Are you sure that you want to delete files %{filenames} from the group?
-          single: Are you sure that you want to delete file '%{filename}' from the group?
+          paired_end: Are you sure that you want to delete files %{filenames} from the %{attachable_type}?
+          single: Are you sure that you want to delete file '%{filename}' from the %{attachable_type}?
         submit_button: Confirm
         title: Delete File
       new_attachment_component:

--- a/test/system/groups/attachments_test.rb
+++ b/test/system/groups/attachments_test.rb
@@ -203,7 +203,7 @@ module Groups
       assert_text 'Displaying 1-2 of 2 items'
       assert_selector 'table tbody tr', count: 2
 
-      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+      fill_in placeholder: I18n.t(:'groups.attachments.index.search.placeholder'),
               with: @attachment1.file.filename.to_s
 
       assert_text 'Displaying 1 item'
@@ -216,7 +216,7 @@ module Groups
         assert_no_text @attachment2.file.filename.to_s
       end
 
-      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+      fill_in placeholder: I18n.t(:'groups.attachments.index.search.placeholder'),
               with: @attachment2.puid
 
       assert_text 'Displaying 1 item'
@@ -312,7 +312,7 @@ module Groups
       assert_text 'Displaying 1-2 of 2 items'
       assert_selector 'table tbody tr', count: 2
 
-      click_on I18n.t('projects.attachments.index.upload_files')
+      click_on I18n.t('groups.attachments.index.upload_files')
 
       within('dialog') do
         attach_file 'attachment[files][]', [Rails.root.join('test/fixtures/files/TestSample_S1_L001_R2_001.fastq.gz'),
@@ -329,7 +329,7 @@ module Groups
         assert_selector 'tr:first-child td:nth-child(4)', text: 'illumina_pe'
       end
 
-      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+      fill_in placeholder: I18n.t(:'groups.attachments.index.search.placeholder'),
               with: 'fastq.gz'
 
       assert_selector '#attachments-table table tbody tr', count: 2
@@ -342,6 +342,23 @@ module Groups
         assert_selector 'tr:nth-child(2) td:nth-child(2)', text: 'TestSample_S1_L001_R1_001.fastq.gz'
         assert_selector 'tr:nth-child(2) td:nth-child(3)', text: 'fastq'
         assert_selector 'tr:nth-child(2) td:nth-child(4)', text: 'illumina_pe'
+      end
+    end
+
+    test 'empty search state' do
+      visit group_attachments_path(@namespace)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      assert_selector 'table tbody tr', count: 2
+
+      fill_in placeholder: I18n.t(:'groups.attachments.index.search.placeholder'),
+              with: 'filter that results in no attachments'
+
+      assert_no_selector 'table'
+
+      within 'div[role="alert"]' do
+        assert_text I18n.t('components.viral.pagy.empty_state.title')
+        assert_text I18n.t('components.viral.pagy.empty_state.description')
       end
     end
   end

--- a/test/system/projects/attachments_test.rb
+++ b/test/system/projects/attachments_test.rb
@@ -345,5 +345,22 @@ module Projects
         assert_selector 'tr:nth-child(2) td:nth-child(4)', text: 'illumina_pe'
       end
     end
+
+    test 'empty search state' do
+      visit namespace_project_attachments_path(@namespace, @project1)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      assert_selector 'table tbody tr', count: 2
+
+      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+              with: 'filter that results in no attachments'
+
+      assert_no_selector 'table'
+
+      within 'div[role="alert"]' do
+        assert_text I18n.t('components.viral.pagy.empty_state.title')
+        assert_text I18n.t('components.viral.pagy.empty_state.description')
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds the empty search state for group and project attachment pages.
In addition,  a small fix to the delete attachments dialog where it previously had "...delete attachment from group" for both groups and project. It now shows group/project dependent on where the attachment is being deleted.

## Screenshots or screen recordings
Empty Search:
![image](https://github.com/user-attachments/assets/d69d8f44-bd96-45d1-a468-18f346bcb010)

No files initially:
![image](https://github.com/user-attachments/assets/c4da4ce5-a3f4-4600-bd90-879cb0e6aa10)

Delete attachment from project:
![image](https://github.com/user-attachments/assets/b21f5ae1-df79-46c0-937b-21ff055f48f8)

Delete attachment from group:
![image](https://github.com/user-attachments/assets/21fc0e2c-a559-41d1-856e-4c3150293523)

## How to set up and validate locally
In both project and groups:
1. In a project/group with no files, ensure the "No Files" header and description are present
2. In a project/group with files, filter to where there are no files, ensure the "No Items Found" header and description are present
3. In a project/group, check the delete confirmation dialog and ensure "... from project/group" is shown for the correct type.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
