### PR TITLE
Shared Groups: Filter

### DIFF
--- a/app/components/namespace_tree/namespace_tree_component.html.erb
+++ b/app/components/namespace_tree/namespace_tree_component.html.erb
@@ -6,6 +6,7 @@
     type: @type,
     collapsed: collapsed,
     render_flat_list: render_flat_list,
+    search_params: search_params,
     icon_size: icon_size,
   ) %>
 </ul>

--- a/app/components/namespace_tree/namespace_tree_component.rb
+++ b/app/components/namespace_tree/namespace_tree_component.rb
@@ -3,11 +3,11 @@
 module NamespaceTree
   # Component to render a namespace tree
   class NamespaceTreeComponent < Component
-    attr_reader :collapsed, :icon_size, :namespaces, :parent, :path, :path_args, :render_flat_list
+    attr_reader :collapsed, :icon_size, :namespaces, :parent, :path, :path_args, :render_flat_list, :search_params
 
     # rubocop: disable Metrics/ParameterLists
     def initialize(namespaces:, type:, parent: nil, path: nil, path_args: {}, render_flat_list: false,
-                   icon_size: :small)
+                   search_params: nil, icon_size: :small)
       @parent = parent
       @namespaces = namespaces
       @path = path
@@ -15,6 +15,7 @@ module NamespaceTree
       @type = type
       @collapsed = true
       @render_flat_list = render_flat_list
+      @search_params = search_params
       @icon_size = icon_size
     end
 

--- a/app/components/namespace_tree/row/row_contents_component.html.erb
+++ b/app/components/namespace_tree/row/row_contents_component.html.erb
@@ -28,13 +28,26 @@
       <div class="flex flex-wrap items-center mr-3 font-semibold title">
         <div class="flex items-center space-x-2">
           <% if @namespace.type == "Group" %>
-            <%= link_to @namespace.name, group_path(@namespace), data: { turbo: false } %>
+            <%= link_to group_path(@namespace), data: { turbo: false } do %>
+              <%= highlight(
+                @namespace.name,
+                defined?(@search_params[:name_or_puid_cont]) &&
+                  @search_params[:name_or_puid_cont],
+                highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>',
+              ) %>
+            <% end %>
           <% else %>
-            <%= link_to @namespace.name,
-            project_path(@namespace.project),
+            <%= link_to project_path(@namespace.project),
             data: {
               turbo: false,
-            } %>
+            } do %>
+              <%= highlight(
+                @namespace.name,
+                defined?(@search_params[:name_or_puid_cont]) &&
+                  @search_params[:name_or_puid_cont],
+                highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>',
+              ) %>
+            <% end %>
           <% end %>
           <%= render PuidComponent.new(puid: @namespace.puid) %>
           <%= viral_pill(

--- a/app/components/namespace_tree/row/row_contents_component.rb
+++ b/app/components/namespace_tree/row/row_contents_component.rb
@@ -4,13 +4,17 @@ module NamespaceTree
   module Row
     # Component for the contents of NamespaceTree row
     class RowContentsComponent < Viral::Component
-      def initialize(namespace:, path: nil, path_args: {}, collapsed: false, icon_size: :small)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(namespace:, path: nil, path_args: {}, collapsed: false, icon_size: :small, search_params: nil)
         @namespace = namespace
         @path = path
         @path_args = path_args
         @collapsed = collapsed
         @icon_size = icon_size
+        @search_params = search_params
       end
+
+      # rubocop:enable Metrics/ParameterLists
     end
   end
 end

--- a/app/components/namespace_tree/row/without_children_component.html.erb
+++ b/app/components/namespace_tree/row/without_children_component.html.erb
@@ -10,6 +10,7 @@
       path: @path,
       path_args: @path_args,
       icon_size: @icon_size,
+      search_params: @search_params
     ) %>
   </div>
 </li>

--- a/app/components/namespace_tree/row/without_children_component.rb
+++ b/app/components/namespace_tree/row/without_children_component.rb
@@ -4,11 +4,12 @@ module NamespaceTree
   module Row
     # Component for the contents of a namespace row that has no children
     class WithoutChildrenComponent < Viral::Component
