### PR TITLE
Fix: Nextflow Metadata Fields

### DIFF
--- a/app/controllers/workflow_executions/submissions_controller.rb
+++ b/app/controllers/workflow_executions/submissions_controller.rb
@@ -18,7 +18,8 @@ module WorkflowExecutions
     def create
       @namespace = Namespace.find_by(id: @namespace_id)
       fields_for_namespace_or_template(
-        namespace: @namespace
+        namespace: @namespace,
+        template: 'all'
       )
       render status: :ok
     end

--- a/test/controllers/workflow_executions/submission_controller_test.rb
+++ b/test/controllers/workflow_executions/submission_controller_test.rb
@@ -12,5 +12,16 @@ module WorkflowExecutions
       get pipeline_selection_workflow_executions_submissions_path(format: :turbo_stream)
       assert_response :ok
     end
+
+    test 'create submission' do
+      sign_in users(:john_doe)
+      project1 = projects(:project1)
+      sample1 = samples(:sample1)
+      post workflow_executions_submissions_path(namespace_id: project1.namespace.id,
+                                                workflow_name: 'phac-nml/iridanextexample',
+                                                workflow_version: '1.0.3',
+                                                samples: [sample1.id], format: :turbo_stream)
+      assert_response :ok
+    end
   end
 end

--- a/test/controllers/workflow_executions/submission_controller_test.rb
+++ b/test/controllers/workflow_executions/submission_controller_test.rb
@@ -11,20 +11,18 @@ module WorkflowExecutions
     include Devise::Test::IntegrationHelpers
 
     setup do
+      sign_in users(:john_doe)
       @group = groups(:group_one)
       @project = projects(:project1)
       @controller = TestController.new
     end
 
     test 'should render pipeline selection on turbo stream request' do
-      sign_in users(:john_doe)
-
       get pipeline_selection_workflow_executions_submissions_path(format: :turbo_stream)
       assert_response :ok
     end
 
     test 'create submission' do
-      sign_in users(:john_doe)
       sample1 = samples(:sample1)
       post workflow_executions_submissions_path(namespace_id: @project.namespace.id,
                                                 workflow_name: 'phac-nml/iridanextexample',
@@ -35,8 +33,6 @@ module WorkflowExecutions
     end
 
     test '@fields in create' do
-      sign_in users(:john_doe)
-
       post workflow_executions_submissions_path(format: :turbo_stream, workflow_name: 'phac-nml/iridanextexample',
                                                 workflow_version: '1.0.3', namespace_id: @group.id)
       assert_response :ok

--- a/test/controllers/workflow_executions/submission_controller_test.rb
+++ b/test/controllers/workflow_executions/submission_controller_test.rb
@@ -2,10 +2,6 @@
 
 require 'test_helper'
 
-class TestController < ApplicationController
-  include Metadata
-end
-
 module WorkflowExecutions
   class SubmissionControllerTest < ActionDispatch::IntegrationTest
     include Devise::Test::IntegrationHelpers
@@ -14,7 +10,6 @@ module WorkflowExecutions
       sign_in users(:john_doe)
       @group = groups(:group_one)
       @project = projects(:project1)
-      @controller = TestController.new
     end
 
     test 'should render pipeline selection on turbo stream request' do
@@ -34,7 +29,7 @@ module WorkflowExecutions
 
     test '@fields in create' do
       post workflow_executions_submissions_path(format: :turbo_stream, workflow_name: 'phac-nml/iridanextexample',
-                                                workflow_version: '1.0.3', namespace_id: @group.id)
+                                                workflow_version: '1.0.2', namespace_id: @group.id)
       assert_response :ok
       assert_equal ['metadatafield1', 'metadatafield2', 'unique.metadata.field'],
                    @controller.instance_eval('@fields', __FILE__, __LINE__)


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where metadata fields weren't rendering on nextflow samplesheet

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. In `config/pipelines/pipelines.json`, add the `fastmatch` pipeline:
```
{
    "url": "https://github.com/phac-nml/fastmatchirida",
    "name": "phac-nml/fastmatchirida",
    "description": "IRIDA Next Fast Match Pipeline",
    "versions": [
      {
        "name": "0.1.0"
      }
    ]
  }
```
![image](https://github.com/user-attachments/assets/302e80d3-fccc-4dd1-bb58-06cbf0d765c9)

2. Restart your server
3. Navigate to any project or group with samples that have metadata and select some samples.
4. Start a fastmatch workflow
5. On the metadata tabs, verify the project/group's metadata fields appear in the dropdowns.
6. Select one of the metadata fields, and verify the samples' metadata value is automatically populated

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
