### PR TITLE
Workflow execution: Update and lock metadata

### DIFF
--- a/app/services/samples/metadata/update_service.rb
+++ b/app/services/samples/metadata/update_service.rb
@@ -16,6 +16,7 @@ module Samples
         @analysis_id = params['analysis_id']
         @metadata_changes = { added: [], updated: [], deleted: [], not_updated: [], unchanged: [] }
         @include_activity = params.key?(:include_activity) ? params[:include_activity] : true
+        @force_update = params.key?('force_update') ? params['force_update'] : false
       end
 
       def execute # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -84,7 +85,6 @@ module Samples
 
           key = key.to_s.downcase.strip
           value = value.to_s.strip # remove data types
-
           status = get_metadata_change_status(key, value)
           next unless status
 
@@ -119,7 +119,7 @@ module Samples
               @sample.metadata_provenance[key]['source'] == 'analysis'
           :not_updated
         elsif @sample.field?(key) && @sample.metadata[key] == value
-          :unchanged
+          @force_update ? :updated : :unchanged
         else
           @sample.field?(key) ? :updated : :added
         end

--- a/app/services/workflow_executions/completion_service.rb
+++ b/app/services/workflow_executions/completion_service.rb
@@ -138,7 +138,8 @@ module WorkflowExecutions
         params = {
           'metadata' => swe.metadata,
           'analysis_id' => @workflow_execution.id,
-          include_activity: false
+          include_activity: false,
+          'force_update' => true
         }
         Samples::Metadata::UpdateService.new(
           swe.sample.project, swe.sample, current_user, params

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -354,7 +354,7 @@ module Samples
         assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user',
                                              'updated_at' => Time.current },
                        'metadatafield2' => { 'id' => @user.id, 'source' => 'user',
-                                             'updated_at' => '2000-01-01T00:00:00.000+00:00'  } },
+                                             'updated_at' => '2000-01-01T00:00:00.000+00:00' } },
                      @sample32.metadata_provenance)
         assert_equal({ added: [], updated: %w[metadatafield1], deleted: [], not_updated: [], unchanged: [] },
                      metadata_changes)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -315,7 +315,6 @@ module Samples
       end
 
       test 'unchanged metadata value when updating to current value' do
-        freeze_time
         params = { 'metadata' => { 'metadatafield1' => 'value1' } }
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample32.metadata)
@@ -333,6 +332,31 @@ module Samples
                                              'updated_at' => '2000-01-01T00:00:00.000+00:00' } },
                      @sample32.metadata_provenance)
         assert_equal({ added: [], updated: [], deleted: [], not_updated: [], unchanged: %w[metadatafield1] },
+                     metadata_changes)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project29.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+      end
+
+      test 'unchanged metadata value when updating to current value with force update' do
+        freeze_time
+        params = { 'metadata' => { 'metadatafield1' => 'value1' }, 'force_update' => true }
+
+        assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample32.metadata)
+        assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project29.namespace.metadata_summary)
+        assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)
+        assert_equal({ 'metadatafield1' => 3, 'metadatafield2' => 3 }, @group12.metadata_summary)
+
+        metadata_changes = Samples::Metadata::UpdateService.new(@project29, @sample32, @user, params).execute
+
+        assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample32.metadata)
+        # timestamps should not update as the fields are unchanged
+        assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user',
+                                             'updated_at' => Time.current },
+                       'metadatafield2' => { 'id' => @user.id, 'source' => 'user',
+                                             'updated_at' => '2000-01-01T00:00:00.000+00:00'  } },
+                     @sample32.metadata_provenance)
+        assert_equal({ added: [], updated: %w[metadatafield1], deleted: [], not_updated: [], unchanged: [] },
                      metadata_changes)
         assert_equal({ 'metadatafield1' => 1, 'metadatafield2' => 1 }, @project29.namespace.metadata_summary)
         assert_equal({ 'metadatafield1' => 2, 'metadatafield2' => 2 }, @subgroup12a.metadata_summary)

--- a/test/services/samples/metadata/update_service_test.rb
+++ b/test/services/samples/metadata/update_service_test.rb
@@ -350,7 +350,7 @@ module Samples
         metadata_changes = Samples::Metadata::UpdateService.new(@project29, @sample32, @user, params).execute
 
         assert_equal({ 'metadatafield1' => 'value1', 'metadatafield2' => 'value2' }, @sample32.metadata)
-        # timestamps should not update as the fields are unchanged
+        # timestamp should update as the field is updated
         assert_equal({ 'metadatafield1' => { 'id' => @user.id, 'source' => 'user',
                                              'updated_at' => Time.current },
                        'metadatafield2' => { 'id' => @user.id, 'source' => 'user',


### PR DESCRIPTION
## What does this PR do and why?
Metadata fields should update & lock after a pipeline runs, even if the value does not change.
STRY0017322

## Screenshots or screen recordings
N/A

## How to set up and validate locally
1. Select a sample. Preferably with no metadata.
2. Run a pipeline with `Update samples with analysis results` selected.
3. Verify the results metadata have been added to the sample.
4. Repeat step 2.
5. Verify the results metadata have been updated within the sample.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
