### PR TITLE
Samples Table: Search by metadata field and value presence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,9 @@ gem 'pagy', '~> 9.0.5' # omit patch digit
 # Ransack
 gem 'ransack', '~> 4.2.1'
 
+# Search Syntax
+gem 'search_syntax'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,6 +417,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.7)
+    polyglot (0.3.5)
     prettier_print (1.2.1)
     psych (5.1.2)
       stringio
@@ -536,6 +537,8 @@ GEM
       nokogiri (>= 1.13.10)
       rexml
     rubyzip (2.3.2)
+    search_syntax (0.1.3)
+      treetop (~> 1.6)
     securerandom (0.3.1)
     signet (0.19.0)
       addressable (~> 2.8)
@@ -603,6 +606,8 @@ GEM
     timecop (0.9.10)
     timeout (0.4.1)
     trailblazer-option (0.1.2)
+    treetop (1.6.12)
+      polyglot (~> 0.3)
     turbo-rails (2.0.6)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -707,6 +712,7 @@ DEPENDENCIES
   rubocop
   rubocop-graphql
   rubocop-rails
+  search_syntax
   simplecov
   solargraph
   sprockets-rails

--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -148,7 +148,6 @@
               <% @metadata_fields.each do |field| %>
                 <%= render_cell(
                 tag: 'td',
-                scope: 'col',
                 classes: class_names('px-3 py-3')
               ) do %>
                   <%= sample.metadata[field] %>

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -87,11 +87,7 @@ module Groups
         updated_params[:s] = default_sort
         update_store(search_key, updated_params)
       end
-      query_parser = Irida::SearchSyntax::Ransack.new(text: :name_or_puid_cont,
-                                                      # params: { project: 'project_namespace_puid' },
-                                                      metadata_fields: @fields)
-      parsed_params = query_parser.parse(@search_params.fetch(:name_or_puid_cont, nil))
-      updated_params.except(:name_or_puid_cont).merge(parsed_params)
+      updated_params
     end
 
     def search_key

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -75,9 +75,7 @@ module Groups
       authorize! @group, to: :sample_listing?
       @search_params = search_params
       set_metadata_fields
-      query_parser = Irida::SearchSyntax::Ransack.new(text: :name_or_puid_cont,
-                                                      # params: { project: 'project_namespace_puid' },
-                                                      metadata_fields: @fields)
+      query_parser = Irida::SearchSyntax::Ransack.new(text: :name_or_puid_cont, metadata_fields: @fields)
       parsed_params = query_parser.parse(@search_params.fetch(:name_or_puid_cont, nil))
       @q = authorized_samples.ransack(@search_params.except(:name_or_puid_cont).merge(parsed_params))
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -36,6 +36,7 @@ class Sample < ApplicationRecord
   end
 
   def self.ransackable_associations(_auth_object = nil)
+    #%w[project]
     %w[]
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -36,7 +36,6 @@ class Sample < ApplicationRecord
   end
 
   def self.ransackable_associations(_auth_object = nil)
-    #%w[project]
     %w[]
   end
 

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -28,7 +28,7 @@
                 },
                 class:
                   "flex items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
               ) %>
             <% else %>
               <% dropdown.with_item(
@@ -72,7 +72,12 @@
                 ) do |f| %>
             <input type="hidden" name="format" value="turbo_stream"/>
             <input type="hidden" name="select" value="on"/>
-            <input type="hidden" name="timestamp" value="<%=@timestamp%>"/>
+            <input
+              type="hidden"
+              name="timestamp"
+              value="<%=@timestamp%>"
+              data-turbo-temporary
+            />
             <%= f.submit t(".select_all_button"),
                      class: "button button--state-default button--size-default" %>
           <% end %>

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -111,6 +111,7 @@
                 <%= viral_icon(name: "magnifying_glass", classes: "h-5 w-5") %>
               </div>
               <%= f.search_field :name_or_puid_cont,
