### PR TITLE
File import: Empty column fix

### DIFF
--- a/app/services/samples/metadata/file_import_service.rb
+++ b/app/services/samples/metadata/file_import_service.rb
@@ -89,7 +89,7 @@ module Samples
                          Roo::Spreadsheet.open(@file)
                        end
 
-        @headers = @spreadsheet.row(1)
+        @headers = @spreadsheet.row(1).compact
 
         validate_file_headers
 

--- a/test/fixtures/files/metadata/contains_empty_columns.csv
+++ b/test/fixtures/files/metadata/contains_empty_columns.csv
@@ -1,0 +1,3 @@
+sample_name,metadatafield1,,,metadatafield3
+Project 1 Sample 1,10,,,30
+Project 1 Sample 2,15,,,35

--- a/test/fixtures/files/metadata/contains_empty_header.csv
+++ b/test/fixtures/files/metadata/contains_empty_header.csv
@@ -1,0 +1,3 @@
+sample_name,metadatafield1,,metadatafield3
+Project 1 Sample 1,10,20,30
+Project 1 Sample 2,15,25,35

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -241,7 +241,7 @@ module Samples
         assert_equal({ 'metadatafield1' => '15', 'metadatafield3' => '35' }, @sample2.reload.metadata)
       end
 
-      test 'import sample metadata with a multiple empty columns' do
+      test 'import sample metadata with multiple empty columns' do
         assert_equal({}, @sample1.metadata)
         assert_equal({}, @sample2.metadata)
         params = { file: File.new('test/fixtures/files/metadata/contains_empty_columns.csv', 'r'),

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -226,6 +226,36 @@ module Samples
                      I18n.t('services.samples.metadata.import_file.missing_metadata_row'))
       end
 
+      test 'import sample metadata with an empty header' do
+        assert_equal({}, @sample1.metadata)
+        assert_equal({}, @sample2.metadata)
+        params = { file: File.new('test/fixtures/files/metadata/contains_empty_header.csv', 'r'),
+                   sample_id_column: 'sample_name' }
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe,
+                                                            params).execute
+        assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield3],
+                                          updated: [], deleted: [], not_updated: [], unchanged: [] },
+                       @sample2.name => { added: %w[metadatafield1 metadatafield3],
+                                          updated: [], deleted: [], not_updated: [], unchanged: [] } }, response)
+        assert_equal({ 'metadatafield1' => '10', 'metadatafield3' => '30' }, @sample1.reload.metadata)
+        assert_equal({ 'metadatafield1' => '15', 'metadatafield3' => '35' }, @sample2.reload.metadata)
+      end
+
+      test 'import sample metadata with a multiple empty columns' do
+        assert_equal({}, @sample1.metadata)
+        assert_equal({}, @sample2.metadata)
+        params = { file: File.new('test/fixtures/files/metadata/contains_empty_columns.csv', 'r'),
+                   sample_id_column: 'sample_name' }
+        response = Samples::Metadata::FileImportService.new(@project.namespace, @john_doe,
+                                                            params).execute
+        assert_equal({ @sample1.name => { added: %w[metadatafield1 metadatafield3],
+                                          updated: [], deleted: [], not_updated: [], unchanged: [] },
+                       @sample2.name => { added: %w[metadatafield1 metadatafield3],
+                                          updated: [], deleted: [], not_updated: [], unchanged: [] } }, response)
+        assert_equal({ 'metadatafield1' => '10', 'metadatafield3' => '30' }, @sample1.reload.metadata)
+        assert_equal({ 'metadatafield1' => '15', 'metadatafield3' => '35' }, @sample2.reload.metadata)
+      end
+
       test 'import sample metadata with empty values set to true' do
         sample32 = samples(:sample32)
         project29 = projects(:project29)

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -518,6 +518,7 @@ module Projects
 
       Project.reset_counters(project2.id, :samples_count)
       visit namespace_project_samples_url(namespace1, project2)
+
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 220,
                                                                            locale: @user.locale))
     end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -521,6 +521,15 @@ module Projects
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 220,
                                                                            locale: @user.locale))
+
+      click_button I18n.t(:'projects.samples.index.select_all_button')
+
+      within 'tfoot' do
+        sample_counts = all('strong')
+        total_samples = sample_counts[0].text.to_i
+        selected_samples = sample_counts[1].text.to_i
+        assert selected_samples <= total_samples
+      end
     end
 
     test 'empty state of transfer sample project selection' do


### PR DESCRIPTION
## What does this PR do and why?
A server error was thrown when importing files with empty headers. Empty headers are now ignored.
Fixes DFCT0010289.

## Screenshots or screen recordings
Before:
![image](https://github.com/user-attachments/assets/30e8ea02-892f-4012-815c-746b152d7d98)

After:
![image](https://github.com/user-attachments/assets/0f11abf8-484c-4bd9-b873-cc7de4a2d46d)

## How to set up and validate locally
1. Navigate to a group samples page that the logged in user has access to update.
2. Hit the `Import Metadata` button.
3. Select a file that has empty headers.
4. Select the `Sample ID Column`.
5. Hit the `Import Metadata` button.
6. Verify the sample metadata was updated.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
