### PR TITLE
Fix: Workflow Execution Submission

### DIFF
--- a/app/models/samples_workflow_execution.rb
+++ b/app/models/samples_workflow_execution.rb
@@ -10,5 +10,5 @@ class SamplesWorkflowExecution < ApplicationRecord
   has_many_attached :inputs
   has_many :outputs, dependent: :destroy, class_name: 'Attachment', as: :attachable
 
-  validates_with WorkflowExecutionSamplesheetParamsValidator
+  # validates_with WorkflowExecutionSamplesheetParamsValidator
 end

--- a/test/models/samples_workflow_executions_test.rb
+++ b/test/models/samples_workflow_executions_test.rb
@@ -26,6 +26,7 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
   end
 
   test 'invalid mismatch puid' do
+    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_invalid_mismatch_sample_puid.valid?
     assert_not_nil @samples_workflow_executions_invalid_mismatch_sample_puid.errors
     expected_error = 'Sample Provided Sample PUID INXT_SAM_AAAAAAAAAB does not match SampleWorkflowExecution Sample PUID INXT_SAM_AAAAAAAAAA' # rubocop:disable Layout/LineLength
@@ -33,6 +34,7 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
   end
 
   test 'invalid no sample puid' do
+    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_invalid_no_sample_puid.valid?
     assert_not_nil @samples_workflow_executions_invalid_no_sample_puid.errors
     expected_error = 'Sample No Sample PUID provided'
@@ -40,6 +42,7 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
   end
 
   test 'invalid file id' do
+    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_invalid_file_id.valid?
     assert_not_nil @samples_workflow_executions_invalid_file_id.errors
     expected_error = 'Attachment 12345 is not a valid IRIDA Next ID.'
@@ -50,6 +53,7 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
   end
 
   test 'mismatch file id' do
+    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_mismatch_file_id.valid?
     assert_not_nil @samples_workflow_executions_mismatch_file_id.errors
     expected_error = 'Attachment Attachment does not belong to Sample INXT_SAM_AAAAAAAAAA.'

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -373,6 +373,7 @@ module WorkflowExecutions
     end
 
     test 'create new workflow execution with non matching sample puid in sample sheet' do
+      skip 'validator needs rewrite'
       samples_workflow_executions_attributes = {
         '0': {
           sample_id: samples(:sample1).id,
@@ -409,6 +410,7 @@ module WorkflowExecutions
     end
 
     test 'create new workflow execution with non matching attachments to sample' do
+      skip 'validator needs rewrite'
       samples_workflow_executions_attributes = {
         '0': {
           sample_id: samples(:sample2).id,


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

PR #838 added in samplesheet validation, but we missed that it assumed that all entries except for `sample` were attachments, so any pipeline that uses non `attachment` fields i.e. metadata or text values would fail validation and then silently prevent a user from submitting a workflow execution.

This PR disables that validation, it will need to be fixed in a later PR to work with the UI to display any errors and also updated to only validate attachments for fields that actually specify files.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
