### PR TITLE
Fix Activity Component Preview

### DIFF
--- a/test/components/previews/activity_component_preview.rb
+++ b/test/components/previews/activity_component_preview.rb
@@ -7,9 +7,11 @@ class ActivityComponentPreview < ViewComponent::Preview
   def default
     project_namespace = Project.first.namespace
     @activities = project_namespace.human_readable_activity(project_namespace.retrieve_project_activity).reverse
+    @pagy = Pagy.new(count: @activities.length, page: 1, limit: 10)
 
     render_with_template(locals: {
-                           activities: @activities
+                           activities: @activities,
+                           pagy: @pagy
                          })
   end
 end

--- a/test/components/previews/activity_component_preview/default.html.erb
+++ b/test/components/previews/activity_component_preview/default.html.erb
@@ -1,1 +1,1 @@
-<%= render ActivityComponent.new(activities:) %>
+<%= render ActivityComponent.new(activities:, pagy:) %>


### PR DESCRIPTION
## What does this PR do and why?
Fixing the broken  activity component preview. 

## Screenshots or screen recordings
Before:
![image](https://github.com/user-attachments/assets/f51acc5e-baa3-4c3c-a5ae-e5058110dcbd)

After:
![image](https://github.com/user-attachments/assets/329a70bb-7401-4c23-9817-c25bbcef1027)

## How to set up and validate locally
1. Navigate to `http://localhost:3000/rails/lookbook/inspect/activity/default`.
2. Verify the activity component preview loads.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
