### PR TITLE
Workflow Executions: Workflow and Samplesheet validation

### DIFF
--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -25,6 +25,7 @@
   >
     <%= text_for(@workflow.description) %>
   </p>
+  <%= helpers.turbo_frame_tag "workflow_execution_errors" %>
   <%= form_with url: url, method: (instance.nil? ? :post : :patch),
                 data: { turbo_frame: "_top", "nextflow--samplesheet-target": "form" } do |form| %>
     <input id="submission_turbo" type="hidden" name="format" value="turbo_stream"/>

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -12,7 +12,8 @@ class WorkflowExecutionsController < ApplicationController
     if @workflow_execution.persisted?
       redirect_to workflow_executions_path
     else
-      render turbo_stream: [], status: :unprocessable_entity
+      render locals: { message: t('.error_message'), errors: @workflow_execution.errors.full_messages },
+             status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -158,7 +158,7 @@ export default class extends Controller {
 
   submitSamplesheet(event) {
     event.preventDefault();
-    this.#enableProcessingState(this.processingRequestValue);
+    this.#enableProcessingState();
     // 50ms timeout allows the browser to update the DOM elements enabling the overlay prior to starting the submission
     setTimeout(() => {
       let missingData = this.#validateData();
@@ -183,10 +183,20 @@ export default class extends Controller {
           this.#disableProcessingState();
           if (response.redirected && response.status == "200") {
             window.location.href = response.url;
+            return nil
+          } else if (response.status == "422") {
+            return response.text();
           } else {
             this.#enableErrorState(this.submissionErrorValue);
+            return nil;
           }
-        });
+        }).then(((data) => {
+          if (data) {
+            let responseElement = document.createElement("div");
+            responseElement.innerHTML = data;
+            document.querySelector('main').appendChild(responseElement);
+          }
+        }));
       }
     }, 50);
   }

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -158,7 +158,7 @@ export default class extends Controller {
 
   submitSamplesheet(event) {
     event.preventDefault();
-    this.#enableProcessingState();
+    this.#enableProcessingState(this.processingRequestValue);
     // 50ms timeout allows the browser to update the DOM elements enabling the overlay prior to starting the submission
     setTimeout(() => {
       let missingData = this.#validateData();

--- a/app/models/samples_workflow_execution.rb
+++ b/app/models/samples_workflow_execution.rb
@@ -12,5 +12,5 @@ class SamplesWorkflowExecution < ApplicationRecord
 
   # TODO: Re-enable after validator has been rewritten to validate based on samplesheet schema from the pipeline
   # instead of assuming that all fields other than sample are attachemnts
-  # validates_with WorkflowExecutionSamplesheetParamsValidator
+  validates_with WorkflowExecutionSamplesheetParamsValidator
 end

--- a/app/models/samples_workflow_execution.rb
+++ b/app/models/samples_workflow_execution.rb
@@ -10,7 +10,5 @@ class SamplesWorkflowExecution < ApplicationRecord
   has_many_attached :inputs
   has_many :outputs, dependent: :destroy, class_name: 'Attachment', as: :attachable
 
-  # TODO: Re-enable after validator has been rewritten to validate based on samplesheet schema from the pipeline
-  # instead of assuming that all fields other than sample are attachemnts
   validates_with WorkflowExecutionSamplesheetParamsValidator
 end

--- a/app/validators/workflow_execution_samplesheet_params_validator.rb
+++ b/app/validators/workflow_execution_samplesheet_params_validator.rb
@@ -1,39 +1,174 @@
 # frozen_string_literal: true
 
 # Validator for Workflow Execution Samplesheet Params
-# This will cause the validation to fail if any of the attachment ids cannot be resolved
-class WorkflowExecutionSamplesheetParamsValidator < ActiveModel::Validator
-  def validate(record) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-    record.samplesheet_params.each do |key, value| # rubocop:disable Metrics/BlockLength
-      if key == 'sample'
-        if value.nil? || value == ''
-          error_message = 'No Sample PUID provided'
-          record.errors.add :sample, error_message
-          record.workflow_execution.errors.add :sample, error_message
-        elsif value != (record.sample.puid)
-          error_message = "Provided Sample PUID #{value} does not match SampleWorkflowExecution Sample PUID #{record.sample.puid}" # rubocop:disable Layout/LineLength
-          record.errors.add :sample, error_message
-          record.workflow_execution.errors.add :sample, error_message
-        end
-        next
-      end
+class WorkflowExecutionSamplesheetParamsValidator < ActiveModel::Validator # rubocop:disable Metrics/ClassLength
+  def validate(record)
+    return if record.persisted? # only validate on creation
 
-      next if value == ''
+    workflow = Irida::Pipelines.instance.find_pipeline_by(record.workflow_execution.metadata['workflow_name'],
+                                                          record.workflow_execution.metadata['workflow_version'],
+                                                          'available')
 
-      begin
-        # Attempt to parse an object from the id provided
-        attachment = IridaSchema.object_from_id(value, { expected_type: Attachment })
-        unless attachment.attachable == record.sample
-          error_message = "Attachment does not belong to Sample #{record.sample.puid}."
-          record.errors.add :attachment, error_message
-          record.workflow_execution.errors.add :attachment, error_message
-        end
-      rescue StandardError => e
-        error_message = e.message
-        record.errors.add :attachment, error_message
-        record.workflow_execution.errors.add :attachment, error_message
-        next
+    return if workflow.blank?
+
+    workflow_params = workflow.workflow_params
+    samplesheet_schema = workflow_params[:input_output_options][:properties][:input][:schema]
+    @required_properties = samplesheet_schema['items']['required']
+    @properties = extract_properties(samplesheet_schema)
+
+    validate_samplesheet_params(record)
+  end
+
+  private
+
+  def extract_properties(schema)
+    properties = schema['items']['properties']
+    properties.each do |property, entry|
+      properties[property]['required'] = schema['items']['required'].include?(property)
+      properties[property]['cell_type'] = identify_cell_type(property, entry)
+    end
+
+    if @required_properties.include?('fastq_1') && @required_properties.include?('fastq_2')
+      properties['fastq_1']['pe_only'] = true
+    end
+
+    properties
+  end
+
+  def identify_cell_type(property, entry)
+    return 'sample_cell' if property == 'sample'
+
+    return 'sample_name_cell' if property == 'sample_name'
+
+    return 'fastq_cell' if property.match(/fastq_\d+/)
+
+    return 'file_cell' if check_for_file(entry)
+
+    return 'metadata_cell' if entry['meta'].present?
+
+    return 'dropdown_cell' if entry['enum'].present?
+
+    'input_cell'
+  end
+
+  def check_for_file(entry)
+    entry['format'] == 'file-path' || (entry.key?('anyOf') && entry['anyOf'].any? do |e|
+      e['format'] == 'file-path'
+    end)
+  end
+
+  def validate_samplesheet_params(record)
+    @properties.each do |property, entry|
+      value = record.samplesheet_params[property]
+      case entry['cell_type']
+      when 'sample_cell'
+        validate_sample_cell(record, value, property)
+      when 'sample_name_cell'
+        validate_sample_name_cell(record, value, property)
+      when 'fastq_cell'
+        validate_fastq_cell(record, value, property, entry)
+      when 'file_cell'
+        validate_file_cell(record, value, property, entry)
       end
     end
+  end
+
+  def validate_sample_cell(record, value, property)
+    validate_required(record, value, property) if @required_properties.include?(property)
+
+    return if value.blank?
+
+    return unless value != (record.sample&.puid)
+
+    record.errors.add :samplesheet_params,
+                      I18n.t('validators.workflow_execution_samplesheet_params_validator.sample_puid_error',
+                             property:)
+
+    false
+  end
+
+  def validate_sample_name_cell(record, value, property)
+    validate_required(record, value, property) if @required_properties.include?(property)
+
+    return if value.blank?
+
+    return unless value != (record.sample&.name)
+
+    record.errors.add :samplesheet_params,
+                      I18n.t('validators.workflow_execution_samplesheet_params_validator.sample_name_error', property:)
+
+    false
+  end
+
+  def validate_fastq_cell(record, value, property, entry)
+    validate_file_cell(record, value, property, entry)
+  end
+
+  def validate_file_cell(record, value, property, entry)
+    validate_required(record, value, property) if @required_properties.include?(property)
+
+    return if value.blank?
+
+    validate_attachment(record, value, property, entry)
+  end
+
+  def validate_required(record, value, property)
+    return if value.present?
+
+    record.errors.add :samplesheet_params,
+                      I18n.t('validators.workflow_execution_samplesheet_params_validator.blank_error', property:)
+  end
+
+  def validate_attachment(record, value, property, entry)
+    gid = validate_attachment_gid(record, value, property)
+
+    return if gid.blank?
+
+    attachment = GlobalID.find(gid)
+    return unless validate_sample_attachment(record, attachment, property)
+
+    validate_attachment_format(record, attachment, property, entry)
+  end
+
+  def validate_attachment_gid(record, value, property)
+    gid = GlobalID.parse(value)
+    return gid if gid && gid.model_class == Attachment
+
+    record.errors.add :samplesheet_params,
+                      I18n.t('validators.workflow_execution_samplesheet_params_validator.attachment_gid_error',
+                             property:)
+    nil
+  end
+
+  def validate_sample_attachment(record, attachment, property)
+    return true if attachment.attachable == record.sample
+
+    record.errors.add :samplesheet_params,
+                      I18n.t('validators.workflow_execution_samplesheet_params_validator.sample_attachment_error',
+                             property:)
+
+    false
+  end
+
+  def validate_attachment_format(record, attachment, property, entry) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength
+    valid = true
+    case entry['cell_type']
+    when 'fastq_cell'
+      valid = attachment.fastq?
+    when 'file_cell'
+      if entry.key?[:pattern]
+        valid = attachment.filename.match?(entry[:pattern])
+      elsif entry.key?(:any_of)
+        entry.key[:any_of].each do |matcher|
+          valid = attachment.filename.match?(matcher[:pattern]) if matcher.key?[:pattern]
+        end
+      end
+    end
+
+    return if valid
+
+    record.errors.add :samplesheet_params,
+                      I18n.t('validators.workflow_execution_samplesheet_params_validator.attachment_format_error',
+                             property:)
   end
 end

--- a/app/validators/workflow_execution_samplesheet_params_validator.rb
+++ b/app/validators/workflow_execution_samplesheet_params_validator.rb
@@ -2,8 +2,8 @@
 
 # Validator for Workflow Execution Samplesheet Params
 class WorkflowExecutionSamplesheetParamsValidator < ActiveModel::Validator # rubocop:disable Metrics/ClassLength
-  def validate(record)
-    return if record.persisted? # only validate on creation
+  def validate(record) # rubocop:disable Metrics/AbcSize
+    return unless record.workflow_execution.state == 'initial' # only validate on creation
 
     workflow = Irida::Pipelines.instance.find_pipeline_by(record.workflow_execution.metadata['workflow_name'],
                                                           record.workflow_execution.metadata['workflow_version'],

--- a/app/views/workflow_executions/create.turbo_stream.erb
+++ b/app/views/workflow_executions/create.turbo_stream.erb
@@ -1,0 +1,18 @@
+<%= turbo_stream.update 'workflow_execution_errors' do %>
+  <%= viral_alert(message:, type: :alert, classes: "mb-4 h-30 overflow-y-auto") do %>
+    <ul class="mt-1.5 ml-4 list-disc list-inside">
+      <% errors.each do |error| %>
+        <%- error_parts = error.split(":") %>
+        <%- if error_parts.length > 1 %>
+          <li><%= error_parts[0] %>
+            <ul class="mt-1.5 ml-4 list-disc list-inside">
+              <li><%= error_parts[1] %></li>
+            </ul>
+          </li>
+        <% else %>
+          <li><%= error %></li>
+        <% end %>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,9 @@ module Irida
                                        end
 
     ActiveRecord::SessionStore::Session.serializer = :json
+
+    # index nested attribute errors
+    config.active_record.index_nested_attribute_errors = true
   end
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1861,6 +1861,8 @@ en:
       add_all: Add all
       remove_all: Remove all
   workflow_executions:
+    create:
+      error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1836,6 +1836,13 @@ en:
       group_error: There group has errors
       numeric_operator_error: can only be used on numbers
       uniqueness_error: must be unique
+    workflow_execution_samplesheet_params_validator:
+      attachment_format_error: property '%{property}' must match the expected file format
+      attachment_gid_error: property '%{property}' must be a valid Attachment GID
+      blank_error: property '%{property}' is required and cannot be blank
+      sample_attachment_error: property '%{property}' must belong to the Sample
+      sample_name_error: property '%{property}' must match Sample Name
+      sample_puid_error: property '%{property}' must match Sample PUID
   viral:
     pagy:
       limit_component:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1840,7 +1840,7 @@ en:
       numeric_operator_error: can only be used on numbers
       uniqueness_error: must be unique
     workflow_execution_samplesheet_params_validator:
-      attachment_format_error: property '%{property}' must match the expected file format
+      attachment_format_error: property '%{property}' must match the expected file format of '%{file_format}'
       attachment_gid_error: property '%{property}' must be a valid Attachment GID
       blank_error: property '%{property}' is required and cannot be blank
       sample_attachment_error: property '%{property}' must belong to the Sample

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,9 @@ en:
           attributes:
             scopes:
               inclusion: can only contain available scopes
+        workflow_execution:
+          invalid_namespace: can only be Group or Project
+          invalid_workflow: unable to find workflow with name '%{workflow_name}' and version '%{workflow_version}'
     exceptions:
       personal_access_token:
         not_found: Could not find personal access token with id %{token_id}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1861,6 +1861,8 @@ fr:
       add_all: Add all
       remove_all: Remove all
   workflow_executions:
+    create:
+      error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1840,7 +1840,7 @@ fr:
       numeric_operator_error: can only be used on numbers
       uniqueness_error: must be unique
     workflow_execution_samplesheet_params_validator:
-      attachment_format_error: property '%{property}' must match the expected file format
+      attachment_format_error: property '%{property}' must match the expected file format of '%{file_format}'
       attachment_gid_error: property '%{property}' must be a valid Attachment GID
       blank_error: property '%{property}' is required and cannot be blank
       sample_attachment_error: property '%{property}' must belong to the Sample

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1836,6 +1836,13 @@ fr:
       group_error: There group has errors
       numeric_operator_error: can only be used on numbers
       uniqueness_error: must be unique
+    workflow_execution_samplesheet_params_validator:
+      attachment_format_error: property '%{property}' must match the expected file format
+      attachment_gid_error: property '%{property}' must be a valid Attachment GID
+      blank_error: property '%{property}' is required and cannot be blank
+      sample_attachment_error: property '%{property}' must belong to the Sample
+      sample_name_error: property '%{property}' must match Sample Name
+      sample_puid_error: property '%{property}' must match Sample PUID
   viral:
     pagy:
       limit_component:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -206,6 +206,9 @@ fr:
           attributes:
             scopes:
               inclusion: can only contain available scopes
+        workflow_execution:
+          invalid_namespace: can only be Group or Project
+          invalid_workflow: unable to find workflow with name '%{workflow_name}' and version '%{workflow_version}'
     exceptions:
       personal_access_token:
         not_found: Could not find personal access token with id %{token_id}

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -8,6 +8,11 @@ attachment2_file_test_file_B_fastq:
   record: attachment2 (Attachment)
   blob: attachment2_file_test_file_B_fastq_blob
 
+attachment3_file_test_file_5_fasta:
+  name: file
+  record: attachment3 (Attachment)
+  blob: attachment3_file_test_file_5_fasta_blob
+
 attachmentA_file_test_file_fastq:
   name: file
   record: attachmentA (Attachment)

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -2,6 +2,8 @@ attachment1_file_test_file_A_fastq_blob: <%= ActiveStorage::FixtureSet.blob file
 
 attachment2_file_test_file_B_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_B.fastq", service_name: "test" %>
 
+attachment3_file_test_file_5_fasta_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_5.fasta", service_name: "test" %>
+
 test_file_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file.fastq", service_name: "test" %>
 
 test_file_A_fastq_blob: <%= ActiveStorage::FixtureSet.blob filename: "test_file_A.fastq", service_name: "test" %>

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -12,6 +12,12 @@ attachment2:
   puid: INXT_ATT_AAAAAAAAAB
   created_at: <%= 2.hours.ago %>
 
+attachment3:
+  metadata: { "compression": "none", "format": "fasta" }
+  attachable: sample3 (Sample)
+  puid: INXT_ATT_BAAAAAAAAB
+  created_at: <%= 2.hours.ago %>
+
 attachmentA:
   metadata: { "compression": "none", "format": "fastq" }
   attachable: sampleA (Sample)

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -45,6 +45,15 @@ samples_workflow_executions_mismatch_file_id:
       "fastq_1": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachmentA, :uuid)}" %>
     }
 
+samples_workflow_executions_invalid_file_format:
+  sample_id: <%= ActiveRecord::FixtureSet.identify(:sample3, :uuid) %>
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:workflow_execution_valid, :uuid) %>
+  samplesheet_params:
+    {
+      "sample": INXT_SAM_AAAAAAAAAC,
+      "fastq_2": <%= "gid://irida/Attachment/#{ActiveRecord::FixtureSet.identify(:attachment3, :uuid)}" %>
+    }
+
 sample1_irida_next_example:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample1, :uuid) %>
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example, :uuid) %>

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -82,7 +82,7 @@ irida_next_example_prepared:
   run_id: "my_run_id_4"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:prepared] %>
