### PR TITLE
Metadata: Lower case index to support case insensitive searching

### DIFF
--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -5,10 +5,18 @@ module Arel
     def contains_key(other)
       Arel::Nodes::InfixOperation.new(:'?', self, Arel::Nodes::Quoted.new(other))
     end
+
+    # contains but case insensitive
+    def contains_ci(other)
+      Arel::Nodes::Contains.new(
+        Arel::Nodes::SqlLiteral.new("lower(\"#{relation.name}\".\"#{name}\"::text)::jsonb"),
+        Arel::Nodes.build_quoted(other, self)
+      )
+    end
   end
 end
 
 Ransack.configure do |config|
-  config.add_predicate 'jcont', arel_predicate: 'contains', formatter: proc { |v| JSON.parse(v.to_s) }
-  config.add_predicate 'jcont_key', arel_predicate: 'contains_key'
+  config.add_predicate 'jcont', arel_predicate: 'contains_ci', formatter: proc { |v| JSON.parse(v.to_s.downcase) }
+  config.add_predicate 'jcont_key', arel_predicate: 'contains_key', formatter: proc { |v| v.to_s.downcase }
 end

--- a/db/migrate/20241003125314_update_metadata_indexes.rb
+++ b/db/migrate/20241003125314_update_metadata_indexes.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Update metadata index for attachments and samples to be on lower case
+class UpdateMetadataIndexes < ActiveRecord::Migration[7.2]
+  def change # rubocop:disable Metrics/MethodLength
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          DROP INDEX index_attachments_on_metadata;
+          CREATE INDEX index_attachments_on_metadata ON attachments USING GIN ((LOWER(metadata::text)::jsonb));
+
+          DROP INDEX index_samples_on_metadata;
+          CREATE INDEX index_samples_on_metadata ON samples USING GIN ((LOWER(metadata::text)::jsonb));
+        SQL
+      end
+
+      dir.down do
+        execute <<~SQL.squish
+          DROP INDEX index_attachments_on_metadata;
+          DROP INDEX index_samples_on_metadata;
+        SQL
+        add_index :attachments, :metadata, using: :gin
+        add_index :samples, :metadata, using: :gin
+      end
+    end
+  end
+end

--- a/db/migrate/20241003125314_update_metadata_indexes.rb
+++ b/db/migrate/20241003125314_update_metadata_indexes.rb
@@ -7,17 +7,17 @@ class UpdateMetadataIndexes < ActiveRecord::Migration[7.2]
       dir.up do
         execute <<~SQL.squish
           DROP INDEX index_attachments_on_metadata;
-          CREATE INDEX index_attachments_on_metadata ON attachments USING GIN ((LOWER(metadata::text)::jsonb));
+          CREATE INDEX index_attachments_on_metadata_ci ON attachments USING GIN ((LOWER(metadata::text)::jsonb));
 
           DROP INDEX index_samples_on_metadata;
-          CREATE INDEX index_samples_on_metadata ON samples USING GIN ((LOWER(metadata::text)::jsonb));
+          CREATE INDEX index_samples_on_metadata_ci ON samples USING GIN ((LOWER(metadata::text)::jsonb));
         SQL
       end
 
       dir.down do
         execute <<~SQL.squish
-          DROP INDEX index_attachments_on_metadata;
-          DROP INDEX index_samples_on_metadata;
+          DROP INDEX index_attachments_on_metadata_ci;
+          DROP INDEX index_samples_on_metadata_ci;
         SQL
         add_index :attachments, :metadata, using: :gin
         add_index :samples, :metadata, using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,7 +74,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_03_125314) do
     t.jsonb "log_data"
     t.uuid "attachable_id", null: false
     t.string "puid", null: false
-    t.index "((lower((metadata)::text))::jsonb)", name: "index_attachments_on_metadata", using: :gin
+    t.index "((lower((metadata)::text))::jsonb)", name: "index_attachments_on_metadata_ci", using: :gin
     t.index ["attachable_id"], name: "index_attachments_on_attachable_id"
     t.index ["created_at"], name: "index_attachments_on_created_at"
     t.index ["puid"], name: "index_attachments_on_puid"
