### PR TITLE
Nextflow Samplesheet: Bug Fixes (submission and table load)

### DIFF
--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -126,6 +126,7 @@
       <% if @samples.empty? %>
       type="submit"
       <% else %>
+      disabled="disabled"
       data-action="click->nextflow--samplesheet#submitSamplesheet"
       <% end %>
     >
@@ -136,10 +137,12 @@
       <% end %>
     </button>
   <% end %>
-  <span
-    class="hidden flex items-center p-4 space-x-4"
-    data-nextflow--samplesheet-target="spinner"
-  >
-    <%= render SpinnerComponent.new(message: t(".processing_request")) %>
-  </span>
+  <% unless @samples.empty? %>
+    <span
+      class="flex items-center p-4 space-x-4"
+      data-nextflow--samplesheet-target="spinner"
+    >
+      <%= render SpinnerComponent.new(message: t(".processing_request")) %>
+    </span>
+  <% end %>
 </div>

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -70,7 +70,6 @@ export default class extends Controller {
 
   connect() {
     if (this.hasWorkflowAttributesTarget) {
-      this.#enableProcessingState();
       this.#setSamplesheetParametersAndData();
       this.#disableProcessingState();
     }

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -70,7 +70,9 @@ export default class extends Controller {
 
   connect() {
     if (this.hasWorkflowAttributesTarget) {
+      this.#enableProcessingState();
       this.#setSamplesheetParametersAndData();
+      this.#disableProcessingState();
     }
   }
 
@@ -163,7 +165,7 @@ export default class extends Controller {
         },
       }).then((response) => {
         this.#disableProcessingState();
-        if (response.redirected && response.statusText == "OK") {
+        if (response.redirected && response.status == "200") {
           window.location.href = response.url;
         } else {
           this.#enableErrorState(this.submissionErrorValue);


### PR DESCRIPTION
## What does this PR do and why?
This PR adds/fixes a couple things that differ between local and QA environments:
- The samplesheet submission will now check `status == '200'` rather than `statusText == 'OK'`
- A loading overlay will be present while the sample table is being loaded in. This is to avoid weird rendering for large sample requests.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Verify you can still submit a workflow with the correct parameters.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
