### PR TITLE
Metadata: Error when adding nested json

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1609,7 +1609,7 @@ en:
           key_exists: Sample already contains metadata field '%{key}'.
           metadata_was_not_changed: Metadata fields were not changed.
           user_cannot_edit_metadata_key: Metadata key '%{key}' cannot be updated by a user.
-        user_cannot_update_metadata: 'Metadata fields ''%{metadata_fields}'' of sample ''%{sample_name}'' cannot be overwritten by a user as it was previously updated with an analysis. '
+        user_cannot_update_metadata: Metadata fields '%{metadata_fields}' of sample '%{sample_name}' cannot be overwritten by a user as it was previously updated with an analysis.
       transfer:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1609,7 +1609,7 @@ fr:
           key_exists: Sample already contains metadata field '%{key}'.
           metadata_was_not_changed: Metadata fields were not changed.
           user_cannot_edit_metadata_key: Metadata key '%{key}' cannot be updated by a user.
-        user_cannot_update_metadata: 'Metadata fields ''%{metadata_fields}'' of sample ''%{sample_name}'' cannot be overwritten by a user as it was previously updated with an analysis. '
+        user_cannot_update_metadata: Metadata fields '%{metadata_fields}' of sample '%{sample_name}' cannot be overwritten by a user as it was previously updated with an analysis.
       transfer:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -282,7 +282,7 @@ module Samples
         params = { file: csv, sample_id_column: 'sample_name' }
         response = Samples::Metadata::FileImportService.new(project31.namespace, @john_doe, params).execute
         assert_empty response
-        assert_equal("Sample 'Sample 34' with field(s) 'metadatafield1, metadatafield3' cannot be updated.",
+        assert_equal("Sample 'Sample 34' with field(s) 'metadatafield1' cannot be updated.",
                      project31.namespace.errors.messages_for(:sample).first)
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2', 'metadatafield3' => '20' },
                      sample34.reload.metadata)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -168,8 +168,8 @@ module Samples
                                              'updated_at' => '2000-01-01T00:00:00.000+00:00' },
                        'metadatafield3' => { 'id' => @user.id, 'source' => 'user', 'updated_at' => Time.current } },
                      @sample34.metadata_provenance)
-        assert_equal({ added: %w[], updated: [], deleted: [],
-                       not_updated: %w[metadatafield1 metadatafield3], unchanged: [] }, metadata_changes)
+        assert_equal({ added: %w[metadatafield3], updated: [], deleted: [],
+                       not_updated: %w[metadatafield1], unchanged: [] }, metadata_changes)
         assert @sample34.errors.full_messages.include?(
           I18n.t('services.samples.metadata.user_cannot_update_metadata',
                  sample_name: @sample34.name,


### PR DESCRIPTION
## What does this PR do and why?
Updating the metadata update service to return an error message when users try to add nested json to sample metadata via GraphQL.

## Screenshots or screen recordings
N/A

## How to set up and validate locally
1. Navigate to `http://localhost:3000` and login as admin.
2. Navigate to `http://localhost:3000/graphiql`.
3. Run the following to retrieve a project:
```
query getProject{
  project(fullPath: "bacillus/bacillus-anthracis/outbreak-2022") {
    id
    name
    path
  }
}
```
4. Run the following to create a fresh sample:
```
mutation createSample{
  createSample(input: { 
    projectId: "<insert here>", 
    name: "Sample Name", 
    description: "Sample Description" 
  }) {
    sample {
      id,
      puid,
      name,
      description
    }
    errors {
      path,
      message
    }
  }
}
```
5. Run the following to add metadata to the sample:
```
mutation addMetadataToSample{
  updateSampleMetadata(input: {
    sampleId: "<insert here>", 
    metadata: { true_boolean: true, false_boolean: false, nil: null, empty: "", number: 123, date: "2024-03-11", nested_json: {key1: {key2: "value2"}} }
  }) {
    sample{
      id,
      name,
      description,
      metadata
    },
    status,
    errors {
      path
      message
    }
  }
}
```
6. Verify an error message was returned regard the nested_json.
7. Verify the sample metadata was unchanged.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
