### PR TITLE
Searchkick: Increase total field limit to 10000 for Samples

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -60,7 +60,16 @@ class Sample < ApplicationRecord # rubocop:disable Metrics/ClassLength
       ]
     },
     deep_paging: true,
-    text_middle: %i[name puid]
+    text_middle: %i[name puid],
+    settings: {
+      index: {
+        mapping: {
+          total_fields: {
+            limit: 10_000
+          }
+        }
+      }
+    }
 
   belongs_to :project, counter_cache: true
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Due to the dynamic nature of metadata I have updated the total field limit from 1000 to 10000 for Samples. Since a metadata field that is not a data field is indexed 2 different ways it counts as 2 fields to the limit. With this change we allow support for up to ~4990 unique non date metadata fields to be indexed.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Navigate to http://localhost:9200/_list/indices to find the index starting with `samples_development`
2. Check `http://localhost:9200/INDEX_NAME/_settings` for `total_fields` which should not show up
3.  Run `bin/rails db:reset` and then repeat steps 1-2 and confirm that `total_fields` is now present with a value of 10000

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
