### PR TITLE
Quality of Life: Enable web console as a development option

### DIFF
--- a/app/controllers/console_controller.rb
+++ b/app/controllers/console_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# On webpage console for dev environments
+class ConsoleController < ApplicationController
+  def show; end
+end

--- a/app/views/console/show.html.erb
+++ b/app/views/console/show.html.erb
@@ -1,0 +1,5 @@
+<h1>Rails Console</h1>
+<!-- We don't want to double render the console -->
+<% if Rails.configuration.enable_web_console == false %>
+  <%= console %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,5 +40,9 @@
         <% end %>
       <% end %>
     <% end %>
+
+  <% if Rails.env.development? and Rails.configuration.enable_web_console == true %>
+    <%= console %>
+  <% end %>
   </body>
 </html>

--- a/app/views/layouts/groups.html.erb
+++ b/app/views/layouts/groups.html.erb
@@ -73,5 +73,9 @@
         <% end %>
       <% end %>
     <% end %>
+
+    <% if Rails.env.development? and Rails.configuration.enable_web_console == true %>
+      <%= console %>
+    <% end %>
   </body>
 </html>

--- a/app/views/layouts/profiles.html.erb
+++ b/app/views/layouts/profiles.html.erb
@@ -44,5 +44,9 @@
         <% end %>
       <% end %>
     <% end %>
+
+    <% if Rails.env.development? and Rails.configuration.enable_web_console == true %>
+      <%= console %>
+    <% end %>
   </body>
 </html>

--- a/app/views/layouts/projects.html.erb
+++ b/app/views/layouts/projects.html.erb
@@ -93,5 +93,9 @@
         <% end %>
       <% end %>
     <% end %>
+
+    <% if Rails.env.development? and Rails.configuration.enable_web_console == true %>
+      <%= console %>
+    <% end %>
   </body>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -102,6 +102,8 @@ Rails.application.configure do
     ]
   }
 
+  config.enable_web_console = false
+
   # Create a new production log file [daily, weekly, monthly,..]
   # if ENV['RAILS_DAILY_LOG_ROTATION'].present?
   #   logger           = ActiveSupport::Logger.new(config.default_log_file, 'daily')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -102,7 +102,7 @@ Rails.application.configure do
     ]
   }
 
-  config.enable_web_console = false
+  config.enable_web_console = ENV['RAILS_ENABLE_WEB_CONSOLE'].present?
 
   # Create a new production log file [daily, weekly, monthly,..]
   # if ENV['RAILS_DAILY_LOG_ROTATION'].present?

--- a/config/routes/development.rb
+++ b/config/routes/development.rb
@@ -7,5 +7,7 @@ if Rails.env.development?
   get '/rails/info/routes'     => 'rails/info#routes'
   get '/rails/info'            => 'rails/info#index'
 
+  get '/console', to: 'console#show'
+
   mount Lookbook::Engine, at: '/rails/lookbook'
 end

--- a/docs-site/docs/configuration/options.md
+++ b/docs-site/docs/configuration/options.md
@@ -34,3 +34,4 @@ Primary ENV Variable which sets what type of environment to run
 | `SEED_ATTACHMENT_PER_SAMPLE` | Set number of attachments per sample when seeding the database with test data                            | `2`                        |
 | `ENABLE_CRON`                | Enables built in cron cleanup jobs for samples, attachments, and data exports.                           | `true`                     |
 | `CRON_CLEANUP_AFTER_DAYS`    | Set the number of days old a deleted sample/attachment must be before it is cleaned.                     | `7`                        |
+| `RAILS_ENABLE_WEB_CONSOLE`    | Development mode only: When set, a rails console will be present on every webpage.                      | `nil`                        |


### PR DESCRIPTION
## What does this PR do and why?

Enables the built in rails web console when launching in development mode
* can see web pages change from db commits reflected live without needing to use another console or refresh the page.
* can run any code to trigger rdbg breakpoints without needing a corresponding web interaction

Functionality: 
* can only be visible when running in development mode
* by default, only shows on the `/console` endpoint
* changing `config.enable_web_console` to `true` in `config/environments/development.rb` will enable the console on every page

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._
![image](https://github.com/user-attachments/assets/01660162-b40c-4252-a03b-dd440f908755)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
