### PR TITLE
Fix: Rendering of Metadata Field selection in Nextflow Samplesheet

### DIFF
--- a/app/components/nextflow/samplesheet/header_component.html.erb
+++ b/app/components/nextflow/samplesheet/header_component.html.erb
@@ -32,7 +32,7 @@
                    id: "field-#{header}",
                    "aria-label": header,
                    class:
-                     "bg-slate-50 text-slate-900 text-sm border-none focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500 font-semibold tracking-wider uppercase",
+                     "bg-slate-50 text-slate-900 text-sm border-none focus:ring-primary-500 focus:border-primary-500 block min-w-56 w-full p-2.5 dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500 font-semibold tracking-wider uppercase",
                    onchange: "Turbo.navigator.submitForm(this.form)",
                  } %>
       <% end %>

--- a/app/components/nextflow/samplesheet/header_component.rb
+++ b/app/components/nextflow/samplesheet/header_component.rb
@@ -23,7 +23,7 @@ module Nextflow
       private
 
       def metadata_fields_for_field(field)
-        options = @metadata_fields.include?(field) ? @metadata_fields : @metadata_fields.unshift(field)
+        options = @metadata_fields.include?(field) ? @metadata_fields : [field].concat(@metadata_fields)
         label = t('.default', label: field)
         options.map { |f| [f.eql?(field) ? label : f, f] }
       end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This updates the Nextflow Samplesheet HeaderComponent to render with a minimum width that ensures displays of most common metadata field params (e.g. metadata_X)

This also fixes the option generator for the metadata fields to not include metadata params from other metadata columns (see screenshots below).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before:
![image](https://github.com/user-attachments/assets/402d087f-232e-4d50-afac-2b65d0a89fa9)

After:
![image](https://github.com/user-attachments/assets/f64a7827-e5a2-431a-90c3-8179552e42a2)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Create `development.json` inside of `config/pipelines.json` if it does not exist
2. Add the SNVPhyl pipeline to `development.json` if it doesn't already exist inside
```json
{
      "url": "https://github.com/phac-nml/snvphylnfc",
      "name": "phac-nml/snvphylnfc",
      "description": "SNVPhyl nf-core pipeline",
      "versions": [
        {
          "name": "2.2.0"
        }
      ]
    }
```
3. Launch the server (if already started, stop then restart)
4. Through one of the seeded projects or groups, start a workflow that contains metadata (such as `SNVPhyl`)
5. Note the display of the metadata columns in the samplesheet and confirm that you can see the header and not just a dropdown.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
