### PR TITLE
Fix: Number and Date regex in native advanced search

### DIFF
--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -159,10 +159,10 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
         scope.where(node.lteq(condition.value))
       elsif metadata_key.end_with?('_date')
         scope
-          .where(node.matches_regexp('^\d{4}-\d{2}-\d{2}$'))
+          .where(node.matches_regexp('^\d{4}(-\d{2}){0,2}$'))
           .where(
             Arel::Nodes::NamedFunction.new(
-              'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DATE'))]
+              'TO_DATE', [node, Arel::Nodes::SqlLiteral.new("'YYYY-MM-DD'")]
             ).lteq(condition.value)
           )
       else
@@ -179,10 +179,10 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
         scope.where(node.gteq(condition.value))
       elsif metadata_key.end_with?('_date')
         scope
-          .where(node.matches_regexp('^\d{4}-\d{2}-\d{2}$'))
+          .where(node.matches_regexp('^\d{4}(-\d{2}){0,2}$'))
           .where(
             Arel::Nodes::NamedFunction.new(
-              'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DATE'))]
+              'TO_DATE', [node, Arel::Nodes::SqlLiteral.new("'YYYY-MM-DD'")]
             ).gteq(condition.value)
           )
       else

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -167,7 +167,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
           )
       else
         scope
-          .where(node.matches_regexp('^\d+\.?\d+$'))
+          .where(node.matches_regexp('^\d+(\.\d+)?$'))
           .where(
             Arel::Nodes::NamedFunction.new(
               'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
@@ -187,7 +187,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
           )
       else
         scope
-          .where(node.matches_regexp('^\d+\.?\d+$'))
+          .where(node.matches_regexp('^\d+(\.\d+)?$'))
           .where(
             Arel::Nodes::NamedFunction.new(
               'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]

--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -167,7 +167,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
           )
       else
         scope
-          .where(node.matches_regexp('^\d+(\.\d+)?$'))
+          .where(node.matches_regexp('^-?\d+(\.\d+)?$'))
           .where(
             Arel::Nodes::NamedFunction.new(
               'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
@@ -187,7 +187,7 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
           )
       else
         scope
-          .where(node.matches_regexp('^\d+(\.\d+)?$'))
+          .where(node.matches_regexp('^-?\d+(\.\d+)?$'))
           .where(
             Arel::Nodes::NamedFunction.new(
               'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Number regex was previously only matching positive numbers with at least 2 digits, this pr updates the regex to match numbers that are single digits as well as numbers that are prefix with `-` indicating that they are negative.

Date regex was previously only matching `YYYY-MM-DD`, this PR updates the regex to match partial dates as well (e.g. `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

### Verifying updated Number regex

1. Run server with `RANSACK_ONLY_SEARCH=true bin/dev` or `env RANSACK_ONLY_SEARCH=true bin/dev` (if using zsh or fish)
2. Create a Project
3. In the Project create a sample and add a metadata field with name `number` and value `1`
4. Go back to Project Samples page
5. Click advanced search and add the following condition
![image](https://github.com/user-attachments/assets/4a2789e6-58b8-4ec8-858f-39a5703c9e46)
6. Click `Apply filter` and confirm that the sample you created is present in the search results
7. Repeat this for `<=` operator

### Verifying updated Date regex
1. Run server with `RANSACK_ONLY_SEARCH=true bin/dev` or `env RANSACK_ONLY_SEARCH=true bin/dev` (if using zsh or fish)
2. Create a Project
3. In the Project create a sample and add a metadata field with name `partial date` and value `2025`
4. Go back to Project Samples page
5. Click advanced search and add the following condition
![image](https://github.com/user-attachments/assets/d5d3ef37-a180-4035-92bd-00d806073474)
6. Click `Apply filter` and confirm that the sample you created is present in the search results
8. Repeat this for `<=` operator
9. Repeat this with changing the metadata field value to `2025-01` and confirm that it still is included in the results (refresh page to ensure search has performed)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
