### PR TITLE
Refactor member activities

### DIFF
--- a/app/components/activities/list_item_component.html.erb
+++ b/app/components/activities/list_item_component.html.erb
@@ -48,6 +48,8 @@
         <%= render Activities::Projects::SampleCloneActivityComponent.new(
           activity: activity,
         ) %>
+      <% elsif member_action %>
+        <%= render Activities::MemberActivityComponent.new(activity: activity) %>
       <% elsif project_namespace_transfer_action %>
         <%= render Activities::Projects::TransferActivityComponent.new(activity: activity) %>
       <% else %>
@@ -55,8 +57,6 @@
       <% end %>
     <% elsif activity[:type] == 'WorkflowExecution' %>
       <%= render Activities::WorkflowExecutionActivityComponent.new(activity: activity) %>
-    <% elsif activity[:type] == 'Member' %>
-      <%= render Activities::MemberActivityComponent.new(activity: activity) %>
     <% elsif activity[:type] == 'NamespaceGroupLink' %>
       <%= render Activities::NamespaceGroupLinkActivityComponent.new(activity: activity) %>
     <% end %>

--- a/app/components/activities/list_item_component.html.erb
+++ b/app/components/activities/list_item_component.html.erb
@@ -22,6 +22,8 @@
         <%= render Activities::Groups::TransferOutActivityComponent.new(activity: activity) %>
       <% elsif subgroup_action %>
         <%= render Activities::Groups::SubgroupActivityComponent.new(activity: activity) %>
+      <% elsif member_action %>
+        <%= render Activities::MemberActivityComponent.new(activity: activity) %>
       <% elsif project_crud_action %>
         <%= render Activities::Groups::Projects::CrudActivityComponent.new(
           activity: activity,

--- a/app/components/activities/list_item_component.rb
+++ b/app/components/activities/list_item_component.rb
@@ -9,12 +9,16 @@ module Activities
       @activity = activity
     end
 
-    def project_crud_action
-      @activity[:key].include?('group.projects.create') ||  @activity[:key].include?('group.projects.destroy')
+    def member_action
+      %w[member_create member_update member_destroy].include?(@activity[:action])
     end
 
     def metadata_template_action
       %w[metadata_template_create metadata_template_destroy metadata_template_update].include?(@activity[:action])
+    end
+
+    def project_crud_action
+      @activity[:key].include?('group.projects.create') ||  @activity[:key].include?('group.projects.destroy')
     end
 
     def project_namespace_transfer_action

--- a/app/components/activities/member_activity_component.html.erb
+++ b/app/components/activities/member_activity_component.html.erb
@@ -1,26 +1,25 @@
 <span>
   <% if member_exists %>
-    <%= t(
-      @activity[:key],
-      user: @activity[:user],
-      href:
-        link_to(
+    <% href = link_to(
           @activity[:member_email],
           members_page,
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
-        ),
-      namespace_type: @activity[:namespace_type],
-      name: @activity[:name],
-      member: @activity[:member_email],
-    ) %>
+        )%>
   <% else %>
-    <%= t(
-      @activity[:key],
-      user: @activity[:user],
-      href: @activity[:member_email],
-      namespace_type: @activity[:namespace_type],
-      name: @activity[:name],
-      member: @activity[:member_email],
-    ) %>
+    <% href = link_to(
+          @activity[:member_email],
+          "#",
+          class: "text-slate-800 dark:text-slate-300 font-medium cursor-not-allowed",
+          disabled: true
+        ) %>
   <% end %>
+
+  <%= t(
+    @activity[:key],
+    user: @activity[:user],
+    href: href,
+    namespace_type: @activity[:namespace_type],
+    name: @activity[:name],
+    member: @activity[:member_email],
+  ) %>
 </span>

--- a/app/components/activities/member_activity_component.html.erb
+++ b/app/components/activities/member_activity_component.html.erb
@@ -5,22 +5,22 @@
       user: @activity[:user],
       href:
         link_to(
-          @activity[:member].user.email,
+          @activity[:member_email],
           members_page,
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
         ),
       namespace_type: @activity[:namespace_type],
       name: @activity[:name],
-      member: @activity[:member].user.email,
+      member: @activity[:member_email],
     ) %>
   <% else %>
     <%= t(
       @activity[:key],
       user: @activity[:user],
-      href: @activity[:member].user.email,
+      href: @activity[:member_email],
       namespace_type: @activity[:namespace_type],
       name: @activity[:name],
-      member: @activity[:member].user.email,
+      member: @activity[:member_email],
     ) %>
   <% end %>
 </span>

