### PR TITLE
Enhancement: Metadata edit confirmation dialog

### DIFF
--- a/app/components/viral/button_component.html.erb
+++ b/app/components/viral/button_component.html.erb
@@ -1,16 +1,16 @@
 <%= render Viral::BaseComponent.new(tag: 'button', **system_arguments) do %>
   <% if content.present? %>
-    <span><%= content %></span>
+    <span class="pointer-events-none"><%= content %></span>
   <% end %>
 
   <% if disclosure.present? %>
     <% case disclosure %>
-      <% when :down %>
-        <%= viral_icon(name: "chevron_down", classes: "ml-2 w-4 h-4") %>
-        <% when :up %>
-          <%= viral_icon(name: "chevron_up", classes: "ml-2 w-4 h-4") %>
-          <% when :right %>
-            <%= viral_icon(name: "chevron_right", classes: "ml-2 w-4 h-4") %>
-          <% end %>
-        <% end %>
-      <% end %>
+    <% when :down %>
+      <%= viral_icon(name: "chevron_down", classes: "ml-2 w-4 h-4") %>
+    <% when :up %>
+      <%= viral_icon(name: "chevron_up", classes: "ml-2 w-4 h-4") %>
+    <% when :right %>
+      <%= viral_icon(name: "chevron_right", classes: "ml-2 w-4 h-4") %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -16,7 +16,6 @@ export default class extends Controller {
   connect() {
     try {
       this.inputTarget.focus();
-      this.inputTarget.select();
     } catch (error) {
       console.error("Failed to focus/select input:", error);
     }
@@ -88,6 +87,10 @@ export default class extends Controller {
     this.#cleanup(); // Cleanup any existing listeners
     this.#abortController = new AbortController();
     const signal = this.#abortController.signal;
+    const newValueNode = dialog.querySelector("[data-new-value]");
+    if (newValueNode) {
+      newValueNode.textContent = this.inputTarget.value;
+    }
 
     try {
       await this.#showDialog(dialog, signal);

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -116,7 +116,6 @@ export default class extends Controller {
 
     const handleClick = (event) => {
       const button = event.target;
-      console.log(event);
       if (button.value === "confirm") {
         this.submit();
       } else {

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -72,6 +72,7 @@ export default class extends Controller {
    */
   async handleBlurEvent(event) {
     if (!this.#hasValueChanged()) {
+      this.inputTarget.value = this.originalValue;
       this.submit();
       return;
     }
@@ -161,7 +162,10 @@ export default class extends Controller {
    * @returns {boolean}
    */
   #hasValueChanged() {
-    return this.inputTarget.value !== this.originalValue;
+    return (
+      this.inputTarget.value.trim() &&
+      this.inputTarget.value !== this.originalValue
+    );
   }
 
   /**

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -10,172 +10,88 @@ export default class extends Controller {
     original: String,
   };
 
-  /** @type {AbortController|null} */
-  #abortController = null;
-
   connect() {
-    try {
-      this.inputTarget.focus();
-    } catch (error) {
-      console.error("Failed to focus/select input:", error);
-    }
+    this.inputTarget.focus();
   }
 
-  disconnect() {
-    this.#cleanup();
-  }
-
-  /**
-   * Submits the form
-   * @private
-   */
-  submit() {
-    try {
-      this.element.requestSubmit();
-    } catch (error) {
-      console.error("Form submission failed:", error);
-      // Fallback to reset if submission fails
+  // Handle keyboard events
+  keydown(event) {
+    if (event.key === "Escape") {
       this.reset();
-    }
-  }
-
-  /**
-   * Resets the input to its original value
-   * @private
-   */
-  reset() {
-    this.inputTarget.value = this.originalValue;
-    this.submit();
-  }
-
-  /**
-   * Handles keyboard input events
-   * @param {KeyboardEvent} event
-   */
-  inputKeydown(event) {
-    if (!event?.key) return;
-
-    switch (event.key) {
-      case "Escape":
-        this.reset();
-        break;
-      case "Tab":
-        event.preventDefault();
-        this.submit();
-        break;
-    }
-  }
-
-  /**
-   * Handles blur events and shows confirmation dialog if value changed
-   * @param {FocusEvent} event
-   */
-  async handleBlurEvent(event) {
-    if (!this.#hasValueChanged()) {
-      this.inputTarget.value = this.originalValue;
+    } else if (event.key === "Tab") {
+      event.preventDefault();
       this.submit();
+    }
+  }
+
+  // Handle blur event
+  async blur(event) {
+    if (!this.hasChanges) {
+      this.reset();
       return;
     }
 
     event.preventDefault();
-
     const dialog = this.element.querySelector("dialog");
-    if (!dialog) {
-      console.error("Dialog element not found");
-      return;
-    }
+    if (!dialog) return;
 
-    this.#cleanup();
-    this.#abortController = new AbortController();
-    const signal = this.#abortController.signal;
-
-    this.#updateNewValueTarget();
-
-    try {
-      await this.#showDialog(dialog, signal);
-    } catch (error) {
-      if (error.name === "AbortError") return;
-      console.error("Dialog operation failed:", error);
-      this.reset();
-    }
+    this.updateNewValue();
+    await this.showConfirmDialog(dialog);
   }
 
-  /**
-   * Updates the new value target
-   * @private
-   */
-  #updateNewValueTarget() {
+  // Private methods
+  get hasChanges() {
+    const newValue = this.inputTarget.value.trim();
+    return newValue && newValue !== this.originalValue;
+  }
+
+  updateNewValue() {
     if (this.hasNewValueTarget) {
       this.newValueTarget.textContent = this.inputTarget.value;
     }
   }
 
-  /**
-   * Shows the confirmation dialog and sets up event handlers
-   * @private
-   * @param {HTMLDialogElement} dialog
-   * @param {AbortSignal} signal
-   * @returns {Promise<void>}
-   */
-  async #showDialog(dialog, signal) {
+  async showConfirmDialog(dialog) {
     dialog.showModal();
 
-    // Focus management for accessibility
+    // Focus the cancel button for accessibility
     const cancelButton = dialog.querySelector('button[value="cancel"]');
     if (cancelButton) {
       requestAnimationFrame(() => cancelButton.focus());
     }
 
-    const handleClick = (event) => {
-      const button = event.target;
-      if (button.value === "confirm") {
-        this.submit();
-      } else {
-        this.reset();
-      }
-      dialog.close();
-    };
+    // Handle dialog actions
+    dialog.addEventListener(
+      "click",
+      (e) => {
+        if (e.target.tagName !== "BUTTON") return;
 
-    const handleKeydown = (event) => {
-      if (event.key === "Escape") {
+        e.target.value === "confirm" ? this.submit() : this.reset();
         dialog.close();
+      },
+      { once: true },
+    );
+
+    // Handle dialog close
+    dialog.addEventListener(
+      "close",
+      () => {
         this.inputTarget.focus();
-      }
-    };
-
-    const handleClose = () => {
-      this.#cleanup();
-    };
-
-    // Add event listeners with abort signal
-    dialog.querySelectorAll("button").forEach((button) => {
-      button.addEventListener("click", handleClick, { signal });
-    });
-
-    dialog.addEventListener("keydown", handleKeydown, { signal });
-    dialog.addEventListener("close", handleClose, { signal });
-  }
-
-  /**
-   * Checks if the input value has changed
-   * @private
-   * @returns {boolean}
-   */
-  #hasValueChanged() {
-    return (
-      this.inputTarget.value.trim() &&
-      this.inputTarget.value !== this.originalValue
+      },
+      { once: true },
     );
   }
 
-  /**
-   * Cleans up event listeners
-   * @private
-   */
-  #cleanup() {
-    if (this.#abortController) {
-      this.#abortController.abort();
-      this.#abortController = null;
+  submit() {
+    try {
+      this.element.requestSubmit();
+    } catch {
+      this.reset();
     }
+  }
+
+  reset() {
+    this.inputTarget.value = this.originalValue;
+    this.submit();
   }
 }

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -88,9 +88,7 @@ export default class extends Controller {
     this.#abortController = new AbortController();
     const signal = this.#abortController.signal;
 
-    if (this.hasNewValueTarget) {
-      this.newValueTarget.textContent = this.inputTarget.value;
-    }
+    this.#updateNewValueTarget();
 
     try {
       await this.#showDialog(dialog, signal);
@@ -98,6 +96,16 @@ export default class extends Controller {
       if (error.name === "AbortError") return;
       console.error("Dialog operation failed:", error);
       this.reset();
+    }
+  }
+
+  /**
+   * Updates the new value target
+   * @private
+   */
+  #updateNewValueTarget() {
+    if (this.hasNewValueTarget) {
+      this.newValueTarget.textContent = this.inputTarget.value;
     }
   }
 

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -1,45 +1,166 @@
 import { Controller } from "@hotwired/stimulus";
 
+/**
+ * Controller for handling inline editing functionality
+ * @extends Controller
+ */
 export default class extends Controller {
   static targets = ["input"];
   static values = {
     original: String,
   };
 
+  /** @type {AbortController|null} */
+  #abortController = null;
+
   connect() {
-    this.inputTarget.focus();
-    this.inputTarget.select();
+    try {
+      this.inputTarget.focus();
+      this.inputTarget.select();
+    } catch (error) {
+      console.error("Failed to focus/select input:", error);
+    }
   }
 
+  disconnect() {
+    this.#cleanup();
+  }
+
+  /**
+   * Submits the form
+   * @private
+   */
   submit() {
-    this.element.requestSubmit();
+    try {
+      this.element.requestSubmit();
+    } catch (error) {
+      console.error("Form submission failed:", error);
+      // Fallback to reset if submission fails
+      this.reset();
+    }
   }
 
+  /**
+   * Resets the input to its original value
+   * @private
+   */
   reset() {
     this.inputTarget.value = this.originalValue;
     this.submit();
   }
 
+  /**
+   * Handles keyboard input events
+   * @param {KeyboardEvent} event
+   */
   inputKeydown(event) {
-    if (event.key === "Escape") {
-      this.reset();
-    } else if (event.key === "Tab") {
-      event.preventDefault();
-      this.submit();
+    if (!event?.key) return;
+
+    switch (event.key) {
+      case "Escape":
+        this.reset();
+        break;
+      case "Tab":
+        event.preventDefault();
+        this.submit();
+        break;
     }
   }
 
-  handleBlurEvent(event) {
-    // Use a dialog to confirm the change
-    if (this.inputTarget.value !== this.originalValue) {
-      event.preventDefault();
-      if (confirm("Are you sure?")) {
-        console.log("confirmed");
+  /**
+   * Handles blur events and shows confirmation dialog if value changed
+   * @param {FocusEvent} event
+   */
+  async handleBlurEvent(event) {
+    if (!this.#hasValueChanged()) {
+      this.submit();
+      return;
+    }
+
+    event.preventDefault();
+
+    const dialog = this.element.querySelector("dialog");
+    if (!dialog) {
+      console.error("Dialog element not found");
+      return;
+    }
+
+    this.#cleanup(); // Cleanup any existing listeners
+    this.#abortController = new AbortController();
+    const signal = this.#abortController.signal;
+
+    try {
+      await this.#showDialog(dialog, signal);
+    } catch (error) {
+      if (error.name === "AbortError") return;
+      console.error("Dialog operation failed:", error);
+      this.reset();
+    }
+  }
+
+  /**
+   * Shows the confirmation dialog and sets up event handlers
+   * @private
+   * @param {HTMLDialogElement} dialog
+   * @param {AbortSignal} signal
+   * @returns {Promise<void>}
+   */
+  async #showDialog(dialog, signal) {
+    dialog.showModal();
+
+    // Focus management for accessibility
+    const cancelButton = dialog.querySelector('button[value="cancel"]');
+    if (cancelButton) {
+      requestAnimationFrame(() => cancelButton.focus());
+    }
+
+    const handleClick = (event) => {
+      const button = event.target;
+      if (button.value === "confirm") {
+        this.submit();
       } else {
-        console.log("canceled");
+        this.reset();
       }
-    } else {
-      this.submit(); // Resets the to non-input state
+      dialog.close();
+    };
+
+    const handleKeydown = (event) => {
+      if (event.key === "Escape") {
+        dialog.close();
+        this.inputTarget.focus();
+      }
+    };
+
+    const handleClose = () => {
+      this.#cleanup();
+    };
+
+    // Add event listeners with abort signal
+    dialog.querySelectorAll("button").forEach((button) => {
+      button.addEventListener("click", handleClick, { signal });
+    });
+
+    dialog.addEventListener("keydown", handleKeydown, { signal });
+    dialog.addEventListener("close", handleClose, { signal });
+  }
+
+  /**
+   * Checks if the input value has changed
+   * @private
+   * @returns {boolean}
+   */
+  #hasValueChanged() {
+    return this.inputTarget.value !== this.originalValue;
+  }
+
+  /**
+   * Cleans up event listeners
+   * @private
+   */
+  #cleanup() {
+    if (this.#abortController) {
+      this.#abortController.abort();
+      this.#abortController = null;
     }
   }
 }

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -21,11 +21,25 @@ export default class extends Controller {
   }
 
   inputKeydown(event) {
-    if(event.key === "Escape") {
+    if (event.key === "Escape") {
       this.reset();
-    } else if(event.key === "Tab") {
+    } else if (event.key === "Tab") {
       event.preventDefault();
       this.submit();
+    }
+  }
+
+  handleBlurEvent(event) {
+    // Use a dialog to confirm the change
+    if (this.inputTarget.value !== this.originalValue) {
+      event.preventDefault();
+      if (confirm("Are you sure?")) {
+        console.log("confirmed");
+      } else {
+        console.log("canceled");
+      }
+    } else {
+      this.submit(); // Resets the to non-input state
     }
   }
 }

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -5,7 +5,7 @@ import { Controller } from "@hotwired/stimulus";
  * @extends Controller
  */
 export default class extends Controller {
-  static targets = ["input"];
+  static targets = ["input", "newValue"];
   static values = {
     original: String,
   };
@@ -84,12 +84,12 @@ export default class extends Controller {
       return;
     }
 
-    this.#cleanup(); // Cleanup any existing listeners
+    this.#cleanup();
     this.#abortController = new AbortController();
     const signal = this.#abortController.signal;
-    const newValueNode = dialog.querySelector("[data-new-value]");
-    if (newValueNode) {
-      newValueNode.textContent = this.inputTarget.value;
+
+    if (this.hasNewValueTarget) {
+      this.newValueTarget.textContent = this.inputTarget.value;
     }
 
     try {

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -116,6 +116,7 @@ export default class extends Controller {
 
     const handleClick = (event) => {
       const button = event.target;
+      console.log(event);
       if (button.value === "confirm") {
         this.submit();
       } else {

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
 
   connect() {
     this.inputTarget.focus();
+    this.inputTarget.select();
   }
 
   // Handle keyboard events
@@ -42,7 +43,7 @@ export default class extends Controller {
   // Private methods
   get hasChanges() {
     const newValue = this.inputTarget.value.trim();
-    return newValue && newValue !== this.originalValue;
+    return newValue !== this.originalValue;
   }
 
   updateNewValue() {

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -5,7 +5,7 @@ import { Controller } from "@hotwired/stimulus";
  * @extends Controller
  */
 export default class extends Controller {
-  static targets = ["input", "newValue"];
+  static targets = ["input", "newValue", "descriptionWith", "descriptionWithout"];
   static values = {
     original: String,
   };
@@ -53,7 +53,14 @@ export default class extends Controller {
   }
 
   async showConfirmDialog(dialog) {
+    console.log(this.descriptionWithTarget, this.descriptionWithoutTarget);
+
     dialog.showModal();
+    if (this.inputTarget.value.trim() === "") {
+      this.descriptionWithoutTarget.classList.remove("hidden");
+    } else {
+      this.descriptionWithTarget.classList.remove("hidden");
+    }
 
     // Focus the cancel button for accessibility
     const cancelButton = dialog.querySelector('button[value="cancel"]');

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -18,12 +18,21 @@
         title: t("shared.samples.metadata.editing_field_cell.dialog.title"),
       ) %>
       <%= dialog.with_section do %>
-        <p class="text-base text-slate-900 dark:text-white text-wrap" data-description>
-          <%= raw t(
-            "shared.samples.metadata.editing_field_cell.dialog.description",
-            value: @value,
-            count: @value.present? ? @value.length : 0,
-          ) %>
+
+        <p class="text-base text-slate-900 dark:text-white text-wrap">
+          <span data-inline-edit-target="descriptionWith" class="hidden">
+            <%= raw t(
+              "shared.samples.metadata.editing_field_cell.dialog.description_with_new_value",
+              value: @value,
+              count: @value.present? ? @value.length : 0,
+            ) %>
+          </span>
+          <span data-inline-edit-target="descriptionWithout" class="hidden">
+            <%= raw t(
+              "shared.samples.metadata.editing_field_cell.dialog.description_without_new_value",
+              value: @value,
+            ) %>
+          </span>
         </p>
       <% end %>
       <% dialog.with_secondary_action do %>

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -19,13 +19,19 @@
       ) %>
       <%= dialog.with_section do %>
 
-        <p class="text-base text-slate-900 dark:text-white text-wrap">
+        <p class="text-base leading-8 text-slate-900 dark:text-white text-wrap">
           <span data-inline-edit-target="descriptionWith" class="hidden">
-            <%= raw t(
-              "shared.samples.metadata.editing_field_cell.dialog.description_with_new_value",
-              value: @value,
-              count: @value.present? ? @value.length : 0,
-            ) %>
+            <% if @value.present? %>
+              <%= raw t(
+                "shared.samples.metadata.editing_field_cell.dialog.description_with_new_value.with_original_value",
+                value: @value,
+              ) %>
+            <% else %>
+              <%= raw t(
+                "shared.samples.metadata.editing_field_cell.dialog.description_with_new_value.without_original_value",
+                value: @value,
+              ) %>
+            <% end %>
           </span>
           <span data-inline-edit-target="descriptionWithout" class="hidden">
             <%= raw t(

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -5,7 +5,7 @@
     <%= f.hidden_field :original_value, value: @value %>
     <%= f.hidden_field :format, value: "turbo_stream" %>
     <%= f.text_field :value,
-                 placeholder: @value,
+                 value: @value,
                  class:
                    "w-full m-0 border-slate-300 text-slate-900 text-sm focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",
                  data: {
@@ -22,6 +22,7 @@
           <%= raw t(
             "shared.samples.metadata.editing_field_cell.dialog.description",
             value: @value,
+            count: @value.present? ? @value.length : 0,
           ) %>
         </p>
       <% end %>

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -11,7 +11,10 @@
                  data: {
                    "inline-edit-target": "input",
                    action:
-                     "blur->inline-edit#reset keydown->inline-edit#inputKeydown",
+                     "blur->inline-edit#handleBlurEvent keydown->inline-edit#inputKeydown",
                  } %>
+  <%= render ConfirmationComponent.new  do %>
+    HELLO, PLEASE HELP ME
+  <% end %>
   <% end %>
 </td>

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -11,8 +11,7 @@
                  data: {
                    "test-selector": "field-input",
                    "inline-edit-target": "input",
-                   action:
-                     "blur->inline-edit#handleBlurEvent keydown->inline-edit#inputKeydown",
+                   action: "blur->inline-edit#blur keydown->inline-edit#keydown",
                  } %>
     <%= viral_dialog(open: false) do |dialog| %>
       <%= dialog.with_header(

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -5,25 +5,34 @@
     <%= f.hidden_field :original_value, value: @value %>
     <%= f.hidden_field :format, value: "turbo_stream" %>
     <%= f.text_field :value,
-                 value: @value,
+                 placeholder: @value,
                  class:
                    "w-full m-0 border-slate-300 text-slate-900 text-sm focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500",
                  data: {
+                   "test-selector": "field-input",
                    "inline-edit-target": "input",
                    action:
                      "blur->inline-edit#handleBlurEvent keydown->inline-edit#inputKeydown",
                  } %>
     <%= viral_dialog(open: false) do |dialog| %>
-      <%= dialog.with_header(title: "Confirmation required") %>
+      <%= dialog.with_header(
+        title: t("shared.samples.metadata.editing_field_cell.dialog.title"),
+      ) %>
       <%= dialog.with_section do %>
-        <p class="text-base text-slate-900 dark:text-white text-wrap">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        <p class="text-base text-slate-900 dark:text-white text-wrap" data-description>
+          <%= raw t(
+            "shared.samples.metadata.editing_field_cell.dialog.description",
+            value: @value,
+          ) %>
         </p>
       <% end %>
       <% dialog.with_secondary_action do %>
-        <%= viral_button(value: "confirm", state: :primary) { "Update" } %>
-        <%= viral_button(value: "cancel", state: :default) { "Discard" } %>
+        <%= viral_button(value: "confirm", state: :primary) do
+          t("shared.samples.metadata.editing_field_cell.dialog.confirm_button")
+        end %>
+        <%= viral_button(value: "cancel", state: :default) do
+          t("shared.samples.metadata.editing_field_cell.dialog.discard_button")
+        end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
+++ b/app/views/shared/samples/metadata/fields/_editing_field_cell.html.erb
@@ -13,8 +13,18 @@
                    action:
                      "blur->inline-edit#handleBlurEvent keydown->inline-edit#inputKeydown",
                  } %>
-  <%= render ConfirmationComponent.new  do %>
-    HELLO, PLEASE HELP ME
-  <% end %>
+    <%= viral_dialog(open: false) do |dialog| %>
+      <%= dialog.with_header(title: "Confirmation required") %>
+      <%= dialog.with_section do %>
+        <p class="text-base text-slate-900 dark:text-white text-wrap">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      <% end %>
+      <% dialog.with_secondary_action do %>
+        <%= viral_button(value: "confirm", state: :primary) { "Update" } %>
+        <%= viral_button(value: "cancel", state: :default) { "Discard" } %>
+      <% end %>
+    <% end %>
   <% end %>
 </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,7 +287,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -372,7 +372,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -410,7 +410,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -423,7 +423,7 @@ en:
         success: Successfully revoked personal access token %{pat_name}
     file_import_actions:
       create:
-        error: "Metadata was not successfully imported for the following samples:"
+        error: 'Metadata was not successfully imported for the following samples:'
         success: Sample metadata was successfully imported.
     membership_actions:
       create:
@@ -518,14 +518,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -592,7 +592,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -622,7 +622,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -696,18 +696,18 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -858,10 +858,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -869,11 +869,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -884,15 +884,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -909,7 +909,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -979,8 +979,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1044,7 +1044,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1072,7 +1072,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1150,20 +1150,20 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1276,11 +1276,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1288,20 +1288,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1332,8 +1332,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1376,7 +1376,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1417,7 +1417,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1465,8 +1465,8 @@ en:
         uploading: Uploading
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1630,8 +1630,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1661,8 +1661,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
   shared:
     alert:
       list:
@@ -1672,6 +1672,12 @@ en:
         loading: Loading...
     samples:
       metadata:
+        editing_field_cell:
+          dialog:
+            confirm_button: Save
+            description: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
+            discard_button: Discard
+            title: Confirmation required
         file_imports:
           dialog:
             description: Importing a metadata spreadsheet allows multiple metadata fields to multiple samples be added, updated or removed at once.
@@ -1680,7 +1686,7 @@ en:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: "The spreadsheet is required to have a column that contains a sample identifier. "
+              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1690,17 +1696,11 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!
             ok_button: OK
-        editing_field_cell:
-          dialog:
-            confirm_button: Save
-            discard_button: Discard
-            title: Confirmation required
-            description: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1700,7 +1700,7 @@ en:
             confirm_button: Save
             discard_button: Discard
             title: Confirmation required
-            description: Click `Save` to update the value to <span class='font-bold' data-new-value>[VALUE]</span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
+            description: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1675,9 +1675,10 @@ en:
         editing_field_cell:
           dialog:
             confirm_button: Save
-            description:
-              zero: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous empty value.
-              other: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
+            description_with_new_value:
+              other: Click <kbd>Save</kbd> to update the value to <span class='font-bold underline' data-inline-edit-target="newValue"></span>, or <kbd>Discard</kbd> to cancel and return to the previous value of <span class='font-bold underline'>%{value}</span>.
+              zero: Click <kbd>Save</kbd> to update the value to <span class='font-bold underline' data-inline-edit-target="newValue"></span>, or <kbd>Discard</kbd> to cancel and return to the previous empty value.
+            description_without_new_value: Click <kbd>Save</kbd> to remove the current value, or <kbd>Discard</kbd> to cancel and return to the previous value of <span class='font-bold underline'>%{value}</span>.
             discard_button: Discard
             title: Confirmation required
         file_imports:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,7 +287,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -372,7 +372,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -410,7 +410,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -423,7 +423,7 @@ en:
         success: Successfully revoked personal access token %{pat_name}
     file_import_actions:
       create:
-        error: 'Metadata was not successfully imported for the following samples:'
+        error: "Metadata was not successfully imported for the following samples:"
         success: Sample metadata was successfully imported.
     membership_actions:
       create:
@@ -518,14 +518,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -592,7 +592,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -622,7 +622,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -696,18 +696,18 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -858,10 +858,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -869,11 +869,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -884,15 +884,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -909,7 +909,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -979,8 +979,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1044,7 +1044,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1072,7 +1072,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1150,20 +1150,20 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1276,11 +1276,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1288,20 +1288,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1332,8 +1332,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1376,7 +1376,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1417,7 +1417,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1465,8 +1465,8 @@ en:
         uploading: Uploading
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1630,8 +1630,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1661,8 +1661,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
   shared:
     alert:
       list:
@@ -1680,7 +1680,7 @@ en:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
+              description: "The spreadsheet is required to have a column that contains a sample identifier. "
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1690,11 +1690,17 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!
             ok_button: OK
+        editing_field_cell:
+          dialog:
+            confirm_button: Save
+            discard_button: Discard
+            title: Confirmation required
+            description: Click `Save` to update the value to <span class='font-bold' data-new-value>[VALUE]</span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1676,8 +1676,8 @@ en:
           dialog:
             confirm_button: Save
             description_with_new_value:
-              other: Click <kbd>Save</kbd> to update the value to <span class='font-bold underline' data-inline-edit-target="newValue"></span>, or <kbd>Discard</kbd> to cancel and return to the previous value of <span class='font-bold underline'>%{value}</span>.
-              zero: Click <kbd>Save</kbd> to update the value to <span class='font-bold underline' data-inline-edit-target="newValue"></span>, or <kbd>Discard</kbd> to cancel and return to the previous empty value.
+              with_original_value: Click <kbd>Save</kbd> to update the value to <span class='font-bold underline' data-inline-edit-target="newValue"></span>, or <kbd>Discard</kbd> to cancel and return to the previous value of <span class='font-bold underline'>%{value}</span>.
+              without_original_value: Click <kbd>Save</kbd> to update the value to <span class='font-bold underline' data-inline-edit-target="newValue"></span>, or <kbd>Discard</kbd> to cancel and return to the previous empty value.
             description_without_new_value: Click <kbd>Save</kbd> to remove the current value, or <kbd>Discard</kbd> to cancel and return to the previous value of <span class='font-bold underline'>%{value}</span>.
             discard_button: Discard
             title: Confirmation required

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1675,7 +1675,9 @@ en:
         editing_field_cell:
           dialog:
             confirm_button: Save
-            description: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
+            description:
+              zero: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous empty value.
+              other: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
             discard_button: Discard
             title: Confirmation required
         file_imports:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -287,7 +287,7 @@ fr:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -372,7 +372,7 @@ fr:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -410,7 +410,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -423,7 +423,7 @@ fr:
         success: Successfully revoked personal access token %{pat_name}
     file_import_actions:
       create:
-        error: "Metadata was not successfully imported for the following samples:"
+        error: 'Metadata was not successfully imported for the following samples:'
         success: Sample metadata was successfully imported.
     membership_actions:
       create:
@@ -518,14 +518,14 @@ fr:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -592,7 +592,7 @@ fr:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -622,7 +622,7 @@ fr:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -696,18 +696,18 @@ fr:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -858,10 +858,10 @@ fr:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -869,11 +869,11 @@ fr:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -884,15 +884,15 @@ fr:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -909,7 +909,7 @@ fr:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -979,8 +979,8 @@ fr:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1044,7 +1044,7 @@ fr:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1072,7 +1072,7 @@ fr:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1150,20 +1150,20 @@ fr:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1276,11 +1276,11 @@ fr:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1288,20 +1288,20 @@ fr:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1332,8 +1332,8 @@ fr:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1376,7 +1376,7 @@ fr:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1417,7 +1417,7 @@ fr:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1465,8 +1465,8 @@ fr:
         uploading: Uploading
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1630,8 +1630,8 @@ fr:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1661,8 +1661,8 @@ fr:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
   shared:
     alert:
       list:
@@ -1674,10 +1674,11 @@ fr:
       metadata:
         editing_field_cell:
           dialog:
-            confirm_button: Enregistrer
-            description:
-              zero: Cliquez sur `Enregistrer` pour mettre à jour la valeur à <span class='font-bold' data-inline-edit-target="newValue"></span>, ou `Annuler` pour annuler et revenir à la valeur précédente vide.
-              other: Cliquez sur `Enregistrer` pour mettre à jour la valeur à <span class='font-bold' data-inline-edit-target="newValue"></span>, ou `Annuler` pour annuler et revenir à la valeur précédente de <span class='font-bold'>%{value}</span>.
+            confirm_button: Save
+            description_with_new_value:
+              other: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur à <span class='font-bold underline' data-inline-edit-target="newValue"></span>, ou <kbd>Annuler</kbd> pour annuler et revenir à la valeur précédente de <span class='font-bold'>%{value}</span>.
+              zero: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur à <span class='font-bold underline' data-inline-edit-target="newValue"></span>, ou <kbd>Annuler</kbd> pour annuler et revenir à la valeur précédente vide.
+            description_without_new_value: Cliquez sur <kbd>Enregistrer</kbd> pour supprimer la valeur actuelle de <span class='font-bold'>%{value}</span>.
             discard_button: Annuler
             title: Confirmation requise
         file_imports:
@@ -1688,7 +1689,7 @@ fr:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: "The spreadsheet is required to have a column that contains a sample identifier. "
+              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1698,7 +1699,7 @@ fr:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1676,8 +1676,8 @@ fr:
           dialog:
             confirm_button: Save
             description_with_new_value:
-              other: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur à <span class='font-bold underline' data-inline-edit-target="newValue"></span>, ou <kbd>Annuler</kbd> pour annuler et revenir à la valeur précédente de <span class='font-bold'>%{value}</span>.
-              zero: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur à <span class='font-bold underline' data-inline-edit-target="newValue"></span>, ou <kbd>Annuler</kbd> pour annuler et revenir à la valeur précédente vide.
+              with_original_value: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur à <span class='font-bold underline' data-inline-edit-target="newValue"></span>, ou <kbd>Annuler</kbd> pour annuler et revenir à la valeur précédente de <span class='font-bold'>%{value}</span>.
+              without_original_value: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur à <span class='font-bold underline' data-inline-edit-target="newValue"></span>, ou <kbd>Annuler</kbd> pour annuler et revenir à la valeur précédente vide.
             description_without_new_value: Cliquez sur <kbd>Enregistrer</kbd> pour supprimer la valeur actuelle de <span class='font-bold'>%{value}</span>.
             discard_button: Annuler
             title: Confirmation requise

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -287,7 +287,7 @@ fr:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -372,7 +372,7 @@ fr:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -410,7 +410,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -423,7 +423,7 @@ fr:
         success: Successfully revoked personal access token %{pat_name}
     file_import_actions:
       create:
-        error: 'Metadata was not successfully imported for the following samples:'
+        error: "Metadata was not successfully imported for the following samples:"
         success: Sample metadata was successfully imported.
     membership_actions:
       create:
@@ -518,14 +518,14 @@ fr:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -592,7 +592,7 @@ fr:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -622,7 +622,7 @@ fr:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -696,18 +696,18 @@ fr:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -858,10 +858,10 @@ fr:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -869,11 +869,11 @@ fr:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -884,15 +884,15 @@ fr:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -909,7 +909,7 @@ fr:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -979,8 +979,8 @@ fr:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1044,7 +1044,7 @@ fr:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1072,7 +1072,7 @@ fr:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1150,20 +1150,20 @@ fr:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1276,11 +1276,11 @@ fr:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1288,20 +1288,20 @@ fr:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1332,8 +1332,8 @@ fr:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1376,7 +1376,7 @@ fr:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1417,7 +1417,7 @@ fr:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1465,8 +1465,8 @@ fr:
         uploading: Uploading
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1630,8 +1630,8 @@ fr:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1661,8 +1661,8 @@ fr:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
   shared:
     alert:
       list:
@@ -1674,10 +1674,12 @@ fr:
       metadata:
         editing_field_cell:
           dialog:
-            confirm_button: Save
-            description: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
-            discard_button: Discard
-            title: Confirmation required
+            confirm_button: Enregistrer
+            description:
+              zero: Cliquez sur `Enregistrer` pour mettre à jour la valeur à <span class='font-bold' data-inline-edit-target="newValue"></span>, ou `Annuler` pour annuler et revenir à la valeur précédente vide.
+              other: Cliquez sur `Enregistrer` pour mettre à jour la valeur à <span class='font-bold' data-inline-edit-target="newValue"></span>, ou `Annuler` pour annuler et revenir à la valeur précédente de <span class='font-bold'>%{value}</span>.
+            discard_button: Annuler
+            title: Confirmation requise
         file_imports:
           dialog:
             description: Importing a metadata spreadsheet allows multiple metadata fields to multiple samples be added, updated or removed at once.
@@ -1686,7 +1688,7 @@ fr:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
+              description: "The spreadsheet is required to have a column that contains a sample identifier. "
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1696,7 +1698,7 @@ fr:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1672,6 +1672,12 @@ fr:
         loading: Loading...
     samples:
       metadata:
+        editing_field_cell:
+          dialog:
+            confirm_button: Save
+            description: Click `Save` to update the value to <span class='font-bold' data-inline-edit-target="newValue"></span>, or `Discard` to cancel and return to the previous value of <span class='font-bold'>%{value}</span>.
+            discard_button: Discard
+            title: Confirmation required
         file_imports:
           dialog:
             description: Importing a metadata spreadsheet allows multiple metadata fields to multiple samples be added, updated or removed at once.

--- a/embedded_gems/pathogen/app/components/pathogen/button.html.erb
+++ b/embedded_gems/pathogen/app/components/pathogen/button.html.erb
@@ -4,7 +4,7 @@
       <%= leading_visual %>
     </span>
   <% end %>
-  <%= trimmed_content %>
+  <span><%= trimmed_content %></span>
   <% if trailing_visual %>
     <span class="ml-2">
       <% if @trailing_visual_counter %>

--- a/embedded_gems/pathogen/app/components/pathogen/button.html.erb
+++ b/embedded_gems/pathogen/app/components/pathogen/button.html.erb
@@ -4,7 +4,7 @@
       <%= leading_visual %>
     </span>
   <% end %>
-  <span><%= trimmed_content %></span>
+  <%= trimmed_content %>
   <% if trailing_visual %>
     <span class="ml-2">
       <% if @trailing_visual_counter %>

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2376,16 +2376,29 @@ module Projects
     end
 
     test 'shows confirmation dialog when editing metadata field with changes' do
-      login_as users(:john_doe)
+      ### SETUP START ###
       visit namespace_project_samples_url(@namespace, @project)
+      assert_selector 'table thead tr th', count: 6
+
       find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click
-      assert_selector 'table thead tr th', count: 7
+      assert_selector 'table thead tr th', count: 8
+
+      fill_in placeholder: I18n.t(:'projects.samples.index.search.placeholder'), with: @sample1.name
+      find('input.t-search-component').native.send_keys(:return)
 
       within('table tbody tr:first-child td:nth-child(7)') do
-        find('.editable-field').click
-      end
+        ### ACTIONS START ###
+        # check within the from with method get that the value is 'value1':
+        within('form[method="get"]') do
+          find('button').click
+        end
+        assert_selector "form[data-controller='inline-edit']"
 
-      fill_in 'metadata_field', with: 'New Value'
+        within('form[data-controller="inline-edit"]') do
+          find('input[name="value"]').send_keys 'New Value'
+        end
+        ### ACTIONS END ###
+      end
       find('body').click
 
       assert_selector 'dialog[open]'

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2406,7 +2406,7 @@ module Projects
       assert_selector 'dialog button', text: I18n.t('shared.samples.metadata.editing_field_cell.dialog.discard_button')
 
       click_button I18n.t('shared.samples.metadata.editing_field_cell.dialog.confirm_button')
-        ### ACTIONS END ###
+      ### ACTIONS END ###
 
       ### VERIFY START ###
       assert_no_selector 'dialog[open]'
@@ -2447,7 +2447,7 @@ module Projects
       assert_selector 'dialog button', text: I18n.t('shared.samples.metadata.editing_field_cell.dialog.discard_button')
 
       click_button I18n.t('shared.samples.metadata.editing_field_cell.dialog.discard_button')
-        ### ACTIONS END ###
+      ### ACTIONS END ###
 
       ### VERIFY START ###
       assert_no_selector 'dialog[open]'

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2385,6 +2385,7 @@ module Projects
 
       fill_in placeholder: I18n.t(:'projects.samples.index.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
+      ### SETUP END ###
 
       within('table tbody tr:first-child td:nth-child(7)') do
         ### ACTIONS START ###
@@ -2397,7 +2398,6 @@ module Projects
         within('form[data-controller="inline-edit"]') do
           find('input[name="value"]').send_keys 'New Value'
         end
-        ### ACTIONS END ###
       end
       find('body').click
 
@@ -2406,11 +2406,55 @@ module Projects
       assert_selector 'dialog button', text: I18n.t('shared.samples.metadata.editing_field_cell.dialog.discard_button')
 
       click_button I18n.t('shared.samples.metadata.editing_field_cell.dialog.confirm_button')
+        ### ACTIONS END ###
 
+      ### VERIFY START ###
       assert_no_selector 'dialog[open]'
       within('table tbody tr:first-child td:nth-child(7)') do
         assert_selector 'button', text: 'New Value'
       end
+      ### VERIFY END ###
+    end
+
+    test 'shows confirmation dialog can be cancelled resetting the value' do
+      ### SETUP START ###
+      visit namespace_project_samples_url(@namespace, @project)
+      assert_selector 'table thead tr th', count: 6
+
+      find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click
+      assert_selector 'table thead tr th', count: 8
+
+      fill_in placeholder: I18n.t(:'projects.samples.index.search.placeholder'), with: @sample1.name
+      find('input.t-search-component').native.send_keys(:return)
+      ### SETUP END ###
+
+      within('table tbody tr:first-child td:nth-child(7)') do
+        ### ACTIONS START ###
+        # check within the from with method get that the value is 'value1':
+        within('form[method="get"]') do
+          find('button').click
+        end
+        assert_selector "form[data-controller='inline-edit']"
+
+        within('form[data-controller="inline-edit"]') do
+          find('input[name="value"]').send_keys 'New Value'
+        end
+      end
+      find('body').click
+
+      assert_selector 'dialog[open]'
+      assert_selector 'dialog button', text: I18n.t('shared.samples.metadata.editing_field_cell.dialog.confirm_button')
+      assert_selector 'dialog button', text: I18n.t('shared.samples.metadata.editing_field_cell.dialog.discard_button')
+
+      click_button I18n.t('shared.samples.metadata.editing_field_cell.dialog.discard_button')
+        ### ACTIONS END ###
+
+      ### VERIFY START ###
+      assert_no_selector 'dialog[open]'
+      within('table tbody tr:first-child td:nth-child(7)') do
+        assert_selector 'button', text: ''
+      end
+      ### VERIFY END ###
     end
 
     def long_filter_text

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2402,13 +2402,15 @@ module Projects
       find('body').click
 
       assert_selector 'dialog[open]'
-      assert_selector 'dialog button', text: I18n.t('shared.confirmation.confirm')
-      assert_selector 'dialog button', text: I18n.t('shared.confirmation.cancel')
+      assert_selector 'dialog button', text: I18n.t('shared.samples.metadata.editing_field_cell.dialog.confirm_button')
+      assert_selector 'dialog button', text: I18n.t('shared.samples.metadata.editing_field_cell.dialog.discard_button')
 
-      click_button I18n.t('shared.confirmation.confirm')
+      click_button I18n.t('shared.samples.metadata.editing_field_cell.dialog.confirm_button')
 
       assert_no_selector 'dialog[open]'
-      assert_selector '.editable-field', text: 'New Value'
+      within('table tbody tr:first-child td:nth-child(7)') do
+        assert_selector 'button', text: 'New Value'
+      end
     end
 
     def long_filter_text


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

On the samples page, a confirmation dialogue will open when a metadata field is being edited and the user clicks away from a **changed** value.  The user is presented with 2 options:

1. `Save`: Save the updated value and revert the cell to the un-editing state, displaying the new value.
2. `Discard`: Discard the updated value and revert the cell to the original value and render the unediting state.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/b78835cd-0996-44e8-ba3f-a0d58e697087)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Login as a user with privileges on a project (e.g. user5)
2. Go to a project the user owns, and then to the project samples page.
3. Toggle on metadata fields
4. Click on a field and edit, then click away, the confirmation dialog should appear.
5. Try to discard, and then save the new value.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