+  state: "prepared"
   email_notification: true
   cleaned: false
 
@@ -103,7 +103,7 @@ irida_next_example_submitted:
   run_id: "my_run_id_5"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:submitted] %>
+  state: "submitted"
   cleaned: false
 
 irida_next_example_completed:
@@ -123,7 +123,7 @@ irida_next_example_completed:
   run_id: "my_run_id_6"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -145,7 +145,7 @@ irida_next_example_completed_2_files:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
   name: 'irida_next_example_completed_2_files'
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -166,7 +166,7 @@ irida_next_example_completed_unclean:
   run_id: "my_run_id_6a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -187,7 +187,7 @@ irida_next_example_error:
   run_id: "my_run_id_7"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:error] %>
+  state: "error"
   cleaned: true
 
 irida_next_example_error_unclean:
@@ -207,7 +207,7 @@ irida_next_example_error_unclean:
   run_id: "my_run_id_7a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:error] %>
+  state: "error"
   cleaned: false
 
 irida_next_example_canceling:
@@ -227,7 +227,7 @@ irida_next_example_canceling:
   run_id: "my_run_id_8"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:canceling] %>
+  state: "canceling"
   cleaned: false
 
 irida_next_example_canceled:
@@ -247,7 +247,7 @@ irida_next_example_canceled:
   run_id: "my_run_id_9"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:canceled] %>