@@ -238,7 +238,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_03_125314) do
     t.string "puid", null: false
     t.uuid "project_id", null: false
     t.datetime "attachments_updated_at"
-    t.index "((lower((metadata)::text))::jsonb)", name: "index_samples_on_metadata", using: :gin
+    t.index "((lower((metadata)::text))::jsonb)", name: "index_samples_on_metadata_ci", using: :gin
     t.index ["created_at"], name: "index_samples_on_created_at"
     t.index ["deleted_at"], name: "index_samples_on_deleted_at"
     t.index ["id", "project_id"], name: "index_samples_on_id_and_project_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_25_155747) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_03_125314) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -74,9 +74,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_25_155747) do
     t.jsonb "log_data"
     t.uuid "attachable_id", null: false
     t.string "puid", null: false
+    t.index "((lower((metadata)::text))::jsonb)", name: "index_attachments_on_metadata", using: :gin
     t.index ["attachable_id"], name: "index_attachments_on_attachable_id"
     t.index ["created_at"], name: "index_attachments_on_created_at"
-    t.index ["metadata"], name: "index_attachments_on_metadata", using: :gin
     t.index ["puid"], name: "index_attachments_on_puid"
   end
 
@@ -238,10 +238,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_25_155747) do
     t.string "puid", null: false
     t.uuid "project_id", null: false
     t.datetime "attachments_updated_at"
+    t.index "((lower((metadata)::text))::jsonb)", name: "index_samples_on_metadata", using: :gin
     t.index ["created_at"], name: "index_samples_on_created_at"
     t.index ["deleted_at"], name: "index_samples_on_deleted_at"
     t.index ["id", "project_id"], name: "index_samples_on_id_and_project_id", unique: true
-    t.index ["metadata"], name: "index_samples_on_metadata", using: :gin
     t.index ["metadata_provenance"], name: "index_samples_on_metadata_provenance", using: :gin
     t.index ["name", "project_id"], name: "index_sample_name_with_project", unique: true, where: "(deleted_at IS NULL)"
     t.index ["project_id"], name: "index_samples_on_project_id"

--- a/test/graphql/samples_query_ransack_test.rb
+++ b/test/graphql/samples_query_ransack_test.rb
@@ -192,10 +192,34 @@ class SamplesQueryRansackTest < ActiveSupport::TestCase
     assert_equal 4, data.count
   end
 
+  test 'ransack samples query with metadata_jcont_key filter should work ignoring case' do
+    result = IridaSchema.execute(SAMPLES_RANSACK_QUERY,
+                                 context: { current_user: @user },
+                                 variables: { filter: { metadata_jcont_key: 'MetadataField1' } })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['samples']['nodes']
+
+    assert_equal 4, data.count
+  end
+
   test 'ransack samples query with metadata_jcont filter should work' do
     result = IridaSchema.execute(SAMPLES_RANSACK_QUERY,
                                  context: { current_user: @user },
                                  variables: { filter: { metadata_jcont: { metadatafield1: 'value1' } } })
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['samples']['nodes']
+
+    assert_equal 4, data.count
+  end
+
+  test 'ransack samples query with metadata_jcont filter should work ignoring case' do
+    result = IridaSchema.execute(SAMPLES_RANSACK_QUERY,
+                                 context: { current_user: @user },
+                                 variables: { filter: { metadata_jcont: { MetadataField1: 'Value1' } } })
 
     assert_nil result['errors'], 'should work and have no errors.'
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Removes the existing case sensitive GIN index for metadata on attachments and samples, and replaces it with a lowercase GIN index. This lower case index allows for case insensitive  searching, by first downcasing metadata column before searching (note: this requires that the query be downcased prior to searching, which is automatically done via ransack predicates).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Run db migrations to replace indexes
2. Follow testing instructions in #768 but use varying cases and ensure that searches work regardless of case.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