-      def initialize(namespace:, path: nil, path_args: {}, icon_size: :small)
+      def initialize(namespace:, path: nil, path_args: {}, icon_size: :small, search_params: nil)
         @namespace = namespace
         @path = path
         @path_args = path_args
         @icon_size = icon_size
+        @search_params = search_params
       end
     end
   end

--- a/app/components/namespace_tree/row_component.rb
+++ b/app/components/namespace_tree/row_component.rb
@@ -9,19 +9,20 @@ module NamespaceTree
       <% if @namespace.children_of_type?(@type) && !@render_flat_list %>
         <%= render NamespaceTree::Row::WithChildrenComponent.new(namespace: @namespace, type: @type, children: Group.none, path: @path, path_args: @path_args, collapsed: @collapsed, icon_size: @icon_size) %>
         <% else %>
-        <%= render NamespaceTree::Row::WithoutChildrenComponent.new(namespace: @namespace, path: @path, path_args: @path_args, icon_size: @icon_size) %>
+        <%= render NamespaceTree::Row::WithoutChildrenComponent.new(namespace: @namespace, path: @path, path_args: @path_args, icon_size: @icon_size, search_params: @search_params) %>
       <% end %>
     ERB
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(namespace:, type:, path: nil, path_args: {}, collapsed: true, render_flat_list: false,
-                   icon_size: :small)
+                   search_params: nil, icon_size: :small)
       @namespace = namespace
       @type = type
       @path = path
       @path_args = path_args
       @collapsed = collapsed
       @render_flat_list = render_flat_list
+      @search_params = search_params
       @icon_size = icon_size
     end
 

--- a/app/components/namespace_tree_container_component.rb
+++ b/app/components/namespace_tree_container_component.rb
@@ -4,19 +4,20 @@
 class NamespaceTreeContainerComponent < ViewComponent::Base
   erb_template <<-ERB
       <div class="namespace-tree-container">
-        <%= render NamespaceTree::NamespaceTreeComponent.new(namespaces: @namespaces, path: @path, path_args: @path_args, type: @type, render_flat_list: @render_flat_list, icon_size: @icon_size) %>
+        <%= render NamespaceTree::NamespaceTreeComponent.new(namespaces: @namespaces, path: @path, path_args: @path_args, type: @type, render_flat_list: @render_flat_list, icon_size: @icon_size, search_params: @search_params) %>
       </div>
   ERB
 
   # rubocop: disable Metrics/ParameterLists
   def initialize(namespaces:, path: nil, path_args: {}, type: Group.sti_name, render_flat_list: false,
-                 icon_size: :small)
+                 icon_size: :small, search_params: nil)
     @namespaces = namespaces
     @path = path
     @path_args = path_args
     @type = type
     @render_flat_list = render_flat_list
     @icon_size = icon_size
+    @search_params = search_params
   end
   # rubocop: enable Metrics/ParameterLists
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -17,6 +17,8 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     authorize! @group, to: :read?
 
     @q = namespaces_query
+    @search_params = search_params
+
     set_default_sort
     @pagy, @namespaces = pagy(@q.result.include_route)
   end
@@ -224,6 +226,12 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
                     else
                       t(:'groups.sidebar.general')
                     end
+  end
+
+  def search_params
+    search_params = {}
+    search_params[:name_or_puid_cont] = params.dig(:q, :name_or_puid_cont)
+    search_params
   end
 
   protected

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -136,13 +136,13 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
 
   def namespaces_query
     if @tab == 'shared_namespaces'
-      if flat_list_requested?
+      if @render_flat_list
         shared_namespaces_descendants.ransack(params[:q])
       else
         @group.shared_namespaces.ransack(params[:q])
       end
 
-    elsif flat_list_requested?
+    elsif @render_flat_list
       namespace_descendants.ransack(params[:q])
     else
       namespace_children.ransack(params[:q])

--- a/app/views/groups/shared_namespaces/_index.html.erb
+++ b/app/views/groups/shared_namespaces/_index.html.erb
@@ -13,8 +13,8 @@
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: "Shared groups and projects") %>
   <% else %>
     <%= viral_empty(
-      title: t(:"groups.show.subgroups.no_subgroups.title"),
-      description: t(:"groups.show.subgroups.no_subgroups.description"),
+      title: t(:"groups.show.shared_namespaces.no_shared.title"),
+      description: t(:"groups.show.shared_namespaces.no_shared.description"),
       icon_name: :squares_2x2,
     ) %>
   <% end %>