+  state: "canceled"
   cleaned: true
 
 irida_next_example_canceled_unclean:
@@ -267,7 +267,7 @@ irida_next_example_canceled_unclean:
   run_id: "my_run_id_9a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:canceled] %>
+  state: "canceled"
   cleaned: false
 
 irida_next_example_running:
@@ -287,7 +287,7 @@ irida_next_example_running:
   run_id: "my_run_id_10"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:running] %>
+  state: "running"
   cleaned: false
 
 irida_next_example_new:
@@ -307,7 +307,7 @@ irida_next_example_new:
   run_id: "my_run_id_12"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:initial] %>
+  state: "initial"
   cleaned: false
 
 irida_next_example_completing_a:
@@ -327,7 +327,7 @@ irida_next_example_completing_a:
   run_id: "my_run_id_a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completing] %>
+  state: "completing"
   blob_run_directory: "not a run dir"
   email_notification: true
   cleaned: false
@@ -349,7 +349,7 @@ irida_next_example_completing_b:
   run_id: "my_run_id_b"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completing] %>
+  state: "completing"
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -370,7 +370,7 @@ irida_next_example_completing_c:
   run_id: "my_run_id_c"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completing] %>
+  state: "completing"
   blob_run_directory: "not a run dir"
   update_samples: true
   cleaned: false
