### PR TITLE
Add close button to Advanced Search dialog

### DIFF
--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -1,127 +1,103 @@
-<%= viral_dialog(id: 'advanced-search-dialog', size: :large, open: @open, closable: false) do |dialog| %>
-  <%= dialog.with_trigger do %>
-    <% if @status %>
-      <div class="inline-flex rounded-md" role="group">
-        <button
-          type="button"
-          class="
-            inline-flex items-center justify-center w-1/2 text-sm border rounded-s-md
-            cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white text-slate-900
-            border-slate-200 focus:outline-none focus:ring-slate-200 hover:bg-slate-100
-            hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600
-            dark:focus:ring-slate-700 dark:border-slate-600 dark:hover:text-white
-            dark:hover:bg-slate-700
-          "
-          data-action="viral--dialog#open"
-          aria-label="<%= t(".title") %>"
-        >
-          <%= t(".title") %>
-        </button>
-        <button
-          type="button"
-          class="
-            inline-flex items-center justify-center w-1/2 text-sm border border-l-0
-            rounded-e-md cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white
-            text-slate-900 border-slate-200 focus:outline-none focus:ring-slate-200
-            hover:bg-slate-100 hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400
-            dark:border-slate-600 dark:focus:ring-slate-700 dark:border-slate-600
-            dark:hover:text-white dark:hover:bg-slate-700
-          "
-          data-action="advanced-search#clearForm filters#submit"
-          aria-label="<%= t(".clear_aria_label") %>"
-        >
-          <%= viral_icon(name: "x_mark", classes: "size-5") %>
-        </button>
-      </div>
-    <% else %>
-      <%= viral_button(data: { action: "viral--dialog#open" }) { t(".title") } %>
-    <% end %>
-  <% end %>
-  <%= dialog.with_header(title: t(".title")) %>
-  <%= dialog.with_section do %>
-    <div class="space-y-4">
-      <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
-        <%= t(".description") %>
-      </p>
-      <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
-        <%= t(".rules") %>
-      </p>
-      <% @search.groups.each_with_index do |group, group_index| %>
-        <%= render AdvancedSearch::Group.new(
-          form: @form,
-          group: group,
-          group_index: group_index,
-          show_remove_group_button: @search.groups.count > 1,
-          fields: @fields,
-          operations: @operations,
-        ) %>
+<div
+  data-controller="advanced-search"
+  data-advanced-search-confirm-close-text-value='<%= t(".confirm_close_text") %>'
+  data-advanced-search-list-filter-outlet=".list-filter"
+>
+  <%= viral_dialog(id: 'advanced-search-dialog', size: :large, open: @open, header_system_arguments: {close_action: "advanced-search#close"}, data: { action: "keydown.esc->advanced-search#close"}) do |dialog| %>
+    <%= dialog.with_trigger do %>
+      <% if @status %>
+        <div class="inline-flex rounded-md" role="group">
+          <button
+            type="button"
+            class="
+              inline-flex items-center justify-center w-1/2 text-sm border rounded-s-md
+              cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white text-slate-900
+              border-slate-200 focus:outline-none focus:ring-slate-200 hover:bg-slate-100
+              hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600
+              dark:focus:ring-slate-700 dark:border-slate-600 dark:hover:text-white
+              dark:hover:bg-slate-700
+            "
+            data-action="advanced-search#idempotentConnect viral--dialog#open"
+            aria-label="<%= t(".title") %>"
+          >
+            <%= t(".title") %>
+          </button>
+          <button
+            type="button"
+            class="
+              inline-flex items-center justify-center w-1/2 text-sm border border-l-0
+              rounded-e-md cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white
+              text-slate-900 border-slate-200 focus:outline-none focus:ring-slate-200
+              hover:bg-slate-100 hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400
+              dark:border-slate-600 dark:focus:ring-slate-700 dark:border-slate-600
+              dark:hover:text-white dark:hover:bg-slate-700
+            "
+            data-action="advanced-search#clearForm filters#submit"
+            aria-label="<%= t(".clear_aria_label") %>"
+          >
+            <%= viral_icon(name: "x_mark", classes: "size-5") %>
+          </button>
+        </div>
+      <% else %>
+        <%= viral_button(
+          data: {
+            action: "advanced-search#idempotentConnect viral--dialog#open",
+          },
+        ) { t(".title") } %>
       <% end %>
-      <div class="flex justify-end space-x-2">
-        <%= viral_button(data: { action: "advanced-search#addGroup" }) do %>
-          <%= t(".add_group_button") %>
-        <% end %>
+    <% end %>
+    <%= dialog.with_header(title: t(".title")) %>
+    <%= dialog.with_section do %>
+      <div class="space-y-4">
+        <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
+          <%= t(".description") %>
+        </p>
+        <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
+          <%= t(".rules") %>
+        </p>
+        <div class="space-y-4" data-advanced-search-target="searchGroupsContainer">
+        </div>
+        <div class="flex justify-end space-x-2">
+          <%= viral_button(data: { action: "advanced-search#addGroup" }) do %>
+            <%= t(".add_group_button") %>
+          <% end %>
+        </div>
+        <template data-advanced-search-target="searchGroupsTemplate">
+          <% @search.groups.each_with_index do |group, group_index| %>
+            <%= render AdvancedSearch::Group.new(
+              form: @form,
+              group: group,
+              group_index: group_index,
+              show_remove_group_button: @search.groups.count > 1,
+              fields: @fields,
+              operations: @operations,
+            ) %>
+          <% end %>
+        </template>
       </div>
