### PR TITLE
Advanced Search: Adding new 'exists' and 'not_exists' operators

### DIFF
--- a/app/components/advanced_search/value.html.erb
+++ b/app/components/advanced_search/value.html.erb
@@ -1,5 +1,7 @@
 <% invalid_value = @condition.errors.include?(:value) %>
-<% operator_exists = @condition.operator.blank? %>
+<% operator_exists =
+  @condition.operator.blank? ||
+    %w[exists not_exists].include?(@condition.operator) %>
 <div
   class="
     form-field w-6/12 value <%= 'invalid' if invalid_value %>

--- a/app/components/advanced_search/value.html.erb
+++ b/app/components/advanced_search/value.html.erb
@@ -1,9 +1,9 @@
 <% invalid_value = @condition.errors.include?(:value) %>
-<% exists_operator = %w[exists not_exists].include?(@condition.operator) %>
+<% operator_exists = @condition.operator.blank? %>
 <div
   class="
     form-field w-6/12 value <%= 'invalid' if invalid_value %>
-    <%= 'invisible' if exists_operator %>
+    <%= 'invisible' if operator_exists %>
   "
 >
   <% if %w[in not_in].include?(@condition.operator) %>

--- a/app/components/advanced_search/value.html.erb
+++ b/app/components/advanced_search/value.html.erb
@@ -15,7 +15,13 @@
   <% else %>
     <%= @conditions_form.text_field :value,
                                 placeholder: t("advanced_search_component.value"),
-                                "aria-label": t("advanced_search_component.value") %>
+                                "aria-label": t("advanced_search_component.value"),
+                                class:
+                                  class_names(
+                                    invisible: %w[exists not_exists].include?(
+                                      @condition.operator,
+                                    ),
+                                  ) %>
   <% end %>
   <%= render "shared/form/field_errors",
   errors: @condition.errors.full_messages_for(:value) %>

--- a/app/components/advanced_search/value.html.erb
+++ b/app/components/advanced_search/value.html.erb
@@ -1,5 +1,11 @@
 <% invalid_value = @condition.errors.include?(:value) %>
-<div class="form-field w-6/12 value <%= 'invalid' if invalid_value %>">
+<% exists_operator = %w[exists not_exists].include?(@condition.operator) %>
+<div
+  class="
+    form-field w-6/12 value <%= 'invalid' if invalid_value %>
+    <%= 'invisible' if exists_operator %>
+  "
+>
   <% if %w[in not_in].include?(@condition.operator) %>
     <div
       data-controller="list-filter"
@@ -15,13 +21,7 @@
   <% else %>
     <%= @conditions_form.text_field :value,
                                 placeholder: t("advanced_search_component.value"),
-                                "aria-label": t("advanced_search_component.value"),
-                                class:
-                                  class_names(
-                                    invisible: %w[exists not_exists].include?(
-                                      @condition.operator,
-                                    ),
-                                  ) %>
+                                "aria-label": t("advanced_search_component.value") %>
   <% end %>
   <%= render "shared/form/field_errors",
   errors: @condition.errors.full_messages_for(:value) %>

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -121,7 +121,7 @@
         <% end %>
       </select>
     </div>
-    <div class="form-field w-6/12 value">
+    <div class="form-field w-6/12 value invisible">
       <input
         type="text"
         name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][value]"

--- a/app/javascript/controllers/advanced_search_controller.js
+++ b/app/javascript/controllers/advanced_search_controller.js
@@ -125,11 +125,15 @@ export default class extends Controller {
       ),
     ].indexOf(condition);
 