@@ -392,7 +392,7 @@ irida_next_example_completing_d:
   run_id: "my_run_id_d"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completing] %>
+  state: "completing"
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -413,7 +413,7 @@ irida_next_example_completing_e:
   run_id: "my_run_id_e"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completing] %>
+  state: "completing"
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -434,7 +434,7 @@ irida_next_example_completing_f:
   run_id: "my_run_id_f"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completing] %>
+  state: "completing"
   blob_run_directory: "not a run dir"
   update_samples: false
   email_notification: true
@@ -457,7 +457,7 @@ irida_next_example_completing_g:
   run_id: "my_run_id_g"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:projectA_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completing] %>
+  state: "completing"
   blob_run_directory: "not a run dir"
   update_samples: true
   email_notification: true
@@ -481,7 +481,7 @@ irida_next_example_completed_with_output:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
   name: "irida_next_example_completed_with_output"
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -502,7 +502,7 @@ automated_workflow_execution:
   run_id: "my_run_id_13"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -524,7 +524,7 @@ workflow_execution<%= (n) %>:
   run_id: <%= "my_run_id_#{n}" %>
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jane_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project33_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:initial] %>
+  state: "initial"
   cleaned: false
 <% end %>
 
@@ -563,7 +563,7 @@ automated_example_prepared:
   run_id: "my_run_id_4"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:prepared] %>
+  state: "prepared"
   email_notification: true
   cleaned: false
 
@@ -584,7 +584,7 @@ automated_example_submitted:
   run_id: "my_run_id_5"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:submitted] %>
+  state: "submitted"
   cleaned: false
 
 automated_example_completed:
@@ -605,7 +605,7 @@ automated_example_completed:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
   name: "automated_example_completed"
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -626,7 +626,7 @@ automated_example_error:
   run_id: "my_run_id_7"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:error] %>
+  state: "error"
   cleaned: true
 
 automated_example_canceling:
@@ -646,7 +646,7 @@ automated_example_canceling:
   run_id: "my_run_id_8"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:canceling] %>
+  state: "canceling"
   cleaned: false
 
 automated_example_canceled:
@@ -667,7 +667,7 @@ automated_example_canceled:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
   name: "automated_example_canceled"
-  state: <%= WorkflowExecution.states[:canceled] %>
+  state: "canceled"
   cleaned: true
 
 automated_example_running:
@@ -687,7 +687,7 @@ automated_example_running:
   run_id: "my_run_id_10"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:running] %>
+  state: "running"
   cleaned: false
 
 automated_example_new:
@@ -707,7 +707,7 @@ automated_example_new:
   run_id: "my_run_id_12"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:initial] %>
+  state: "initial"
   cleaned: false
 
 automated_workflow_execution_existing:
@@ -745,7 +745,7 @@ irida_next_example_end_to_end:
   workflow_url: "https://github.com/phac-nml/iridanextexample"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
-  state: <%= WorkflowExecution.states[:initial] %>
+  state: "initial"
   cleaned: false
 
 irida_next_example_completed_DELETE:
@@ -766,7 +766,7 @@ irida_next_example_completed_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   cleaned: true
 
 irida_next_example_error_DELETE:
@@ -783,7 +783,7 @@ irida_next_example_error_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: <%= WorkflowExecution.states[:error] %>
+  state: "error"
   cleaned: true
 
 irida_next_example_canceled_DELETE:
@@ -800,7 +800,7 @@ irida_next_example_canceled_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: <%= WorkflowExecution.states[:canceled] %>
+  state: "canceled"
   cleaned: true
 
 irida_next_example_completed_unclean_DELETE:
@@ -817,7 +817,7 @@ irida_next_example_completed_unclean_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   cleaned: false
 
 irida_next_example_error_unclean_DELETE:
@@ -834,7 +834,7 @@ irida_next_example_error_unclean_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: <%= WorkflowExecution.states[:error] %>
+  state: "error"
   cleaned: false
 
 irida_next_example_canceled_unclean_DELETE:
@@ -851,7 +851,7 @@ irida_next_example_canceled_unclean_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: <%= WorkflowExecution.states[:canceled] %>
+  state: "canceled"
   cleaned: false
 
 workflow_execution_valid_on_group:
