### PR TITLE
Fix: Allow template fields that are not within the sample metadata to be exported

### DIFF
--- a/app/components/viral/sortable_list/list_component.html.erb
+++ b/app/components/viral/sortable_list/list_component.html.erb
@@ -6,19 +6,7 @@
     data-viral--sortable-lists--list-group-name-value="<%= group %>"
     class="<%= @system_arguments[:list_classes] %>"
     tabindex="0"
-    >
-    <% list_items.each do |list_item| %>
-      <li
-      id="<%= list_item %>"
-      class="
-      block
-      w-full
-      px-4
-      py-2
-      border-b
-      border-slate-200
-      cursor-move
-      dark:border-slate-600"><%= list_item %></li>
-    <% end %>
+  >
+    <%= render Viral::SortableList::ListItemComponent.with_collection(list_items) %>
   </ul>
 </div>

--- a/app/components/viral/sortable_list/list_item_component.html.erb
+++ b/app/components/viral/sortable_list/list_item_component.html.erb
@@ -1,0 +1,7 @@
+<li
+  id="<%= list_item %>"
+  class="
+    block w-full px-4 py-2 border-b cursor-move border-slate-200
+    dark:border-slate-600
+  "
+><%= list_item %></li>

--- a/app/components/viral/sortable_list/list_item_component.rb
+++ b/app/components/viral/sortable_list/list_item_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Viral
+  module SortableList
+    # A component representing an item in a sortable list.
+    # This component is used to render individual list items.
+    class ListItemComponent < Viral::Component
+      attr_reader :list_item
+
+      def initialize(list_item:)
+        @list_item = list_item
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -27,6 +27,7 @@ export default class extends Controller {
     // Get a handle on the original available list
     this.#originalAvailableList = [
       ...this.availableList.querySelectorAll("li"),
+      ...this.selectedList.querySelectorAll("li"),
     ];
     Object.freeze(this.#originalAvailableList);
 
@@ -64,16 +65,18 @@ export default class extends Controller {
 
   #checkStates() {
     this.#checkButtonStates();
+
     if (this.hasTemplateSelectorTarget) {
       this.#checkTemplateSelectorState();
-
-      // Make sure the items in the availableList are in the originalAvailableList
-      this.availableList.querySelectorAll("li").forEach((li) => {
-        if (!this.#originalAvailableList.includes(li)) {
-          this.availableList.removeChild(li);
-        }
-      });
+      this.#cleanupAvailableList();
     }
+  }
+
+  #cleanupAvailableList() {
+    const itemsToRemove = Array.from(this.availableList.querySelectorAll("li"))
+      .filter(li => !this.#originalAvailableList.includes(li));
+
+    itemsToRemove.forEach(li => li.remove());
   }
 
   #checkButtonStates() {

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -66,6 +66,13 @@ export default class extends Controller {
     this.#checkButtonStates();
     if (this.hasTemplateSelectorTarget) {
       this.#checkTemplateSelectorState();
+
+      // Make sure the items in the availableList are in the originalAvailableList
+      this.availableList.querySelectorAll("li").forEach((li) => {
+        if (!this.#originalAvailableList.includes(li)) {
+          this.availableList.removeChild(li);
+        }
+      });
     }
   }
 

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -204,7 +204,7 @@ export default class extends Controller {
         } else {
           const template = this.itemTemplateTarget.content.cloneNode(true);
           template.querySelector("li").innerText = element;
-          template.id = element;
+          template.querySelector("li").id = element.replace(/\s+/g, "-");
           this.selectedList.append(template);
         }
       });

--- a/app/views/data_exports/_new_linelist_export_dialog.html.erb
+++ b/app/views/data_exports/_new_linelist_export_dialog.html.erb
@@ -103,6 +103,13 @@
               list_classes: "overflow-y-auto max-w-[356px] min-w-[356px] w-full",
             ) %>
           <% end %>
+
+          <template
+            id="sortable-list-item-template"
+            data-viral--sortable-lists--two-lists-selection-target="itemTemplate"
+          >
+            <%= render Viral::SortableList::ListItemComponent.new(list_item: "NAME_HERE") %>
+          </template>
           <%= form_for(:data_export, url: data_exports_path, method: :post,
               data: {
                 controller: "form--hidden-inputs",


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Currently, if a metadata template has fields that do not exist within the metadata fields on a project that field was ignored.  Now you can export that field

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/d720e088-dae1-4dfa-8b18-c1b07388c848)
"favourite sport" was added to the template, but does not exist in the project.

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
