### PR TITLE
actioncable-enhanced-postgresql-adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'rubocop-graphql', require: false
 gem 'rubocop-rails', require: false
 
 # postgresql
+gem 'actioncable-enhanced-postgresql-adapter'
 gem 'pg'
 
 # Authorization

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,10 @@ GEM
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
+    actioncable-enhanced-postgresql-adapter (1.0.1)
+      actioncable (>= 6.0)
+      connection_pool (>= 2.2.5)
+      pg (~> 1.5)
     actionmailbox (7.2.2.1)
       actionpack (= 7.2.2.1)
       activejob (= 7.2.2.1)
@@ -647,6 +651,7 @@ DEPENDENCIES
   action_policy
   action_policy-graphql
   actioncable
+  actioncable-enhanced-postgresql-adapter
   active_storage_validations
   activerecord-session_store (~> 2.1)
   activerecord_json_validator (~> 3.0.0)

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,10 @@
 development:
-  adapter: postgresql
+  adapter: enhanced_postgresql
 
 test:
   adapter: test
 
 production:
-  adapter: postgresql
+  adapter: enhanced_postgresql
   url: <%= ENV['DATABASE_URL'] %>
   channel_prefix:


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

ActionCable postgresql adapter is limited to payloads up to 8000 bytes, this PR adds in a gem which allows larger payloads.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Run `bin/bundle` to install the gem
2. Run `bin/dev`
3. Create a Project with 90 samples in it.
4. Copy the Samples to an empty project.
5. Then attempt to copy the Samples again to the previously empty project.
6. On `main` this would result in a `ERROR:  payload string too long` message showing up in the good job logs, on this PR no error message occurs and the dialog is updated to show that it could not copy the samples.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