@@ -915,7 +915,7 @@ workflow_execution_completed_shared1:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:james_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace, :uuid) %>
   name: "irida_next_user_shared_example_completed_with_output"
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: false
   shared_with_namespace: true
@@ -938,7 +938,7 @@ workflow_execution_completed_shared2:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:micha_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace, :uuid) %>
   name: "irida_next_member_shared_example_completed_with_output"
-  state: <%= WorkflowExecution.states[:completed] %>
+  state: "completed"
   blob_run_directory: "not a run dir"
   cleaned: false
   shared_with_namespace: true

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -31,6 +31,16 @@ workflow_execution_invalid_metadata:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
 
+workflow_execution_invalid_workflow:
+  <<: *DEFAULTS
+  metadata: { "workflow_name": "wn1", "workflow_version": "invalid" }
+  workflow_params: { "key_a": "value_a" }
+  workflow_engine_parameters: { "-r": "dev" }
+  workflow_url: "my_workflow_url"
+  run_id: "my_run_id_2"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:james_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
+
 workflow_execution_invalid_namespace:
   <<: *DEFAULTS
   metadata: { "workflow_name": "wn1", "workflow_version": "wv1" }

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -13,7 +13,7 @@ DEFAULTS: &DEFAULTS
 
 workflow_execution_valid:
   <<: *DEFAULTS
-  metadata: { "workflow_name": "wn1", "workflow_version": "wv1" }
+  metadata: { "workflow_name": "phac-nml/iridanextexample", "workflow_version": "1.0.3" }
   workflow_params: { "key_a": "value_a" }
   workflow_engine_parameters: { "-r": "dev" }
   workflow_url: "my_workflow_url"
@@ -82,7 +82,7 @@ irida_next_example_prepared:
   run_id: "my_run_id_4"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "prepared"
+  state: <%= WorkflowExecution.states[:prepared] %>
   email_notification: true
   cleaned: false
 
@@ -103,7 +103,7 @@ irida_next_example_submitted:
   run_id: "my_run_id_5"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "submitted"
+  state: <%= WorkflowExecution.states[:submitted] %>
   cleaned: false
 
 irida_next_example_completed:
@@ -123,7 +123,7 @@ irida_next_example_completed:
   run_id: "my_run_id_6"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -145,7 +145,7 @@ irida_next_example_completed_2_files:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
   name: 'irida_next_example_completed_2_files'
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -166,7 +166,7 @@ irida_next_example_completed_unclean:
   run_id: "my_run_id_6a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -187,7 +187,7 @@ irida_next_example_error:
   run_id: "my_run_id_7"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "error"
+  state: <%= WorkflowExecution.states[:error] %>
   cleaned: true
 
 irida_next_example_error_unclean:
@@ -207,7 +207,7 @@ irida_next_example_error_unclean:
   run_id: "my_run_id_7a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "error"
+  state: <%= WorkflowExecution.states[:error] %>
   cleaned: false
 
 irida_next_example_canceling:
@@ -227,7 +227,7 @@ irida_next_example_canceling:
   run_id: "my_run_id_8"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "canceling"
+  state: <%= WorkflowExecution.states[:canceling] %>
   cleaned: false
 
 irida_next_example_canceled:
@@ -247,7 +247,7 @@ irida_next_example_canceled:
   run_id: "my_run_id_9"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "canceled"
+  state: <%= WorkflowExecution.states[:canceled] %>
   cleaned: true
 
 irida_next_example_canceled_unclean:
@@ -267,7 +267,7 @@ irida_next_example_canceled_unclean:
   run_id: "my_run_id_9a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "canceled"
+  state: <%= WorkflowExecution.states[:canceled] %>
   cleaned: false
 
 irida_next_example_running:
@@ -287,7 +287,7 @@ irida_next_example_running:
   run_id: "my_run_id_10"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "running"
+  state: <%= WorkflowExecution.states[:running] %>
   cleaned: false
 
 irida_next_example_new:
@@ -307,7 +307,7 @@ irida_next_example_new:
   run_id: "my_run_id_12"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "initial"
+  state: <%= WorkflowExecution.states[:initial] %>
   cleaned: false
 
 irida_next_example_completing_a:
@@ -327,7 +327,7 @@ irida_next_example_completing_a:
   run_id: "my_run_id_a"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: "completing"
+  state: <%= WorkflowExecution.states[:completing] %>
   blob_run_directory: "not a run dir"
   email_notification: true
   cleaned: false
@@ -349,7 +349,7 @@ irida_next_example_completing_b:
   run_id: "my_run_id_b"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: "completing"
+  state: <%= WorkflowExecution.states[:completing] %>
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -370,7 +370,7 @@ irida_next_example_completing_c:
   run_id: "my_run_id_c"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: "completing"
+  state: <%= WorkflowExecution.states[:completing] %>
   blob_run_directory: "not a run dir"
   update_samples: true
   cleaned: false
@@ -392,7 +392,7 @@ irida_next_example_completing_d:
   run_id: "my_run_id_d"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: "completing"
+  state: <%= WorkflowExecution.states[:completing] %>
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -413,7 +413,7 @@ irida_next_example_completing_e:
   run_id: "my_run_id_e"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: "completing"
+  state: <%= WorkflowExecution.states[:completing] %>
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -434,7 +434,7 @@ irida_next_example_completing_f:
   run_id: "my_run_id_f"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: "completing"
+  state: <%= WorkflowExecution.states[:completing] %>
   blob_run_directory: "not a run dir"
   update_samples: false
   email_notification: true
@@ -457,7 +457,7 @@ irida_next_example_completing_g:
   run_id: "my_run_id_g"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:projectA_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
-  state: "completing"
+  state: <%= WorkflowExecution.states[:completing] %>
   blob_run_directory: "not a run dir"
   update_samples: true
   email_notification: true
@@ -481,7 +481,7 @@ irida_next_example_completed_with_output:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
   name: "irida_next_example_completed_with_output"
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: false
 
@@ -502,7 +502,7 @@ automated_workflow_execution:
   run_id: "my_run_id_13"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -524,7 +524,7 @@ workflow_execution<%= (n) %>:
   run_id: <%= "my_run_id_#{n}" %>
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:jane_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project33_namespace, :uuid) %>
-  state: "initial"
+  state: <%= WorkflowExecution.states[:initial] %>
   cleaned: false
 <% end %>
 
