### PR TITLE
Developer Experience: Remove solargraph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -160,9 +160,6 @@ group :development do
   gem 'listen'
   gem 'lookbook', '~> 2.1', '>= 2.1.1'
 
-  # Solargraph
-  gem 'solargraph'
-
   # i18n-tasks
   gem 'i18n-tasks', '~> 1.0.14'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,10 +126,8 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.9.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    benchmark (0.3.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -178,12 +176,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    diff-lcs (1.5.1)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.4.1)
     drb (2.2.1)
-    e2mmap (0.1.0)
     erb-formatter (0.7.3)
       syntax_tree (~> 6.0)
     erubi (1.13.0)
@@ -302,7 +298,6 @@ GEM
     irb (1.14.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jaro_winkler (1.6.0)
     jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -315,10 +310,6 @@ GEM
       simpleidn (~> 0.2)
     jwt (2.8.2)
       base64
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -413,7 +404,7 @@ GEM
     parallel (1.26.3)
     paranoia (3.0.0)
       activerecord (>= 6, < 8.1)
-    parser (3.3.4.2)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.7)
@@ -483,7 +474,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
@@ -498,10 +488,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     retriable (3.1.2)
-    reverse_markdown (2.1.1)
-      nokogiri
-    rexml (3.3.5)
-      strscan
+    rexml (3.3.8)
     roo (2.10.1)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
@@ -510,18 +497,17 @@ GEM
       roo (>= 2.0.0, < 3)
       spreadsheet (> 0.9.0)
     rouge (4.3.0)
-    rubocop (1.65.1)
+    rubocop (1.67.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.4, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.0)
+    rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
     rubocop-graphql (1.5.4)
       rubocop (>= 1.50, < 2)
@@ -555,22 +541,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    solargraph (0.50.0)
-      backport (~> 1.2)
-      benchmark
-      bundler (~> 2.0)
-      diff-lcs (~> 1.4)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      rbs (~> 2.0)
-      reverse_markdown (~> 2.0)
-      rubocop (~> 1.38)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
     spreadsheet (1.3.1)
       bigdecimal
       ruby-ole
@@ -584,7 +554,6 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.1)
-    strscan (3.1.0)
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
     tailwindcss-rails (2.7.6)
@@ -601,8 +570,7 @@ GEM
       railties (>= 7.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.3.1)
-    tilt (2.4.0)
+    thor (1.3.2)
     timecop (0.9.10)
     timeout (0.4.1)
     trailblazer-option (0.1.2)
@@ -615,7 +583,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
     uri (0.13.0)
     useragent (0.16.10)
     version_gem (1.1.4)
@@ -640,7 +608,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.36)
+    yard (0.9.37)
     zeitwerk (2.6.17)
     zip_kit (6.3.1)
 
@@ -714,7 +682,6 @@ DEPENDENCIES
   rubocop-rails
   search_syntax
   simplecov
-  solargraph
   sprockets-rails
   stimulus-rails
   tailwindcss-rails (~> 2.7)


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Removes `solargraph` gem to allow using latest version of `shopify.ruby-lsp` vscode extension.

See https://github.com/Shopify/ruby-lsp/issues/2282

Reference for ruby-lsp here https://shopify.github.io/ruby-lsp/rails-add-on.html

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Go to extensions in vscode
2. Search for `ruby-lsp`
3. Install the latest version and enable auto updates
![image](https://github.com/user-attachments/assets/96394fbe-32d7-43db-b0dc-1c0517fd7edd)
4. View an erb file after ruby-lsp is loaded and see that no errors are present

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