-    </div>
-  <% end %>
-  <%= dialog.with_primary_action("data-action": "filters#submit") do
-    t(".apply_filter_button")
-  end %>
-  <% dialog.with_secondary_action do %>
-    <%= viral_button(data: { action: "advanced-search#clearForm filters#submit" }) do %>
-      <%= t(".clear_filter_button") %>
+    <% end %>
+    <%= dialog.with_primary_action("data-action": "filters#submit") do
+      t(".apply_filter_button")
+    end %>
+    <% dialog.with_secondary_action do %>
+      <%= viral_button(data: { action: "advanced-search#clearForm filters#submit" }) do %>
+        <%= t(".clear_filter_button") %>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
-<template data-advanced-search-target="listValueTemplate">
-  <div class="form-field w-6/12 value">
-    <div data-controller="list-filter" class="list-filter">
-      <%= render ListInputComponent.new(
-        list_input_form_name:
-          "q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][value][]",
-        show_description: false,
-      ) %>
+  <template data-advanced-search-target="listValueTemplate">
+    <div class="form-field w-6/12 value">
+      <div data-controller="list-filter" class="list-filter">
+        <%= render ListInputComponent.new(
+          list_input_form_name:
+            "q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][value][]",
+          show_description: false,
+        ) %>
+      </div>
     </div>
-  </div>
-</template>
-<template data-advanced-search-target="valueTemplate">
-  <div class="form-field w-6/12 value">
-    <input
-      type="text"
-      name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][value]"
-      placeholder="<%= t(".value") %>"
-      aria-label="<%= t(".value") %>"
-    />
-  </div>
-</template>
-<template data-advanced-search-target="conditionTemplate">
-  <div
-    data-advanced-search-target="conditionsContainer"
-    class="flex space-x-2 p-4"
-  >
-    <div class="form-field w-1/3">
-      <select
-        aria-label="<%= t(".field") %>"
-        name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][field]"
-      >
-        <option value="" selected><%= t(".field") %></option>
-        <% @fields.each do |field| %>
-          <option value="<%=field%>"><%= field %></option>
-        <% end %>
-      </select>
-    </div>
-    <div class="form-field w-1/6">
-      <select
-        aria-label="<%= t(".operator") %>"
-        data-action="advanced-search#handleOperatorChange"
-        name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][operator]"
-      >
-        <option value="" selected><%= t(".operator") %></option>
-        <% @operations.each do |operation| %>
-          <option value="<%=operation%>"><%= operation %></option>
-        <% end %>
-      </select>
-    </div>
-    <div class="form-field w-6/12 value invisible">
+  </template>
+  <template data-advanced-search-target="valueTemplate">
+    <div class="form-field w-6/12 value">
       <input
         type="text"
         name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][value]"
@@ -129,28 +105,66 @@
         aria-label="<%= t(".value") %>"
       />
     </div>
-    <button
-      type="button"
-      class="text-slate-400 hover:text-slate-900 dark:hover:text-white"
-      aria-label="<%= t(".remove_condition_aria_label") %>"
-      data-action="advanced-search#removeCondition"
+  </template>
+  <template data-advanced-search-target="conditionTemplate">
+    <div
+      data-advanced-search-target="conditionsContainer"
+      class="flex space-x-2 p-4"
     >
-      <%= viral_icon(name: "x_mark", classes: "h-5 w-5") %>
-    </button>
-  </div>
-</template>
-<template data-advanced-search-target="groupTemplate">
-  <div
-    data-advanced-search-target="groupsContainer"
-    class="border border-gray-300 rounded-lg"
-  >
-    <div class="flex justify-end space-x-2 p-4">
-      <%= viral_button(data: { action: "advanced-search#addCondition" }) do %>
-        <%= t(".add_condition_button") %>
-      <% end %>
-      <%= viral_button(data: { action: "advanced-search#removeGroup" }) do %>
-        <%= t(".remove_group_button") %>
-      <% end %>
+      <div class="form-field w-1/3">
+        <select
+          aria-label="<%= t(".field") %>"
+          name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][field]"
+        >
+          <option value="" selected><%= t(".field") %></option>
+          <% @fields.each do |field| %>
+            <option value="<%=field%>"><%= field %></option>
+          <% end %>
+        </select>
+      </div>
+      <div class="form-field w-1/6">
+        <select
+          aria-label="<%= t(".operator") %>"
+          data-action="advanced-search#handleOperatorChange"
+          name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][operator]"
+        >
+          <option value="" selected><%= t(".operator") %></option>
+          <% @operations.each do |operation| %>
+            <option value="<%=operation%>"><%= operation %></option>
+          <% end %>
+        </select>
+      </div>
+      <div class="form-field w-6/12 value invisible">
+        <input
+          type="text"
+          name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][value]"
+          placeholder="<%= t(".value") %>"
+          aria-label="<%= t(".value") %>"
+        />
+      </div>
+      <button
+        type="button"
+        class="text-slate-400 hover:text-slate-900 dark:hover:text-white"
+        aria-label="<%= t(".remove_condition_aria_label") %>"
+        data-action="advanced-search#removeCondition"
+      >
+        <%= viral_icon(name: "x_mark", classes: "h-5 w-5") %>
+      </button>
     </div>