@@ -563,7 +563,7 @@ automated_example_prepared:
   run_id: "my_run_id_4"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "prepared"
+  state: <%= WorkflowExecution.states[:prepared] %>
   email_notification: true
   cleaned: false
 
@@ -584,7 +584,7 @@ automated_example_submitted:
   run_id: "my_run_id_5"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "submitted"
+  state: <%= WorkflowExecution.states[:submitted] %>
   cleaned: false
 
 automated_example_completed:
@@ -605,7 +605,7 @@ automated_example_completed:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
   name: "automated_example_completed"
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: true
 
@@ -626,7 +626,7 @@ automated_example_error:
   run_id: "my_run_id_7"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "error"
+  state: <%= WorkflowExecution.states[:error] %>
   cleaned: true
 
 automated_example_canceling:
@@ -646,7 +646,7 @@ automated_example_canceling:
   run_id: "my_run_id_8"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "canceling"
+  state: <%= WorkflowExecution.states[:canceling] %>
   cleaned: false
 
 automated_example_canceled:
@@ -667,7 +667,7 @@ automated_example_canceled:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
   name: "automated_example_canceled"
-  state: "canceled"
+  state: <%= WorkflowExecution.states[:canceled] %>
   cleaned: true
 
 automated_example_running:
@@ -687,7 +687,7 @@ automated_example_running:
   run_id: "my_run_id_10"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "running"
+  state: <%= WorkflowExecution.states[:running] %>
   cleaned: false
 
 automated_example_new:
@@ -707,7 +707,7 @@ automated_example_new:
   run_id: "my_run_id_12"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:project1_automation_bot, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
-  state: "initial"
+  state: <%= WorkflowExecution.states[:initial] %>
   cleaned: false
 
 automated_workflow_execution_existing:
@@ -745,7 +745,7 @@ irida_next_example_end_to_end:
   workflow_url: "https://github.com/phac-nml/iridanextexample"
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
-  state: "initial"
+  state: <%= WorkflowExecution.states[:initial] %>
   cleaned: false
 
 irida_next_example_completed_DELETE:
@@ -766,7 +766,7 @@ irida_next_example_completed_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   cleaned: true
 
 irida_next_example_error_DELETE:
@@ -783,7 +783,7 @@ irida_next_example_error_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: "error"
+  state: <%= WorkflowExecution.states[:error] %>
   cleaned: true
 
 irida_next_example_canceled_DELETE:
@@ -800,7 +800,7 @@ irida_next_example_canceled_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: "canceled"
+  state: <%= WorkflowExecution.states[:canceled] %>
   cleaned: true
 
 irida_next_example_completed_unclean_DELETE:
@@ -817,7 +817,7 @@ irida_next_example_completed_unclean_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   cleaned: false
 
 irida_next_example_error_unclean_DELETE:
@@ -834,7 +834,7 @@ irida_next_example_error_unclean_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: "error"
+  state: <%= WorkflowExecution.states[:error] %>
   cleaned: false
 
 irida_next_example_canceled_unclean_DELETE:
@@ -851,7 +851,7 @@ irida_next_example_canceled_unclean_DELETE:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:janitor_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_janitor_namespace, :uuid) %>
   blob_run_directory: "not a run dir"
-  state: "canceled"
+  state: <%= WorkflowExecution.states[:canceled] %>
   cleaned: false
 
 workflow_execution_valid_on_group:
@@ -915,7 +915,7 @@ workflow_execution_completed_shared1:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:james_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace, :uuid) %>
   name: "irida_next_user_shared_example_completed_with_output"
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: false
   shared_with_namespace: true
@@ -938,7 +938,7 @@ workflow_execution_completed_shared2:
   submitter_id: <%= ActiveRecord::FixtureSet.identify(:micha_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project22_namespace, :uuid) %>
   name: "irida_next_member_shared_example_completed_with_output"
-  state: "completed"
+  state: <%= WorkflowExecution.states[:completed] %>
   blob_run_directory: "not a run dir"
   cleaned: false
   shared_with_namespace: true

--- a/test/graphql/workflow_executions_query_test.rb
+++ b/test/graphql/workflow_executions_query_test.rb
@@ -156,13 +156,7 @@ class WorkflowExecutionsQueryTest < ActiveSupport::TestCase
 
   test 'workflow executions nodes query should on groups' do
     user = users(:james_doe)
-    prelim_query = IridaSchema.execute(
-      WORKFLOW_EXECUTIONS_QUERY,
-      context: { current_user: user },
-      variables: { first: 1 }
-    )['data']
-
-    workflow_execution_id = prelim_query['workflowExecutions']['nodes'][0]['id']
+    workflow_execution_id = workflow_executions(:workflow_execution_valid_on_group).to_global_id.to_s
 
     result = IridaSchema.execute(WORKFLOW_EXECUTIONS_NODE_QUERY, context: { current_user: user },
                                                                  variables: { workflow_execution_id: })

--- a/test/graphql/workflow_executions_query_test.rb
+++ b/test/graphql/workflow_executions_query_test.rb
@@ -132,7 +132,7 @@ class WorkflowExecutionsQueryTest < ActiveSupport::TestCase
 
     data = result['data']['node']
 
-    exp_metadata = { 'workflow_name' => 'wn1', 'workflow_version' => 'wv1' }
+    exp_metadata = { 'workflow_name' => 'phac-nml/iridanextexample', 'workflow_version' => '1.0.3' }
     assert_equal exp_metadata, data['metadata']
   end
 

--- a/test/models/samples_workflow_executions_test.rb
+++ b/test/models/samples_workflow_executions_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
-  def setup
+  def setup # rubocop:disable Metrics/MethodLength
     @samples_workflow_executions_valid = samples_workflow_executions(
       :samples_workflow_executions_valid
     )
@@ -15,6 +15,9 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
     )
     @samples_workflow_executions_invalid_file_id = samples_workflow_executions(
       :samples_workflow_executions_invalid_file_id
+    )
+    @samples_workflow_executions_invalid_file_format = samples_workflow_executions(
+      :samples_workflow_executions_invalid_file_format
     )
     @samples_workflow_executions_mismatch_file_id = samples_workflow_executions(
       :samples_workflow_executions_mismatch_file_id
@@ -53,6 +56,16 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
       expected_error,
       @samples_workflow_executions_invalid_file_id.errors.full_messages[0]
     )