--- a/app/models/concerns/track_activity.rb
+++ b/app/models/concerns/track_activity.rb
@@ -110,6 +110,7 @@ module TrackActivity # rubocop:disable Metrics/ModuleLength
       namespace_type: activity_trackable.namespace.type.downcase,
       name: activity_trackable.namespace.name,
       member: activity_trackable,
+      member_email: activity.parameters[:member_email],
       type: 'Member'
     }
   end

--- a/app/models/concerns/track_activity.rb
+++ b/app/models/concerns/track_activity.rb
@@ -8,9 +8,11 @@ module TrackActivity # rubocop:disable Metrics/ModuleLength
     include PublicActivity::Common
   end
 
-  def human_readable_activity(public_activities) # rubocop:disable Metrics/MethodLength
+  def human_readable_activity(public_activities) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
     activities = []
     public_activities.each do |activity|
+      next if !activity.parameters[:member_email].nil? && activity.parameters[:member_email].include?('automation')
+
       trackable_type = activity.trackable_type
       activity[:parameters] = convert_activity_parameter_keys(activity)
 

--- a/app/models/concerns/track_activity.rb
+++ b/app/models/concerns/track_activity.rb
@@ -108,8 +108,8 @@ module TrackActivity # rubocop:disable Metrics/ModuleLength
     member_action_types = %w[member_create member_destroy member_update]
     return params unless member_action_types.include?(activity.parameters[:action])
 
