### PR TITLE
Fix: Dialog Component now closes on disconnect

### DIFF
--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -11,14 +11,16 @@ export default class extends Controller {
   }
 
   disconnect() {
-    this.openValue = false;
+    this.close();
   }
 
   open() {
+    this.openValue = true;
     this.dialogTarget.showModal();
   }
 
   close() {
+    this.openValue = false;
     this.dialogTarget.close();
   }
 

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -132,6 +132,9 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       assert_text 'Samples: 13'
       within('table tbody') do
         assert_selector 'tr', count: 13
@@ -210,6 +213,9 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       assert_text 'Samples: 13'
       within('table tbody') do
         assert_selector 'tr', count: 13
@@ -244,6 +250,9 @@ module Groups
 
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -281,6 +290,9 @@ module Groups
 
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -363,6 +375,9 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       assert_text '1-13 of 13'
       within('table tbody') do
         assert_selector 'tr', count: 13
@@ -406,6 +421,9 @@ module Groups
 
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -694,6 +712,9 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       assert_text 'Samples: 1'
       assert_selector 'table tbody tr', count: 1
 
@@ -714,6 +735,9 @@ module Groups
 
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: ' '
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       assert_text 'Samples: 26'
       assert_selector 'tfoot strong[data-selection-target="selected"]', text: '0'
@@ -912,6 +936,9 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       assert_selector 'label', text: I18n.t('projects.samples.shared.metadata_toggle.label'), count: 1
       find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click
 
@@ -958,6 +985,9 @@ module Groups
 
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample28.name
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       ### SETUP END ###
 

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -852,6 +852,9 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       # verify sort is still applied
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
       ### actions and VERIFY END ###
@@ -872,6 +875,9 @@ module Projects
       # apply filter
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -897,6 +903,9 @@ module Projects
       # apply filter
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample2.puid
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -917,6 +926,9 @@ module Projects
       ### ACTIONS START ###
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: 'sample'
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -938,6 +950,9 @@ module Projects
       ### ACTIONS START ###
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -965,6 +980,9 @@ module Projects
       # apply filter
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: filter_text
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       assert_selector "tr[id='#{@sample1.id}']"
       assert_no_selector "tr[id='#{@sample2.id}']"
@@ -1015,6 +1033,9 @@ module Projects
       # apply filter
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: filter_text
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -2037,6 +2058,9 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: samples(:sample1).name
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       within 'tbody' do
         assert_selector 'input[name="sample_ids[]"]', count: 1
         assert_selector 'input[name="sample_ids[]"]:checked', count: 0
@@ -2055,6 +2079,9 @@ module Projects
       # remove filter
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: ' '
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       within 'tfoot' do
         assert_text "#{I18n.t('samples.table_component.counts.samples')}: 3"
@@ -2451,6 +2478,9 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
+
       assert_selector 'label', text: I18n.t('projects.samples.shared.metadata_toggle.label'), count: 1
       find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click
 
@@ -2537,6 +2567,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample2.name
       find('input.t-search-component').native.send_keys(:return)
 
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
       ### SETUP END ###
 
       ### VERIFY START ###
@@ -2556,6 +2588,9 @@ module Projects
 
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       assert_selector 'label', text: I18n.t('projects.samples.shared.metadata_toggle.label'), count: 1
       find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click
@@ -2613,6 +2648,9 @@ module Projects
 
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
+
+      assert_selector 'div#spinner'
+      assert_no_selector 'div#spinner'
 
       assert_selector 'label', text: I18n.t('projects.samples.shared.metadata_toggle.label'), count: 1
       find('label', text: I18n.t('projects.samples.shared.metadata_toggle.label')).click


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Previously the Dialog Component would set `openValue` to false on `disconnect` (fired on page navigation), which resulted in a weird rendering issue if you opened a dialog then clicked the `back` button and then clicked the `forward` button. The dialog would render but it would be incorrectly.

Now when you click back and then forward, while a dialog is open it will no longer be open on forward navigation.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