+                             value: @search_params[:name_or_puid_cont],
                              "data-action": "filters#submit",
                              class:
                                "block w-full p-2.5 pl-10 text-sm text-slate-900 border border-slate-300 rounded-lg bg-slate-50 focus:ring-primary-500 focus:border-primary-500 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -57,7 +57,7 @@
                 },
                 class:
                   "flex items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
               ) %>
             <% else %>
               <% dropdown.with_item(
@@ -126,7 +126,12 @@
                 ) do |f| %>
             <input type="hidden" name="format" value="turbo_stream"/>
             <input type="hidden" name="select" value="on"/>
-            <input type="hidden" name="timestamp" value="<%=@timestamp%>"/>
+            <input
+              type="hidden"
+              name="timestamp"
+              value="<%=@timestamp%>"
+              data-turbo-temporary
+            >
             <%= f.submit t(".select_all_button"),
                      class: "button button--state-default button--size-default" %>
           <% end %>

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -168,6 +168,7 @@
                 <%= viral_icon(name: "magnifying_glass", classes: "h-5 w-5") %>
               </div>
               <%= f.search_field :name_or_puid_cont,
+                             value: @search_params[:name_or_puid_cont],
                              "data-action": "filters#submit",
                              class:
                                "block w-full p-2.5 pl-10 text-sm text-slate-900 border border-slate-300 rounded-lg bg-slate-50 focus:ring-primary-500 focus:border-primary-500 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",

--- a/lib/irida/search_syntax/ransack.rb
+++ b/lib/irida/search_syntax/ransack.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'ransack_transformer'
+
+module Irida
+  module SearchSyntax
+    # IRIDA Next specific Ransack search syntax parser that supports metadata_fields
+    class Ransack
+      def initialize(text:, params: [], metadata_fields: [], sort: nil)
+        @transformer = RansackTransformer.new(text:, params:, metadata_fields:, sort:)
+        @parser = ::SearchSyntax::Parser.new
+      end
+
+      def parse_with_errors(text)
+        @transformer.transform_with_errors(@parser.parse(text || '').value)
+      end
+
+      def parse(text)
+        parse_with_errors(text)[0]
+      end
+    end
+  end
+end

--- a/lib/irida/search_syntax/ransack_transformer.rb
+++ b/lib/irida/search_syntax/ransack_transformer.rb
@@ -33,13 +33,13 @@ module Irida
                 result[key] = node[:value]
               end
               false
-            elsif @metadata_fields.include?(node[:name])
+            elsif @metadata_fields.include?(node[:name].downcase)
               # all metadata searching uses metadata_jcont ransacker
               key = 'metadata_jcont'
               search_value = {}
               search_value = JSON.parse(result[key]) if result.key?(key)
               # if we already processed a metadata field, ignore subsequent instances of field and push an error
-              if search_value.key?(node[:name])
+              if search_value.key?(node[:name].downcase)
                 errors.push(::SearchSyntax::DuplicateParamError.new(
                               name: node[:name],
                               start: node[:start],
@@ -47,7 +47,7 @@ module Irida
                             ))
               # else add it to the search_value hash and then transform back to a JSON string
               else
-                search_value[node[:name]] = node[:value]
+                search_value[node[:name].downcase] = node[:value]
                 result[key] = JSON.generate(search_value)
               end
               false

