### PR TITLE
Fix for advanced search for metadata fields

### DIFF
--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -113,7 +113,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
     groups.each do |group|
       and_conditions = {}
       group.conditions.map do |condition|
-        key = condition.field.gsub(/(?<!metadata)\./, '___')
+        key = condition.field.gsub(/(?<!^metadata)\./, '___')
         case condition.operator
         when '=', 'in'
           and_conditions[key] = condition.value

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -113,17 +113,18 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
     groups.each do |group|
       and_conditions = {}
       group.conditions.map do |condition|
+        key = condition.field.gsub(/(?<!metadata)\./, '___')
         case condition.operator
         when '=', 'in'
-          and_conditions[condition.field] = condition.value
+          and_conditions[key] = condition.value
         when '!=', 'not_in'
-          and_conditions[condition.field] = { not: condition.value }
+          and_conditions[key] = { not: condition.value }
         when '<='
-          between_condition(and_conditions, condition, :lte)
+          between_condition(and_conditions, condition, key, :lte)
         when '>='
-          between_condition(and_conditions, condition, :gte)
+          between_condition(and_conditions, condition, key, :gte)
         when 'contains'
-          and_conditions[condition.field] = { ilike: "%#{condition.value}%" }
+          and_conditions[key] = { ilike: "%#{condition.value}%" }
         end
       end
       or_conditions << and_conditions
@@ -131,20 +132,20 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
     { _or: or_conditions }
   end
 
-  def between_condition(and_conditions, condition, operation) # rubocop:disable Metrics/AbcSize
+  def between_condition(and_conditions, condition, key, operation) # rubocop:disable Metrics/AbcSize
     if %w[created_at updated_at attachments_updated_at].include?(condition.field) || condition.field.end_with?('_date')
-      and_conditions[condition.field] = if and_conditions[condition.field].nil?
-                                          { operation => condition.value }
-                                        else
-                                          and_conditions[condition.field].merge({ operation => condition.value })
-                                        end
+      and_conditions[key] = if and_conditions[key].nil?
+                              { operation => condition.value }
+                            else
+                              and_conditions[key].merge({ operation => condition.value })
+                            end
     else
-      and_conditions["#{condition.field}.numeric"] = if and_conditions["#{condition.field}.numeric"].nil?
-                                                       { operation => condition.value.to_i }
-                                                     else
-                                                       and_conditions["#{condition.field}.numeric"]
-                                                         .merge({ operation => condition.value.to_i })
-                                                     end
+      and_conditions["#{key}.numeric"] = if and_conditions["#{key}.numeric"].nil?
+                                           { operation => condition.value.to_i }
+                                         else
+                                           and_conditions["#{key}.numeric"]
+                                             .merge({ operation => condition.value.to_i })
+                                         end
     end
   end
 

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -66,7 +66,7 @@ david_doe_group_four:
   path: group-4
   description: David's first group
   puid: INXT_GRP_AAAAAAAAAF
-  metadata_summary: { "unique_metadata_field": 1 }
+  metadata_summary: { "unique.metadata.field": 1 }
   samples_count: 1
 
 group_five:

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -302,7 +302,7 @@ project28_namespace:
   description: Project 28 description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:david_doe_group_four, :uuid) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:david_doe, :uuid) %>
-  metadata_summary: { "unique_metadata_field": 1 }
+  metadata_summary: { "unique.metadata.field": 1 }
   puid: INXT_PRJ_AAAAAAAABA
 
 project29_namespace:

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -109,8 +109,8 @@ sample28:
   puid: INXT_SAM_AAAAAAAAA6
   created_at: <%= 31.weeks.ago %>
   updated_at: <%= 31.days.ago %>
-  metadata: { 'unique_metadata_field': 'unique_value' }
-  metadata_provenance: { 'unique_metadata_field': { 'id': 1, 'source': 'analysis', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
+  metadata: { 'unique.metadata.field': 'unique_value' }
+  metadata_provenance: { 'unique.metadata.field': { 'id': 1, 'source': 'analysis', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
 
 sample29:
   name: Sample 2

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -199,11 +199,11 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   test '#metadata_summary' do
-    assert_equal %w[metadatafield1 metadatafield2 unique_metadata_field], @group.metadata_fields
+    assert_equal %w[metadatafield1 metadatafield2 unique.metadata.field], @group.metadata_fields
   end
 
   test '#metadata_summary incorporates fields from shared groups' do
-    assert_equal %w[unique_metadata_field metadatafield1 metadatafield2], groups(:david_doe_group_four).metadata_fields
+    assert_equal %w[unique.metadata.field metadatafield1 metadatafield2], groups(:david_doe_group_four).metadata_fields
   end
 
   test '#metadata_summary incorporates fields from shared projects' do

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -12,6 +12,7 @@ module Groups
       @group = groups(:group_one)
       @sample1 = samples(:sample1)
       @sample2 = samples(:sample2)
+      @sample3 = samples(:sample3)
       @sample9 = samples(:sample9)
       @sample25 = samples(:sample25)
       @sample28 = samples(:sample28)
@@ -476,6 +477,53 @@ module Groups
         assert_selector "tr[id='#{@sample1.id}']"
         assert_selector "tr[id='#{@sample2.id}']"
         assert_selector "tr[id='#{@sample9.id}']"
+      end
+    end
+
+    test 'filter samples with advanced search using metadata fields names with extra periods' do
+      visit group_samples_url(@group)
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 26,
+                                                                           locale: @user.locale))
+
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{@sample1.id}']"
+        assert_selector "tr[id='#{@sample2.id}']"
+        assert_selector "tr[id='#{@sample3.id}']"
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            find("select[name$='[field]']").find("option[value='metadata.unique.metadata.field']").select_option
+            find("select[name$='[operator]']").find("option[value='=']").select_option
+            find("input[name$='[value]']").fill_in with: @sample28.metadata['unique.metadata.field']
+          end
+        end
+
+        click_button I18n.t(:'advanced_search_component.apply_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 1
+        # sample28 found
+        assert_no_selector "tr[id='#{@sample1.id}']"
+        assert_no_selector "tr[id='#{@sample2.id}']"
+        assert_no_selector "tr[id='#{@sample3.id}']"
+        assert_selector "tr[id='#{@sample28.id}']"
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        click_button I18n.t(:'advanced_search_component.clear_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{@sample1.id}']"
+        assert_selector "tr[id='#{@sample2.id}']"
+        assert_selector "tr[id='#{@sample3.id}']"
       end
     end
 


### PR DESCRIPTION
## What does this PR do and why?
This is a fix for when a metadata field has a name with periods in it, no search results are returned.

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/a55bff4b-efec-49fd-90ed-b16dba6324ef)
![image](https://github.com/user-attachments/assets/654b1d69-5baf-4a38-ada3-215ca70b7e7e)

## How to set up and validate locally
1. Create a sample that has metadata with a period in the field name. 
1. Navigate to the samples page.
1. Click the `Advanced Search` button.
1. Select the search criteria using the metadata field name.
1. Click the `Apply Filter` button. 
1. Verify the table shows the sample. 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
