### PR TITLE
Fix for advanced search button dark mode

### DIFF
--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -6,7 +6,11 @@
           type="button"
           class="
             inline-flex items-center justify-center w-1/2 text-sm border rounded-s-md
-            cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5
+            cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white text-slate-900
+            border-slate-200 focus:outline-none focus:ring-slate-200 hover:bg-slate-100
+            hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600
+            dark:focus:ring-slate-700 dark:border-slate-600 dark:hover:text-white
+            dark:hover:bg-slate-700
           "
           data-action="viral--dialog#open"
           aria-label="<%= t(".title") %>"
@@ -17,7 +21,11 @@
           type="button"
           class="
             inline-flex items-center justify-center w-1/2 text-sm border rounded-e-md
-            cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5
+            cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white text-slate-900
+            border-slate-200 focus:outline-none focus:ring-slate-200 hover:bg-slate-100
+            hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600
+            dark:focus:ring-slate-700 dark:border-slate-600 dark:hover:text-white
+            dark:hover:bg-slate-700
           "
           data-action="advanced-search#clearForm filters#submit"
           aria-label="<%= t(".clear_aria_label") %>"

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -20,12 +20,12 @@
         <button
           type="button"
           class="
-            inline-flex items-center justify-center w-1/2 text-sm border rounded-e-md
-            cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white text-slate-900
-            border-slate-200 focus:outline-none focus:ring-slate-200 hover:bg-slate-100
-            hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600
-            dark:focus:ring-slate-700 dark:border-slate-600 dark:hover:text-white
-            dark:hover:bg-slate-700
+            inline-flex items-center justify-center w-1/2 text-sm border border-l-0
+            rounded-e-md cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white
+            text-slate-900 border-slate-200 focus:outline-none focus:ring-slate-200
+            hover:bg-slate-100 hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400
+            dark:border-slate-600 dark:focus:ring-slate-700 dark:border-slate-600
+            dark:hover:text-white dark:hover:bg-slate-700
           "
           data-action="advanced-search#clearForm filters#submit"
           aria-label="<%= t(".clear_aria_label") %>"


### PR DESCRIPTION
## What does this PR do and why?
Fixes dark mode for advanced search button when a search is active. 

## Screenshots or screen recordings
Before:
![image](https://github.com/user-attachments/assets/cd97f5cc-1aca-44f0-b299-c0c0e5346d67)

After:
![image](https://github.com/user-attachments/assets/ef1e99e5-f810-4c3c-88bf-c13027129384)

## How to set up and validate locally
1. Navigate to a group or project samples page in dark mode. 
2. Filter samples via advanced search.
3. Verify the style of the `Advanced search` button.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
