### PR TITLE
Fix: Replaces deprecated Turbo confirm method

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,9 +1,11 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails";
 import "controllers";
-import * as ActiveStorage from "@rails/activestorage";
-import LocalTime from "local-time";
 import "flowbite";
+
+import * as ActiveStorage from "@rails/activestorage";
+
+import LocalTime from "local-time";
 
 LocalTime.start();
 ActiveStorage.start();
@@ -12,7 +14,7 @@ document.addEventListener("turbo:morph", () => {
   LocalTime.run();
 });
 
-Turbo.setConfirmMethod((message, element) => {
+Turbo.config.forms.confirm = (message, element) => {
   const dialog = document.getElementById("turbo-confirm");
   if (!dialog) {
     console.error(
@@ -63,4 +65,4 @@ Turbo.setConfirmMethod((message, element) => {
       { once: true },
     );
   });
-});
+};


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

`Turbo.setConfirmMethod(confirmMethod)` is set to be deprecated in the next release of Turbo.  This updates it to the new method of `Turbo.config.forms.confirm = confirmMethod`

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/d50f56a2-4dec-4b47-abd8-1b4d9a1dfda5)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Login as users and go to a project that is owned.
Try to delete a sample from the project samples page.
Confirmation dialog should load as expected

Ensure tests pass.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
