### PR TITLE
Fix upload dialog upload button for groups/project not disabling when uploading

### DIFF
--- a/app/components/attachments/dialogs/new_attachment_component.html.erb
+++ b/app/components/attachments/dialogs/new_attachment_component.html.erb
@@ -43,31 +43,7 @@
 
         <div>
           <%= form.submit t(".upload"),
-                      class: "
-                        inline-flex
-                        items-center
-                        justify-center
-                        w-1/2
-                        text-sm
-                        border
-                        rounded-md
-                        cursor-pointer
-                        sm:w-auto
-                        focus:z-10
-                        px-5
-                        py-2.5
-                        text-white
-                        border-primary-800
-                        bg-primary-700
-                        focus:outline-none
-                        hover:bg-primary-800
-                        focus:ring-primary-300
-                        dark:focus:ring-primary-700
-                        dark:bg-primary-800
-                        dark:text-white
-                        dark:border-primary-900
-                        dark:hover:bg-primary-700
-                      ",
+                      class: "button button--state-primary button--size-default",
                       data: {
                         "attachment-upload-target": "submitButton",
                       } %>

--- a/test/system/groups/attachments_test.rb
+++ b/test/system/groups/attachments_test.rb
@@ -37,7 +37,10 @@ module Groups
 
       within('dialog') do
         attach_file 'attachment[files][]', Rails.root.join('test/fixtures/files/test_file_2.fastq.gz')
+        # check that button goes from being enabled to disabled when clicked
+        assert_selector 'input[type=submit]:not(:disabled)'
         click_on I18n.t('attachments.dialogs.new_attachment_component.upload')
+        assert_selector 'input[type=submit]:disabled'
       end
 
       assert_selector '#attachments-table table tbody tr', count: 3

--- a/test/system/projects/attachments_test.rb
+++ b/test/system/projects/attachments_test.rb
@@ -38,7 +38,10 @@ module Projects
 
       within('dialog') do
         attach_file 'attachment[files][]', Rails.root.join('test/fixtures/files/test_file_2.fastq.gz')
+        # check that button goes from being enabled to disabled when clicked
+        assert_selector 'input[type=submit]:not(:disabled)'
         click_on I18n.t('attachments.dialogs.new_attachment_component.upload')
+        assert_selector 'input[type=submit]:disabled'
       end
 
       assert_selector '#attachments-table table tbody tr', count: 3

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -95,7 +95,10 @@ module Projects
 
       within('dialog') do
         attach_file 'attachment[files][]', Rails.root.join('test/fixtures/files/test_file_2.fastq.gz')
+        # check that button goes from being enabled to disabled when clicked
+        assert_selector 'input[type=submit]:not(:disabled)'
         click_on I18n.t('projects.samples.show.upload')
+        assert_selector 'input[type=submit]:disabled'
       end
 
       assert_text I18n.t('projects.samples.attachments.create.success', filename: 'test_file_2.fastq.gz')


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Fixes #790 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._
1. Upload a large file to a namespace
2. Verify that the upload button changes to "Uploading" and is disabled during upload.
3. Upload a large file to a group
4. Verify that the upload button changes to "Uploading" and is disabled during upload.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
