### PR TITLE
Seeds: Prevent Turbo Broadcasts

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,7 +35,7 @@ end
   filename: 'reference.fasta'
 ).signed_id
 
-def seed_project(project_params:, creator:, namespace:)
+def seed_project(project_params:, creator:, namespace:) # rubocop:disable Metrics/MethodLength
   project = Projects::CreateService.new(creator,
                                         {
                                           namespace_attributes: project_params.slice(
@@ -52,6 +52,7 @@ def seed_project(project_params:, creator:, namespace:)
     end
   end
 
+  # prevent sample broadcasts
   Sample.suppressing_turbo_broadcasts do
     # seed the project samples
     seed_samples(project, project_params[:sample_count]) if project_params[:sample_count]
@@ -102,6 +103,7 @@ def seed_samples(project, sample_count)
 
     # Add metadata
     Samples::Metadata::UpdateService.new(project, sample, project.creator, { 'metadata' => fake_metadata }).execute
+    # prevent sample attachment broadcasts
     Attachment.suppressing_turbo_broadcasts do
       seed_attachments(sample)
     end
@@ -137,6 +139,7 @@ def seed_group(group_params:, owner: nil, parent: nil) # rubocop:disable Metrics
   if group_params[:projects] # rubocop:disable Style/SafeNavigation
     group_params[:projects].each do |project_params|
       Rails.logger.info { "seeding... Group: #{group_params[:name]}, Project: #{project_params[:name]}" }
+      # prevent project broadcasts
       Project.suppressing_turbo_broadcasts do
         seed_project(project_params:, creator: owner, namespace: group)
       end
@@ -790,11 +793,13 @@ if Rails.env.development?
     seed_namespace_group_links(proj.namespace.owner, proj.namespace, direct_group_to_link_to_namespace,
                                Member::AccessLevel::ANALYST)
   end
+  # prevent workflow and workflow attachment broadcasts
   Attachment.suppressing_turbo_broadcasts do
     WorkflowExecution.suppressing_turbo_broadcasts do
       seed_workflow_executions
     end
   end
+  # prevent data export broadcasts
   DataExport.suppressing_turbo_broadcasts do
     seed_exports
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,8 +52,10 @@ def seed_project(project_params:, creator:, namespace:)
     end
   end
 
-  # seed the project samples
-  seed_samples(project, project_params[:sample_count]) if project_params[:sample_count]
+  Sample.suppressing_turbo_broadcasts do
+    # seed the project samples
+    seed_samples(project, project_params[:sample_count]) if project_params[:sample_count]
+  end
 end
 
 def seed_members(email, access_level, namespace)
@@ -100,8 +102,9 @@ def seed_samples(project, sample_count)
 
     # Add metadata
     Samples::Metadata::UpdateService.new(project, sample, project.creator, { 'metadata' => fake_metadata }).execute
-
-    seed_attachments(sample)
+    Attachment.suppressing_turbo_broadcasts do
+      seed_attachments(sample)
+    end
   end
 end
 
@@ -134,7 +137,9 @@ def seed_group(group_params:, owner: nil, parent: nil) # rubocop:disable Metrics
   if group_params[:projects] # rubocop:disable Style/SafeNavigation
     group_params[:projects].each do |project_params|
       Rails.logger.info { "seeding... Group: #{group_params[:name]}, Project: #{project_params[:name]}" }
-      seed_project(project_params:, creator: owner, namespace: group)
+      Project.suppressing_turbo_broadcasts do
+        seed_project(project_params:, creator: owner, namespace: group)
+      end
     end
   end
 
@@ -785,8 +790,12 @@ if Rails.env.development?
     seed_namespace_group_links(proj.namespace.owner, proj.namespace, direct_group_to_link_to_namespace,
                                Member::AccessLevel::ANALYST)
   end
-
-  seed_workflow_executions
-
-  seed_exports
+  Attachment.suppressing_turbo_broadcasts do
+    WorkflowExecution.suppressing_turbo_broadcasts do
+      seed_workflow_executions
+    end
+  end
+  DataExport.suppressing_turbo_broadcasts do
+    seed_exports
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR prevents `turbo_broadcasts` from occurring during seeding as they are unnecessary and slow down the seeding process.

## Screenshots or screen recordings
Seed logs with broadcasts:
![image](https://github.com/user-attachments/assets/708ed4de-17da-49a7-b36f-f9b139d75179)

Seed logs without broadcasts (as expected):
![image](https://github.com/user-attachments/assets/5ca71ae6-e2d9-4518-b731-ab961af03b0f)

## How to set up and validate locally
1. Seed your database from main with `./scripts/clean_dev.sh` to see what the logs looks like when `turbo_broadcasts` are enabled (feel free to stop seeding after a few seconds as you'll get the idea very quickly)
2. Now Seed your database from this branch, ensure no `broadcasts` occur.
3. Ensure broadcasts still work on the website. This would include:
- `Last Updated` updates on the project listing index, sample listing index, and sample attachments.
- Running an export and watching the data exports listing table status update from `processing` to `ready`
- Running a workflow execution and viewing the state changes from the workflow execution index listing

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
