### PR TITLE
Native Advanced Search: Include nil values in results for != and not_in operators

### DIFF
--- a/app/models/sample/query.rb
+++ b/app/models/sample/query.rb
@@ -144,13 +144,13 @@ class Sample::Query # rubocop:disable Style/ClassAndModuleChildren, Metrics/Clas
       end
     when '!='
       if metadata_field || %w[name puid].include?(condition.field)
-        scope.where(node.does_not_match(condition.value))
+        scope.where(node.eq(nil).or(node.does_not_match(condition.value)))
       else
         scope.where(node.not_eq(condition.value))
       end
     when 'not_in'
       if metadata_field || %w[name puid].include?(condition.field)
-        scope.where(node.does_not_match_all(condition.value))
+        scope.where(node.eq(nil).or(node.does_not_match_all(condition.value)))
       else
         scope.where(node.not_in(condition.value))
       end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updates the `!=` and `not_in` operators to include nil values in results.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Run server with native searching enabled `RANSACK_ONLY_SEARCH=true bin/dev` or `env RANSACK_ONLY_SEARCH=true bin/dev`
2. Create a Project
3. Create a 2 Samples in the Project
4. Add a `age` field with value `80` to one of the samples
5. Filter by `metadata.age != 80` confirm that the sample without a value for age is present
6. Filter by `metadata.age not_in 80` confirm that the sample with a value for age is present

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