+  end
+
+  test 'invalid file format' do
+    assert_not @samples_workflow_executions_invalid_file_format.valid?
+    assert_not_nil @samples_workflow_executions_invalid_file_format.errors
+    expected_error =
+      "Samplesheet params #{I18n.t('validators.workflow_execution_samplesheet_params_validator.attachment_format_error',
+                                   property: 'fastq_2', file_format: '^\\S+\\.f(ast)?q(\\.gz)?$')}"
+    assert_includes @samples_workflow_executions_invalid_file_format.errors.full_messages,
+                    expected_error
   end
 
   test 'mismatch file id' do

--- a/test/models/samples_workflow_executions_test.rb
+++ b/test/models/samples_workflow_executions_test.rb
@@ -26,26 +26,29 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
   end
 
   test 'invalid mismatch puid' do
-    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_invalid_mismatch_sample_puid.valid?
     assert_not_nil @samples_workflow_executions_invalid_mismatch_sample_puid.errors
-    expected_error = 'Sample Provided Sample PUID INXT_SAM_AAAAAAAAAB does not match SampleWorkflowExecution Sample PUID INXT_SAM_AAAAAAAAAA' # rubocop:disable Layout/LineLength
+    expected_error =
+      "Samplesheet params #{I18n.t('validators.workflow_execution_samplesheet_params_validator.sample_puid_error',
+                                   property: 'sample')}"
     assert_equal expected_error, @samples_workflow_executions_invalid_mismatch_sample_puid.errors.full_messages[0]
   end
 
   test 'invalid no sample puid' do
-    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_invalid_no_sample_puid.valid?
     assert_not_nil @samples_workflow_executions_invalid_no_sample_puid.errors
-    expected_error = 'Sample No Sample PUID provided'
+    expected_error =
+      "Samplesheet params #{I18n.t('validators.workflow_execution_samplesheet_params_validator.blank_error',
+                                   property: 'sample')}"
     assert_equal expected_error, @samples_workflow_executions_invalid_no_sample_puid.errors.full_messages[0]
   end
 
   test 'invalid file id' do
-    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_invalid_file_id.valid?
     assert_not_nil @samples_workflow_executions_invalid_file_id.errors
-    expected_error = 'Attachment 12345 is not a valid IRIDA Next ID.'
+    expected_error =
+      "Samplesheet params #{I18n.t('validators.workflow_execution_samplesheet_params_validator.attachment_gid_error',
+                                   property: 'fastq_1')}"
     assert_equal(
       expected_error,
       @samples_workflow_executions_invalid_file_id.errors.full_messages[0]
@@ -53,10 +56,11 @@ class SamplesWorkflowExecutionsTest < ActiveSupport::TestCase
   end
 
   test 'mismatch file id' do
-    skip 'validator needs rewrite'
     assert_not @samples_workflow_executions_mismatch_file_id.valid?
     assert_not_nil @samples_workflow_executions_mismatch_file_id.errors
-    expected_error = 'Attachment Attachment does not belong to Sample INXT_SAM_AAAAAAAAAA.'
+    expected_error =
+      "Samplesheet params #{I18n.t('validators.workflow_execution_samplesheet_params_validator.sample_attachment_error',
+                                   property: 'fastq_1')}"
     assert_equal(
       expected_error,
       @samples_workflow_executions_mismatch_file_id.errors.full_messages[0]

--- a/test/models/workflow_execution_test.rb
+++ b/test/models/workflow_execution_test.rb
@@ -6,6 +6,7 @@ class WorkflowExecutionTest < ActiveSupport::TestCase
   def setup
     @workflow_execution_valid = workflow_executions(:workflow_execution_valid)
     @workflow_execution_invalid_metadata = workflow_executions(:workflow_execution_invalid_metadata)
+    @workflow_execution_invalid_workflow = workflow_executions(:workflow_execution_invalid_workflow)
     @workflow_execution_invalid_namespace = workflow_executions(:workflow_execution_invalid_namespace)
   end
 
@@ -17,9 +18,8 @@ class WorkflowExecutionTest < ActiveSupport::TestCase
   test 'workflow execution with an invalid namespace_id' do
     assert_not @workflow_execution_invalid_namespace.valid?
     assert_not_nil @workflow_execution_invalid_namespace.errors[:namespace]
-    assert @workflow_execution_invalid_namespace
-      .errors[:base]
-      .include?('workflow executions can only belong to a Project or Group namespace')
+    assert_includes @workflow_execution_invalid_namespace.errors[:namespace],
+                    I18n.t('activerecord.errors.models.workflow_execution.invalid_namespace')
   end
 
   test 'valid workflow execution' do
@@ -29,10 +29,17 @@ class WorkflowExecutionTest < ActiveSupport::TestCase
   test 'invalid metadata' do
     assert_not @workflow_execution_invalid_metadata.valid?
     assert_not_nil @workflow_execution_invalid_metadata.errors[:metadata]
-    assert_equal(
-      ['Metadata object at root is missing required properties: workflow_version'],
-      @workflow_execution_invalid_metadata.errors.full_messages
-    )
+    assert_includes @workflow_execution_invalid_metadata.errors.full_messages,
+                    'Metadata object at root is missing required properties: workflow_version'
+  end
+
+  test 'invalid workflow specified' do
+    assert_not @workflow_execution_invalid_workflow.valid?
+    assert_not_nil @workflow_execution_invalid_workflow.errors[:base]
+    assert_includes @workflow_execution_invalid_workflow.errors[:base],
+                    I18n.t('activerecord.errors.models.workflow_execution.invalid_workflow',
+                           workflow_name: @workflow_execution_invalid_workflow.metadata['workflow_name'],
+                           workflow_version: @workflow_execution_invalid_workflow.metadata['workflow_version'])
   end
 
   test 'state with type enum using key assignment' do

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -10,11 +10,13 @@ module WorkflowExecutions
       @user = users(:john_doe)
       @project = projects(:project1)
       @sample = samples(:sample1)
+      @attachment = attachments(:attachment1)
       @samples_workflow_executions_attributes = {
         '0': {
           sample_id: @sample.id,
           samplesheet_params: {
-            sample: @sample.puid
+            sample: @sample.puid,
+            fastq_1: @attachment.to_global_id
           }
         }
       }
@@ -364,7 +366,6 @@ module WorkflowExecutions
     end
 
     test 'create new workflow execution with non matching sample puid in sample sheet' do
-      skip 'validator needs rewrite'
       samples_workflow_executions_attributes = {
         '0': {
           sample_id: samples(:sample1).id,
@@ -389,13 +390,13 @@ module WorkflowExecutions
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
 
-      assert @workflow_execution.errors.full_messages
-                                .include?('Sample Provided Sample PUID INXT_SAM_AAAAAAAAAB does not match SampleWorkflowExecution Sample PUID INXT_SAM_AAAAAAAAAA') # rubocop:disable Layout/LineLength
+      assert_includes @workflow_execution.errors.full_messages,
+                      "Samples workflow executions[0] samplesheet params #{I18n.t('validators.workflow_execution_samplesheet_params_validator.sample_puid_error',
+                                                                                  property: 'sample')}"
       assert_enqueued_jobs(0, except: Turbo::Streams::BroadcastStreamJob)
     end
 
     test 'create new workflow execution with non matching attachments to sample' do
-      skip 'validator needs rewrite'
       samples_workflow_executions_attributes = {
         '0': {
           sample_id: samples(:sample2).id,
@@ -421,8 +422,10 @@ module WorkflowExecutions
 
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
 
-      assert @workflow_execution.errors.full_messages
-                                .include?('Attachment Attachment does not belong to Sample INXT_SAM_AAAAAAAAAB.')
+      assert_includes @workflow_execution.errors.full_messages,
+                      "Samples workflow executions[0] samplesheet params #{I18n.t(
+                        'validators.workflow_execution_samplesheet_params_validator.sample_attachment_error', property: 'fastq_1'
+                      )}"
       assert_enqueued_jobs(0, except: Turbo::Streams::BroadcastStreamJob)
     end
   end

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -16,7 +16,7 @@ module WorkflowExecutions
           sample_id: @sample.id,
           samplesheet_params: {
             sample: @sample.puid,
-            fastq_1: @attachment.to_global_id
+            fastq_1: @attachment.to_global_id # rubocop:disable Naming/VariableNumber
           }
         }
       }
