### PR TITLE
Activity page fixes

### DIFF
--- a/app/components/project_dashboard/information_component.html.erb
+++ b/app/components/project_dashboard/information_component.html.erb
@@ -30,7 +30,7 @@
   <%= viral_tooltip(title: t(:"components.project_dashboard.information.number_of_members")) do %>
     <span class="flex items-center">
       <%= viral_icon(name: :users, color: :subdued, classes: "h-5 w-5 m-0 mr-2") %>
-      <%= @project.namespace.project_members.count %>
+      <%= @project.namespace.project_members.without_automation_bots.count %>
     </span>
   <% end %>
 </span>

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -180,6 +180,11 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     case action_name
     when 'new', 'create', 'show'
       @context_crumbs
+    when 'activity'
+      @context_crumbs += [{
+        name: I18n.t('groups.activity.title'),
+        path: group_activity_path
+      }]
     else
       @context_crumbs += [{
         name: I18n.t('groups.edit.title'),

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -162,6 +162,11 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
         name: I18n.t('projects.edit.title'),
         path: namespace_project_edit_path
       }]
+    when 'activity'
+      @context_crumbs += [{
+        name: I18n.t('projects.activity.title'),
+        path: namespace_project_activity_path
+      }]
     end
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -31,6 +31,12 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   scope :not_expired, -> { where('expires_at IS NULL OR expires_at > ?', Time.zone.now.beginning_of_day) }
 
+  scope :without_automation_bots, lambda {
+                                    joins(:user).where.not(
+                                      user: { user_type: User.user_types[:project_automation_bot] }
+                                    )
+                                  }
+
   class << self
     DEFAULT_CAN_OPTIONS = {
       include_group_links: true

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -24,7 +24,7 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
   end
 
   def view_history?
-    return true if Member.can_view?(user, record, include_group_links: false) == true
+    return true if Member.can_view?(user, record) == true
 
     details[:name] = record.name
     false

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -12,7 +12,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
 
   def view_history?
     return true if record.namespace.parent.user_namespace? && record.namespace.parent.owner == user
-    return true if Member.can_view?(user, record.namespace, include_group_links: false) == true
+    return true if Member.can_view?(user, record.namespace) == true
 
     details[:name] = record.name
     false

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -44,6 +44,7 @@
               selectable_pages: [
                 t(:"groups.sidebar.general"),
                 t(:"groups.sidebar.bot_accounts"),
+                t(:"groups.sidebar.history"),
               ],
               current_page: @current_page
               ) do |multi_level_menu| %>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes incorrect breadcrumbs for project and group activity page, fixes a bug with the settings menu opening, updates the project details page to show the count of members without automation bots, and updates the view_history policy methods to allow members of shared groups with access level >= MAINTAINER to view history items for a group and/or project.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/929bf04c-0513-415a-9426-3103d406bb34)

![image](https://github.com/user-attachments/assets/4582ad66-9af4-422f-abbb-12ae377107b6)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