-  </div>
-</template>
+  </template>
+  <template data-advanced-search-target="groupTemplate">
+    <div
+      data-advanced-search-target="groupsContainer"
+      class="border border-gray-300 rounded-lg"
+    >
+      <div class="flex justify-end space-x-2 p-4">
+        <%= viral_button(data: { action: "advanced-search#addCondition" }) do %>
+          <%= t(".add_condition_button") %>
+        <% end %>
+        <%= viral_button(data: { action: "advanced-search#removeGroup" }) do %>
+          <%= t(".remove_group_button") %>
+        <% end %>
+      </div>
+    </div>
+  </template>
+</div>

--- a/app/components/viral/dialog/header_component.html.erb
+++ b/app/components/viral/dialog/header_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Viral::BaseComponent.new(tag: "div", **system_arguments) do %>
+<%= render Viral::BaseComponent.new(tag: "div", **system_arguments.except(:close_action)) do %>
   <h1 class="dialog--title">
     <%= title %>
   </h1>
@@ -6,7 +6,10 @@
     <button
       type="button"
       class="dialog--close"
-      data-action="click->viral--dialog#close"
+      data-action="
+        <%= system_arguments[:close_action]%>
+        click->viral--dialog#close
+      "
       aria-label="<%= t(:"components.dialog.close") %>"
     >
       <%= viral_icon(name: "x_mark", classes: "h-5 w-5") %>

--- a/app/components/viral/dialog/header_component.rb
+++ b/app/components/viral/dialog/header_component.rb
@@ -6,10 +6,11 @@ module Viral
     class HeaderComponent < Viral::BaseComponent
       attr_reader :title, :closable
 
-      def initialize(title:, closable: true)
+      def initialize(title:, closable: true, **system_arguments)
         @title = title
         @closable = closable
-        @system_arguments = {}
+        @system_arguments = system_arguments
+
         @system_arguments[:classes] = class_names(@system_arguments[:classes], 'dialog--header')
       end
     end

--- a/app/components/viral/dialog_component.rb
+++ b/app/components/viral/dialog_component.rb
@@ -24,7 +24,7 @@ module Viral
 
     renders_one :trigger
 
-    def initialize(id: 'dialog', title: '', size: SIZE_DEFAULT, open: false, closable: true, header_system_arguments: {}, **system_arguments) # rubocop:disable Metrics/ParameterLists,Layout/LineLength
+    def initialize(id: 'dialog', title: '', size: SIZE_DEFAULT, open: false, closable: true, header_system_arguments: {}, **system_arguments) # rubocop:disable Metrics/ParameterLists,Layout/LineLength,Metrics/MethodLength
       @id = id
       @title = title
       @open = open
@@ -33,7 +33,11 @@ module Viral
       @header_system_arguments = header_system_arguments
       @system_arguments = system_arguments
 
-      @system_arguments[:data].merge!({ 'viral--dialog-target' => 'dialog' })
+      @system_arguments[:data] = if @system_arguments.key?(:data)
+                                   @system_arguments[:data].merge({ 'viral--dialog-target' => 'dialog' })
+                                 else
+                                   { 'viral--dialog-target' => 'dialog' }
+                                 end
 
       return if closable
 

--- a/app/components/viral/dialog_component.rb
+++ b/app/components/viral/dialog_component.rb
@@ -3,10 +3,10 @@
 module Viral
   # A component for displaying a dialog.
   class DialogComponent < Viral::Component
