### PR TITLE
Fix for filtering floats via advanced search 

### DIFF
--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -151,10 +151,10 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
                             end
     else
       and_conditions["#{key}.numeric"] = if and_conditions["#{key}.numeric"].nil?
-                                           { operation => condition.value.to_i }
+                                           { operation => condition.value.to_f }
                                          else
                                            and_conditions["#{key}.numeric"]
-                                             .merge({ operation => condition.value.to_i })
+                                             .merge({ operation => condition.value.to_f })
                                          end
     end
   end

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -142,7 +142,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
     end
   end
 
-  def handle_between_condition(and_conditions, condition, key, operation) # rubocop:disable Metrics/AbcSize
+  def handle_between_condition(and_conditions, condition, key, operation)
     if %w[created_at updated_at attachments_updated_at].include?(condition.field) || condition.field.end_with?('_date')
       and_conditions[key] = if and_conditions[key].nil?
                               { operation => condition.value }
@@ -151,10 +151,10 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
                             end
     else
       and_conditions["#{key}.numeric"] = if and_conditions["#{key}.numeric"].nil?
-                                           { operation => condition.value.to_f }
+                                           { operation => condition.value }
                                          else
                                            and_conditions["#{key}.numeric"]
-                                             .merge({ operation => condition.value.to_f })
+                                             .merge({ operation => condition.value })
                                          end
     end
   end

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -529,3 +529,13 @@ subgroup_papa_a:
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_papa, :uuid) %>
   puid: INXT_GRP_AAAAAAAACN
   samples_count: 0
+
+group_metadata:
+  <<: *DEFAULTS
+  name: Group Metadata
+  path: group-metadata
+  description: Group Metadata description
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
+  metadata_summary: { "float_example": 3, "integer_example": 3 }
+  puid: INXT_GRP_AAAAAAAACO
+  samples_count: 3

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -536,6 +536,6 @@ group_metadata:
   path: group-metadata
   description: Group Metadata description
   owner_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
-  metadata_summary: { "float_example": 3, "integer_example": 3 }
+  metadata_summary: { "example_date": 3, "example_float": 3, "example_integer": 3 }
   puid: INXT_GRP_AAAAAAAACO
   samples_count: 3

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -622,3 +622,15 @@ group_jeff_member_user_bot_account:
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_jeff, :uuid) %>
   access_level: <%= Member::AccessLevel::UPLOADER %>
   expires_at: <%= 20.days.from_now %>
+
+group_metadata_member_metadata_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:group_metadata, :uuid) %>
+  access_level: <%= Member::AccessLevel::OWNER %>
+
+project_metadata_member_metadata_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata_namespace, :uuid) %>
+  access_level: <%= Member::AccessLevel::OWNER %>

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -570,5 +570,6 @@ projectMetadata_namespace:
   description: Project Metadata description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:group_metadata, :uuid) %>
   owner_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
-  metadata_summary: { "float_example": 3, "integer_example": 3 }
+  metadata_summary:
+    { "example_date": 3, "example_float": 3, "example_integer": 3 }
   puid: INXT_PRJ_AAAAAAAACA

--- a/test/fixtures/namespaces/project_namespaces.yml
+++ b/test/fixtures/namespaces/project_namespaces.yml
@@ -562,3 +562,13 @@ projectMikeB_namespace:
   description: Project Mike B description
   parent_id: <%= ActiveRecord::FixtureSet.identify(:subgroup_mike_b, :uuid) %>
   puid: INXT_PRJ_AAAAAAAABZ
+
+projectMetadata_namespace:
+  <<: *DEFAULTS
+  name: Project Metadata
+  path: project-metadata
+  description: Project Metadata description
+  parent_id: <%= ActiveRecord::FixtureSet.identify(:group_metadata, :uuid) %>
+  owner_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
+  metadata_summary: { "float_example": 3, "integer_example": 3 }
+  puid: INXT_PRJ_AAAAAAAACA

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -324,3 +324,8 @@ projectMikeB:
   creator_id: <%= ActiveRecord::FixtureSet.identify(:private_ryan, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectMikeB_namespace, :uuid) %>
   samples_count: 2
