### PR TITLE
Pagy: Fix overflow setting

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -145,8 +145,8 @@ require 'pagy/extras/limit'
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/docs/extras/overflow
-# require 'pagy/extras/overflow'
-# Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
+require 'pagy/extras/overflow'
+Pagy::DEFAULT[:overflow] = :last_page # default  (other options: :last_page and :exception)
 
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/docs/extras/trim


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where if you are currently on a pagy page and the `pagy limit` is changed to where that page no longer exists, the application would error and crash. Now with overflow enabled, you will be render the last page.

## Screenshots or screen recordings
Before fix:
[Screencast from 2024-11-27 02:35:18 PM.webm](https://github.com/user-attachments/assets/c765c866-fed7-481a-a8eb-0ab4d4059e81)

After fix:
[Screencast from 2024-11-27 02:35:52 PM.webm](https://github.com/user-attachments/assets/929fc6eb-0042-434f-9959-e48ef0e4fd0e)

## How to set up and validate locally
1. Navigate to a project  samples table page, and add more samples if there are only 10.
2. Set the limit to 10 (leading to multiple pages of the table) and then navigate to the last page of the table.
3. Set the limit to 100 whereby the page you currently are on would no longer exist (ie: if you have 20 samples with a limit 10, you'll have 2 pages. After setting limit to 100, page 2 no longer exists).
4. Ensure you are now on the last page of the table.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
