### PR TITLE
Fix: Render flat list for groups when filtering

### DIFF
--- a/app/controllers/dashboard/groups_controller.rb
+++ b/app/controllers/dashboard/groups_controller.rb
@@ -4,6 +4,7 @@ module Dashboard
   # Dashboard groups controller
   class GroupsController < ApplicationController
     before_action :current_page
+    before_action :render_flat_list, only: %i[index]
 
     def index
       @q = build_ransack_query
@@ -14,8 +15,8 @@ module Dashboard
 
     private
 
-    def flat_list_requested?
-      params.dig(:q, :name_or_puid_cont).present?
+    def render_flat_list
+      @render_flat_list = params.dig(:q, :name_or_puid_cont).present?
     end
 
     def build_ransack_query
@@ -53,7 +54,7 @@ module Dashboard
     end
 
     def authorized_groups
-      if flat_list_requested?
+      if @render_flat_list
         authorized_scope(Group, type: :relation)
       else
         authorized_scope(Group, type: :relation).without_descendants

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,7 +4,7 @@
 class GroupsController < Groups::ApplicationController # rubocop:disable Metrics/ClassLength
   layout :resolve_layout
   before_action :parent_group, only: %i[new]
-  before_action :tab, only: %i[show]
+  before_action :tab, :render_flat_list, only: %i[show]
   before_action :group, only: %i[activity edit show destroy update transfer]
   before_action :authorized_namespaces, except: %i[index show destroy]
   before_action :current_page
@@ -16,7 +16,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   def show
     authorize! @group, to: :read?
 
-    @q = if flat_list_requested?
+    @q = if @render_flat_list
            namespace_descendants.ransack(params[:q])
          else
            namespace_children.ransack(params[:q])
@@ -117,8 +117,8 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     @q.sorts = 'created_at desc' if @q.sorts.empty?
   end
 
-  def flat_list_requested?
-    params.dig(:q, :name_or_puid_cont).present?
+  def render_flat_list
+    @render_flat_list = params.dig(:q, :name_or_puid_cont).present?
   end
 
   def parent_group

--- a/app/views/groups/subgroups/_index.html.erb
+++ b/app/views/groups/subgroups/_index.html.erb
@@ -8,6 +8,7 @@
         group_id: @group.full_path,
       },
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
+      render_flat_list: @render_flat_list,
     ) %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: "Subgroups and projects") %>
   <% else %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -34,7 +34,7 @@ jobs: &jobs
 development:
   primary:
     <<: *default
-    database: irida_next_development
+    database: irida_next_test
   jobs:
     <<: *jobs
     database: irida_next_jobs_development

--- a/config/database.yml
+++ b/config/database.yml
@@ -34,7 +34,7 @@ jobs: &jobs
 development:
   primary:
     <<: *default
-    database: irida_next_test
+    database: irida_next_development
   jobs:
     <<: *jobs
     database: irida_next_jobs_development

--- a/test/system/dashboard/groups_test.rb
+++ b/test/system/dashboard/groups_test.rb
@@ -205,5 +205,33 @@ module Dashboard
       find('input.t-search-component').native.send_keys(:return)
       assert_text I18n.t(:'dashboard.groups.index.no_groups_description')
     end
+
+    test 'filtering renders flat list' do
+      group1 = groups(:group_one)
+      group3 = groups(:group_three)
+      login_as users(:john_doe)
+      visit dashboard_groups_url
+
+      within('#groups_tree') do
+        within("#group_#{group1.id}") do
+          assert_text group1.name
+          assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+        end
+
+        within("#group_#{group3.id}") do
+          assert_text group3.name
+          assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+        end
+      end
+
+      fill_in I18n.t(:'dashboard.groups.index.search.placeholder'), with: 'group'
+      find('input.t-search-component').native.send_keys(:return)
+
+      within('#groups_tree') do
+        assert_text group1.name
+        assert_text group3.name
+        assert_no_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+      end
+    end
   end
 end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -413,4 +413,37 @@ class GroupsTest < ApplicationSystemTestCase
 
     assert_selector 'li.namespace-entry', count: 5
   end
+
+  test 'filtering renders flat list for subgroups and projects' do
+    group12 = groups(:group_twelve)
+    subgroup12a = groups(:subgroup_twelve_a)
+    subgroup12b = groups(:subgroup_twelve_b)
+    subgroup12aa = groups(:subgroup_twelve_a_a)
+
+    visit group_url(group12)
+
+    within('div.namespace-tree-container') do
+      assert_selector 'li', count: 2
+      within("#group_#{subgroup12a.id}") do
+        assert_text subgroup12a.name
+        assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+      end
+
+      within("#group_#{subgroup12b.id}") do
+        assert_text subgroup12b.name
+        assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+      end
+    end
+
+    fill_in I18n.t(:'general.search.name_puid'), with: 'subgroup'
+    find('input.t-search-component').native.send_keys(:return)
+
+    within('div.namespace-tree-container') do
+      assert_selector 'li', count: 3
+      assert_text subgroup12a.name
+      assert_text subgroup12b.name
+      assert_text subgroup12aa.name
+      assert_no_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+    end
+  end
 end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -433,6 +433,8 @@ class GroupsTest < ApplicationSystemTestCase
         assert_text subgroup12b.name
         assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
       end
+
+      assert_no_text subgroup12aa.name
     end
 
     fill_in I18n.t(:'general.search.name_puid'), with: 'subgroup'


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where the expected flat list when filtering for groups (on dashboard and subgroups/projects) was not rendering properly.

## Screenshots or screen recordings
Before:
![image](https://github.com/user-attachments/assets/07499791-0e63-432d-a8df-ca84121949cf)

Now:
![image](https://github.com/user-attachments/assets/792e0e64-2c56-40c2-ab9b-8f03d8c129a0)

## How to set up and validate locally
On both dashboard groups and groups subgroups and projects
1. Use the search bar to filter down the list (filter with an overlapping name a group(s) and their subgroup(s)). 
2. Verify any groups that would have subgroups no longer has the dropdown to view its subgroups within, and that any subgroups that fit the filter are now listed.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