-    member = Member.joins(:user, :namespace).with_deleted.find_by(user: { email: activity.parameters[:member_email] },
-                                                                  namespace: { id: activity_trackable.id })
+    member = Member.joins(:user, :namespace).with_deleted.where(user: { email: activity.parameters[:member_email] },
+                                                                namespace: { id: activity_trackable.id }).last
 
     params.merge!(member: member, member_email: activity.parameters[:member_email])
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -120,11 +120,6 @@ class Group < Namespace # rubocop:disable Metrics/ClassLength
       trackable_type: 'Namespace'
     ).or(
       PublicActivity::Activity.where(
-        trackable_id: Member.joins(:user).with_deleted.where(namespace: self).select(:id).where.not(user:
-        { user_type: User.user_types[:project_automation_bot] }), trackable_type: 'Member'
-      )
-    ).or(
-      PublicActivity::Activity.where(
         trackable_id: NamespaceGroupLink.with_deleted.where(namespace: self).select(:id),
         trackable_type: 'NamespaceGroupLink'
       )

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -98,11 +98,6 @@ module Namespaces
         trackable_type: 'Namespace'
       ).or(
         PublicActivity::Activity.where(
-          trackable_id: Member.joins(:user).with_deleted.where(namespace: self).select(:id).where.not(user:
-          { user_type: User.user_types[:project_automation_bot] }), trackable_type: 'Member'
-        )
-      ).or(
-        PublicActivity::Activity.where(
           trackable_id: NamespaceGroupLink.with_deleted.where(namespace: self).select(:id),
           trackable_type: 'NamespaceGroupLink'
         )

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -31,9 +31,16 @@ module Members
       if member.save
         send_emails if @email_notification && !has_previous_access
         if @member.user != current_user
-          member.create_activity key: 'member.create', owner: current_user, parameters: {
-            member_email: @member.user.email
-          }
+          namespace_key = if member.namespace.group_namespace?
+                            'group'
+                          else
+                            'namespaces_project_namespace'
+                          end
+          member.namespace.create_activity key: "#{namespace_key}.member.create", owner: current_user,
+                                           parameters: {
+                                             member_email: @member.user.email,
+                                             action: 'member_create'
+                                           }
         end
       end
 

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -30,7 +30,11 @@ module Members
       end
       if member.save
         send_emails if @email_notification && !has_previous_access
-        member.create_activity key: 'member.create', owner: current_user if @member.user != current_user
+        if @member.user != current_user
+          member.create_activity key: 'member.create', owner: current_user, parameters: {
+            member_email: @member.user.email
+          }
+        end
       end
 
       member

--- a/app/services/members/destroy_service.rb
+++ b/app/services/members/destroy_service.rb
@@ -46,9 +46,13 @@ module Members
 
     def create_activities
       if current_user == member.user
-        member.create_activity key: 'member.destroy_self', owner: current_user
+        member.create_activity key: 'member.destroy_self', owner: current_user, parameters: {
+          member_email: member.user.email
+        }
       else
-        member.create_activity key: 'member.destroy', owner: current_user
+        member.create_activity key: 'member.destroy', owner: current_user, parameters: {
+          member_email: member.user.email
+        }
       end
     end
   end

--- a/app/services/members/destroy_service.rb
+++ b/app/services/members/destroy_service.rb
@@ -44,7 +44,7 @@ module Members
       MemberMailer.access_revoked_user_email(member, namespace).deliver_later
     end
 
-    def create_activities
+    def create_activities # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       namespace_key = if member.namespace.group_namespace?
                         'group'
                       else

--- a/app/services/members/destroy_service.rb
+++ b/app/services/members/destroy_service.rb
@@ -45,13 +45,21 @@ module Members
     end
 
     def create_activities
+      namespace_key = if member.namespace.group_namespace?
+                        'group'
+                      else
+                        'namespaces_project_namespace'
+                      end
+
       if current_user == member.user
-        member.create_activity key: 'member.destroy_self', owner: current_user, parameters: {
-          member_email: member.user.email
+        member.namespace.create_activity key: "#{namespace_key}.member.destroy_self", owner: current_user, parameters: {
+          member_email: member.user.email,
+          action: 'member_destroy'
         }
       else
-        member.create_activity key: 'member.destroy', owner: current_user, parameters: {
-          member_email: member.user.email
+        member.namespace.create_activity key: "#{namespace_key}.member.destroy", owner: current_user, parameters: {
+          member_email: member.user.email,
+          action: 'member_destroy'
         }
       end
     end

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -30,7 +30,9 @@ module Members
 
       if updated
         UpdateMembershipsJob.perform_later(member.id)
-        member.create_activity key: 'member.update', owner: current_user
+        member.create_activity key: 'member.update', owner: current_user, parameters: {
+          member_email: member.user.email
+        }
       end
 
       updated

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -30,8 +30,15 @@ module Members
 
       if updated
         UpdateMembershipsJob.perform_later(member.id)
-        member.create_activity key: 'member.update', owner: current_user, parameters: {
-          member_email: member.user.email
+
+        namespace_key = if member.namespace.group_namespace?
+                          'group'
+                        else
+                          'namespaces_project_namespace'
+                        end
+        member.namespace.create_activity key: "#{namespace_key}.member.update", owner: current_user, parameters: {
+          member_email: member.user.email,
+          action: 'member_update'
         }
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,7 +267,7 @@ en:
       create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to %{namespace_type}"
       destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{member}</span> from %{namespace_type}"
       destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{member}</span> removed themself from %{namespace_type}"
-      update_html: "%{user} updated %{namespace_type} member %{href} attributes"
+      update_html: "%{user} updated %{namespace_type} member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
     namespace_group_link:
       create_html: "%{user} shared %{namespace_type} with group %{href}"
       destroy_html: "%{user} unshared %{namespace_type} with group <span class='font-medium text-slate-800 dark:text-slate-300'>%{group_name}</span>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,6 +247,11 @@ en:
     group:
       create_html: "%{user} created group"
       destroy_html: "%{user} removed group"
+      member:
+        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to group"
+        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from group"
+        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from group"
+        update_html: "%{user} updated group member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
       metadata_template:
         create_html: "%{user} created metadata template %{href}"
         destroy_html: "%{user} removed metadata template %{href}"
@@ -263,11 +268,6 @@ en:
       transfer_in_no_exisiting_namespace_html: "%{user} transferred group %{href} into group %{new_namespace}"
       transfer_out_html: "%{user} transferred group %{transferred_group_puid} into group %{new_namespace}"
       update_html: "%{user} updated group attributes"
-    member:
-      create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to %{namespace_type}"
-      destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{member}</span> from %{namespace_type}"
-      destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{member}</span> removed themself from %{namespace_type}"
-      update_html: "%{user} updated %{namespace_type} member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
     namespace_group_link:
       create_html: "%{user} shared %{namespace_type} with group %{href}"
       destroy_html: "%{user} unshared %{namespace_type} with group <span class='font-medium text-slate-800 dark:text-slate-300'>%{group_name}</span>"
@@ -275,6 +275,11 @@ en:
     namespaces_project_namespace:
       create_html: "%{user} created project"
       destroy_html: "%{user} removed project"
+      member:
+        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to project"
+        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from project"
+        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from project"
+        update_html: "%{user} updated project member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
       metadata_template:
         create_html: "%{user} created metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span>"
         destroy_html: "%{user} removed metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{template_name}</span>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,10 +248,10 @@ en:
       create_html: "%{user} created group"
       destroy_html: "%{user} removed group"
       member:
-        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to group"
-        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from group"
-        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from group"
-        update_html: "%{user} updated group member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
+        create_html: "%{user} added member %{href} to group"
+        destroy_html: "%{user} removed member %{href} from group"
+        destroy_self_html: "%{href} removed themself from group"
+        update_html: "%{user} updated group member %{href} attributes"
       metadata_template:
         create_html: "%{user} created metadata template %{href}"
         destroy_html: "%{user} removed metadata template %{href}"
@@ -276,10 +276,10 @@ en:
       create_html: "%{user} created project"
       destroy_html: "%{user} removed project"
       member:
-        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to project"
-        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from project"
-        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from project"
-        update_html: "%{user} updated project member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
+        create_html: "%{user} added member %{href} to project"
+        destroy_html: "%{user} removed member %{href} from project"
+        destroy_self_html: "%{href} removed themself from project"
+        update_html: "%{user} updated project member %{href} attributes"
       metadata_template:
         create_html: "%{user} created metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span>"
         destroy_html: "%{user} removed metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{template_name}</span>"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -247,6 +247,11 @@ fr:
     group:
       create_html: "%{user} created group"
       destroy_html: "%{user} removed group"
+      member:
+        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to group"
+        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from group"
+        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from group"
+        update_html: "%{user} updated group member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
       metadata_template:
         create_html: "%{user} created metadata template %{href}"
         destroy_html: "%{user} removed metadata template %{href}"
@@ -263,11 +268,6 @@ fr:
       transfer_in_no_exisiting_namespace_html: "%{user} transferred group %{href} into group %{new_namespace}"
       transfer_out_html: "%{user} transferred group %{transferred_group_puid} into group %{new_namespace}"
       update_html: "%{user} updated group attributes"
-    member:
-      create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to %{namespace_type}"
-      destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{member}</span> from %{namespace_type}"
-      destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{member}</span> removed themself from %{namespace_type}"
-      update_html: "%{user} updated %{namespace_type} member %{href} attributes"
     namespace_group_link:
       create_html: "%{user} shared %{namespace_type} with group %{href}"
       destroy_html: "%{user} unshared %{namespace_type} with group <span class='font-medium text-slate-800 dark:text-slate-300'>%{group_name}</span>"
@@ -275,6 +275,11 @@ fr:
     namespaces_project_namespace:
       create_html: "%{user} created project"
       destroy_html: "%{user} removed project"
+      member:
+        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to project"
+        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from project"
+        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from project"
+        update_html: "%{user} updated project member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
       metadata_template:
         create_html: "%{user} created metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span>"
         destroy_html: "%{user} removed metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{template_name}</span>"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -248,10 +248,10 @@ fr:
       create_html: "%{user} created group"
       destroy_html: "%{user} removed group"
       member:
-        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to group"
-        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from group"
-        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from group"
-        update_html: "%{user} updated group member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
+        create_html: "%{user} added member %{href} to group"
+        destroy_html: "%{user} removed member %{href} from group"
+        destroy_self_html: "%{href} removed themself from group"
+        update_html: "%{user} updated group member %{href} attributes"
       metadata_template:
         create_html: "%{user} created metadata template %{href}"
         destroy_html: "%{user} removed metadata template %{href}"
@@ -276,10 +276,10 @@ fr:
       create_html: "%{user} created project"
       destroy_html: "%{user} removed project"
       member:
-        create_html: "%{user} added member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> to project"
-        destroy_html: "%{user} removed member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> from project"
-        destroy_self_html: "<span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> removed themself from project"
-        update_html: "%{user} updated project member <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span> attributes"
+        create_html: "%{user} added member %{href} to project"
+        destroy_html: "%{user} removed member %{href} from project"
+        destroy_self_html: "%{href} removed themself from project"
+        update_html: "%{user} updated project member %{href} attributes"
       metadata_template:
         create_html: "%{user} created metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{href}</span>"
         destroy_html: "%{user} removed metadata template <span class='font-medium text-slate-800 dark:text-slate-300'>%{template_name}</span>"

--- a/db/migrate/20250219001422_add_user_email_to_member_activities.rb
+++ b/db/migrate/20250219001422_add_user_email_to_member_activities.rb
@@ -10,7 +10,7 @@ class AddUserEmailToMemberActivities < ActiveRecord::Migration[7.2]
       member = Member.with_deleted.find_by(id: activity.trackable_id)
 
       unless member.nil?
-        activity.parameters['member_email'] = member.user.email
+        activity.parameters[:member_email] = member.user.email
         activity.save
       end
     end

--- a/db/migrate/20250219001422_add_user_email_to_member_activities.rb
+++ b/db/migrate/20250219001422_add_user_email_to_member_activities.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Migration to add member email to member activities
+class AddUserEmailToMemberActivities < ActiveRecord::Migration[7.2]
+  def change
+    activity_keys = %w[member.create member.update member.destroy member.destroy_self]
+    activities = PublicActivity::Activity.where(key: activity_keys)
+
+    activities.each do |activity|
+      member = Member.with_deleted.find_by(id: activity.trackable_id)
+
+      unless member.nil?
+        activity.parameters['member_email'] = member.user.email
+        activity.save
+      end
+    end
+  end
+end

--- a/db/migrate/20250219172718_move_member_activities_to_namespace.rb
+++ b/db/migrate/20250219172718_move_member_activities_to_namespace.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Migration to move member trackable_type activities to namespace and add action to parameters
+class MoveMemberActivitiesToNamespace < ActiveRecord::Migration[7.2]
+  def change # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    activity_keys = %w[member.create member.update member.destroy member.destroy_self]
+    activities = PublicActivity::Activity.where(key: activity_keys)
+
+    activities.each do |activity| # rubocop:disable Metrics/BlockLength
+      member = Member.with_deleted.find_by(id: activity.trackable_id)
+
+      next if member.nil?
+
+      ns = Namespace.with_deleted.find_by(id: member.namespace_id)
+
+      # go to next activity as if the namespace doesn't exist
+      # or is soft deleted, we cannot update it's activity. This may
+      # leave activities with the trackable_type Member which are
+      # no longer used. Leaving this activity as is since we can restore
+      # a namespace and then would want its existing activity
+      next if ns.deleted? || ns.nil?
+
+      ns_type = if ns.type == Group.sti_name
+                  'group'
+                else
+                  'namespaces_project_namespace'
+                end
+
+      if activity.key == 'member.create'
+        activity.parameters[:action] = 'member_create'
+        activity.key = "#{ns_type}.member.create"
+
+      elsif (activity.key == 'member.destroy') || (activity.key == 'member.destroy_self')
+        activity.parameters[:action] = 'member_destroy'
+
+        destroy_key = if activity.key == 'member.destroy'
+                        'destroy'
+                      else
+                        'destroy_self'
+                      end
+
+        activity.key = "#{ns_type}.member.#{destroy_key}"
+      else
+        activity.parameters[:action] = 'member_update'
+        activity.key = "#{ns_type}.member.update"
+      end
+
+      activity.trackable_type = 'Namespace'
+      activity.trackable_id = ns.id
+      activity.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_18_231716) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_19_001422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -750,40 +750,40 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_18_231716) do
   SQL
 
 
-  create_trigger :logidze_on_attachments, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_attachments BEFORE INSERT OR UPDATE ON public.attachments FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_automated_workflow_executions, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_automated_workflow_executions BEFORE INSERT OR UPDATE ON public.automated_workflow_executions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_data_exports, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_data_exports BEFORE INSERT OR UPDATE ON public.data_exports FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_members, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_members BEFORE INSERT OR UPDATE ON public.members FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_metadata_templates, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_metadata_templates BEFORE INSERT OR UPDATE ON public.metadata_templates FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_namespace_bots, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_namespace_bots BEFORE INSERT OR UPDATE ON public.namespace_bots FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-  create_trigger :logidze_on_namespace_group_links, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_namespace_group_links BEFORE INSERT OR UPDATE ON public.namespace_group_links FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_users, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_namespaces, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_namespaces BEFORE INSERT OR UPDATE ON public.namespaces FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{created_at,metadata_summary,updated_at,attachments_updated_at}')
   SQL
-  create_trigger :logidze_on_personal_access_tokens, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{last_used_at}')
+  create_trigger :logidze_on_members, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_members BEFORE INSERT OR UPDATE ON public.members FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_samples, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_samples BEFORE INSERT OR UPDATE ON public.samples FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{created_at,metadata_provenance,updated_at,attachments_updated_at}')
   SQL
-  create_trigger :logidze_on_users, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_personal_access_tokens, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{last_used_at}')
+  SQL
+  create_trigger :logidze_on_namespace_group_links, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_namespace_group_links BEFORE INSERT OR UPDATE ON public.namespace_group_links FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_attachments, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_attachments BEFORE INSERT OR UPDATE ON public.attachments FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
   create_trigger :logidze_on_workflow_executions, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_workflow_executions BEFORE INSERT OR UPDATE ON public.workflow_executions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{run_id,name,state,deleted_at}', 'true')
+  SQL
+  create_trigger :logidze_on_data_exports, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_data_exports BEFORE INSERT OR UPDATE ON public.data_exports FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_namespace_bots, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_namespace_bots BEFORE INSERT OR UPDATE ON public.namespace_bots FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_automated_workflow_executions, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_automated_workflow_executions BEFORE INSERT OR UPDATE ON public.automated_workflow_executions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+  create_trigger :logidze_on_metadata_templates, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_metadata_templates BEFORE INSERT OR UPDATE ON public.metadata_templates FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_19_001422) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_19_172718) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"

