### PR TITLE
Fix for advanced search date validation

### DIFF
--- a/app/validators/advanced_search_group_validator.rb
+++ b/app/validators/advanced_search_group_validator.rb
@@ -67,6 +67,8 @@ class AdvancedSearchGroupValidator < ActiveModel::Validator
   end
 
   def validate_date_field(condition)
+    return if %w[exists not_exists].include?(condition.operator)
+
     if %w[contains in not_not].include?(condition.operator)
       condition.errors.add :operator, I18n.t('validators.advanced_search_group_validator.date_operator_error')
     else

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -2307,6 +2307,47 @@ module Projects
       ### actions and VERIFY END ###
     end
 
+    test 'filter samples with advanced search using exists' do
+      ### SETUP START ###
+      user = users(:metadata_doe)
+      login_as user
+      sample61 = samples(:sample61)
+      sample62 = samples(:sample62)
+      sample63 = samples(:sample63)
+      project = projects(:projectMetadata)
+      namespace = groups(:group_metadata)
+      visit namespace_project_samples_url(namespace, project)
+      # verify samples table has loaded to prevent flakes
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
+                                                                           locale: user.locale))
+      within '#samples-table table tbody' do
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
+        assert_selector "tr[id='#{sample63.id}']"
+      end
+      ### SETUP END ###
+
+      ### actions and VERIFY START ###
+      click_button I18n.t(:'advanced_search_component.title')
+      within '#advanced-search-dialog' do
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            find("select[name$='[field]']").find("option[value='metadata.example_date']").select_option
+            find("select[name$='[operator]']").find("option[value='exists']").select_option
+          end
+        end
+        click_button I18n.t(:'advanced_search_component.apply_filter_button')
+      end
+
+      within '#samples-table table tbody' do
+        assert_selector 'tr', count: 3
+        assert_selector "tr[id='#{sample61.id}']"
+        assert_selector "tr[id='#{sample63.id}']"
+        assert_selector "tr[id='#{sample62.id}']"
+      end
+    end
+
     test 'filter samples with advanced search using between dates' do
       ### SETUP START ###
       user = users(:metadata_doe)


### PR DESCRIPTION
## What does this PR do and why?
Fixes filtering dates with `exists` and `not_exists` operator. 

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/993606ca-44e2-45a6-a6a7-29402cbf49a9)

## How to set up and validate locally
1. Navigate to the samples table page.
1. Click the Advanced Search button.
1. Verify the Advanced Search dialog opened.
1. Select a field that ends with `_date` and `exists` and/or `not_exists` operator to filter by.
1. Click the Apply Filter button.
1. Verify the table displays the correct search results.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