--- a/app/views/groups/shared_namespaces/_index.html.erb
+++ b/app/views/groups/shared_namespaces/_index.html.erb
@@ -8,6 +8,7 @@
         group_id: @group.full_path
       },
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
+      render_flat_list: @render_flat_list,
     ) %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: "Shared groups and projects") %>
   <% else %>

--- a/app/views/groups/shared_namespaces/_index.html.erb
+++ b/app/views/groups/shared_namespaces/_index.html.erb
@@ -1,18 +1,20 @@
-<%= turbo_stream.update "group_show_tab_content" do %>
+<div class="space-y-2">
+
   <% if @namespaces.length > 0 %>
     <%= render NamespaceTreeContainerComponent.new(
       namespaces: @namespaces,
       path: "group_subgroups_path",
       path_args: {
-        group_id: @group.full_path,
+        group_id: @group.full_path
       },
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
     ) %>
+    <%= render Viral::Pagy::FullComponent.new(@pagy, item: "Shared groups and projects") %>
   <% else %>
     <%= viral_empty(
-      title: t(:"groups.show.shared_namespaces.no_shared.title"),
-      description: t(:"groups.show.shared_namespaces.no_shared.description"),
+      title: t(:"groups.show.subgroups.no_subgroups.title"),
+      description: t(:"groups.show.subgroups.no_subgroups.description"),
       icon_name: :squares_2x2,
     ) %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/groups/shared_namespaces/_index.html.erb
+++ b/app/views/groups/shared_namespaces/_index.html.erb
@@ -10,7 +10,7 @@
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
       render_flat_list: @render_flat_list,
     ) %>
-    <%= render Viral::Pagy::FullComponent.new(@pagy, item: "Shared groups and projects") %>
+    <%= render Viral::Pagy::FullComponent.new(@pagy, item: t(".pagy.item")) %>
   <% else %>
     <%= viral_empty(
       title: t(:"groups.show.shared_namespaces.no_shared.title"),

--- a/app/views/groups/shared_namespaces/_index.html.erb
+++ b/app/views/groups/shared_namespaces/_index.html.erb
@@ -5,7 +5,7 @@
       namespaces: @namespaces,
       path: "group_subgroups_path",
       path_args: {
-        group_id: @group.full_path
+        group_id: @group.full_path,
       },
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
       render_flat_list: @render_flat_list,

--- a/app/views/groups/shared_namespaces/_index.html.erb
+++ b/app/views/groups/shared_namespaces/_index.html.erb
@@ -9,6 +9,7 @@
       },
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
       render_flat_list: @render_flat_list,
+      search_params: @search_params
     ) %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: t(".pagy.item")) %>
   <% else %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -28,17 +28,18 @@
 
   <%= tabs.with_tab_content do %>
     <div class="mt-2">
+      <div class="flex flex-row-reverse mb-2">
+        <%= render SearchComponent.new(query: @q, url: group_path(@group), search_attribute: :name_or_puid_cont, placeholder: t(".search.placeholder")) do %>
+
+          <% if @tab == "shared_namespaces" %>
+            <input type="hidden" name="tab" value="shared_namespaces">
+          <% end %>
+        <% end %>
+      </div>
+
       <% if @tab == "shared_namespaces" %>
-        <div class="flex flex-row-reverse mb-2">
-            <%= render SearchComponent.new(query: @q, url: group_path(@group), search_attribute: :name_or_puid_cont, placeholder: t(".search.placeholder")) do %>
-              <input type="hidden" name="tab" value="shared_namespaces">
-            <% end %>
-        </div>
         <%= render "groups/shared_namespaces/index", locals: { namespaces: @namespaces } %>
       <% else %>
-        <div class="flex flex-row-reverse mb-2">
-            <%= render SearchComponent.new(query: @q, url: group_path(@group), search_attribute: :name_or_puid_cont, placeholder: t("general.search.name_puid")) %>
-        </div>
         <%= render "groups/subgroups/index", locals: { namespaces: @namespaces } %>
       <% end %>
     </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -29,30 +29,12 @@
   <%= tabs.with_tab_content do %>
     <div class="mt-2">
       <% if @tab == "shared_namespaces" %>