--- a/test/components/activity_component_test.rb
+++ b/test/components/activity_component_test.rb
@@ -20,7 +20,7 @@ class ActivityComponentTest < ViewComponentTestCase
 
     assert_equal(1, @activities.count { |activity| activity[:key].include?('project_namespace.create') })
     assert_equal(1, @activities.count { |activity| activity[:key].include?('project_namespace.samples.create') })
-    assert_equal(2, @activities.count { |activity| activity[:key].include?('member.create') })
+    assert_equal(2, @activities.count { |activity| activity[:key].include?('project_namespace.member.create') })
     assert_equal(1, @activities.count { |activity| activity[:key].include?('project_namespace.samples.clone') })
     assert_equal(1, @activities.count { |activity| activity[:key].include?('project_namespace.samples.transfer') })
     assert_equal(1, @activities.count do |activity|
@@ -73,7 +73,7 @@ class ActivityComponentTest < ViewComponentTestCase
     assert_equal(1, @activities.count { |activity| activity[:key].include?('group.projects.create') })
     assert_equal(1, @activities.count { |activity| activity[:key].include?('group.projects.transfer_out') })
     assert_equal(1, @activities.count { |activity| activity[:key].include?('group.projects.transfer_in') })
-    assert_equal(1, @activities.count { |activity| activity[:key].include?('member.create') })
+    assert_equal(1, @activities.count { |activity| activity[:key].include?('group.member.create') })
 
     render_inline ActivityComponent.new(activities: @activities, pagy: @pagy)
 

--- a/test/components/members/member_activity_component_test.rb
+++ b/test/components/members/member_activity_component_test.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require 'view_component_test_case'
+
+class MemberActivityComponentTest < ViewComponentTestCase
+  include ActionView::Helpers::SanitizeHelper
+
+  setup do
+    @user = users(:john_doe)
+    @member = members(:project_one_member_ryan_doe)
+    @project_namespace = namespaces_project_namespaces(:project1_namespace)
+    @group = groups(:group_one)
+  end
+
+  test 'add member to project activity' do
+    activities = @project_namespace.human_readable_activity(@project_namespace.retrieve_project_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.create') && activity[:member] == @member
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.namespaces_project_namespace.member.create_html' && a[:member] == @member
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.namespaces_project_namespace.member.create_html',
+             user: 'System',
+             href: @member.user.email)
+    )
+    assert_selector 'a',
+                    text: @member.user.email
+  end
+
+  test 'update member in project activity' do
+    update_params = { access_level: Member::AccessLevel::UPLOADER }
+    ::Members::UpdateService.new(@member, @project_namespace, @user, update_params).execute
+
+    activities = @project_namespace.human_readable_activity(@project_namespace.retrieve_project_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.update')
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.namespaces_project_namespace.member.update_html'
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.namespaces_project_namespace.member.update_html',
+             user: @user.email,
+             href: @member.user.email)
+    )
+    assert_selector 'a',
+                    text: @member.user.email
+  end
+
+  test 'soft delete member in project activity' do
+    ::Members::DestroyService.new(@member, @project_namespace, @user).execute
+
+    activities = @project_namespace.human_readable_activity(@project_namespace.retrieve_project_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.destroy')
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.namespaces_project_namespace.member.destroy_html'
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.namespaces_project_namespace.member.destroy_html',
+             user: @user.email,
+             href: @member.user.email)
+    )
+    assert_no_selector 'a',
+                       text: @member.user.email
+  end
+
+  test 'create project member then really destroy activity' do
+    @member.destroy
+    Member.only_deleted.where(id: @member.id).first.destroy
+
+    activities = @project_namespace.human_readable_activity(@project_namespace.retrieve_project_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.create') && activity[:member_email] == @member.user.email
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.namespaces_project_namespace.member.create_html' && a[:member_email] == @member.user.email
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.namespaces_project_namespace.member.create_html',
+             user: 'System',
+             href: @member.user.email)
+    )
+    assert_no_selector 'a',
+                       text: @member.user.email
+  end
+
+  test 'add member to group activity' do
+    member = members(:group_one_member_james_doe)
+    activities = @group.human_readable_activity(@group.retrieve_group_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.create') && activity[:member] == member
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.group.member.create_html' && a[:member] == member
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.group.member.create_html',
+             user: 'System',
+             href: member.user.email)
+    )
+    assert_selector 'a',
+                    text: member.user.email
+  end
+
+  test 'update member in group activity' do
+    member = members(:group_one_member_james_doe)
+    update_params = { access_level: Member::AccessLevel::UPLOADER }
+    ::Members::UpdateService.new(member, @group, @user, update_params).execute
+
+    activities = @group.human_readable_activity(@group.retrieve_group_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.update')
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.group.member.update_html'
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.group.member.update_html',
+             user: @user.email,
+             href: member.user.email)
+    )
+    assert_selector 'a',
+                    text: member.user.email
+  end
+
+  test 'soft delete member in group activity' do
+    member = members(:group_one_member_james_doe)
+    ::Members::DestroyService.new(member, @group, @user).execute
+
+    activities = @group.human_readable_activity(@group.retrieve_group_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.destroy')
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.group.member.destroy_html'
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.group.member.destroy_html',
+             user: @user.email,
+             href: member.user.email)
+    )
+    assert_no_selector 'a',
+                       text: member.user.email
+  end
+
+  test 'create group member then really destroy activity' do
+    member = members(:group_one_member_james_doe)
+    member.destroy
+    Member.only_deleted.where(id: member.id).first.destroy
+
+    activities = @group.human_readable_activity(@group.retrieve_group_activity).reverse
+
+    assert_equal(1, activities.count do |activity|
+      activity[:key].include?('member.create') && activity[:member_email] == member.user.email
+    end)
+
+    activity_to_render = activities.find do |a|
+      a[:key] == 'activity.group.member.create_html' && a[:member_email] == member.user.email
+    end
+
+    render_inline Activities::MemberActivityComponent.new(activity: activity_to_render)
+
+    assert_text strip_tags(
+      I18n.t('activity.group.member.create_html',
+             user: 'System',
+             href: member.user.email)
+    )
+    assert_no_selector 'a',
+                       text: member.user.email
+  end
+end