--- a/lib/irida/search_syntax/ransack_transformer.rb
+++ b/lib/irida/search_syntax/ransack_transformer.rb
@@ -1,0 +1,71 @@
+module Irida
+  module SearchSyntax
+    # IRIDA Next specific RansackTransformer that supoorts metadata_fields
+    class RansackTransformer < ::SearchSyntax::RansackTransformer
+      def initialize(text:, params:, metadata_fields:, sort: nil)
+        super(text:, params:, sort:)
+        @metadata_fields = metadata_fields
+      end
+
+      def transform_with_errors(ast) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
+        errors = []
+        result = {}
+
+        if @allowed_params.length.positive? || @metadata_fields.length.positive?
+          ast = ast.filter do |node| # rubocop:disable Metrics/BlockLength
+            if node[:type] != :param
+              true
+            elsif node[:name] == @sort
+              result[:s] = transform_sort_param(node[:value])
+              false
+            elsif @allowed_params.include?(node[:name])
+              key = name_with_predicate(node)
+              if result.key?(key)
+                errors.push(::SearchSyntax::DuplicateParamError.new(
+                              name: node[:name],
+                              start: node[:start],
+                              finish: node[:finish]
+                            ))
+              else
+                result[key] = node[:value]
+              end
+              false
+            elsif @metadata_fields.include?(node[:name])
+              key = 'metadata_jcont'
+              search_value = {}
+              search_value = JSON.parse(result[key]) if result.key?(key)
+              if search_value.key?(node[:name])
+                errors.push(::SearchSyntax::DuplicateParamError.new(
+                              name: node[:name],
+                              start: node[:start],
+                              finish: node[:finish]
+                            ))
+              else
+                search_value[node[:name]] = node[:value]
+                result[key] = JSON.generate(search_value)
+              end
+              false
+            else
+              errors.push(::SearchSyntax::UnknownParamError.new(
+                            name: node[:name],
+                            start: node[:start],
+                            finish: node[:finish],
+                            did_you_mean: @spell_checker.correct(node[:name])
+                          ))
+              true
+            end
+          end
+        end
+
+        previous = -1
+        result[@text] = ast.map do |node|
+          separator = previous == node[:start] || previous == -1 ? '' : ' '
+          previous = node[:finish]
+          separator + node[:raw]
+        end.join
+
+        [result, errors]
+      end
+    end
+  end
+end

--- a/lib/irida/search_syntax/ransack_transformer.rb
+++ b/lib/irida/search_syntax/ransack_transformer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Irida
   module SearchSyntax
     # IRIDA Next specific RansackTransformer that supoorts metadata_fields
@@ -7,6 +9,7 @@ module Irida
         @metadata_fields = metadata_fields
       end
 
+      # Note this method is a copy of SearchSyntax::RanstackTronsformer but with additional processing for metadata
       def transform_with_errors(ast) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
         errors = []
         result = {}
@@ -31,15 +34,18 @@ module Irida
               end
               false
             elsif @metadata_fields.include?(node[:name])
+              # all metadata searching uses metadata_jcont ransacker
               key = 'metadata_jcont'
               search_value = {}
               search_value = JSON.parse(result[key]) if result.key?(key)
+              # if we already processed a metadata field, ignore subsequent instances of field and push an error
               if search_value.key?(node[:name])
                 errors.push(::SearchSyntax::DuplicateParamError.new(
                               name: node[:name],
                               start: node[:start],
                               finish: node[:finish]
                             ))
+              # else add it to the search_value hash and then transform back to a JSON string
               else
                 search_value[node[:name]] = node[:value]
                 result[key] = JSON.generate(search_value)

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -128,6 +128,37 @@ module Groups
       assert_no_text @sample2.name
     end
 
+    test 'can search the list of samples by metadata field and value presence when metadata is toggled' do
+      visit group_samples_url(@group)
+      filter_text = 'metadatafield1:value1'
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 26,
+                                                                           locale: @user.locale))
+
+      assert_selector 'table tbody tr', count: 20
+      assert_text @sample1.name
+      assert_text @sample2.name
+
+      assert_selector 'label', text: I18n.t('projects.samples.shared.metadata_toggle.label'), count: 1
+      find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 26,
+                                                                           locale: @user.locale))
+
+      assert_selector '#samples-table table thead tr th', count: 9
+      assert_selector 'div#limit-component button div span', text: '20'
+
+      fill_in placeholder: I18n.t(:'groups.samples.index.search.placeholder'), with: filter_text
+
+      assert_selector '#samples-table table tbody tr', count: 1
+      assert_selector '#samples-table table thead tr th', count: 9
+      assert_selector 'div#limit-component button div span', text: '20'
+
+      assert_text @sample30.name
+      assert_no_text @sample1.name
+      assert_no_text @sample2.name
+    end
+
     test 'can sort the list of samples' do
       visit group_samples_url(@group)
 

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -482,6 +482,8 @@ module Projects
 
       Project.reset_counters(project38.id, :samples_count)
       visit namespace_project_samples_url(namespace17, project38)
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 200,
+                                                                           locale: user.locale))
 
       click_button I18n.t(:'projects.samples.index.select_all_button')
 
