### PR TITLE
Fix: Workflow Executions stuck on completing when sample is deleted during execution

### DIFF
--- a/app/models/samples_workflow_execution.rb
+++ b/app/models/samples_workflow_execution.rb
@@ -6,7 +6,7 @@ class SamplesWorkflowExecution < ApplicationRecord
   acts_as_paranoid
 
   belongs_to :workflow_execution
-  belongs_to :sample
+  belongs_to :sample, optional: true
   has_many_attached :inputs
   has_many :outputs, dependent: :destroy, class_name: 'Attachment', as: :attachable
 

--- a/app/services/workflow_executions/completion_service.rb
+++ b/app/services/workflow_executions/completion_service.rb
@@ -97,8 +97,6 @@ module WorkflowExecutions
           puid: sample_file_paths_tuple[:sample_puid]
         )
 
-        next if samples_workflow_execution.sample.nil?
-
         @attachable_blobs_tuple_list.append({ attachable: samples_workflow_execution,
                                               blob_id_list: sample_file_blob_list })
       end

--- a/test/fixtures/samples_workflow_executions.yml
+++ b/test/fixtures/samples_workflow_executions.yml
@@ -155,43 +155,85 @@ sample1_irida_next_example_new:
 
 sample41_irida_next_example_completing_c:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample41, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABQ"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_c, :uuid) %>
 
 sample42_irida_next_example_completing_c:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample42, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABR"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_c, :uuid) %>
 
 sample41_irida_next_example_completing_d:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample41, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABQ"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_d, :uuid) %>
 
 sample42_irida_next_example_completing_d:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample42, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABR"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_d, :uuid) %>
 
 sample41_irida_next_example_completing_e:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample41, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABQ"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_e, :uuid) %>
 
 sample42_irida_next_example_completing_e:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample42, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABR"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_e, :uuid) %>
 
 sample41_irida_next_example_completing_f:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample41, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABQ"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_f, :uuid) %>
 
 sample42_irida_next_example_completing_f:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample42, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABR"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_f, :uuid) %>
 
 sampleA_irida_next_example_completing_g:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sampleA, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAAA3"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_g, :uuid) %>
 
 sampleB_irida_next_example_completing_g:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sampleB, :uuid) %>
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAAA4"
+  }
   workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_g, :uuid) %>
+
+sample41_irida_next_example_completing_h:
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABQ"
+  }
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_h, :uuid) %>
+
+sample42_irida_next_example_completing_h:
+  samplesheet_params: {
+    "sample": "INXT_SAM_AAAAAAAABR"
+  }
+  workflow_execution_id: <%= ActiveRecord::FixtureSet.identify(:irida_next_example_completing_h, :uuid) %>
 
 sample46_irida_next_example_completed_with_output:
   sample_id: <%= ActiveRecord::FixtureSet.identify(:sample46, :uuid) %>

--- a/test/fixtures/workflow_executions.yml
+++ b/test/fixtures/workflow_executions.yml
@@ -483,6 +483,28 @@ irida_next_example_completing_g:
   email_notification: true
   cleaned: false
 
+irida_next_example_completing_h:
+  <<: *DEFAULTS
+  metadata:
+    {
+      "workflow_name": "phac-nml/iridanextexample",
+      "workflow_version": "1.0.2",
+    }
+  workflow_params:
+    {
+      "input": "/blah/samplesheet.csv",
+      "outdir": "/blah/output",
+    }
+  workflow_engine_parameters: { "-r": "dev" }
+  workflow_url: "https://github.com/phac-nml/irida_next_example_completed"
+  run_id: "my_run_id_h"
+  submitter_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:projectA_namespace, :uuid) %>
+  state: "completing"
+  blob_run_directory: "not a run dir"
+  update_samples: true
+  cleaned: false
+
 irida_next_example_completed_with_output:
   <<: *DEFAULTS
   metadata:


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Currently a WorkflowExecution can get stuck on `completing` if a User deletes one of  Sample used in the analysis after it has been `prepared` and before it enters `completing` state.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Create a new Project
3. Create a new Sample in the newly created sample
4. Upload pairend fastq files to the sample
5. Launch an `phac-nml/iridanextexample` pipeline with the newly created sample
   * Select `Update samples with analysis results`
6. After Workflow Execution changes to `prepared`
7. Navigate back to Project and delete the newly created sample
8. Wait and observe that WorkflowExecution transitions from `completing` to `completed`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