--- a/test/components/members/member_activity_component_test.rb
+++ b/test/components/members/member_activity_component_test.rb
@@ -79,8 +79,7 @@ class MemberActivityComponentTest < ViewComponentTestCase
              user: @user.email,
              href: @member.user.email)
     )
-    assert_no_selector 'a',
-                       text: @member.user.email
+    assert_selector 'a[disabled="disabled"]', text: @member.user.email
   end
 
   test 'create project member then really destroy activity' do
@@ -104,8 +103,8 @@ class MemberActivityComponentTest < ViewComponentTestCase
              user: 'System',
              href: @member.user.email)
     )
-    assert_no_selector 'a',
-                       text: @member.user.email
+
+    assert_selector 'a[disabled="disabled"]', text: @member.user.email
   end
 
   test 'add member to group activity' do
@@ -178,8 +177,8 @@ class MemberActivityComponentTest < ViewComponentTestCase
              user: @user.email,
              href: member.user.email)
     )
-    assert_no_selector 'a',
-                       text: member.user.email
+
+    assert_selector 'a[disabled="disabled"]', text: member.user.email
   end
 
   test 'create group member then really destroy activity' do
@@ -204,7 +203,7 @@ class MemberActivityComponentTest < ViewComponentTestCase
              user: 'System',
              href: member.user.email)
     )