-        <%= turbo_frame_tag "group_show_tab_content", "data-turbo-temporary": true, src: group_shared_namespaces_path(@group, format: :turbo_stream) do %>
-          <table class="min-w-full table-fixed dark:divide-slate-600">
-            <tbody
-              class="
-                bg-white divide-y divide-slate-200 dark:bg-slate-800 dark:divide-slate-700
-              "
-            >
-              <% 10.times do %>
-                <tr>
-
-                  <td class="p-4 animate-pulse">
-                    <div class="flex-1 py-1 space-y-6">
-                      <div class="space-y-3">
-                        <div class="w-48 h-2 rounded bg-slate-200"></div>
-                        <div class="w-32 h-2 rounded bg-slate-200"></div>
-                      </div>
-                    </div>
-                  </td>
-
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        <% end %>
+        <div class="flex flex-row-reverse mb-2">
+            <%= render SearchComponent.new(query: @q, url: group_path(@group), search_attribute: :name_or_puid_cont, placeholder: t(".search.placeholder")) do %>
+              <input type="hidden" name="tab" value="shared_namespaces">
+            <% end %>
+        </div>
+        <%= render "groups/shared_namespaces/index", locals: { namespaces: @namespaces } %>
       <% else %>
         <div class="flex flex-row-reverse mb-2">
             <%= render SearchComponent.new(query: @q, url: group_path(@group), search_attribute: :name_or_puid_cont, placeholder: t("general.search.name_puid")) %>

--- a/app/views/groups/subgroups/_index.html.erb
+++ b/app/views/groups/subgroups/_index.html.erb
@@ -9,6 +9,7 @@
       },
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
       render_flat_list: @render_flat_list,
+      search_params: @search_params
     ) %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: t('.pagy.item')) %>
   <% else %>

--- a/app/views/groups/subgroups/_index.html.erb
+++ b/app/views/groups/subgroups/_index.html.erb
@@ -10,7 +10,7 @@
       type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
       render_flat_list: @render_flat_list,
     ) %>
-    <%= render Viral::Pagy::FullComponent.new(@pagy, item: "Subgroups and projects") %>
+    <%= render Viral::Pagy::FullComponent.new(@pagy, item: t('.pagy.item')) %>
   <% else %>
     <%= viral_empty(
       title: t(:"groups.show.subgroups.no_subgroups.title"),

--- a/app/views/groups/subgroups/index.turbo_stream.erb
+++ b/app/views/groups/subgroups/index.turbo_stream.erb
@@ -1,15 +1,18 @@
 <%= turbo_stream.update "group_show_tab_content" do %>
   <% if @namespaces.length > 0 %>
-  <%= render NamespaceTreeContainerComponent.new(
-    namespaces: @namespaces,
-    path: "group_subgroups_path",
-    path_args: { group_id: @group.full_path },
-    type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name]
-  ) %>
+    <%= render NamespaceTreeContainerComponent.new(
+      namespaces: @namespaces,
+      path: "group_subgroups_path",
+      path_args: {
+        group_id: @group.full_path,
+      },
+      type: [Group.sti_name, Namespaces::ProjectNamespace.sti_name],
+    ) %>
   <% else %>
     <%= viral_empty(
-          title: t(:"groups.show.subgroups.no_subgroups.title"),
-          description: t(:'groups.show.subgroups.no_subgroups.description'),
-          icon_name: :squares_2x2) %>
+      title: t(:"groups.show.subgroups.no_subgroups.title"),
+      description: t(:"groups.show.subgroups.no_subgroups.description"),
+      icon_name: :squares_2x2,
+    ) %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -427,7 +427,7 @@ en:
         no_groups_title: No groups found
         row_aria_label: See %{name} subgroups
         search:
-          placeholder: Filter by name or puid
+          placeholder: Filter by ID or name
         sorting:
           created_at_asc: Oldest created
           created_at_desc: Last created
@@ -444,7 +444,7 @@ en:
         row:
           samples: Samples
         search:
-          placeholder: Filter by name or puid
+          placeholder: Filter by ID or name
         sorting:
           created_at_asc: Oldest created
           created_at_desc: Last created

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,8 +580,6 @@ en:
         project: Create new project
     screen_reader:
       close: Close
-    search:
-      name_puid: Search by name or ID
   groups:
     activity:
       title: Group activity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -792,6 +792,8 @@ en:
     show:
       create_project_button: New project
       create_subgroup_button: New subgroup
+      search:
+        placeholder: Filter by ID or name
       shared_namespaces:
         no_shared:
           description: Groups and projects can be shared with other groups through their members page.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -787,6 +787,10 @@ en:
       table:
         no_associated_samples: There are no samples associated with this group.
         no_samples: No Samples
+    shared_namespaces:
+      index:
+        pagy:
+          item: Shared groups and projects
     show:
       create_project_button: New project
       create_subgroup_button: New subgroup
@@ -814,6 +818,10 @@ en:
       members: Members
       samples: Samples
       settings: Settings
+    subgroups:
+      index:
+        pagy:
+          item: Subgroups and projects
     table_component:
       action: Action
       expires_at: Expiration

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -580,8 +580,6 @@ fr:
         project: Create new project
     screen_reader:
       close: Close
-    search:
-      name_puid: Search by name or ID
   groups:
     activity:
       title: Group activity

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -787,6 +787,10 @@ fr:
       table:
         no_associated_samples: There are no samples associated with this group.
         no_samples: No Samples
+    shared_namespaces:
+      index:
+        pagy:
+          item: Shared groups and projects
     show:
       create_project_button: New project
       create_subgroup_button: New subgroup
@@ -814,6 +818,10 @@ fr:
       members: Members
       samples: Samples
       settings: Settings
+    subgroups:
+      index:
+        pagy:
+          item: Subgroups and projects
     table_component:
       action: Action
       expires_at: Expiration

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -792,6 +792,8 @@ fr:
     show:
       create_project_button: New project
       create_subgroup_button: New subgroup
+      search:
+        placeholder: Filter by ID or name
       shared_namespaces:
         no_shared:
           description: Groups and projects can be shared with other groups through their members page.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -427,7 +427,7 @@ fr:
         no_groups_title: No groups found
         row_aria_label: See %{name} subgroups
         search:
-          placeholder: Filter by name or puid
+          placeholder: Filter by ID or name
         sorting:
           created_at_asc: Oldest created
           created_at_desc: Last created
@@ -444,7 +444,7 @@ fr:
         row:
           samples: Samples
         search:
-          placeholder: Filter by name or puid
+          placeholder: Filter by ID or name
         sorting:
           created_at_asc: Oldest created
           created_at_desc: Last created

--- a/test/system/dashboard/groups_test.rb
+++ b/test/system/dashboard/groups_test.rb
@@ -155,17 +155,20 @@ module Dashboard
 
     test 'can expand parent groups to see their children' do
       login_as users(:john_doe)
+      group1 = groups(:group_one)
+      subgroup1 = groups(:subgroup1)
       visit dashboard_groups_url
 
-      within :xpath, "//li[contains(@class, 'namespace-entry')][.//*/a[text()='#{groups(:group_one).name}']]" do
-        assert_text groups(:group_one).name
+      within("li#group_#{group1.id}") do
+        assert_text group1.name
         assert_no_selector 'ul.groups-list.namespace-list-tree'
+        assert_no_text subgroup1.name
         find('a.folder-toggle-wrap').click
       end
 
-      within(:xpath, "//li[contains(@class, 'namespace-entry')][.//*/a[text()='#{groups(:group_one).name}']]") do
-        assert_text groups(:group_one).name
-        assert_text groups(:subgroup1).name
+      within("li#group_#{group1.id}") do
+        assert_text group1.name
+        assert_text subgroup1.name
       end
     end
 

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -10,6 +10,8 @@ class GroupsTest < ApplicationSystemTestCase
     @subgroup12a = groups(:subgroup_twelve_a)
     @subgroup12aa = groups(:subgroup_twelve_a_a)
     @subgroup12b = groups(:subgroup_twelve_b)