-    attr_reader :id, :open, :closable, :dialog_size, :title
+    attr_reader :id, :open, :closable, :dialog_size, :title, :header_system_arguments
 
     renders_one :header, lambda { |title:|
-      Viral::Dialog::HeaderComponent.new(title:, closable: @closable)
+      Viral::Dialog::HeaderComponent.new(title:, closable: @closable, **header_system_arguments)
     }
     renders_many :sections, Viral::Dialog::SectionComponent
     renders_one :primary_action, lambda { |**system_arguments|
@@ -24,15 +24,16 @@ module Viral
 
     renders_one :trigger
 
-    def initialize(id: 'dialog', title: '', size: SIZE_DEFAULT, open: false, closable: true, **system_arguments) # rubocop:disable Metrics/ParameterLists
+    def initialize(id: 'dialog', title: '', size: SIZE_DEFAULT, open: false, closable: true, header_system_arguments: {}, **system_arguments) # rubocop:disable Metrics/ParameterLists,Layout/LineLength
       @id = id
       @title = title
       @open = open
       @closable = closable
       @dialog_size = SIZE_MAPPINGS[size]
+      @header_system_arguments = header_system_arguments
       @system_arguments = system_arguments
 
-      @system_arguments[:data] = { 'viral--dialog-target' => 'dialog' }
+      @system_arguments[:data].merge!({ 'viral--dialog-target' => 'dialog' })
 
       return if closable
 

--- a/app/helpers/class_name_helper.rb
+++ b/app/helpers/class_name_helper.rb
@@ -19,7 +19,7 @@ module ClassNameHelper
     array.each do |class_name|
       classes.concat(class_names(class_name).split) if class_name
     end
-    classes.split
+    classes
   end
 
   def class_names_from_hash(hash)

--- a/app/helpers/class_name_helper.rb
+++ b/app/helpers/class_name_helper.rb
@@ -5,11 +5,11 @@ module ClassNameHelper
   def class_names(*args)
     classes = []
     args.each do |class_name|
-      classes << class_name if class_name.is_a?(String) && class_name.present?
-      classes += class_names_from_array(class_name) if class_name.is_a?(Array)
-      classes += class_names_from_hash(class_name) if class_name.is_a?(Hash)
+      classes.concat(class_name.split) if class_name.is_a?(String) && class_name.present?
+      classes.concat(class_names_from_array(class_name)) if class_name.is_a?(Array)
+      classes.concat(class_names_from_hash(class_name)) if class_name.is_a?(Hash)
     end
-    classes.compact.uniq.join(' ')
+    classes.compact.sort.uniq.join(' ')
   end
 
   private
@@ -17,15 +17,15 @@ module ClassNameHelper
   def class_names_from_array(array)
     classes = []
     array.each do |class_name|
-      classes << class_names(class_name) if class_name
+      classes.concat(class_names(class_name).split) if class_name
     end
-    classes
+    classes.split
   end
 
   def class_names_from_hash(hash)
     classes = []
     hash.each do |class_name, value|
-      classes << class_name if value
+      classes.concat(class_name.to_s.split) if value
     end
     classes
   end

--- a/app/javascript/controllers/advanced_search_controller.js
+++ b/app/javascript/controllers/advanced_search_controller.js
@@ -16,6 +16,10 @@ export default class extends Controller {
     confirmCloseText: String,
   };
 
+  connect() {
+    this.idempotentConnect();
+  }
+
   idempotentConnect() {
     this.searchGroupsContainerTarget.innerHTML =
       this.searchGroupsTemplateTarget.innerHTML;

--- a/app/javascript/controllers/advanced_search_controller.js
+++ b/app/javascript/controllers/advanced_search_controller.js
@@ -6,10 +6,41 @@ export default class extends Controller {
     "conditionTemplate",
     "groupsContainer",
     "groupTemplate",
-    "valueTemplate",
     "listValueTemplate",
+    "searchGroupsContainer",
+    "searchGroupsTemplate",
+    "valueTemplate",
   ];
   static outlets = ["list-filter"];
+  static values = {
+    confirmCloseText: String,
+  };
+
+  idempotentConnect() {
+    this.searchGroupsContainerTarget.innerHTML =
+      this.searchGroupsTemplateTarget.innerHTML;
+  }
+
+  clear() {
+    this.searchGroupsContainerTarget.innerHTML = "";
+  }
+
+  close(event) {
+    if (
+      this.searchGroupsContainerTarget.innerHTML.trim() ===
+      this.searchGroupsTemplateTarget.innerHTML.trim()
+    ) {
+      this.clear();
+    } else {
+      if (window.confirm(this.confirmCloseTextValue)) {
+        this.clear();
+      } else {
+        // TODO: Confirm if the user wants to abort which would clear filters
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      }
+    }
+  }
 
   addCondition(event) {
     let group = event.currentTarget.parentElement.closest(
@@ -47,10 +78,10 @@ export default class extends Controller {
     }
   }
 
-  addGroup(event) {
+  addGroup() {
     let group_index = this.groupsContainerTargets.length;
-    event.currentTarget.parentElement.insertAdjacentHTML(
-      "beforebegin",
+    this.searchGroupsContainerTarget.insertAdjacentHTML(
+      "beforeend",
       this.groupTemplateTarget.innerHTML,
     );
     let newCondition = this.conditionTemplateTarget.innerHTML
@@ -96,19 +127,8 @@ export default class extends Controller {
   }
 
   clearForm() {
-    this.groupsContainerTargets.forEach((group, group_index) => {
-      if (group_index > 0) {
-        group.remove();
-      } else {
-        let conditions = group.querySelectorAll(
-          "div[data-advanced-search-target='conditionsContainer']",
-        );
-        conditions.forEach((condition) => {
-          condition.remove();
-        });
-        this.#addConditionToGroup(group);
-      }
-    });
+    this.clear();
+    this.addGroup();
   }
 
   handleOperatorChange(event) {

--- a/app/javascript/controllers/advanced_search_controller.js
+++ b/app/javascript/controllers/advanced_search_controller.js
@@ -39,7 +39,6 @@ export default class extends Controller {
       if (window.confirm(this.confirmCloseTextValue)) {
         this.clear();
       } else {
-        // TODO: Confirm if the user wants to abort which would clear filters
         event.stopImmediatePropagation();
         event.preventDefault();
       }

--- a/app/views/groups/samples/_table_filter.html.erb
+++ b/app/views/groups/samples/_table_filter.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @query, scope: :q, url: search_group_samples_url, method: :post, data: { controller: "advanced-search filters selection metadata-toggle", "advanced-search-list-filter-outlet":".list-filter", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters flex items-center space-x-2" do |f| %>
+<%= form_with model: @query, scope: :q, url: search_group_samples_url, method: :post, data: { controller: "filters selection metadata-toggle", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters flex items-center space-x-2" do |f| %>
   <%= f.label :name_or_puid_cont, t(".search.placeholder"), class: "sr-only" %>
   <div class="relative">
     <%= f.search_field :name_or_puid_cont,

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @query, scope: :q, url: search_namespace_project_samples_url, method: :post, data: { turbo_stream: true, controller: "advanced-search filters selection metadata-toggle", "advanced-search-list-filter-outlet":".list-filter", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters flex items-center space-x-2" do |f| %>
+<%= form_with model: @query, scope: :q, url: search_namespace_project_samples_url, method: :post, data: { turbo_stream: true, controller: "filters selection metadata-toggle", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters flex items-center space-x-2" do |f| %>
   <%= f.label :name_or_puid_cont, t(".search.placeholder"), class: "sr-only" %>
   <div class="relative">
     <%= f.search_field :name_or_puid_cont,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,7 @@ en:
     add_condition_button: Add Condition
     add_group_button: Add Group
     apply_filter_button: Apply filter
+    confirm_close_text: Are you sure that you want to discard your filter modifications and close the advanced search dialog?
     clear_aria_label: Clear Advanced Search
     clear_filter_button: Clear filter
     description: This advanced search uses fields, operators and values to filter samples. Add groups with conditions to define the search criteria.
@@ -325,7 +326,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -410,7 +411,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -452,7 +453,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -564,14 +565,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -638,7 +639,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -668,7 +669,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -742,18 +743,18 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -912,10 +913,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -923,11 +924,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -938,15 +939,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -963,7 +964,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -1041,7 +1042,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: 'The following samples are missing required data: '
+    data_missing_error: "The following samples are missing required data: "
     name:
       helper: A custom name will make it easier to search for this in the future.
       label: Name (Optional)
@@ -1070,8 +1071,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1135,7 +1136,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1163,7 +1164,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1241,20 +1242,20 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1372,11 +1373,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1384,20 +1385,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1428,8 +1429,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1470,7 +1471,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1511,7 +1512,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1563,8 +1564,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1734,8 +1735,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1765,8 +1766,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
   shared:
     alert:
       list:
@@ -1793,7 +1794,7 @@ en:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
+              description: "The spreadsheet is required to have a column that contains a sample identifier. "
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1804,7 +1805,7 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,9 +300,9 @@ en:
     add_condition_button: Add Condition
     add_group_button: Add Group
     apply_filter_button: Apply filter
-    confirm_close_text: Are you sure that you want to discard your filter modifications and close the advanced search dialog?
     clear_aria_label: Clear Advanced Search
     clear_filter_button: Clear filter
+    confirm_close_text: Are you sure that you want to discard your filter modifications and close the advanced search dialog?
     description: This advanced search uses fields, operators and values to filter samples. Add groups with conditions to define the search criteria.
     field: Field
     operator: Operator
@@ -326,7 +326,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -411,7 +411,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -453,7 +453,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -565,14 +565,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -639,7 +639,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -669,7 +669,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -743,18 +743,18 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -913,10 +913,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -924,11 +924,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -939,15 +939,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -964,7 +964,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -1042,7 +1042,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: "The following samples are missing required data: "
+    data_missing_error: 'The following samples are missing required data: '
     name:
       helper: A custom name will make it easier to search for this in the future.
       label: Name (Optional)
@@ -1071,8 +1071,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1136,7 +1136,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1164,7 +1164,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1242,20 +1242,20 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1373,11 +1373,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1385,20 +1385,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1429,8 +1429,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1471,7 +1471,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1512,7 +1512,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1564,8 +1564,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1735,8 +1735,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1766,8 +1766,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
   shared:
     alert:
       list:
@@ -1794,7 +1794,7 @@ en:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: "The spreadsheet is required to have a column that contains a sample identifier. "
+              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1805,7 +1805,7 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -300,9 +300,9 @@ fr:
     add_condition_button: Add Condition
     add_group_button: Add Group
     apply_filter_button: Apply filter
-    confirm_close_text: Are you sure that you want to discard your filter modifications and close the advanced search dialog?
     clear_aria_label: Clear Advanced Search
     clear_filter_button: Clear filter
+    confirm_close_text: Are you sure that you want to discard your filter modifications and close the advanced search dialog?
     description: This advanced search uses fields, operators and values to filter samples. Add groups with conditions to define the search criteria.
     field: Field
     operator: Operator
@@ -326,7 +326,7 @@ fr:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -411,7 +411,7 @@ fr:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -453,7 +453,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -565,14 +565,14 @@ fr:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -639,7 +639,7 @@ fr:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -669,7 +669,7 @@ fr:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -743,18 +743,18 @@ fr:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -913,10 +913,10 @@ fr:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -924,11 +924,11 @@ fr:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -939,15 +939,15 @@ fr:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -964,7 +964,7 @@ fr:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -1042,7 +1042,7 @@ fr:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: "The following samples are missing required data: "
+    data_missing_error: 'The following samples are missing required data: '
     name:
       helper: A custom name will make it easier to search for this in the future.
       label: Name (Optional)
@@ -1071,8 +1071,8 @@ fr:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1136,7 +1136,7 @@ fr:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1164,7 +1164,7 @@ fr:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1242,20 +1242,20 @@ fr:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1373,11 +1373,11 @@ fr:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1385,20 +1385,20 @@ fr:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1429,8 +1429,8 @@ fr:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1471,7 +1471,7 @@ fr:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1512,7 +1512,7 @@ fr:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1564,8 +1564,8 @@ fr:
           placeholder: Filtrer par ID ou nom
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1735,8 +1735,8 @@ fr:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1766,8 +1766,8 @@ fr:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
   shared:
     alert:
       list:
@@ -1794,7 +1794,7 @@ fr:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: "The spreadsheet is required to have a column that contains a sample identifier. "
+              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1805,7 +1805,7 @@ fr:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -300,6 +300,7 @@ fr:
     add_condition_button: Add Condition
     add_group_button: Add Group
     apply_filter_button: Apply filter
+    confirm_close_text: Are you sure that you want to discard your filter modifications and close the advanced search dialog?
     clear_aria_label: Clear Advanced Search
     clear_filter_button: Clear filter
     description: This advanced search uses fields, operators and values to filter samples. Add groups with conditions to define the search criteria.
@@ -325,7 +326,7 @@ fr:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -410,7 +411,7 @@ fr:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -452,7 +453,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -564,14 +565,14 @@ fr:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1 mr-1">processing</span>, the contents of the export are being created. Once the export status is <span class="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-xs font-medium px-2.5 py-0.5 rounded-full ml-1">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -638,7 +639,7 @@ fr:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -668,7 +669,7 @@ fr:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -742,18 +743,18 @@ fr:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -912,10 +913,10 @@ fr:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -923,11 +924,11 @@ fr:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -938,15 +939,15 @@ fr:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -963,7 +964,7 @@ fr:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -1041,7 +1042,7 @@ fr:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: 'The following samples are missing required data: '
+    data_missing_error: "The following samples are missing required data: "
     name:
       helper: A custom name will make it easier to search for this in the future.
       label: Name (Optional)
@@ -1070,8 +1071,8 @@ fr:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1135,7 +1136,7 @@ fr:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1163,7 +1164,7 @@ fr:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1241,20 +1242,20 @@ fr:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1372,11 +1373,11 @@ fr:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1384,20 +1385,20 @@ fr:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1428,8 +1429,8 @@ fr:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1470,7 +1471,7 @@ fr:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1511,7 +1512,7 @@ fr:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1563,8 +1564,8 @@ fr:
           placeholder: Filtrer par ID ou nom
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1734,8 +1735,8 @@ fr:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1765,8 +1766,8 @@ fr:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
   shared:
     alert:
       list:
@@ -1793,7 +1794,7 @@ fr:
             ignore_empty_values:
               description: If selected, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this not selected, any samples with the metadata key and empty value will be deleted.
             namespace:
-              description: 'The spreadsheet is required to have a column that contains a sample identifier. '
+              description: "The spreadsheet is required to have a column that contains a sample identifier. "
               group:
                 description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
               project:
@@ -1804,7 +1805,7 @@ fr:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -55,4 +55,76 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test 'close dialog prompts for confirmation if filters have not been applied' do
+    visit('rails/view_components/advanced_search_component/empty')
+    within 'span[data-controller-connected="true"]' do
+      click_button I18n.t(:'advanced_search_component.title')
+      within 'dialog' do
+        # verify accessibility
+        assert_accessible
+
+        # verify the form is pre-populated
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        assert_selector "div[data-advanced-search-target='groupsContainer']", count: 1
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          assert_selector "div[data-advanced-search-target='conditionsContainer']", count: 1
+        end
+
+        # verify the dialog has a close button
+        assert_selector ".dialog--header button[aria-label='#{I18n.t('components.dialog.close')}']"
+
+        # verify that the dialog closes without a confirm dialog if no unapplied filters
+        click_button I18n.t('components.dialog.close')
+        assert_no_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+      end
+
+      click_button I18n.t(:'advanced_search_component.title')
+      within 'dialog' do
+        # verify accessibility
+        assert_accessible
+
+        # verify the form is pre-populated
+        assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+        assert_selector "div[data-advanced-search-target='groupsContainer']", count: 1
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          assert_selector "div[data-advanced-search-target='conditionsContainer']", count: 1
+        end
+
+        # verify the dialog has a close button
+        assert_selector ".dialog--header button[aria-label='#{I18n.t('components.dialog.close')}']"
+
+        # add a new filter
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            find("select[name$='[field]']").find("option[value='metadata.age']").select_option
+            find("select[name$='[operator]']").find("option[value='>=']").select_option
+            find("input[name$='[value]']").fill_in with: '25'
+          end
+        end
+
+        # verify that the dialog close action prompts a confirm dialog if unapplied filters
+        text = dismiss_confirm do
+          click_button I18n.t('components.dialog.close')
+        end
+        assert_includes text, I18n.t(:'advanced_search_component.confirm_close_text')
+
+        # verify that dismissing the confirm keeps the unapplied filters and dialog open
+        within all("div[data-advanced-search-target='groupsContainer']")[0] do
+          within all("div[data-advanced-search-target='conditionsContainer']")[0] do
+            assert_equal 'metadata.age', find("select[name$='[field]']").find("option[value='metadata.age']").value
+            assert_equal '>=', find("select[name$='[operator]']").find("option[value='>=']").value
+            assert_equal '25', find("input[name$='[value]']").value
+          end
+        end
+
+        # verify that accepting the confirm discards the unapplied filters and closes the dialog
+        text = accept_confirm do
+          click_button I18n.t('components.dialog.close')
+        end
+        assert_includes text, I18n.t(:'advanced_search_component.confirm_close_text')
+        assert_no_selector 'h1', text: I18n.t(:'advanced_search_component.title')
+      end
+    end
+  end
 end

--- a/test/components/previews/advanced_search_component_preview.rb
+++ b/test/components/previews/advanced_search_component_preview.rb
@@ -28,4 +28,17 @@ class AdvancedSearchComponentPreview < ViewComponent::Preview
                            operations: operations
                          })
   end
+
+  def empty
+    search = Sample::Query.new
+    fields = %w[name puid created_at updated_at attachments_updated_at metadata.age metadata.country
+                metadata.collection_date metadata.food metadata.subject_type metadata.outbreak_code]
+    operations = %w[= != <= >= contains exists not_exists in not_in]
+
+    render_with_template(template: 'advanced_search_component_preview/default', locals: {
+                           search: search,
+                           fields: fields,
+                           operations: operations
+                         })
+  end
 end

--- a/test/components/viral/system/data_table_component_test.rb
+++ b/test/components/viral/system/data_table_component_test.rb
@@ -56,12 +56,12 @@ module System
                             'very very very very very very very very very very very very very long name'
 
       within('thead') do
-        assert_selector 'th[class="px-3 py-3 sticky right-0 bg-slate-50 dark:bg-slate-700 z-10"]',
+        assert_selector 'th[class="bg-slate-50 dark:bg-slate-700 px-3 py-3 right-0 sticky z-10"]',
                         text: I18n.t('viral.data_table_component.header.action').upcase
       end
 
       within('tbody') do
-        assert_selector 'td[class="px-3 py-3 sticky right-0 bg-white dark:bg-slate-800 space-x-2 z-10"]',
+        assert_selector 'td[class="bg-white dark:bg-slate-800 px-3 py-3 right-0 space-x-2 sticky z-10"]',
                         count: 2
       end
     end

--- a/test/helpers/class_name_helper_test.rb
+++ b/test/helpers/class_name_helper_test.rb
@@ -7,41 +7,41 @@ class ClassNameHelperTest < ActionView::TestCase
 
   test 'should combine list of classes' do
     new_classes = class_names('foo', 'bar')
-    assert_equal 'foo bar', new_classes
+    assert_equal 'bar foo', new_classes
   end
 
   test 'should combine list of classes with nil' do
     new_classes = class_names('foo', nil, 'bar')
-    assert_equal 'foo bar', new_classes
+    assert_equal 'bar foo', new_classes
   end
 
   test 'should combine list of classes with empty string' do
     new_classes = class_names('foo', '', 'bar')
-    assert_equal 'foo bar', new_classes
+    assert_equal 'bar foo', new_classes
   end
 
   test 'should combine list of classes with false' do
     new_classes = class_names('foo', false, 'bar')
-    assert_equal 'foo bar', new_classes
+    assert_equal 'bar foo', new_classes
   end
 
   test 'should combine list of classes with true' do
     new_classes = class_names('foo', true, 'bar')
-    assert_equal 'foo bar', new_classes
+    assert_equal 'bar foo', new_classes
   end
 
   test 'should combine list of classes with empty array' do
     new_classes = class_names('foo', [], 'bar')
-    assert_equal 'foo bar', new_classes
+    assert_equal 'bar foo', new_classes
   end
 
   test 'should combine list of classes with array' do
     new_classes = class_names('foo', %w[bar baz], 'qux')
-    assert_equal 'foo bar baz qux', new_classes
+    assert_equal 'bar baz foo qux', new_classes
   end
 
   test 'should combine hash of classes' do
     new_classes = class_names('foo', bar: true, baz: false, qux: nil)
-    assert_equal 'foo bar', new_classes
+    assert_equal 'bar foo', new_classes
   end
 end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -406,6 +406,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.transfer_button')
       ### ACTIONS END ###
 
@@ -429,6 +436,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.transfer_button')
       ### ACTIONS END ###
 
@@ -478,6 +492,13 @@ module Projects
       ### ACTIONS START ###
       # select all 3 samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.transfer_button')
       assert_selector '#dialog'
       within('#dialog') do
@@ -528,6 +549,13 @@ module Projects
       ### ACTIONS START ###
       # select samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       # clear localstorage
       Capybara.execute_script 'sessionStorage.clear()'
       # launch transfer dialog
@@ -573,6 +601,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.transfer_button')
 
       assert_selector '#dialog'
@@ -631,6 +666,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 1
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 1'
+        assert_selector 'strong[data-selection-target="selected"]', text: '1'
+      end
       click_link I18n.t('projects.samples.index.transfer_button')
       ### ACTIONS END ###
 
@@ -719,6 +761,13 @@ module Projects
       ### ACTIONS START ###
       # select samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
 
       # launch dialog
       click_link I18n.t('projects.samples.index.transfer_button')
@@ -1610,6 +1659,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.clone_button')
       ### ACTIONS END ###
 
@@ -1633,6 +1689,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.clone_button')
       ### ACTIONS END ###
 
@@ -1722,6 +1785,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       # clear localstorage
       Capybara.execute_script 'sessionStorage.clear()'
       click_link I18n.t('projects.samples.index.clone_button')
@@ -1770,6 +1840,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.clone_button')
       assert_selector '#dialog'
       within('#dialog') do
@@ -1818,6 +1895,13 @@ module Projects
 
       ### ACTIONS START ####
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.clone_button')
       assert_selector '#dialog'
       within('#dialog') do
@@ -1841,6 +1925,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 1
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 1'
+        assert_selector 'strong[data-selection-target="selected"]', text: '1'
+      end
       click_link I18n.t('projects.samples.index.clone_button')
       ### ACTIONS END ###
 
@@ -2130,6 +2221,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.delete_samples_button')
       ### ACTIONS END ###
 
@@ -2153,6 +2251,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.delete_samples_button')
       ### ACTIONS END ###
 
@@ -2181,6 +2286,13 @@ module Projects
 
       ### ACTIONS START ###
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       click_link I18n.t('projects.samples.index.delete_samples_button')
       within('#dialog') do
         click_on I18n.t('projects.samples.deletions.new_multiple_deletions_dialog.submit_button')
@@ -2213,6 +2325,13 @@ module Projects
       ### ACTIONS START ###
       # select all samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
 
       # destroy sample1 with remove action link
       within '#samples-table table tbody tr:first-child' do

--- a/test/system/workflow_executions/submissions_test.rb
+++ b/test/system/workflow_executions/submissions_test.rb
@@ -740,11 +740,11 @@ module WorkflowExecutions
       # select samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
       within 'tbody' do
-        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 20
       end
       within 'tfoot' do
-        assert_text 'Samples: 3'
-        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+        assert_text 'Samples: 20'
+        assert_selector 'strong[data-selection-target="selected"]', text: '20'
       end
       # launch workflow execution dialog
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
@@ -819,8 +819,8 @@ module WorkflowExecutions
         assert_selector 'input[name="sample_ids[]"]:checked', count: 20
       end
       within 'tfoot' do
-        assert_text 'Samples: 26'
-        assert_selector 'strong[data-selection-target="selected"]', text: '26'
+        assert_text 'Samples: 20'
+        assert_selector 'strong[data-selection-target="selected"]', text: '20'
       end
       # launch workflow execution dialog
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')

--- a/test/system/workflow_executions/submissions_test.rb
+++ b/test/system/workflow_executions/submissions_test.rb
@@ -676,6 +676,13 @@ module WorkflowExecutions
                                                                            locale: user.locale))
       # select samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       # launch workflow execution dialog
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 
@@ -732,6 +739,13 @@ module WorkflowExecutions
                                                                            locale: user.locale))
       # select samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       # launch workflow execution dialog
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 
@@ -801,6 +815,13 @@ module WorkflowExecutions
       ### ACTIONS START ###
       # select samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 20
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 26'
+        assert_selector 'strong[data-selection-target="selected"]', text: '26'
+      end
       # launch workflow execution dialog
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 
@@ -869,6 +890,13 @@ module WorkflowExecutions
                                                                            locale: user.locale))
       # select samples
       click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
+      end
       # launch workflow execution dialog
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds the ability to close the Advanced Search dialog. Which closes the dialog immediately if the filters have already been applied, or prompts the user to confirm that they want to close if filters have been modified and have not yet been applied.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before:
![image](https://github.com/user-attachments/assets/b33bd0ab-de89-4b51-a53e-213c3b78879b)

After:
![image](https://github.com/user-attachments/assets/0b95cdc4-2529-467d-9c24-70ccd0bdb496)

After clicking close, when filters have been modified and not yet applied:
![image](https://github.com/user-attachments/assets/0f46debe-9784-4b0b-a94e-7e680577ad58)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server and sign in with your user of choice
2. Navigate to a Project of your choice
3. Click on the Samples context menu item
4. Click on `Advanced Search`
5. Click the `X` close button on the dialog. Observer that it closes immediately and the page is not reloaded
6. Click on `Advanced Search`
7. Add a filter for field `name`, operator `=`. value `JoeBob`
8. Click the `X` close button on the dialog. Observe that a confirm dialog pops up and if you click `Cancel` it doesn't close the dialog, if you click `Ok` it closes the dialog and clicking `Advanced Search` again doesn't contain your unapplied filter.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