-    assert_no_selector 'a',
-                       text: member.user.email
+
+    assert_selector 'a[disabled="disabled"]', text: member.user.email
   end
 end

--- a/test/fixtures/activities.yml
+++ b/test/fixtures/activities.yml
@@ -15,16 +15,18 @@ project2_namespace_create:
   updated_at: <%= Time.zone.now %>
 
 project1_namespace_member_james_doe_create:
-  trackable_type: "Member"
-  trackable_id: <%= ActiveRecord::FixtureSet.identify(:project_one_member_james_doe, :uuid) %>
-  key: "member.create"
+  trackable_type: "Namespace"
+  trackable_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
+  key: "namespaces_project_namespace.member.create"
+  parameters: { member_email: 'james.doe@localhost', action: 'member_create' }
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>
 
 project1_namespace_member_ryan_doe_create:
-  trackable_type: "Member"
-  trackable_id: <%= ActiveRecord::FixtureSet.identify(:project_one_member_ryan_doe, :uuid) %>
-  key: "member.create"
+  trackable_type: "Namespace"
+  trackable_id: <%= ActiveRecord::FixtureSet.identify(:project1_namespace, :uuid) %>
+  key: "namespaces_project_namespace.member.create"
+  parameters: { member_email: 'ryan.doe@localhost', action: 'member_create' }
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>
 
@@ -242,9 +244,10 @@ group1_project_transfer_in:
   updated_at: <%= Time.zone.now %>
 
 group1_member_james_doe_create:
-  trackable_type: "Member"
-  trackable_id: <%= ActiveRecord::FixtureSet.identify(:group_one_member_james_doe, :uuid) %>
-  key: "member.create"
+  trackable_type: "Namespace"
+  trackable_id: <%= ActiveRecord::FixtureSet.identify(:group_one, :uuid) %>
+  key: "group.member.create"
+  parameters: { member_email: 'james.doe@localhost', action: 'member_create' }
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR refactors the members activities to now be attached to the namespace rather than of type `Member`. This will prevent member activity loss if a member is permanently deleted

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/e76bdb8e-ff57-4b7a-a42c-cba6d8a52f97)

![image](https://github.com/user-attachments/assets/425255a2-260f-49b2-a8fa-a689be1acc88)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Create/update/destroy members for a group and project Ensure the correct activity is listed for each and links to the members page are only clickable within the activity item if the user hasn't been removed

Try this out on main with an existing db and then switch over to this branch and run the migrations. Ensure the activities still display correctly

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