+    @group6 = groups(:group_six)
+    @subgroup2 = groups(:subgroup2)
     login_as @user
   end
 
@@ -869,17 +871,15 @@ class GroupsTest < ApplicationSystemTestCase
   end
 
   test 'filter shared groups and projects by puid' do
-    group6 = groups(:group_six)
-    subgroup2 = groups(:subgroup2)
     subgroup3 = groups(:subgroup3)
-    visit group_url(group6)
+    visit group_url(@group6)
 
     click_on I18n.t(:'groups.show.tabs.shared_namespaces')
 
     within('div.namespace-tree-container') do
       assert_selector 'li', count: 1
-      within("#group_#{subgroup2.id}") do
-        assert_text subgroup2.name
+      within("#group_#{@subgroup2.id}") do
+        assert_text @subgroup2.name
         assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
       end
       assert_no_text subgroup3.name
@@ -898,16 +898,14 @@ class GroupsTest < ApplicationSystemTestCase
   end
 
   test 'filtering renders flat list for shared groups and projects' do
-    group6 = groups(:group_six)
-    subgroup2 = groups(:subgroup2)
-    visit group_url(group6)
+    visit group_url(@group6)
 
     click_on I18n.t(:'groups.show.tabs.shared_namespaces')
 
     within('div.namespace-tree-container') do
       assert_selector 'li', count: 1
-      within("#group_#{subgroup2.id}") do
-        assert_text subgroup2.name
+      within("#group_#{@subgroup2.id}") do
+        assert_text @subgroup2.name
         assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
       end
 
@@ -924,7 +922,7 @@ class GroupsTest < ApplicationSystemTestCase
 
     within('div.namespace-tree-container') do
       assert_selector 'li', count: 9
-      assert_text subgroup2.name
+      assert_text @subgroup2.name
 
       subgroup_num = 3
       8.times do
@@ -934,5 +932,38 @@ class GroupsTest < ApplicationSystemTestCase
 
       assert_no_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
     end
+  end
+
+  test 'displays empty state result after filtering subgroups and projects' do
+    visit group_url(@group6)
+
+    assert_no_text I18n.t('groups.show.subgroups.no_subgroups.title')
+    assert_no_text I18n.t('groups.show.subgroups.no_subgroups.description')
+
+    input_field = find('input.t-search-component')
+    input_field.fill_in with: 'invalid filter'
+    input_field.native.send_keys(:return)
+
+    assert_selector 'div.namespace-entry-contents', count: 0
+
+    assert_text I18n.t('groups.show.subgroups.no_subgroups.title')
+    assert_text I18n.t('groups.show.subgroups.no_subgroups.description')
+  end
+
+  test 'displays empty state result after filtering shared namespaces' do
+    visit group_url(@group6)
+
+    click_on I18n.t(:'groups.show.tabs.shared_namespaces')
+
+    assert_no_text I18n.t('groups.show.shared_namespaces.no_shared.title')
+    assert_no_text I18n.t('groups.show.shared_namespaces.no_shared.description')
+
+    input_field = find('input.t-search-component')
+    input_field.fill_in with: 'invalid filter'
+    input_field.native.send_keys(:return)
+
+    assert_selector 'div.namespace-entry-contents', count: 0
+    assert_text I18n.t('groups.show.shared_namespaces.no_shared.title')
+    assert_text I18n.t('groups.show.shared_namespaces.no_shared.description')
   end
 end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -867,4 +867,42 @@ class GroupsTest < ApplicationSystemTestCase
       assert_text @subgroup12b.samples_count
     end
   end
+
+  test 'filtering renders flat list for shared groups and projects' do
+    group6 = groups(:group_six)
+    subgroup2 = groups(:subgroup2)
+    visit group_url(group6)
+
+    click_on I18n.t(:'groups.show.tabs.shared_namespaces')
+
+    within('div.namespace-tree-container') do
+      assert_selector 'li', count: 1
+      within("#group_#{subgroup2.id}") do
+        assert_text subgroup2.name
+        assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+      end
+
+      subgroup_num = 3
+      8.times do
+        assert_no_text "Subgroup #{subgroup_num}"
+        subgroup_num += 1
+      end
+    end
+
+    fill_in I18n.t(:'groups.show.search.placeholder'), with: 'subgroup'
+    find('input.t-search-component').native.send_keys(:return)
+
+    within('div.namespace-tree-container') do
+      assert_selector 'li', count: 9
+      assert_text subgroup2.name
+
+      subgroup_num = 3
+      8.times do
+        assert_text "Subgroup #{subgroup_num}"
+        subgroup_num += 1
+      end
+
+      assert_no_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+    end
+  end
 end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -868,6 +868,35 @@ class GroupsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'filter shared groups and projects by puid' do
