### PR TITLE
Fix workflow execution completion activities

### DIFF
--- a/app/components/activities/list_item_component.rb
+++ b/app/components/activities/list_item_component.rb
@@ -5,8 +5,9 @@ module Activities
   class ListItemComponent < Component
     attr_accessor :activity
 
-    def initialize(activity: nil)
+    def initialize(activity: nil, pagy: nil)
       @activity = activity
+      @pagy = pagy
     end
   end
 end

--- a/app/components/activities/list_item_component.rb
+++ b/app/components/activities/list_item_component.rb
@@ -5,9 +5,8 @@ module Activities
   class ListItemComponent < Component
     attr_accessor :activity
 
-    def initialize(activity: nil, pagy: nil)
+    def initialize(activity: nil)
       @activity = activity
-      @pagy = pagy
     end
   end
 end

--- a/app/services/workflow_executions/completion_service.rb
+++ b/app/services/workflow_executions/completion_service.rb
@@ -155,6 +155,8 @@ module WorkflowExecutions
     end
 
     def create_activities # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      return unless current_user.automation_bot?
+
       @workflow_execution.samples_workflow_executions&.each do |swe|
         next if swe.metadata.nil? && swe.outputs.empty?
 

--- a/app/views/groups/activity.turbo_stream.erb
+++ b/app/views/groups/activity.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.append "activities" do %>
   <% @activities.each do |activity| %>
-    <%= render Activities::ListItemComponent.new(activity: activity, pagy: @pagy) %>
+    <%= render Activities::ListItemComponent.new(activity: activity) %>
   <% end %>
 <% end %>
 

--- a/app/views/projects/activity.turbo_stream.erb
+++ b/app/views/projects/activity.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.append "activities" do %>
   <% @activities.each do |activity| %>
-    <%= render Activities::ListItemComponent.new(activity: activity, pagy: @pagy) %>
+    <%= render Activities::ListItemComponent.new(activity: activity) %>
   <% end %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,13 +263,13 @@ en:
       transfer_html: "%{user} transferred project from namespace <span class='font-medium text-slate-800 dark:text-slate-300'>%{old_namespace}</span> to <span class='font-medium text-slate-800 dark:text-slate-300'>%{new_namespace}</span>"
       update_html: "%{user} updated project attributes"
     workflow_execution:
-      automated_pipeline_completion:
-        metadata_written_html: Project automation bot wrote pipeline %{href} metadata to sample %{sample_href}
-        outputs_and_metadata_written_html: Project automation bot attached pipeline %{href} outputs and wrote metadata to sample %{sample_href}
-        outputs_written_html: Project automation bot attached pipeline %{href} outputs to sample %{sample_href}
       automated_workflow:
         create_html: "%{user} setup automated pipeline %{href} for the project"
         launch_html: Project automation bot launched pipeline %{href} on sample %{sample_href}
+      automated_workflow_completion:
+        metadata_written_html: Project automation bot wrote pipeline %{href} metadata to sample %{sample_href}
+        outputs_and_metadata_written_html: Project automation bot attached pipeline %{href} outputs and wrote metadata to sample %{sample_href}
+        outputs_written_html: Project automation bot attached pipeline %{href} outputs to sample %{sample_href}
   application:
     errors:
       access_denied: Access Denied.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -263,13 +263,13 @@ fr:
       transfer_html: "%{user} transferred project from namespace <span class='font-medium text-slate-800 dark:text-slate-300'>%{old_namespace}</span> to <span class='font-medium text-slate-800 dark:text-slate-300'>%{new_namespace}</span>"
       update_html: "%{user} updated project attributes"
     workflow_execution:
-      automated_pipeline_completion:
-        metadata_written_html: Project automation bot wrote pipeline %{href} metadata to sample %{sample_href}
-        outputs_and_metadata_written_html: Project automation bot attached pipeline %{href} outputs and wrote metadata to sample %{sample_href}
-        outputs_written_html: Project automation bot attached pipeline %{href} outputs to sample %{sample_href}
       automated_workflow:
         create_html: "%{user} setup automated pipeline %{href} for the project"
         launch_html: Project automation bot launched pipeline %{href} on sample %{sample_href}
+      automated_workflow_completion:
+        metadata_written_html: Project automation bot wrote pipeline %{href} metadata to sample %{sample_href}
+        outputs_and_metadata_written_html: Project automation bot attached pipeline %{href} outputs and wrote metadata to sample %{sample_href}
+        outputs_written_html: Project automation bot attached pipeline %{href} outputs to sample %{sample_href}
   application:
     errors:
       access_denied: Access Denied.