+
+projectMetadata:
+  creator_id: <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata_namespace, :uuid) %>
+  samples_count: 3

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -603,3 +603,13 @@ subgroup_papa_a_route:
   name: Group Papa / Subgroup Papa A
   path: group-papa/subgroup-papa-a
   source: subgroup_papa_a (Namespace)
+
+group_metadata_route:
+  name: Group Metadata
+  path: group-metadata
+  source: group_metadata (Namespace)
+
+projectMetadata_namespace_route:
+  name: Group Metadata / Project Metadata
+  path: group-metadata/project-metadata
+  source: projectMetadata_namespace (Namespace)

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -490,3 +490,31 @@ sample60:
   created_at: <%= 1.week.ago %>
   updated_at: <%= 1.day.ago %>
   attachments_updated_at: <%= 2.hours.ago %>
+
+sample61:
+  name: Sample 61
+  description: Sample 61 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata, :uuid) %>
+  puid: INXT_SAM_AAAAAAAADK
+  metadata: { 'float_example': '0.1', 'integer_example': '1' }
+  metadata_provenance: { 'float_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+  'integer_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
+
+sample62:
+  name: Sample 62
+  description: Sample 62 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata, :uuid) %>
+  puid: INXT_SAM_AAAAAAAADL
+  metadata: { 'float_example': '0.25', 'integer_example': '25' }
+  metadata_provenance: { 'float_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+  'integer_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
+
+sample63:
+  name: Sample 63
+  description: Sample 63 description.
+  project_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata, :uuid) %>
+  puid: INXT_SAM_AAAAAAAADM
+  metadata: { 'float_example': '0.99', 'integer_example': '100' }
+  metadata_provenance: { 'float_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+  'integer_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
+

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -496,25 +496,28 @@ sample61:
   description: Sample 61 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata, :uuid) %>
   puid: INXT_SAM_AAAAAAAADK
