### PR TITLE
Create Github action to trigger an Azure DevOps pipeline on new pushes to main

### DIFF
--- a/.github/workflows/trigger-azure-devops.yml
+++ b/.github/workflows/trigger-azure-devops.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1.2
         with:
-          # Fullyqualified URL to the Azure DevOps organization along with project name(eg, https://dev.azure.com/organization/project-name or https://server.example.com:8080/tfs/DefaultCollection/project-name)
           azure-devops-project-url: ${{ secrets.PROJECT_URL }}
-          # Name of the Azure Pipline to be triggered
           azure-pipeline-name: ${{ secrets.PIPELINE_NAME }}
-          # Paste personal access token of the user as value of secret variable:AZURE_DEVOPS_TOKEN
           azure-devops-token: ${{ secrets.DEVOPS_PAT }}

--- a/.github/workflows/trigger-azure-devops.yml
+++ b/.github/workflows/trigger-azure-devops.yml
@@ -1,0 +1,24 @@
+name: trigger-azure-devops
+
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'phac-nml'
+    steps:
+      - name: Azure Pipelines Action
+        uses: Azure/pipelines@v1.2
+        with:
+          # Fullyqualified URL to the Azure DevOps organization along with project name(eg, https://dev.azure.com/organization/project-name or https://server.example.com:8080/tfs/DefaultCollection/project-name)
+          azure-devops-project-url: ${{ secrets.PROJECT_URL }}
+          # Name of the Azure Pipline to be triggered
+          azure-pipeline-name: ${{ secrets.PIPELINE_NAME }}
+          # Paste personal access token of the user as value of secret variable:AZURE_DEVOPS_TOKEN
+          azure-devops-token: ${{ secrets.DEVOPS_PAT }}


### PR DESCRIPTION
## What does this PR do and why?
- Creates a new Github Action that on new pushes to `main`, triggers an Azure DevOps pipeline.
- This will allow us to use our existing Azure DevOps build pipeline to automatically build IRIDA Next docker containers for NML use.
- The pipeline will only run if the repository owner is `phac-nml`
- The following secrets were added:
```
DEVOPS_PAT
PIPELINE_NAME
PROJECT_URL
```
## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