--- a/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
+++ b/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
@@ -4,6 +4,7 @@
 class RemoveGroupActivitiesWithWorkflowKeys < ActiveRecord::Migration[7.2]
   def change
     PublicActivity::Activity.where(
+      trackable_id: Group.as_ids,
       trackable_type: 'Namespace',
       key: ['workflow_execution.automated_workflow_completion.outputs_and_metadata_written',
             'workflow_execution.automated_workflow_completion.metadata_written',

--- a/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
+++ b/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
@@ -3,20 +3,6 @@
 # Migration to remove any activities from a Group where a Workflow key exists
 class RemoveGroupActivitiesWithWorkflowKeys < ActiveRecord::Migration[7.2]
   def change
-    # SQL option
-    # reversible do |dir|
-    #   dir.up do
-    #     execute <<~SQL.squish
-    #       DELETE FROM activities
-    #       WHERE trackable_type='Namespace' AND key IN
-    #       ('workflow_execution.automated_workflow_completion.outputs_and_metadata_written',
-    #       'workflow_execution.automated_workflow_completion.metadata_written',
-    #       'workflow_execution.automated_workflow_completion.outputs_written')
-    #     SQL
-    #   end
-    # end
-
-    # Ruby option
     PublicActivity::Activity.where(
       trackable_type: 'Namespace',
       key: ['workflow_execution.automated_workflow_completion.outputs_and_metadata_written',

--- a/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
+++ b/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Migration to remove any activities from a Group where a Workflow key exists
+class RemoveGroupActivitiesWithWorkflowKeys < ActiveRecord::Migration[7.2]
+  def change
+    # SQL option
+    # reversible do |dir|
+    #   dir.up do
+    #     execute <<~SQL.squish
+    #       DELETE FROM activities
+    #       WHERE trackable_type='Namespace' AND key IN
+    #       ('workflow_execution.automated_workflow_completion.outputs_and_metadata_written',
+    #       'workflow_execution.automated_workflow_completion.metadata_written',
+    #       'workflow_execution.automated_workflow_completion.outputs_written')
+    #     SQL
+    #   end
+    # end
+
+    # Ruby option
+    PublicActivity::Activity.where(
+      trackable_type: 'Namespace',
+      key: ['workflow_execution.automated_workflow_completion.outputs_and_metadata_written',
+            'workflow_execution.automated_workflow_completion.metadata_written',
+            'workflow_execution.automated_workflow_completion.outputs_written']
+    ).find_each(&:destroy)
+  end
+end

--- a/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
+++ b/db/migrate/20240925155747_remove_group_activities_with_workflow_keys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Migration to remove any activities from a Group where a Workflow key exists
+# Migration to remove any activities from a group where an automated workflow key exists
 class RemoveGroupActivitiesWithWorkflowKeys < ActiveRecord::Migration[7.2]
   def change
     PublicActivity::Activity.where(

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_12_193934) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_25_155747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"

--- a/test/fixtures/files/blob_outputs/normal4/analysis1.txt
+++ b/test/fixtures/files/blob_outputs/normal4/analysis1.txt
@@ -1,0 +1,1 @@
+some text in here

--- a/test/fixtures/files/blob_outputs/normal4/analysis2.txt
+++ b/test/fixtures/files/blob_outputs/normal4/analysis2.txt
@@ -1,0 +1,1 @@
+and more in here

--- a/test/fixtures/files/blob_outputs/normal4/analysis3.txt
+++ b/test/fixtures/files/blob_outputs/normal4/analysis3.txt
@@ -1,0 +1,1 @@
+even more text here

--- a/test/fixtures/files/blob_outputs/normal4/iridanext.output.json
+++ b/test/fixtures/files/blob_outputs/normal4/iridanext.output.json
@@ -1,0 +1,58 @@
+{
+    "files": {
+        "global": [
+            {
+                "path": "summary.txt"
+            }
+        ],
+        "samples": {
+            "INXT_SAM_AAAAAAAAA3": [
+                {
+                    "path": "analysis1.txt"
+                },
+                {
+                    "path": "analysis2.txt"
+                }
+            ],
+            "INXT_SAM_AAAAAAAAA4": [
+                {
+                    "path": "analysis3.txt"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "samples": {
+            "INXT_SAM_AAAAAAAAA3": {
+                "organism": "an organism",
+                "amr": [
+                    {
+                        "gene": "x",
+                        "start": 1234,
+                        "end": 5678
+                    },
+                    {
+                        "gene": "y",
+                        "start": 1,
+                        "end": 2
+                    }
+                ]
+            },
+            "INXT_SAM_AAAAAAAAA4": {
+                "organism": "a different organism",
+                "amr": [
+                    {
+                        "gene": "x",
+                        "start": 2345,
+                        "end": 6789
+                    },
+                    {
+                        "gene": "y",
+                        "start": 2,
+                        "end": 3
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/fixtures/files/blob_outputs/normal4/summary.txt
+++ b/test/fixtures/files/blob_outputs/normal4/summary.txt
@@ -1,0 +1,1 @@
+This is a text file.

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -186,6 +186,24 @@ sample42_irida_next_example_completing_f:
     "fastq_2": ""
   }
 
+sampleA_irida_next_example_completing_g:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sampleA, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_g, :uuid) %>
+  samplesheet_params: {
+    "sample": INXT_SAM_AAAAAAAAA3,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment1, :uuid)}" %>,
+    "fastq_2": ""
+  }
+
+sampleB_irida_next_example_completing_g:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sampleB, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_g, :uuid) %>
+  samplesheet_params: {
+    "sample": INXT_SAM_AAAAAAAAA4,
+    "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment2, :uuid)}" %>,
+    "fastq_2": ""
+  }
+
 sample46_irida_next_example_completed_with_output:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample46, :uuid) %>
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completed_with_output, :uuid) %>

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -439,6 +439,29 @@ irida_next_example_completing_f:
   email_notification: true
   cleaned: false
 
+irida_next_example_completing_g:
+  <<: *DEFAULTS
+  metadata:
+    {
+      "workflow_name": "phac-nml/iridanextexample",
+      "workflow_version": "1.0.2",
+    }
+  workflow_params:
+    {
+      "input": "/blah/samplesheet.csv",
+      "outdir": "/blah/output",
+    }
+  workflow_engine_parameters: { "-r": "dev" }
+  workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
+  run_id: "my_run_id_g"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:projectA_automation_bot, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
+  state: "completing"
+  blob_run_directory: "not a run dir"
+  update_samples: true
+  email_notification: true
+  cleaned: false
+
 irida_next_example_completed_with_output:
   <<: *DEFAULTS
   metadata:

--- a/test/services/workflow_executions/completion_service_test.rb
+++ b/test/services/workflow_executions/completion_service_test.rb
@@ -168,6 +168,11 @@ module WorkflowExecutions
       assert workflow_execution.email_notification
       assert_enqueued_emails 1
       assert_enqueued_email_with PipelineMailer, :complete_user_email, args: [workflow_execution]
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'finalize non complete workflow_execution' do
@@ -181,6 +186,13 @@ module WorkflowExecutions
       assert_not_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      public_activity = PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
+      assert_not_nil public_activity
+      assert_equal public_activity.key, 'namespaces_project_namespace.create'
     end
 
     test 'complete completing workflow_execution with no files' do
@@ -197,6 +209,11 @@ module WorkflowExecutions
       assert_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'sample outputs on samples_workflow_executions' do
@@ -251,6 +268,11 @@ module WorkflowExecutions
       assert_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'sample metadata on samples_workflow_executions' do
@@ -281,6 +303,11 @@ module WorkflowExecutions
       assert_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'metadata on samples_workflow_executions merged into underlying samples when update_samples' do
@@ -327,6 +354,11 @@ module WorkflowExecutions
       assert_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'metadata on samples_workflow_executions are not merged into underlying samples when not update_samples' do
@@ -363,6 +395,11 @@ module WorkflowExecutions
       assert workflow_execution.email_notification
       assert_enqueued_emails 1
       assert_enqueued_email_with PipelineMailer, :complete_user_email, args: [workflow_execution]
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'metadata on automated samples_workflow_executions are not merged into underlying samples when not
@@ -407,6 +444,11 @@ module WorkflowExecutions
         assert_enqueued_email_with PipelineMailer, :complete_manager_email,
                                    args: [workflow_execution, manager_emails, locale]
       end
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'outputs on samples_workflow_executions added to samples attachments when update_samples' do
@@ -432,6 +474,11 @@ module WorkflowExecutions
       assert_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'outputs on samples_workflow_executions not added to samples attachments when not update_samples' do
@@ -455,6 +502,11 @@ module WorkflowExecutions
       assert workflow_execution.email_notification
       assert_enqueued_emails 1
       assert_enqueued_email_with PipelineMailer, :complete_user_email, args: [workflow_execution]
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'complex metadata on samples_workflow_executions' do
@@ -501,6 +553,11 @@ module WorkflowExecutions
       assert_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
 
     test 'sample outputs metadata on samples_workflow_executions missing entry' do
@@ -541,6 +598,11 @@ module WorkflowExecutions
       assert_equal 'completed', workflow_execution.state
 
       assert_no_enqueued_emails
+
+      assert_nil PublicActivity::Activity.find_by(
+        trackable_id: workflow_execution.namespace.id,
+        trackable_type: 'Namespace'
+      )
     end
   end
 end

--- a/test/services/workflow_executions/completion_service_test.rb
+++ b/test/services/workflow_executions/completion_service_test.rb
@@ -174,9 +174,9 @@ module WorkflowExecutions
       )
 
       # associated test samples
-      @sampleA = samples(:sampleA)
-      @sampleB = samples(:sampleB)
-      @sampleC = samples(:sampleC)
+      @sample_a = samples(:sampleA)
+      @sample_b = samples(:sampleB)
+      @sample_c = samples(:sampleC)
       @sample41 = samples(:sample41)
       @sample42 = samples(:sample42)
     end
@@ -499,20 +499,20 @@ module WorkflowExecutions
 
       assert_equal 'my_run_id_g', workflow_execution.run_id
 
-      assert_equal({}, @sampleA.metadata)
-      assert_equal({}, @sampleB.metadata)
-      assert_equal({}, @sampleC.metadata)
+      assert_equal({}, @sample_a.metadata)
+      assert_equal({}, @sample_b.metadata)
+      assert_equal({}, @sample_c.metadata)
 
       assert WorkflowExecutions::CompletionService.new(workflow_execution, {}).execute
 
-      @sampleA.reload
-      assert_not_equal new_metadata1, @sampleA.metadata
+      @sample_a.reload
+      assert_not_equal new_metadata1, @sample_a.metadata
 
-      @sampleB.reload
-      assert_not_equal new_metadata2, @sampleB.metadata
+      @sample_b.reload
+      assert_not_equal new_metadata2, @sample_b.metadata
 
-      @sampleC.reload
-      assert_equal({}, @sampleC.metadata)
+      @sample_c.reload
+      assert_equal({}, @sample_c.metadata)
 
       assert_equal 'completed', workflow_execution.state
 


### PR DESCRIPTION
## What does this PR do and why?
Fixes loading the activity page after a user submits a workflow that was launched from the samples page with the option `Update samples with analysis results` set to true.
For now, we are only displaying workflow execution completion activities if they were launched by an automation bot.
Also, fixed the `Load more` button on the activities page.
Fixes #784.

## Screenshots or screen recordings
**Before:**
![image](https://github.com/user-attachments/assets/46174f26-5d58-46f5-87f6-05d497ab369b)
![image](https://github.com/user-attachments/assets/9d532e34-f074-4d6c-a2d4-7cec3523007c)

**After:**
![image](https://github.com/user-attachments/assets/8c97ea87-1e8f-4cc1-94e6-e3c2f0c08883)
![image](https://github.com/user-attachments/assets/f5aa7808-a9e9-4124-9337-5444d4455464)

## How to set up and validate locally
**To recreate the issue:**
1. Comment out line 158 within `/app/services/workflow_executions/completion_service.rb`.
2. Launch a workflow execution from the group samples page with the option `Update samples with analysis results` set to true.
3. After completion, verify the group activities page does not load.

**To test the migration script:**
1. Run the latest migration called `RemoveGroupActivitiesWithWorkflowKeys`.
2. Verify the group activities page loads with no new workflow execution completion activity.

**To test the fix:**
1. Uncomment line 158 within `/app/services/workflow_executions/completion_service.rb`.
2. Launch a workflow execution from the group samples page with the option `Update samples with analysis results` set to true.
3. After completion, verify the group activities loads with no new workflow execution completion activity.
4. Launch a workflow execution from the project samples page with the option `Update samples with analysis results` set to true.
5. After completion, verify the project activities loads with no new workflow execution completion activity.
6. Launch an automated workflow execution from the project samples page with the option `Update samples with analysis results` set to true.
7. After completion, verify the project activities loads with a new workflow execution completion activity.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
