### PR TITLE
Fix: Sorting on metadata keys that contain spaces

### DIFF
--- a/app/components/samples/table_component.rb
+++ b/app/components/samples/table_component.rb
@@ -32,7 +32,9 @@ module Samples
       @renders_row_actions = @row_actions.select { |_key, value| value }.count.positive?
       @system_arguments = system_arguments
 
-      @sort_key, @sort_direction = search_params[:sort].split
+      # use rpartition to split on the first space encountered from the right side
+      # this allows us to sort by metadata fields which contain spaces
+      @sort_key, _space, @sort_direction = search_params[:sort].rpartition(' ')
 
       @columns = columns
     end

--- a/app/components/sort_component.rb
+++ b/app/components/sort_component.rb
@@ -5,7 +5,9 @@ class SortComponent < Component
   attr_reader :label, :field, :url, :system_arguments
 
   def initialize(sort:, label:, url:, field:, **system_arguments)
-    @sort_key, @sort_direction = sort.split
+    # use rpartition to split on the first space encountered from the right side
+    # this allows us to sort by metadata fields which contain spaces
+    @sort_key, _space, @sort_direction = sort.rpartition(' ')
     @label = label
     @url = url
     @field = field
@@ -13,7 +15,7 @@ class SortComponent < Component
   end
 
   def icon
-    return unless @sort_key.to_s == URI.encode_www_form_component(@field.to_s)
+    return unless @sort_key.to_s == @field.to_s
 
     @sort_direction == 'asc' ? 'arrow_up' : 'arrow_down'
   end

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -46,7 +46,9 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
 
   def sort=(value)
     super
-    column, direction = sort.split
+    # use rpartition to split on the first space encountered from the right side
+    # this allows us to sort by metadata fields which contain spaces
+    column, _space, direction = sort.rpartition(' ')
     column = column.gsub('metadata_', 'metadata.') if column.match?(/metadata_/)
     assign_attributes(column:, direction:)
   end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes sorting on metadata fields which contain spaces in their key, e.g. `check value`.

To fix this I have replaced `split` with `rpartition(' ')` which splits the sort string on the last space.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Create a new Project
2. Create a sample in that project
3. Add a metadata field to that sample with key: `checkm value` and value: '0.11`
4. Navigate back to the Project Samples table
5. Click on `checkm value` column and verify that sort icon shows up and sort is applied.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