-    if (["in", "not_in"].includes(operator)) {
+    if (["exists", "not_exists"].includes(operator)) {
+      value.classList.add("invisible");
+    } else if (["in", "not_in"].includes(operator)) {
+      value.classList.remove("invisible");
       value.outerHTML = this.listValueTemplateTarget.innerHTML
         .replace(/GROUP_INDEX_PLACEHOLDER/g, group_index)
         .replace(/CONDITION_INDEX_PLACEHOLDER/g, condition_index);
     } else {
+      value.classList.remove("invisible");
       value.outerHTML = this.valueTemplateTarget.innerHTML
         .replace(/GROUP_INDEX_PLACEHOLDER/g, group_index)
         .replace(/CONDITION_INDEX_PLACEHOLDER/g, condition_index);

--- a/app/javascript/controllers/advanced_search_controller.js
+++ b/app/javascript/controllers/advanced_search_controller.js
@@ -127,6 +127,10 @@ export default class extends Controller {
 
     if (["", "exists", "not_exists"].includes(operator)) {
       value.classList.add("invisible");
+      let inputs = value.querySelectorAll("input");
+      inputs.forEach((input) => {
+        input.value = "";
+      });
     } else if (["in", "not_in"].includes(operator)) {
       value.classList.remove("invisible");
       value.outerHTML = this.listValueTemplateTarget.innerHTML

--- a/app/javascript/controllers/advanced_search_controller.js
+++ b/app/javascript/controllers/advanced_search_controller.js
@@ -125,7 +125,7 @@ export default class extends Controller {
       ),
     ].indexOf(condition);
 
-    if (["exists", "not_exists"].includes(operator)) {
+    if (["", "exists", "not_exists"].includes(operator)) {
       value.classList.add("invisible");
     } else if (["in", "not_in"].includes(operator)) {
       value.classList.remove("invisible");

--- a/app/validators/advanced_search_group_validator.rb
+++ b/app/validators/advanced_search_group_validator.rb
@@ -50,7 +50,8 @@ class AdvancedSearchGroupValidator < ActiveModel::Validator
                            I18n.t('validators.advanced_search_group_validator.blank_error')
     end
 
-    return unless (condition.value.is_a?(Array) && condition.value.compact_blank.blank?) || condition.value.blank?
+    return unless (condition.value.is_a?(Array) && condition.value.compact_blank.blank?) ||
+                  (%w[exists not_exists].exclude?(condition.operator) && condition.value.blank?)
 
     condition.errors.add :value, I18n.t('validators.advanced_search_group_validator.blank_error')
   end

--- a/app/views/groups/samples/_table_filter.html.erb
+++ b/app/views/groups/samples/_table_filter.html.erb
@@ -24,7 +24,7 @@
     form: f,
     search: @query,
     fields: @advanced_search_fields,
-    operations: %w[= != <= >= contains in not_in],
+    operations: %w[= != <= >= contains exists not_exists in not_in],
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -23,7 +23,7 @@
     form: f,
     search: @query,
     fields: @advanced_search_fields,
-    operations: %w[= != <= >= contains in not_in],
+    operations: %w[= != <= >= contains exists not_exists in not_in],
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/test/components/previews/advanced_search_component_preview.rb
+++ b/test/components/previews/advanced_search_component_preview.rb
@@ -20,7 +20,7 @@ class AdvancedSearchComponentPreview < ViewComponent::Preview
     )
     fields = %w[name puid created_at updated_at attachments_updated_at metadata.age metadata.country
                 metadata.collection_date metadata.food metadata.subject_type metadata.outbreak_code]
-    operations = %w[= != <= >= contains in not_in]
+    operations = %w[= != <= >= contains exists not_exists in not_in]
 
     render_with_template(locals: {
                            search: search,

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -592,6 +592,51 @@ module Groups
       end
     end
 
+    test 'filter samples with advanced search using exists operator' do
+      visit group_samples_url(@group)
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 26,
+                                                                           locale: @user.locale))
+
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{@sample1.id}']"
+        assert_selector "tr[id='#{@sample2.id}']"
+        assert_selector "tr[id='#{@sample3.id}']"
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            find("select[name$='[field]']").find("option[value='metadata.unique.metadata.field']").select_option
+            find("select[name$='[operator]']").find("option[value='exists']").select_option
+          end
+        end
+        click_button I18n.t(:'advanced_search_component.apply_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 1
+        # sample28 found
+        assert_no_selector "tr[id='#{@sample1.id}']"
+        assert_no_selector "tr[id='#{@sample2.id}']"
+        assert_no_selector "tr[id='#{@sample3.id}']"
+        assert_selector "tr[id='#{@sample28.id}']"
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        click_button I18n.t(:'advanced_search_component.clear_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{@sample1.id}']"
+        assert_selector "tr[id='#{@sample2.id}']"
+        assert_selector "tr[id='#{@sample3.id}']"
+      end
+    end
+
     test 'selecting / deselecting all samples' do
       visit group_samples_url(@group)
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 26,


### PR DESCRIPTION
## What does this PR do and why?
The PR adds the ability to search for metadata fields that exists and not exists.

## Screenshots or screen recordings
Exists:
![image](https://github.com/user-attachments/assets/723a8960-28a6-418e-8419-38dda9688dc4)
![image](https://github.com/user-attachments/assets/116c7c76-c948-49c8-8189-f9eeefefd47a)

Not exists:
![image](https://github.com/user-attachments/assets/292c1ccd-d62b-46d7-912e-b02d62746274)
![image](https://github.com/user-attachments/assets/81b4a90e-2faa-48b9-8319-ff513df79635)

## How to set up and validate locally
1. Navigate to a group or project samples page.
1. Click the Advanced Search button. 
1. Verify the Advanced Search dialog opened.
1. Select a field and `exists` or `not_exists` operator to filter by.
1. Click the Apply Filter button.
1. Verify the table displays the correct search results.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