-  metadata: { 'float_example': '0.1', 'integer_example': '1' }
-  metadata_provenance: { 'float_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
-  'integer_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
+  metadata: { 'example_date': '2023-10-17', 'example_float': '0.01', 'example_integer': '1' }
+  metadata_provenance: { 'example_date': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+    'example_float': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+    'example_integer': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
 
 sample62:
   name: Sample 62
   description: Sample 62 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata, :uuid) %>
   puid: INXT_SAM_AAAAAAAADL
-  metadata: { 'float_example': '0.25', 'integer_example': '25' }
-  metadata_provenance: { 'float_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
-  'integer_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
+  metadata: { 'example_date': '2023-11-17', 'example_float': '0.25', 'example_integer': '25' }
+  metadata_provenance: { 'example_date': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+    'example_float': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+    'example_integer': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
 
 sample63:
   name: Sample 63
   description: Sample 63 description.
   project_id: <%= ActiveRecord::FixtureSet.identify(:projectMetadata, :uuid) %>
   puid: INXT_SAM_AAAAAAAADM
-  metadata: { 'float_example': '0.99', 'integer_example': '100' }
-  metadata_provenance: { 'float_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
-  'integer_example': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
+  metadata: { 'example_date': '2023-12-17', 'example_float': '0.99', 'example_integer': '100' }
+  metadata_provenance: { 'example_date': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+    'example_float': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> },
+    'example_integer': { 'id': <%= ActiveRecord::FixtureSet.identify(:metadata_doe, :uuid) %>, 'source': 'user', 'updated_at': <%= DateTime.new(2000,1,1) %> } }
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -213,3 +213,10 @@ empty_doe:
   email: <%= "empty_doe@localhost" %>
   first_name: Empty
   last_name: Doe
+
+metadata_doe:
+  <<: *DEFAULTS
+  email: <%= "metadata_doe@localhost" %>
+  first_name: Metadata
+  last_name: Doe
+

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2314,7 +2314,7 @@ module Projects
       ### actions and VERIFY END ###
     end
 
-    test 'filter samples with advanced search using different a float type' do
+    test 'filter samples with advanced search using a float type' do
       ### SETUP START ###
       user = users(:metadata_doe)
       login_as user

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2314,7 +2314,7 @@ module Projects
       ### actions and VERIFY END ###
     end
 
-    test 'filter samples with advanced search using a float type' do
+    test 'filter samples with advanced search using between dates' do
       ### SETUP START ###
       user = users(:metadata_doe)
       login_as user
@@ -2340,9 +2340,18 @@ module Projects
         assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
         within all("div[data-advanced-search-target='groupsContainer']")[0] do
           within all("div[data-advanced-search-target='conditionsContainer']")[0] do
-            find("select[name$='[field]']").find("option[value='metadata.float_example']").select_option
+            find("select[name$='[field]']").find("option[value='metadata.example_date']").select_option
             find("select[name$='[operator]']").find("option[value='>=']").select_option
-            find("input[name$='[value]']").fill_in with: sample63.metadata['float_example']
+            find("input[name$='[value]']").fill_in with: (DateTime.strptime(sample62.metadata['example_date'],
+                                                                            '%Y-%m-%d') - 1.day).strftime('%Y-%m-%d')
+          end
+          click_button I18n.t(:'advanced_search_component.add_condition_button')
+          assert_selector "div[data-advanced-search-target='conditionsContainer']", count: 2
+          within all("div[data-advanced-search-target='conditionsContainer']")[1] do
+            find("select[name$='[field]']").find("option[value='metadata.example_date']").select_option
+            find("select[name$='[operator]']").find("option[value='<=']").select_option
+            find("input[name$='[value]']").fill_in with: (DateTime.strptime(sample62.metadata['example_date'],
+                                                                            '%Y-%m-%d') + 1.day).strftime('%Y-%m-%d')
           end
         end
         click_button I18n.t(:'advanced_search_component.apply_filter_button')
@@ -2351,9 +2360,137 @@ module Projects
       within '#samples-table table tbody' do
         assert_selector 'tr', count: 1
         assert_no_selector "tr[id='#{sample61.id}']"
-        assert_no_selector "tr[id='#{sample62.id}']"
-        # sample63 found
+        assert_no_selector "tr[id='#{sample63.id}']"
+        # sample62 found
+        assert_selector "tr[id='#{sample62.id}']"
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        click_button I18n.t(:'advanced_search_component.clear_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 3
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
         assert_selector "tr[id='#{sample63.id}']"
+      end
+      ### actions and VERIFY END ###
+    end
+
+    test 'filter samples with advanced search using between floats' do
+      ### SETUP START ###
+      user = users(:metadata_doe)
+      login_as user
+      sample61 = samples(:sample61)
+      sample62 = samples(:sample62)
+      sample63 = samples(:sample63)
+      project = projects(:projectMetadata)
+      namespace = groups(:group_metadata)
+      visit namespace_project_samples_url(namespace, project)
+      # verify samples table has loaded to prevent flakes
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
+                                                                           locale: user.locale))
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
+        assert_selector "tr[id='#{sample63.id}']"
+      end
+      ### SETUP END ###
+
+      ### actions and VERIFY START ###
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            find("select[name$='[field]']").find("option[value='metadata.example_float']").select_option
+            find("select[name$='[operator]']").find("option[value='>=']").select_option
+            find("input[name$='[value]']").fill_in with: sample62.metadata['example_float'].to_f - 0.1
+          end
+          click_button I18n.t(:'advanced_search_component.add_condition_button')
+          assert_selector "div[data-advanced-search-target='conditionsContainer']", count: 2
+          within all("div[data-advanced-search-target='conditionsContainer']")[1] do
+            find("select[name$='[field]']").find("option[value='metadata.example_float']").select_option
+            find("select[name$='[operator]']").find("option[value='<=']").select_option
+            find("input[name$='[value]']").fill_in with: sample62.metadata['example_float'].to_f + 0.1
+          end
+        end
+        click_button I18n.t(:'advanced_search_component.apply_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 1
+        assert_no_selector "tr[id='#{sample61.id}']"
+        assert_no_selector "tr[id='#{sample63.id}']"
+        # sample62 found
+        assert_selector "tr[id='#{sample62.id}']"
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        click_button I18n.t(:'advanced_search_component.clear_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 3
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
+        assert_selector "tr[id='#{sample63.id}']"
+      end
+      ### actions and VERIFY END ###
+    end
+
+    test 'filter samples with advanced search using between integers' do
+      ### SETUP START ###
+      user = users(:metadata_doe)
+      login_as user
+      sample61 = samples(:sample61)
+      sample62 = samples(:sample62)
+      sample63 = samples(:sample63)
+      project = projects(:projectMetadata)
+      namespace = groups(:group_metadata)
+      visit namespace_project_samples_url(namespace, project)
+      # verify samples table has loaded to prevent flakes
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
+                                                                           locale: user.locale))
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
+        assert_selector "tr[id='#{sample63.id}']"
+      end
+      ### SETUP END ###
+
+      ### actions and VERIFY START ###
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            find("select[name$='[field]']").find("option[value='metadata.example_integer']").select_option
+            find("select[name$='[operator]']").find("option[value='>=']").select_option
+            find("input[name$='[value]']").fill_in with: sample62.metadata['example_integer'].to_i - 1
+          end
+          click_button I18n.t(:'advanced_search_component.add_condition_button')
+          assert_selector "div[data-advanced-search-target='conditionsContainer']", count: 2
+          within all("div[data-advanced-search-target='conditionsContainer']")[1] do
+            find("select[name$='[field]']").find("option[value='metadata.example_integer']").select_option
+            find("select[name$='[operator]']").find("option[value='<=']").select_option
+            find("input[name$='[value]']").fill_in with: sample62.metadata['example_integer'].to_i + 1
+          end
+        end
+        click_button I18n.t(:'advanced_search_component.apply_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 1
+        assert_no_selector "tr[id='#{sample61.id}']"
+        assert_no_selector "tr[id='#{sample63.id}']"
+        # sample62 found
+        assert_selector "tr[id='#{sample62.id}']"
       end
 
       click_button I18n.t(:'advanced_search_component.title')

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2314,6 +2314,63 @@ module Projects
       ### actions and VERIFY END ###
     end
 
+    test 'filter samples with advanced search using different a float type' do
+      ### SETUP START ###
+      user = users(:metadata_doe)
+      login_as user
+      sample61 = samples(:sample61)
+      sample62 = samples(:sample62)
+      sample63 = samples(:sample63)
+      project = projects(:projectMetadata)
+      namespace = groups(:group_metadata)
+      visit namespace_project_samples_url(namespace, project)
+      # verify samples table has loaded to prevent flakes
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
+                                                                           locale: user.locale))
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
+        assert_selector "tr[id='#{sample63.id}']"
+      end
+      ### SETUP END ###
+
+      ### actions and VERIFY START ###
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            find("select[name$='[field]']").find("option[value='metadata.float_example']").select_option
+            find("select[name$='[operator]']").find("option[value='>=']").select_option
+            find("input[name$='[value]']").fill_in with: sample63.metadata['float_example']
+          end
+        end
+        click_button I18n.t(:'advanced_search_component.apply_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 1
+        assert_no_selector "tr[id='#{sample61.id}']"
+        assert_no_selector "tr[id='#{sample62.id}']"
+        # sample63 found
+        assert_selector "tr[id='#{sample63.id}']"
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        click_button I18n.t(:'advanced_search_component.clear_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 3
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
+        assert_selector "tr[id='#{sample63.id}']"
+      end
+      ### actions and VERIFY END ###
+    end
+
     test 'filter samples with advanced search using multiple conditions' do
       ### SETUP START ###
       visit namespace_project_samples_url(@namespace, @project)


### PR DESCRIPTION
## What does this PR do and why?
Fixed searching float values. 

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/3b8bfcab-8272-4710-9da9-ffa68a0457e9)
![image](https://github.com/user-attachments/assets/fc4435b1-63ab-4b1f-bbab-ca1207677585)

## How to set up and validate locally
1. Navigate to a sample page that you have access to modify.
1. Add a new metadata field with a value that contains a decimal.
1. Navigate to the samples table page of the recently modified sample. 
1. Click the Advanced Search button. 
1. Verify the Advanced Search dialog opened.
1. Select the new field, a between operator and value to filter by.
1. Click the Apply Filter button.
1. Verify the table displays the correct search results.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