@@ -391,8 +391,10 @@ module WorkflowExecutions
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params).execute
 
       assert_includes @workflow_execution.errors.full_messages,
-                      "Samples workflow executions[0] samplesheet params #{I18n.t('validators.workflow_execution_samplesheet_params_validator.sample_puid_error',
-                                                                                  property: 'sample')}"
+                      "Samples workflow executions[0] samplesheet params #{I18n.t(
+                        'validators.workflow_execution_samplesheet_params_validator.sample_puid_error',
+                        property: 'sample'
+                      )}"
       assert_enqueued_jobs(0, except: Turbo::Streams::BroadcastStreamJob)
     end
 
@@ -424,7 +426,8 @@ module WorkflowExecutions
 
       assert_includes @workflow_execution.errors.full_messages,
                       "Samples workflow executions[0] samplesheet params #{I18n.t(
-                        'validators.workflow_execution_samplesheet_params_validator.sample_attachment_error', property: 'fastq_1'
+                        'validators.workflow_execution_samplesheet_params_validator.sample_attachment_error',
+                        property: 'fastq_1'
                       )}"
       assert_enqueued_jobs(0, except: Turbo::Streams::BroadcastStreamJob)
     end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -94,7 +94,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       assert_selector "tr:nth-child(3) td:nth-child(#{@workflow_name_col})",
                       text: workflow_execution8.metadata['workflow_name']
       assert_selector "tr:last-child td:nth-child(#{@workflow_name_col})",
-                      text: workflow_execution1.metadata['workflow_name']
+                      text: workflow_execution2.metadata['workflow_name']
     end
 
     click_on 'Workflow Name'
@@ -103,9 +103,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within('#workflow-executions-table table tbody') do
       assert_selector 'tr', count: WORKFLOW_EXECUTION_COUNT
       assert_selector "tr:first-child td:nth-child(#{@workflow_name_col})",
-                      text: workflow_execution1.metadata['workflow_name']
-      assert_selector "tr:nth-child(2) td:nth-child(#{@workflow_name_col})",
                       text: workflow_execution2.metadata['workflow_name']
+      assert_selector "tr:nth-child(2) td:nth-child(#{@workflow_name_col})",
+                      text: workflow_execution_shared1.metadata['workflow_name']
       assert_selector "tr:last-child td:nth-child(#{@workflow_name_col})",
                       text: workflow_execution9.metadata['workflow_name']
     end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This updates the WorkflowExecution model to validate that the workflow exists as specified by `metadata['workflow_name']` and `metadata['workflow_version']`, additionally this refactors and reenables the SamplesWorkflowExecution `samplesheet_params` validation.

These validation errors should really only be producible by using the submitWorkflowExecution mutation from the graphql API.

Submissions through the UI should not be able to produce these errors as we automatically set most of the params, or restrict input to valid items (e.g. attachments specific to the sample and regex).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Submitting a workflow execution via graphql with missing `fastq_1` for first sample and mismatched `puid` for second sample, gives the following:

<img width="1550" alt="image" src="https://github.com/user-attachments/assets/02d66d16-08c0-4093-9811-76e7da838cf6" />

Also updated submission to handle rendering errors from controller when validation failed
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/a507d7fe-58ae-4817-8caa-50284723968b" />

To induce this run the following in your javascript console, after selecting a valid pipeline version.
```javascript
document.querySelector("input[name='workflow_execution[metadata][workflow_version]']").value = "invalid"
```

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server (if already running then please stop it and start new)
2. Submit a workflow execution via the graphql api following directions [here](https://phac-nml.github.io/irida-next/docs/extend/graphql_workflow_submission) with the following notes:
   * Make an error in the samplesheet params
   * Omit params
   * incorrect PUID
   * wrong attachment gids
3. Verify that the errors are caught and returned

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
