### PR TITLE
Native Advanced Search

### DIFF
--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -36,9 +36,6 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
       conditions ||= []
       group_attributes.each_value do |conditions_attributes|
         conditions_attributes.each_value do |condition_params|
-          condition_params[:value] = condition_params[:value].compact_blank if condition_params[:value].is_a?(Array)
-          Rails.logger.debug 'Debug Here'
-          Rails.logger.debug condition_params[:value]
           conditions.push(Sample::SearchCondition.new(condition_params))
         end
       end

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -37,6 +37,8 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
       group_attributes.each_value do |conditions_attributes|
         conditions_attributes.each_value do |condition_params|
           condition_params[:value] = condition_params[:value].compact_blank if condition_params[:value].is_a?(Array)
+          Rails.logger.debug 'Debug Here'
+          Rails.logger.debug condition_params[:value]
           conditions.push(Sample::SearchCondition.new(condition_params))
         end
       end
@@ -151,7 +153,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
       end
     when 'not_in'
       if metadata_field || %w[name puid].include?(condition.field)
-        scope.where(node.does_not_match_any(condition.value))
+        scope.where(node.does_not_match_all(condition.value))
       else
         scope.where(node.not_in(condition.value))
       end

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -36,6 +36,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
       conditions ||= []
       group_attributes.each_value do |conditions_attributes|
         conditions_attributes.each_value do |condition_params|
+          condition_params[:value] = condition_params[:value].compact_blank if condition_params[:value].is_a?(Array)
           conditions.push(Sample::SearchCondition.new(condition_params))
         end
       end
@@ -195,7 +196,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
           )
       end
     when 'contains'
-      scope.where(node.matches("%#{condition.value}"))
+      scope.where(node.matches("%#{condition.value}%"))
     when 'exists'
       scope.where(node.not_eq(nil))
     when 'not_exists'

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -70,7 +70,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
   private
 
   def pagy_results(limit, page)
-    if advanced_query && !ENV['RANSACK_ONLY_SEARCH'].present?
+    if advanced_query && ENV['RANSACK_ONLY_SEARCH'].blank?
       pagy_searchkick(searchkick_pagy_results, limit:, page:)
     else
       pagy(ransack_results, limit:, page:)
@@ -78,7 +78,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
   end
 
   def non_pagy_results
-    if advanced_query && !ENV['RANSACK_ONLY_SEARCH'].present?
+    if advanced_query && ENV['RANSACK_ONLY_SEARCH'].blank?
       searchkick_results
     else
       ransack_results
@@ -128,6 +128,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
              Sample.arel_table[condition.field]
            end
 
+    # TODO: Refactor each case into it's own method
     case condition.operator
     when '='
       if metadata_field || %w[name puid].include?(condition.field)


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR implements native advanced search using AREL. To toggle this and skip Searchkick for advanced search you need to set `RANSACK_ONLY_SEARCH=true` in your env before running rails commands

Note: The plan with this PR is to deploy changed to DEV and have QA team compare results and functionality with TEST that will still use Searchkick. Once QA team signs off, a follow up PR with happen to refactor code to be more readable and to remove Searchkick references.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch server with the following command `RANSACK_ONLY_SEARCH=true bin/dev`
2. Navigate to a Sample page and perform advanced searching
3. Confirm that  `Searchkick` is not being used for search
   * While watching rails logs, navigate to Samples page add an advanced search condition and submit
   * Confirm that you don't see a line like `Completed 200 OK in 525ms (Views: 289.4ms | Searchkick: 72.3ms | ActiveRecord: 11.3ms (14 queries, 5 cached) | GC: 120.7ms)` specifically `Searchkick: XXms` should not be present
4. Confirm that filtering is behaving as expected
   * Date range still works
   * Number range still works
   * Number range with float works
   * Text field searches are case insensitive

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