+    group6 = groups(:group_six)
+    subgroup2 = groups(:subgroup2)
+    subgroup3 = groups(:subgroup3)
+    visit group_url(group6)
+
+    click_on I18n.t(:'groups.show.tabs.shared_namespaces')
+
+    within('div.namespace-tree-container') do
+      assert_selector 'li', count: 1
+      within("#group_#{subgroup2.id}") do
+        assert_text subgroup2.name
+        assert_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+      end
+      assert_no_text subgroup3.name
+      assert_no_selector "li#group_#{subgroup3.id}"
+    end
+
+    input_field = find('input.t-search-component')
+    input_field.fill_in with: subgroup3.puid
+    input_field.native.send_keys(:return)
+
+    within('div.namespace-tree-container') do
+      assert_selector 'li', count: 1
+      assert_text subgroup3.name
+      assert_no_selector 'svg[class="Viral-Icon__Svg icon-chevron_right"]'
+    end
+  end
+
   test 'filtering renders flat list for shared groups and projects' do
     group6 = groups(:group_six)
     subgroup2 = groups(:subgroup2)
@@ -889,8 +918,9 @@ class GroupsTest < ApplicationSystemTestCase
       end
     end
 
-    fill_in I18n.t('groups.show.search.placeholder'), with: 'subgroup'
-    find('input.t-search-component').native.send_keys(:return)
+    input_field = find('input.t-search-component')
+    input_field.fill_in with: 'subgroup'
+    input_field.native.send_keys(:return)
 
     within('div.namespace-tree-container') do
       assert_selector 'li', count: 9

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -412,7 +412,7 @@ class GroupsTest < ApplicationSystemTestCase
     @group = groups(:group_one)
     visit group_url(@group)
     assert_text I18n.t(:'components.pagination.next')
-    fill_in I18n.t('general.search.name_puid'), with: 'project 2'
+    fill_in I18n.t('groups.show.search.placeholder'), with: 'project 2'
     find('input.t-search-component').native.send_keys(:return)
 
     assert_selector 'li.namespace-entry', count: 5
@@ -441,7 +441,7 @@ class GroupsTest < ApplicationSystemTestCase
       assert_no_text subgroup12aa.name
     end
 
-    fill_in I18n.t(:'general.search.name_puid'), with: 'subgroup'
+    fill_in I18n.t('groups.show.search.placeholder'), with: 'subgroup'
     find('input.t-search-component').native.send_keys(:return)
 
     within('div.namespace-tree-container') do
@@ -889,7 +889,7 @@ class GroupsTest < ApplicationSystemTestCase
       end
     end
 
-    fill_in I18n.t(:'groups.show.search.placeholder'), with: 'subgroup'
+    fill_in I18n.t('groups.show.search.placeholder'), with: 'subgroup'
     find('input.t-search-component').native.send_keys(:return)
 
     within('div.namespace-tree-container') do


### PR DESCRIPTION
## What does this PR do and why?
This PR adds filtering to groups' shared groups and projects.

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/afa2edb8-0864-401e-b97a-5bef53311d81)

By name:
![image](https://github.com/user-attachments/assets/1553ed3d-93b8-41f0-85b1-f89b126cbe40)

By PUID:
![image](https://github.com/user-attachments/assets/0ecb6127-c2b6-4efd-82a1-582f324ddcb7)

Search including projects:
![image](https://github.com/user-attachments/assets/25e4f7a7-6415-457e-a72d-d571dd208ed6)

## How to set up and validate locally
1. Navigate to a groups' shared groups and projects tab (Bacillus has seeded shared groups)
2. Use the filter and filter by name and puid. Ensure filtering works as expected

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
