### PR TITLE
 Fix: Inline metadata edit, only update if enter or tab key pressed

### DIFF
--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -12,17 +12,17 @@ export default class extends Controller {
   }
 
   submit() {
-    if (!this.submitted) {
-      this.element.requestSubmit();
-    }
+    this.element.requestSubmit();
   }
 
-  cancel(event) {
-    if (event.key === "Escape") {
-      this.inputTarget.value = this.originalValue;
-      this.inputTarget.blur();
-    } else if (event.key === "Enter") {
-      this.submitted = true;
+  reset() {
+    this.inputTarget.value = this.originalValue;
+    this.submit();
+  }
+
+  inputKeydown(event) {
+    if(event.key === "Escape") {
+      this.reset();
     }
   }
 }

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -23,6 +23,9 @@ export default class extends Controller {
   inputKeydown(event) {
     if(event.key === "Escape") {
       this.reset();
+    } else if(event.key === "Tab") {
+      event.preventDefault();
+      this.submit();
     }
   }
 }

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -10,7 +10,8 @@
                    "w-full m-0 border-slate-300 text-slate-900 text-sm focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",
                  data: {
                    "inline-edit-target": "input",
-                   action: "blur->inline-edit#submit keydown->inline-edit#cancel",
+                   action:
+                     "blur->inline-edit#reset keydown->inline-edit#inputKeydown",
                  } %>
   <% end %>
 </td>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Only update the metadata field if the enter or tab key is pressed.  Previously the field was save whenever the input was blurred

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

N/A

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Login as user5 and go to a project or group that is owned and go to the samples page
2. Toggle on the metadata
3. Click on a metadata field and try to update the value pressing enter or tab
4. Click on a metadata field and begin to edit and then click away or press escape, the original value should return

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