@@ -509,6 +511,9 @@ module Projects
 
       Project.reset_counters(project2.id, :samples_count)
       visit namespace_project_samples_url(namespace1, project2)
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 200,
+                                                                           locale: user.locale))
 
       click_button I18n.t(:'projects.samples.index.select_all_button')
 

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -667,6 +667,48 @@ module Projects
       assert_no_text @sample3.name
     end
 
+    test 'can search the list of samples by metadata field and value presence when metadata is toggled' do
+      visit namespace_project_samples_url(@namespace, @project)
+      filter_text = 'metadatafield1:value1'
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
+                                                                           locale: @user.locale))
+      assert_selector '#samples-table table tbody tr', count: 3
+      assert_text @sample1.name
+      assert_text @sample2.name
+      assert_text @sample3.name
+
+      assert_selector 'label', text: I18n.t('projects.samples.shared.metadata_toggle.label'), count: 1
+      find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
+                                                                           locale: @user.locale))
+      assert_selector '#samples-table table tbody tr', count: 3
+      assert_selector '#samples-table table thead tr th', count: 8
+      assert_selector 'div#limit-component button div span', text: '20'
+
+      fill_in placeholder: I18n.t(:'projects.samples.index.search.placeholder'), with: filter_text
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
+                                                                           locale: @user.locale))
+      assert_selector '#samples-table table tbody tr', count: 1
+      assert_text filter_text
+      assert_no_text @sample1.name
+      assert_no_text @sample2.name
+      assert_text @sample3.name
+
+      # Refresh the page to ensure the search is still active
+      visit namespace_project_samples_url(@namespace, @project)
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
+                                                                           locale: @user.locale))
+      assert_selector '#samples-table table tbody tr', count: 1
+      assert_text filter_text
+      assert_no_text @sample1.name
+      assert_no_text @sample2.name
+      assert_text @sample3.name
+    end
+
     test 'can change pagination and then filter by name' do
       visit namespace_project_samples_url(@namespace, @project)
 

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -483,7 +483,7 @@ module Projects
       Project.reset_counters(project38.id, :samples_count)
       visit namespace_project_samples_url(namespace17, project38)
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 200,
-                                                                           locale: user.locale))
+                                                                           locale: @user.locale))
 
       click_button I18n.t(:'projects.samples.index.select_all_button')
 
@@ -512,8 +512,8 @@ module Projects
       Project.reset_counters(project2.id, :samples_count)
       visit namespace_project_samples_url(namespace1, project2)
 
-      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 200,
-                                                                           locale: user.locale))
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 220,
+                                                                           locale: @user.locale))
 
       click_button I18n.t(:'projects.samples.index.select_all_button')
 

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -692,7 +692,7 @@ module Projects
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
       assert_selector '#samples-table table tbody tr', count: 1
-      assert_text filter_text
+      assert_field type: 'search', with: filter_text
       assert_no_text @sample1.name
       assert_no_text @sample2.name
       assert_text @sample3.name
@@ -703,7 +703,7 @@ module Projects
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
       assert_selector '#samples-table table tbody tr', count: 1
-      assert_text filter_text
+      assert_field type: 'search', with: filter_text
       assert_no_text @sample1.name
       assert_no_text @sample2.name
       assert_text @sample3.name


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in support for searching the samples table by metadata field and value presence through the existing search box only when metadata has been toggled to be displayed.

Samples can be searched for by metadata using the following format `FIELD_NAME:FIELD_VALUE`, where the case does not matter for `field_name` or `field_value`.

Note: only string values can be searched for, a separate PR will ensure that we only store string values for metadata (#808 )

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/3bca413c-e8d1-4048-ae5e-01eb3844699d)

![image](https://github.com/user-attachments/assets/64d9e40c-6677-44e8-b202-e511d3e677e6)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Run `bin/bundle` to install the gems required by this branch
2. Go to Project Samples page toggle metadata and try out a search using the format `FIELD_NAME:FIELD_VALUE`
3. Go to Group Samples page toggle metadata and try out a search using the format `FIELD_NAME:FIELD_VALUE`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
