### PR TITLE
Batch Sample Import Form WebUI

### DIFF
--- a/app/components/viral/data_table_component.html.erb
+++ b/app/components/viral/data_table_component.html.erb
@@ -1,10 +1,10 @@
 <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
   <%= render Viral::BaseComponent.new(**system_arguments) do %>
     <table
-      class='
+      class="
         w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
         whitespace-nowrap
-      '
+      "
     >
       <thead class='sticky top-0 z-10 text-xs uppercase'>
         <tr
@@ -25,10 +25,10 @@
         </tr>
       </thead>
       <tbody
-        class='
-          overflow-y-auto bg-white dark:bg-slate-800
-          dark:divide-slate-700
-        '
+        class="
+          overflow-y-auto bg-white border-slate-200 dark:bg-slate-800
+          dark:border-slate-700
+        "
       >
         <% @data.each do |row| %>
           <%= render Viral::BaseComponent.new(**row_arguments(row)) do %>

--- a/app/javascript/controllers/projects/samples/complete_controller.js
+++ b/app/javascript/controllers/projects/samples/complete_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static outlets = ["filters"];
+
+  connect() {
+    this.filtersOutlet.submit();
+  }
+}

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -54,7 +54,7 @@ export default class extends Controller {
   changeSampleNameInput(event) {
     this.#header_map[this.#curr_sample_name] = false;
     const { value } = event.target;
-    this.#curr_sample_name = value.toLowerCase();
+    this.#curr_sample_name = value;
     this.#header_map[this.#curr_sample_name] = true;
     this.#refreshInputOptionsForAllFields();
     this.#checkFormInputsReadyForSubmit();
@@ -63,7 +63,7 @@ export default class extends Controller {
   changeProjectPUIDInput(event) {
     this.#header_map[this.#curr_project_puid] = false;
     const { value } = event.target;
-    this.#curr_project_puid = value.toLowerCase();
+    this.#curr_project_puid = value;
     this.#header_map[this.#curr_project_puid] = true;
     this.#refreshInputOptionsForAllFields();
     this.#checkFormInputsReadyForSubmit();
@@ -72,7 +72,7 @@ export default class extends Controller {
   changeSampleDescriptionInput(event) {
     this.#header_map[this.#curr_sample_description] = false;
     const { value } = event.target;
-    this.#curr_sample_description = value.toLowerCase();
+    this.#curr_sample_description = value;
     this.#header_map[this.#curr_sample_description] = true;
     this.#refreshInputOptionsForAllFields();
     this.#checkFormInputsReadyForSubmit();
@@ -117,7 +117,7 @@ export default class extends Controller {
   #buildHeaderMap() {
     this.#header_map = {}
     this.#headers.forEach(h => {
-      this.#header_map[h.toLowerCase()] = false;
+      this.#header_map[h] = false;
     })
   }
 
@@ -138,7 +138,7 @@ export default class extends Controller {
   #refreshInputOptions(columnTarget, current_selection) {
     // filter out fields other headers are using, but not this target's own selection
     let headers = this.#headers.filter( (header) =>
-      (header.toLowerCase() != current_selection) &&  !(this.#header_map[header.toLowerCase()])
+      (header != current_selection) &&  !(this.#header_map[header])
     );
 
     // delete the old input options, except for one that is currently selected

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -86,9 +86,11 @@ export default class extends Controller {
   }
 
   #clearFormOptions() {
-    this.#removeSampleNameInputOptions();
+    this.#removeInputOptions(this.sampleNameColumnTarget);
+    this.#disableTarget(this.sampleNameColumnTarget);
     // this.#removeProjectPUIDInputOptions();
-    this.#removeSampleDescriptionInputOptions();
+    this.#removeInputOptions(this.sampleDescriptionColumnTarget);
+    this.#disableTarget(this.sampleDescriptionColumnTarget);
     // this.#removeMetadataColumns();
     this.submitButtonTarget.disabled = true;
   }
@@ -106,24 +108,21 @@ export default class extends Controller {
     this.#curr_sample_description = null;
   }
 
-  #removeSampleNameInputOptions() {
-    this.#removeInputOptions(this.sampleNameColumnTarget);
-    this.#disableTarget(this.sampleNameColumnTarget);
-  }
-
   #refreshInputOptionsForAllFields() {
     this.#refreshInputOptions(this.sampleNameColumnTarget, this.#curr_sample_name)
     this.#refreshInputOptions(this.sampleDescriptionColumnTarget, this.#curr_sample_description)
   }
 
   #refreshInputOptions(columnTarget, current_selection) {
+    // filter out fields other headers are using, but not this target's own selection
     let headers = this.#headers.filter( (header) =>
-      // !(this.#header_map[header.toLowerCase()])
       (header.toLowerCase() != current_selection) &&  !(this.#header_map[header.toLowerCase()])
     );
 
+    // delete the old input options, except for one that is currently selected
     this.#removeInputOptions(columnTarget, current_selection);
 
+    // build a list of new input options based on above filtering
     for (let header of headers) {
       const option = document.createElement("option");
       option.value = header;
@@ -131,11 +130,6 @@ export default class extends Controller {
       columnTarget.append(option);
     }
     this.#enableTarget(columnTarget);
-  }
-
-  #removeSampleDescriptionInputOptions() {
-    this.#removeInputOptions(this.sampleDescriptionColumnTarget);
-    this.#disableTarget(this.sampleDescriptionColumnTarget);
   }
 
   // #removeMetadataColumns() {
@@ -182,7 +176,7 @@ export default class extends Controller {
   }
 
   #removeInputOptions(target, current = null) {
-    // When a current selection is passed it, it does not get removed.
+    // When a current selection is passed in, it does not get removed.
     var post_length = 1
     if (current == null){
       post_length = 0

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -6,8 +6,6 @@ export default class extends Controller {
     "sampleNameColumn",
     "projectPUIDColumn",
     "sampleDescriptionColumn",
-    "sortableListsTemplate",
-    "sortableListsItemTemplate",
     "submitButton",
   ];
 
@@ -110,7 +108,6 @@ export default class extends Controller {
     }
     this.#removeInputOptions(this.sampleDescriptionColumnTarget);
     this.#disableTarget(this.sampleDescriptionColumnTarget);
-    // this.#removeMetadataColumns();
     this.submitButtonTarget.disabled = true;
   }
 
@@ -153,41 +150,6 @@ export default class extends Controller {
     }
     this.#enableTarget(columnTarget);
   }
-
-  // #removeMetadataColumns() {
-  //   if (this.hasMetadataColumnsTarget) {
-  //     this.metadataColumnsTarget.innerHTML = "";
-  //   }
-  // }
-
-  // #addMetadataColumns() {
-  //   const ignoreList = [
-  //     "sample name",
-  //     "project id",
-  //     "description",
-  //     "created_at",
-  //     "updated_at",
-  //     "last_updated_at",
-  //   ];
-
-  //   let columns = this.#headers.filter(
-  //     (header) =>
-  //       !ignoreList.includes(header.toLowerCase()) &&
-  //       header.toLowerCase() != this.sampleNameColumnTarget.value.toLowerCase(),
-  //   );
-
-  //   this.metadataColumnsTarget.innerHTML =
-  //     this.sortableListsTemplateTarget.innerHTML;
-
-  //   columns.forEach((column) => {
-  //     const template =
-  //       this.sortableListsItemTemplateTarget.content.cloneNode(true);
-  //     template.querySelector("li").innerText = column;
-  //     template.querySelector("li").id = column.replace(/\s+/g, "-");
-  //     this.metadataColumnsTarget.querySelector("#selected").append(template);
-  //   });
-  //   this.submitButtonTarget.disabled = !columns.length;
-  // }
 
   #checkFormInputsReadyForSubmit() {
     var puid_value = true

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -11,6 +11,10 @@ export default class extends Controller {
     "submitButton",
   ];
 
+  static values = {
+    group: Boolean
+  }
+
   #header_map = {};
 
   #headers = [];
@@ -41,7 +45,10 @@ export default class extends Controller {
 
   connect() {
     this.#disableTarget(this.sampleNameColumnTarget);
-    this.#disableTarget(this.projectPUIDColumnTarget);
+    console.log("Has group value: " + this.groupValue)
+    if (this.groupValue) {
+      this.#disableTarget(this.projectPUIDColumnTarget);
+    }
     this.#disableTarget(this.sampleDescriptionColumnTarget);
   }
 
@@ -98,8 +105,10 @@ export default class extends Controller {
   #clearFormOptions() {
     this.#removeInputOptions(this.sampleNameColumnTarget);
     this.#disableTarget(this.sampleNameColumnTarget);
-    this.#removeInputOptions(this.projectPUIDColumnTarget);
-    this.#disableTarget(this.projectPUIDColumnTarget);
+    if (this.groupValue) {
+      this.#removeInputOptions(this.projectPUIDColumnTarget);
+      this.#disableTarget(this.projectPUIDColumnTarget);
+    }
     this.#removeInputOptions(this.sampleDescriptionColumnTarget);
     this.#disableTarget(this.sampleDescriptionColumnTarget);
     // this.#removeMetadataColumns();
@@ -121,8 +130,12 @@ export default class extends Controller {
   }
 
   #refreshInputOptionsForAllFields() {
+    console.log("in refresh fields")
     this.#refreshInputOptions(this.sampleNameColumnTarget, this.#curr_sample_name)
-    this.#refreshInputOptions(this.projectPUIDColumnTarget, this.#curr_project_puid)
+    if (this.groupValue) {
+      console.log("refreshing puid fields")
+      this.#refreshInputOptions(this.projectPUIDColumnTarget, this.#curr_project_puid)
+    }
     this.#refreshInputOptions(this.sampleDescriptionColumnTarget, this.#curr_sample_description)
   }
 
@@ -181,8 +194,12 @@ export default class extends Controller {
   // }
 
   #checkFormInputsReadyForSubmit() {
-    if (this.hasSampleNameColumnTarget && this.hasProjectPUIDColumnTarget){
-    // if (this.hasSampleNameColumnTarget ){
+    var puid_value = true
+    if (this.groupValue) {
+      puid_value = this.hasProjectPUIDColumnTarget;
+    }
+
+    if (this.hasSampleNameColumnTarget && puid_value ){
         this.submitButtonTarget.disabled = false;
     } else {
       this.submitButtonTarget.disabled = true;

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -4,7 +4,7 @@ import * as XLSX from "xlsx";
 export default class extends Controller {
   static targets = [
     "sampleNameColumn",
-    // "projectPUIDColumn",
+    "projectPUIDColumn",
     "sampleDescriptionColumn",
     "sortableListsTemplate",
     "sortableListsItemTemplate",
@@ -16,6 +16,7 @@ export default class extends Controller {
   #headers = [];
 
   #curr_sample_name = null;
+  #curr_project_puid = null;
   #curr_sample_description = null;
 
   #disabled_classes = [
@@ -40,7 +41,7 @@ export default class extends Controller {
 
   connect() {
     this.#disableTarget(this.sampleNameColumnTarget);
-    // this.#disableTarget(this.projectPUIDColumnTarget);
+    this.#disableTarget(this.projectPUIDColumnTarget);
     this.#disableTarget(this.sampleDescriptionColumnTarget);
   }
 
@@ -49,6 +50,15 @@ export default class extends Controller {
     const { value } = event.target;
     this.#curr_sample_name = value.toLowerCase();
     this.#header_map[this.#curr_sample_name] = true;
+    this.#refreshInputOptionsForAllFields();
+    this.#checkFormInputsReadyForSubmit();
+  }
+
+  changeProjectPUIDInput(event) {
+    this.#header_map[this.#curr_project_puid] = false;
+    const { value } = event.target;
+    this.#curr_project_puid = value.toLowerCase();
+    this.#header_map[this.#curr_project_puid] = true;
     this.#refreshInputOptionsForAllFields();
     this.#checkFormInputsReadyForSubmit();
   }
@@ -88,7 +98,8 @@ export default class extends Controller {
   #clearFormOptions() {
     this.#removeInputOptions(this.sampleNameColumnTarget);
     this.#disableTarget(this.sampleNameColumnTarget);
-    // this.#removeProjectPUIDInputOptions();
+    this.#removeInputOptions(this.projectPUIDColumnTarget);
+    this.#disableTarget(this.projectPUIDColumnTarget);
     this.#removeInputOptions(this.sampleDescriptionColumnTarget);
     this.#disableTarget(this.sampleDescriptionColumnTarget);
     // this.#removeMetadataColumns();
@@ -105,11 +116,13 @@ export default class extends Controller {
 
   #initSelection() {
     this.#curr_sample_name = null;
+    this.#curr_project_puid = null;
     this.#curr_sample_description = null;
   }
 
   #refreshInputOptionsForAllFields() {
     this.#refreshInputOptions(this.sampleNameColumnTarget, this.#curr_sample_name)
+    this.#refreshInputOptions(this.projectPUIDColumnTarget, this.#curr_project_puid)
     this.#refreshInputOptions(this.sampleDescriptionColumnTarget, this.#curr_sample_description)
   }
 
@@ -168,8 +181,9 @@ export default class extends Controller {
   // }
 
   #checkFormInputsReadyForSubmit() {
-    if (this.hasSampleNameColumnTarget ){//&& this.hasProjectPUIDColumnTarget){
-      this.submitButtonTarget.disabled = false;
+    if (this.hasSampleNameColumnTarget && this.hasProjectPUIDColumnTarget){
+    // if (this.hasSampleNameColumnTarget ){
+        this.submitButtonTarget.disabled = false;
     } else {
       this.submitButtonTarget.disabled = true;
     }

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -21,26 +21,6 @@ export default class extends Controller {
   #curr_project_puid = null;
   #curr_sample_description = null;
 
-  #disabled_classes = [
-    "bg-slate-50",
-    "border",
-    "border-slate-300",
-    "text-slate-900",
-    "text-sm",
-    "rounded-lg",
-    "focus:ring-blue-500",
-    "focus:border-blue-500",
-    "block",
-    "w-full",
-    "p-2.5",
-    "dark:bg-slate-700",
-    "dark:border-slate-600",
-    "dark:placeholder-slate-400",
-    "dark:text-white",
-    "dark:focus:ring-blue-500",
-    "dark:focus:border-blue-500",
-  ];
-
   connect() {
     this.#disableTarget(this.sampleNameColumnTarget);
     if (this.groupValue) {
@@ -182,11 +162,9 @@ export default class extends Controller {
 
   #disableTarget(target) {
     target.disabled = true;
-    target.classList.add(...this.#disabled_classes);
   }
 
   #enableTarget(target) {
     target.disabled = false;
-    target.classList.remove(...this.#disabled_classes);
   }
 }

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -147,7 +147,7 @@ export default class extends Controller {
   #removeInputOptions(target, current = null) {
     // When a current selection is passed in, it does not get removed.
     var post_length = 1
-    if (current == null){
+    if (current == null || current == ""){
       post_length = 0
     }
 

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -1,0 +1,200 @@
+import { Controller } from "@hotwired/stimulus";
+import * as XLSX from "xlsx";
+
+export default class extends Controller {
+  static targets = [
+    "sampleNameColumn",
+    "projectPUIDColumn",
+    "sampleDescriptionColumn",
+    "sortableListsTemplate",
+    "sortableListsItemTemplate",
+    "submitButton",
+  ];
+
+  #headers = [];
+  #disabled_classes = [
+    "bg-slate-50",
+    "border",
+    "border-slate-300",
+    "text-slate-900",
+    "text-sm",
+    "rounded-lg",
+    "focus:ring-blue-500",
+    "focus:border-blue-500",
+    "block",
+    "w-full",
+    "p-2.5",
+    "dark:bg-slate-700",
+    "dark:border-slate-600",
+    "dark:placeholder-slate-400",
+    "dark:text-white",
+    "dark:focus:ring-blue-500",
+    "dark:focus:border-blue-500",
+  ];
+
+  connect() {
+    this.#disableTarget(this.sampleNameColumnTarget);
+    this.#disableTarget(this.projectPUIDColumnTarget);
+    this.#disableTarget(this.sampleDescriptionColumnTarget);
+  }
+
+  changeSampleNameInput(event) {
+    const { value } = event.target;
+    this.#checkFormInputs();
+
+    // if (value) {
+    //   if (this.hasMetadataColumnsTarget) {
+    //     this.#addMetadataColumns();
+    //   } else {
+    //     this.submitButtonTarget.disabled = false;
+    //   }
+    // } else {
+    //   if (this.hasMetadataColumnsTarget) {
+    //     this.#removeMetadataColumns();
+    //   } else {
+    //     this.submitButtonTarget.disabled = true;
+    //   }
+    // }
+  }
+
+  changeProjectPUIDInput(event) {
+    const { value } = event.target;
+    this.#checkFormInputs();
+  }
+
+  changeSampleDescriptionInput(event) {
+    const { value } = event.target;
+    this.#checkFormInputs();
+  }
+
+  readFile(event) {
+    const { files } = event.target;
+
+    this.#removeSampleNameInputOptions();
+    this.#removeProjectPUIDInputOptions();
+    this.#removeSampleDescriptionInputOptions();
+    // this.#removeMetadataColumns();
+    this.submitButtonTarget.disabled = true;
+
+    if (!files.length) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.readAsArrayBuffer(files[0]);
+
+    reader.onload = () => {
+      const workbook = XLSX.read(reader.result, { sheetRows: 1 });
+      const worksheetName = workbook.SheetNames[0];
+      const worksheet = workbook.Sheets[worksheetName];
+      this.#headers = XLSX.utils.sheet_to_json(worksheet, { header: 1 })[0];
+      this.#addSampleNameInputOptions();
+      this.#addProjectPUIDInputOptions();
+      this.#addSampleDescriptionInputOptions();
+    };
+  }
+
+  #removeSampleNameInputOptions() {
+    this.#removeInputOptions(this.sampleNameColumnTarget);
+    this.#disableTarget(this.sampleNameColumnTarget);
+  }
+
+  #addSampleNameInputOptions() {
+    for (let header of this.#headers) {
+      const option = document.createElement("option");
+      option.value = header;
+      option.text = header;
+      this.sampleNameColumnTarget.append(option);
+    }
+    this.#enableTarget(this.sampleNameColumnTarget);
+  }
+
+  #removeProjectPUIDInputOptions() {
+    this.#removeInputOptions(this.projectPUIDColumnTarget);
+    this.#disableTarget(this.projectPUIDColumnTarget);
+  }
+
+  #addProjectPUIDInputOptions() {
+    for (let header of this.#headers) {
+      const option = document.createElement("option");
+      option.value = header;
+      option.text = header;
+      this.projectPUIDColumnTarget.append(option);
+    }
+    this.#enableTarget(this.projectPUIDColumnTarget);
+  }
+
+  #removeSampleDescriptionInputOptions() {
+    this.#removeInputOptions(this.sampleDescriptionColumnTarget);
+    this.#disableTarget(this.sampleDescriptionColumnTarget);
+  }
+
+  #addSampleDescriptionInputOptions() {
+    for (let header of this.#headers) {
+      const option = document.createElement("option");
+      option.value = header;
+      option.text = header;
+      this.sampleDescriptionColumnTarget.append(option);
+    }
+    this.#enableTarget(this.sampleDescriptionColumnTarget);
+  }
+
+  // #removeMetadataColumns() {
+  //   if (this.hasMetadataColumnsTarget) {
+  //     this.metadataColumnsTarget.innerHTML = "";
+  //   }
+  // }
+
+  // #addMetadataColumns() {
+  //   const ignoreList = [
+  //     "sample name",
+  //     "project id",
+  //     "description",
+  //     "created_at",
+  //     "updated_at",
+  //     "last_updated_at",
+  //   ];
+
+  //   let columns = this.#headers.filter(
+  //     (header) =>
+  //       !ignoreList.includes(header.toLowerCase()) &&
+  //       header.toLowerCase() != this.sampleNameColumnTarget.value.toLowerCase(),
+  //   );
+
+  //   this.metadataColumnsTarget.innerHTML =
+  //     this.sortableListsTemplateTarget.innerHTML;
+
+  //   columns.forEach((column) => {
+  //     const template =
+  //       this.sortableListsItemTemplateTarget.content.cloneNode(true);
+  //     template.querySelector("li").innerText = column;
+  //     template.querySelector("li").id = column.replace(/\s+/g, "-");
+  //     this.metadataColumnsTarget.querySelector("#selected").append(template);
+  //   });
+  //   this.submitButtonTarget.disabled = !columns.length;
+  // }
+
+  #checkFormInputs() {
+    if (this.hasSampleNameColumnTarget && this.hasProjectPUIDColumnTarget){
+      this.submitButtonTarget.disabled = false;
+    } else {
+      this.submitButtonTarget.disabled = true;
+    }
+  }
+
+  #removeInputOptions(target) {
+    while (target.options.length > 1) {
+      target.remove(target.options.length - 1);
+    }
+  }
+
+  #disableTarget(target) {
+    target.disabled = true;
+    target.classList.add(...this.#disabled_classes);
+  }
+
+  #enableTarget(target) {
+    target.disabled = false;
+    target.classList.remove(...this.#disabled_classes);
+  }
+}

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -45,7 +45,6 @@ export default class extends Controller {
 
   connect() {
     this.#disableTarget(this.sampleNameColumnTarget);
-    console.log("Has group value: " + this.groupValue)
     if (this.groupValue) {
       this.#disableTarget(this.projectPUIDColumnTarget);
     }
@@ -115,7 +114,6 @@ export default class extends Controller {
     this.submitButtonTarget.disabled = true;
   }
 
-
   #buildHeaderMap() {
     this.#header_map = {}
     this.#headers.forEach(h => {
@@ -130,10 +128,8 @@ export default class extends Controller {
   }
 
   #refreshInputOptionsForAllFields() {
-    console.log("in refresh fields")
     this.#refreshInputOptions(this.sampleNameColumnTarget, this.#curr_sample_name)
     if (this.groupValue) {
-      console.log("refreshing puid fields")
       this.#refreshInputOptions(this.projectPUIDColumnTarget, this.#curr_project_puid)
     }
     this.#refreshInputOptions(this.sampleDescriptionColumnTarget, this.#curr_sample_description)

--- a/app/jobs/samples/batch_sample_import_job.rb
+++ b/app/jobs/samples/batch_sample_import_job.rb
@@ -42,19 +42,14 @@ module Samples
     private
 
     def handle_success(broadcast_target, response) # rubocop:disable Metrics/MethodLength
-      results = []
+      problems = []
       response.each do |key, value|
-        if value.is_a? Sample
-          results.push({ sample_name: key,
-                         sample_id: value.puid,
-                         completed: true,
-                         message: nil })
-        else
-          results.push({ sample_name: key,
-                         sample_id: nil,
-                         completed: false,
-                         message: value })
-        end
+        next if value.is_a? Sample
+
+        problems.push({ sample_name: key,
+                        sample_id: nil,
+                        completed: false,
+                        message: value })
       end
 
       Turbo::StreamsChannel.broadcast_replace_to(
@@ -64,7 +59,7 @@ module Samples
         locals: {
           type: :success,
           message: I18n.t('shared.samples.spreadsheet_imports.success.description'),
-          results:
+          problems:
         }
       )
     end

--- a/app/jobs/samples/batch_sample_import_job.rb
+++ b/app/jobs/samples/batch_sample_import_job.rb
@@ -11,7 +11,7 @@ module Samples
       )
 
       if namespace.errors.empty?
-        handle_success(broadcast_target, response)
+        handle_response(broadcast_target, response)
 
       elsif namespace.errors.include?(:sample)
         errors = namespace.errors.messages_for(:sample)
@@ -43,7 +43,7 @@ module Samples
 
     private
 
-    def handle_success(broadcast_target, response) # rubocop:disable Metrics/MethodLength
+    def handle_response(broadcast_target, response) # rubocop:disable Metrics/MethodLength
       problems = []
       response.each do |key, value|
         next if value.is_a? Sample

--- a/app/jobs/samples/batch_sample_import_job.rb
+++ b/app/jobs/samples/batch_sample_import_job.rb
@@ -6,7 +6,9 @@ module Samples
     queue_as :default
 
     def perform(namespace, current_user, broadcast_target, blob_id, params) # rubocop:disable Metrics/MethodLength
-      response = ::Samples::BatchFileImportService.new(namespace, current_user, blob_id, params).execute
+      response = ::Samples::BatchFileImportService.new(namespace, current_user, blob_id, params).execute(
+        Flipper.enabled?(:progress_bars) ? broadcast_target : nil
+      )
 
       if namespace.errors.empty?
         handle_success(broadcast_target, response)

--- a/app/jobs/samples/batch_sample_import_job.rb
+++ b/app/jobs/samples/batch_sample_import_job.rb
@@ -45,9 +45,15 @@ module Samples
       results = []
       response.each do |key, value|
         if value.is_a? Sample
-          results.push "#{key} created successfully."
+          results.push({ sample_name: key,
+                         sample_id: value.puid,
+                         completed: true,
+                         message: nil })
         else
-          results.push "#{key} failed with message: #{value}"
+          results.push({ sample_name: key,
+                         sample_id: nil,
+                         completed: false,
+                         message: value })
         end
       end
 

--- a/app/jobs/samples/batch_sample_import_job.rb
+++ b/app/jobs/samples/batch_sample_import_job.rb
@@ -5,47 +5,46 @@ module Samples
   class BatchSampleImportJob < ApplicationJob
     queue_as :default
 
-    def perform(namespace, current_user, broadcast_target, blob_id, params) # rubocop:disable Lint/UnusedMethodArgument
+    def perform(namespace, current_user, broadcast_target, blob_id, params) # rubocop:disable Metrics/MethodLength
       ::Samples::BatchFileImportService.new(namespace, current_user, blob_id, params).execute
 
-      # TODO: change all these from metadata to batch sample
-      # if namespace.errors.empty?
-      #   Turbo::StreamsChannel.broadcast_replace_to(
-      #     broadcast_target,
-      #     target: 'import_metadata_dialog_content',
-      #     partial: 'shared/samples/metadata/file_imports/success',
-      #     locals: {
-      #       type: :success,
-      #       message: I18n.t('shared.samples.metadata.file_imports.success.description')
-      #     }
-      #   )
+      if namespace.errors.empty?
+        Turbo::StreamsChannel.broadcast_replace_to(
+          broadcast_target,
+          target: 'import_spreadsheet_dialog_content',
+          partial: 'shared/samples/spreadsheet_imports/success',
+          locals: {
+            type: :success,
+            message: I18n.t('shared.samples.spreadsheet_imports.success.description')
+          }
+        )
 
-      # elsif namespace.errors.include?(:sample)
-      #   errors = namespace.errors.messages_for(:sample)
+      elsif namespace.errors.include?(:sample)
+        errors = namespace.errors.messages_for(:sample)
 
-      #   Turbo::StreamsChannel.broadcast_replace_to(
-      #     broadcast_target,
-      #     target: 'import_metadata_dialog_content',
-      #     partial: 'shared/samples/metadata/file_imports/errors',
-      #     locals: {
-      #       type: :alert,
-      #       message: I18n.t('shared.samples.metadata.file_imports.errors.description'),
-      #       errors: errors
-      #     }
-      #   )
-      # else
-      #   errors = namespace.errors.full_messages_for(:base)
+        Turbo::StreamsChannel.broadcast_replace_to(
+          broadcast_target,
+          target: 'import_spreadsheet_dialog_content',
+          partial: 'shared/samples/spreadsheet_imports/errors',
+          locals: {
+            type: :alert,
+            message: I18n.t('shared.samples.spreadsheet_imports.errors.description'),
+            errors: errors
+          }
+        )
+      else
+        errors = namespace.errors.full_messages_for(:base)
 
-      #   Turbo::StreamsChannel.broadcast_replace_to(
-      #     broadcast_target,
-      #     target: 'import_metadata_dialog_content',
-      #     partial: 'shared/samples/metadata/file_imports/errors',
-      #     locals: {
-      #       type: :alert,
-      #       errors: errors
-      #     }
-      #   )
-      # end
+        Turbo::StreamsChannel.broadcast_replace_to(
+          broadcast_target,
+          target: 'import_spreadsheet_dialog_content',
+          partial: 'shared/samples/spreadsheet_imports/errors',
+          locals: {
+            type: :alert,
+            errors: errors
+          }
+        )
+      end
     end
   end
 end

--- a/app/services/samples/batch_file_import_service.rb
+++ b/app/services/samples/batch_file_import_service.rb
@@ -89,31 +89,31 @@ module Samples
 
     def errors_on_sample_row(sample_name, project_puid, response, index)
       if sample_name.nil? || project_puid.nil?
-        {
+        [{
           path: ['sample'],
           message: I18n.t('services.spreadsheet_import.missing_field', index:)
-        }
+        }]
       elsif response.key?(sample_name)
-        {
+        [{
           path: ['sample'],
           message: I18n.t('services.samples.batch_import.duplicate_sample_name', index:)
-        }
+        }]
       end
     end
 
     def errors_with_project(project_puid, project)
       if project.nil?
-        {
+        [{
           path: ['project'],
           message: I18n.t('services.samples.batch_import.project_puid_not_found', project_puid: project_puid)
-        }
+        }]
       elsif !accessible_from_namespace?(project)
-        {
+        [{
           path: ['project'],
           message: I18n.t('services.samples.batch_import.project_puid_not_in_namespace',
                           project_puid: project_puid,
                           namespace: @namespace.full_path)
-        }
+        }]
       end
     end
 

--- a/app/services/samples/batch_file_import_service.rb
+++ b/app/services/samples/batch_file_import_service.rb
@@ -21,10 +21,10 @@ module Samples
       super(namespace, user, blob_id, required_headers, 0, params)
     end
 
-    def execute
+    def execute(broadcast_target = nil)
       authorize! @namespace, to: :import_samples_and_metadata?
       validate_file
-      perform_file_import
+      perform_file_import(broadcast_target)
     rescue FileImportError => e
       @namespace.errors.add(:base, e.message)
       {}
@@ -32,12 +32,16 @@ module Samples
 
     protected
 
-    def perform_file_import # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    def perform_file_import(broadcast_target) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
       response = {}
       parse_settings = @headers.zip(@headers).to_h
 
+      # minus 1 to exclude header
+      total_sample_count = @spreadsheet.count - 1
       @spreadsheet.each_with_index(parse_settings) do |data, index|
         next unless index.positive?
+
+        update_progress_bar(index, total_sample_count, broadcast_target)
 
         sample_name = data[@sample_name_column]
 

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -55,6 +55,14 @@
             },
             class: "button button--size-default button--state-default" %>
           <% end %>
+          <% if allowed_to?(:import_samples_and_metadata?, @group) %>
+            <%= link_to t("projects.samples.index.import_samples_button"),
+            new_group_samples_spreadsheet_import_path,
+            data: {
+              turbo_stream: true,
+            },
+            class: "button button--size-default button--state-default" %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -56,7 +56,7 @@
             class: "button button--size-default button--state-default" %>
           <% end %>
           <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && allowed_to?(:import_samples_and_metadata?, @group) %>
-            <%= link_to t("projects.samples.index.import_samples_button"),
+            <%= link_to t("groups.samples.index.import_samples_button"),
             new_group_samples_spreadsheet_import_path,
             data: {
               turbo_stream: true,

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -55,7 +55,7 @@
             },
             class: "button button--size-default button--state-default" %>
           <% end %>
-          <% if allowed_to?(:import_samples_and_metadata?, @group) %>
+          <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && allowed_to?(:import_samples_and_metadata?, @group) %>
             <%= link_to t("projects.samples.index.import_samples_button"),
             new_group_samples_spreadsheet_import_path,
             data: {

--- a/app/views/groups/samples/spreadsheet_imports/create.turbo_stream.erb
+++ b/app/views/groups/samples/spreadsheet_imports/create.turbo_stream.erb
@@ -1,5 +1,19 @@
-<%= turbo_stream.append "import_dialog_content" do %>
-  <%= render SpinnerComponent.new(
-    message: t("shared.samples.spreadsheet_imports.dialog.spinner_message"),
-  ) %>
+<% if Flipper.enabled?(:progress_bars) %>
+  <%= turbo_stream.update "samples_dialog",
+                      partial: "shared/samples/spreadsheet_imports/dialog",
+                      locals: {
+                        open: true,
+                        url: group_samples_spreadsheet_import_path,
+                        closable: false,
+                      } %>
+
+  <%= turbo_stream.update "import_spreadsheet_dialog_content" do %>
+    <%= render partial: "shared/progress_bar", locals: { percentage: 0 } %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.append "import_spreadsheet_dialog_content" do %>
+    <%= render SpinnerComponent.new(
+      message: t("shared.samples.spreadsheet_imports.dialog.spinner_message"),
+    ) %>
+  <% end %>
 <% end %>

--- a/app/views/groups/samples/spreadsheet_imports/new.turbo_stream.erb
+++ b/app/views/groups/samples/spreadsheet_imports/new.turbo_stream.erb
@@ -1,6 +1,7 @@
 <%= turbo_stream.update "samples_dialog",
-                    partial: "shared/samples/spreadsheet_imports/dialog", # TODO: connect this to web ui stuff
+                    partial: "shared/samples/spreadsheet_imports/dialog",
                     locals: {
                       open: true,
                       url: group_samples_spreadsheet_import_path,
+                      closable: true,
                     } %>

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -107,7 +107,7 @@
           class: "button button--size-default button--state-default" %>
         <% end %>
         <% if @allowed_to[:destroy_sample] %>
-          <%=  t(".delete_samples_button"),
+          <%= link_to t(".delete_samples_button"),
           new_namespace_project_samples_deletion_path(deletion_type: "multiple"),
           data: {
             action: "turbo:morph-element->action-link#idempotentConnect",

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -98,7 +98,7 @@
           class: "button button--size-default button--state-primary",
           "aria-label": t(".actions.button_add_aria_label") %>
         <% end %>
-        <% if allowed_to?(:import_samples_and_metadata?, @project.namespace) %>
+        <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && allowed_to?(:import_samples_and_metadata?, @project.namespace) %>
           <%= link_to t("projects.samples.index.import_samples_button"),
           new_namespace_project_samples_spreadsheet_import_path,
           data: {

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -98,8 +98,16 @@
           class: "button button--size-default button--state-primary",
           "aria-label": t(".actions.button_add_aria_label") %>
         <% end %>
+        <% if allowed_to?(:import_samples_and_metadata?, @project.namespace) %>
+          <%= link_to t("projects.samples.index.import_samples_button"),
+          new_namespace_project_samples_spreadsheet_import_path,
+          data: {
+            turbo_stream: true,
+          },
+          class: "button button--size-default button--state-default" %>
+        <% end %>
         <% if @allowed_to[:destroy_sample] %>
-          <%= link_to t(".delete_samples_button"),
+          <%=  t(".delete_samples_button"),
           new_namespace_project_samples_deletion_path(deletion_type: "multiple"),
           data: {
             action: "turbo:morph-element->action-link#idempotentConnect",

--- a/app/views/projects/samples/spreadsheet_imports/create.turbo_stream.erb
+++ b/app/views/projects/samples/spreadsheet_imports/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.append "import_dialog_content" do %>
+<%= turbo_stream.append "import_spreadsheet_dialog_content" do %>
   <%= render SpinnerComponent.new(
     message: t("shared.samples.spreadsheet_imports.dialog.spinner_message"),
   ) %>

--- a/app/views/projects/samples/spreadsheet_imports/create.turbo_stream.erb
+++ b/app/views/projects/samples/spreadsheet_imports/create.turbo_stream.erb
@@ -1,5 +1,19 @@
-<%= turbo_stream.append "import_spreadsheet_dialog_content" do %>
-  <%= render SpinnerComponent.new(
-    message: t("shared.samples.spreadsheet_imports.dialog.spinner_message"),
-  ) %>
+<% if Flipper.enabled?(:progress_bars) %>
+  <%= turbo_stream.update "samples_dialog",
+                      partial: "shared/samples/spreadsheet_imports/dialog",
+                      locals: {
+                        open: true,
+                        url: namespace_project_samples_spreadsheet_import_path,
+                        closable: false,
+                      } %>
+
+  <%= turbo_stream.update "import_spreadsheet_dialog_content" do %>
+    <%= render partial: "shared/progress_bar", locals: { percentage: 0 } %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.append "import_spreadsheet_dialog_content" do %>
+    <%= render SpinnerComponent.new(
+      message: t("shared.samples.spreadsheet_imports.dialog.spinner_message"),
+    ) %>
+  <% end %>
 <% end %>

--- a/app/views/projects/samples/spreadsheet_imports/new.turbo_stream.erb
+++ b/app/views/projects/samples/spreadsheet_imports/new.turbo_stream.erb
@@ -1,6 +1,7 @@
 <%= turbo_stream.update "samples_dialog",
-                    partial: "shared/samples/spreadsheet_imports/dialog", # TODO: connect this to web ui stuff
+                    partial: "shared/samples/spreadsheet_imports/dialog",
                     locals: {
                       open: true,
                       url: namespace_project_samples_spreadsheet_import_path,
+                      closable: true,
                     } %>

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -7,7 +7,7 @@
 
     <div
       data-controller="spreadsheet-import"
-      <% if @namespace.type == 'Group' %>
+      <% if @namespace.group_namespace? %>
         data-spreadsheet-import-group-value=1
       <% else %>
         data-spreadsheet-import-group-value=0
@@ -21,7 +21,7 @@
             <%= t(".description") %>
           </p>
           <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
-            <% if @namespace.type == 'Group' %>
+            <% if @namespace.group_namespace? %>
               <%= t(".namespace.group.description_html") %>
             <% else %>
               <%= t(".namespace.project.description_html") %>
@@ -60,7 +60,7 @@
                             "change->spreadsheet-import#changeSampleNameInput",
                         } %>
           </div>
-          <% if @namespace.type == 'Group' %>
+          <% if @namespace.group_namespace? %>
             <div class="form-field">
               <%= form.label :project_puid_column,
                         t(".project_puid_column"),

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -48,7 +48,8 @@
             <%= form.label :sample_name_column,
                        t(".sample_name_column"),
                        class:
-                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white
+                         disabled:bg-slate-50 disabled:border disabled:border-slate-300 disabled:rounded-lg disabled:focus:ring-blue-500 disabled:focus:border-blue-500 disabled:w-full disabled:p-2.5 disabled:dark:bg-slate-700 disabled:dark:border-slate-600 disabled:dark:placeholder-slate-400 disabled:dark:focus:ring-blue-500 disabled:dark:focus:border-blue-500" %>
             <%= form.select :sample_name_column,
                         {},
                         { prompt: t(".select_sample_name_column") },
@@ -64,7 +65,8 @@
               <%= form.label :project_puid_column,
                         t(".project_puid_column"),
                         class:
-                          "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+                          "block mb-2 text-sm font-medium text-slate-900 dark:text-white
+                          disabled:bg-slate-50 disabled:border disabled:border-slate-300 disabled:rounded-lg disabled:focus:ring-blue-500 disabled:focus:border-blue-500 disabled:w-full disabled:p-2.5 disabled:dark:bg-slate-700 disabled:dark:border-slate-600 disabled:dark:placeholder-slate-400 disabled:dark:focus:ring-blue-500 disabled:dark:focus:border-blue-500" %>
               <%= form.select :project_puid_column,
                           {},
                           { prompt: t(".select_project_puid_column") },
@@ -80,7 +82,8 @@
             <%= form.label :sample_description_column,
                        t(".sample_description_column"),
                        class:
-                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white
+                         disabled:bg-slate-50 disabled:border disabled:border-slate-300 disabled:rounded-lg disabled:focus:ring-blue-500 disabled:focus:border-blue-500 disabled:w-full disabled:p-2.5 disabled:dark:bg-slate-700 disabled:dark:border-slate-600 disabled:dark:placeholder-slate-400 disabled:dark:focus:ring-blue-500 disabled:dark:focus:border-blue-500" %>
             <%= form.select :sample_description_column,
                         {},
                         { prompt: t(".select_sample_description_column") },

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -7,6 +7,11 @@
 
     <div
       data-controller="spreadsheet-import"
+      <% if @namespace.type == 'Group' %>
+        data-spreadsheet-import-group-value=1
+      <% else %>
+        data-spreadsheet-import-group-value=0
+      <% end %>
     >
 
       <%= form_for(:spreadsheet_import, url: url, method: :post) do |form| %>
@@ -54,21 +59,23 @@
                             "change->spreadsheet-import#changeSampleNameInput viral--sortable-lists--two-lists-selection#idempotentConnect",
                         } %>
           </div>
-          <div class="form-field">
-            <%= form.label :project_puid_column,
-                       t(".project_puid_column"),
-                       class:
-                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
-            <%= form.select :project_puid_column,
-                        {},
-                        { prompt: t(".select_project_puid_column") },
-                          required: true,
-                        data: {
-                          "spreadsheet-import-target": "projectPUIDColumn",
-                          action:
-                            "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect",
-                        } %>
-          </div>
+          <% if @namespace.type == 'Group' %>
+            <div class="form-field">
+              <%= form.label :project_puid_column,
+                        t(".project_puid_column"),
+                        class:
+                          "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+              <%= form.select :project_puid_column,
+                          {},
+                          { prompt: t(".select_project_puid_column") },
+                            required: true,
+                          data: {
+                            "spreadsheet-import-target": "projectPUIDColumn",
+                            action:
+                              "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                          } %>
+            </div>
+          <% end %>
           <div class="form-field">
             <%= form.label :sample_description_column,
                        t(".sample_description_column"),

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -1,0 +1,106 @@
+<%= viral_dialog(open: open, size: :large, closable: closable) do |dialog| %>
+  <% dialog.with_header(title: t(".title")) %>
+  <%= turbo_stream_from @broadcast_target %>
+  <%= turbo_frame_tag "import_spreadsheet_dialog_content" do %>
+
+    <%= turbo_frame_tag "import_spreadsheet_dialog_alert" %>
+
+    <div
+      data-controller="spreadsheet-import"
+    >
+
+      <%= form_for(:spreadsheet_import, url: url, method: :post) do |form| %>
+        <input type="hidden" name="broadcast_target" value="<%= @broadcast_target %>"/>
+        <div class="grid gap-4">
+          <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
+            <%= t(".description") %>
+          </p>
+          <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
+            <% if @namespace.type == 'Group' %>
+              <%= t(".namespace.group.description_html") %>
+            <% else %>
+              <%= t(".namespace.project.description_html") %>
+            <% end %>
+          </p>
+          <div class="form-field">
+            <%= form.label :file,
+                       t(".file"),
+                       class:
+                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+            <%= form.file_field :file,
+                            required: true,
+                            accept:
+                              # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+                              "text/csv,.tsv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                            data: {
+                              action: "change->spreadsheet-import#readFile",
+                            },
+                            class:
+                              "block w-full text-sm text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400" %>
+            <p class="mt-1 text-sm text-slate-500 dark:text-slate-300"><%= t(".file_help") %></p>
+          </div>
+          <div class="form-field">
+            <%= form.label :sample_name_column,
+                       t(".sample_name_column"),
+                       class:
+                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+            <%= form.select :sample_name_column,
+                        {},
+                        { prompt: t(".select_sample_name_column") },
+                        required: true,
+                        data: {
+                          "spreadsheet-import-target": "sampleNameColumn",
+                          action:
+                            "change->spreadsheet-import#changeSampleNameInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                        } %>
+          </div>
+          <div class="form-field">
+            <%= form.label :project_puid_column,
+                       t(".project_puid_column"),
+                       class:
+                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+            <%= form.select :project_puid_column,
+                        {},
+                        { prompt: t(".select_project_puid_column") },
+                        required: true,
+                        data: {
+                          "spreadsheet-import-target": "projectPUIDColumn",
+                          action:
+                            "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                        } %>
+          </div>
+          <div class="form-field">
+            <%= form.label :sample_description_column,
+                       t(".sample_description_column"),
+                       class:
+                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+            <%= form.select :sample_description_column,
+                        {},
+                        { prompt: t(".select_sample_description_column") },
+                        required: false,
+                        data: {
+                          "spreadsheet-import-target": "sampleDescriptionColumn",
+                          action:
+                            "change->spreadsheet-import#changeSampleDescriptionInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                        } %>
+          </div>
+          <%# <div class="flex items-center"> %>
+            <%# ????metadata stuff %>
+          <%# </div> %>
+          <div>
+            <%= form.submit t(".submit_button"),
+                        class: "button button--size-default button--state-primary",
+                        data: {
+                          turbo_frame: "_top",
+                          action:
+                            "click->viral--sortable-lists--two-lists-selection#constructParams",
+                          "viral--sortable-lists--two-lists-selection-target": "submitBtn",
+                          "spreadsheet-import-target": "submitButton",
+                        },
+                        disabled: true %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -54,21 +54,21 @@
                             "change->spreadsheet-import#changeSampleNameInput viral--sortable-lists--two-lists-selection#idempotentConnect",
                         } %>
           </div>
-          <%# <div class="form-field"> %>
-            <%# <%= form.label :project_puid_column, %>
-                       <%# t(".project_puid_column"), %>
-                       <%# class: %>
-                         <%# "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %> %>
-            <%# <%= form.select :project_puid_column, %>
-                        <%# {}, %>
-                        <%# { prompt: t(".select_project_puid_column") }, %>
-                        <%# required: true, %>
-                        <%# data: { %>
-                          <%# "spreadsheet-import-target": "projectPUIDColumn", %>
-                          <%# action: %>
-                            <%# "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect", %>
-                        <%# } %> %>
-          <%# </div> %>
+          <div class="form-field">
+            <%= form.label :project_puid_column,
+                       t(".project_puid_column"),
+                       class:
+                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
+            <%= form.select :project_puid_column,
+                        {},
+                        { prompt: t(".select_project_puid_column") },
+                          required: true,
+                        data: {
+                          "spreadsheet-import-target": "projectPUIDColumn",
+                          action:
+                            "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                        } %>
+          </div>
           <div class="form-field">
             <%= form.label :sample_description_column,
                        t(".sample_description_column"),

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -56,7 +56,7 @@
                         data: {
                           "spreadsheet-import-target": "sampleNameColumn",
                           action:
-                            "change->spreadsheet-import#changeSampleNameInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                            "change->spreadsheet-import#changeSampleNameInput",
                         } %>
           </div>
           <% if @namespace.type == 'Group' %>
@@ -72,7 +72,7 @@
                           data: {
                             "spreadsheet-import-target": "projectPUIDColumn",
                             action:
-                              "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                              "change->spreadsheet-import#changeProjectPUIDInput",
                           } %>
             </div>
           <% end %>
@@ -88,12 +88,9 @@
                         data: {
                           "spreadsheet-import-target": "sampleDescriptionColumn",
                           action:
-                            "change->spreadsheet-import#changeSampleDescriptionInput viral--sortable-lists--two-lists-selection#idempotentConnect",
+                            "change->spreadsheet-import#changeSampleDescriptionInput",
                         } %>
           </div>
-          <%# <div class="flex items-center"> %>
-            <%# ????metadata stuff %>
-          <%# </div> %>
           <div>
             <%= form.submit t(".submit_button"),
                         class: "button button--size-default button--state-primary",

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -54,21 +54,21 @@
                             "change->spreadsheet-import#changeSampleNameInput viral--sortable-lists--two-lists-selection#idempotentConnect",
                         } %>
           </div>
-          <div class="form-field">
-            <%= form.label :project_puid_column,
-                       t(".project_puid_column"),
-                       class:
-                         "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %>
-            <%= form.select :project_puid_column,
-                        {},
-                        { prompt: t(".select_project_puid_column") },
-                        required: true,
-                        data: {
-                          "spreadsheet-import-target": "projectPUIDColumn",
-                          action:
-                            "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect",
-                        } %>
-          </div>
+          <%# <div class="form-field"> %>
+            <%# <%= form.label :project_puid_column, %>
+                       <%# t(".project_puid_column"), %>
+                       <%# class: %>
+                         <%# "block mb-2 text-sm font-medium text-slate-900 dark:text-white" %> %>
+            <%# <%= form.select :project_puid_column, %>
+                        <%# {}, %>
+                        <%# { prompt: t(".select_project_puid_column") }, %>
+                        <%# required: true, %>
+                        <%# data: { %>
+                          <%# "spreadsheet-import-target": "projectPUIDColumn", %>
+                          <%# action: %>
+                            <%# "change->spreadsheet-import#changeProjectPUIDInput viral--sortable-lists--two-lists-selection#idempotentConnect", %>
+                        <%# } %> %>
+          <%# </div> %>
           <div class="form-field">
             <%= form.label :sample_description_column,
                        t(".sample_description_column"),

--- a/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
@@ -8,7 +8,7 @@
     <%= viral_alert(type:, message: error, classes: "mb-4") %>
   <% end %>
 
-  <div>
+  <div class="mt-2">
     <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
       <%= t(".ok_button") %>
     <% end %>

--- a/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
@@ -1,0 +1,18 @@
+<div
+  data-controller="projects--samples--complete"
+  data-projects--samples--metadata--complete-filters-outlet=".filters"
+>
+  <p class="mb-4 dark:text-white"><%= t(".description") %></p>
+
+  <% errors.each do |error| %>
+    <%= viral_alert(type:, message: error, classes: "mb-4") %>
+  <% end %>
+
+  <div>
+    <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+      <%= t(".ok_button") %>
+    <% end %>
+  </div>
+</div>
+
+<turbo-stream action="refresh"></turbo-stream>

--- a/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
@@ -1,6 +1,6 @@
 <div
   data-controller="projects--samples--complete"
-  data-projects--samples--metadata--complete-filters-outlet=".filters"
+  data-projects--samples--complete-filters-outlet=".filters"
 >
   <p class="mb-4 dark:text-white"><%= t(".description") %></p>
 

--- a/app/views/shared/samples/spreadsheet_imports/_success.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_success.html.erb
@@ -12,9 +12,9 @@
     <% end %>
     <% table.with_column("Completed") do |row| %>
       <% if row[:completed] == true %>
-        <%= viral_icon(name: "check", classes: "w-4 h-4 text-green-500 dark:text-green-400") %>
+        <%= viral_icon(name: "check", classes: "w-2 h-2 text-green-500 dark:text-green-400") %>
       <% else %>
-        <%= viral_icon(name: "x_mark", classes: "h-4 w-4 text-red-500 dark:text-red-400") %>
+        <%= viral_icon(name: "x_mark", classes: "h-2 w-2 text-red-500 dark:text-red-400") %>
       <% end %>
     <% end %>
     <% table.with_column("Sample ID") do |row| %>

--- a/app/views/shared/samples/spreadsheet_imports/_success.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_success.html.erb
@@ -4,20 +4,25 @@
   data-controller="projects--samples--complete"
   data-projects--samples--complete-filters-outlet=".filters"
 >
-  <div
-    class="
-      w-12 h-12 rounded-full bg-green-100 dark:bg-green-900 p-2 flex items-center
-      justify-center mx-auto mb-3.5
-    "
-  >
-    <%= viral_icon(name: "check", classes: "w-8 h-8 text-green-500 dark:text-green-400") %>
-    <span class="sr-only"><%= t(".success") %></span>
-  </div>
   <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= t(".description") %></p>
 
-  <% results.each do |result|
-    # <%= viral_alert(type: :info, message: result) %>
-    <p class="mb-4 text-slate-900 dark:text-white"><%= result %></p>
+  <%= viral_data_table(results, id: 'results_table') do |table| %>
+    <% table.with_column("Sample Name") do |row| %>
+      <%= row[:sample_name] %>
+    <% end %>
+    <% table.with_column("Completed") do |row| %>
+      <% if row[:completed] == true %>
+        <%= viral_icon(name: "check", classes: "w-4 h-4 text-green-500 dark:text-green-400") %>
+      <% else %>
+        <%= viral_icon(name: "x_mark", classes: "h-4 w-4 text-red-500 dark:text-red-400") %>
+      <% end %>
+    <% end %>
+    <% table.with_column("Sample ID") do |row| %>
+      <%= row[:sample_id] %>
+    <% end %>
+    <% table.with_column("message") do |row| %>
+      <%= row[:message] %>
+    <% end %>
   <% end %>
 
   <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>

--- a/app/views/shared/samples/spreadsheet_imports/_success.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_success.html.erb
@@ -1,0 +1,22 @@
+<div
+  class="text-center"
+  data-projects-samples--complete-loaded-value="false"
+  data-controller="projects--samples--complete"
+  data-projects--samples--complete-filters-outlet=".filters"
+>
+  <div
+    class="
+      w-12 h-12 rounded-full bg-green-100 dark:bg-green-900 p-2 flex items-center
+      justify-center mx-auto mb-3.5
+    "
+  >
+    <%= viral_icon(name: "check", classes: "w-8 h-8 text-green-500 dark:text-green-400") %>
+    <span class="sr-only"><%= t(".success") %></span>
+  </div>
+  <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= t(".description") %></p>
+  <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+    <%= t(".ok_button") %>
+  <% end %>
+</div>
+
+<turbo-stream action="refresh"></turbo-stream>

--- a/app/views/shared/samples/spreadsheet_imports/_success.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_success.html.erb
@@ -21,10 +21,11 @@
     <% end %>
 
   <% end %>
-
-  <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
-    <%= t(".ok_button") %>
-  <% end %>
+  <div class="mt-2">
+    <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+      <%= t(".ok_button") %>
+    <% end %>
+  </div>
 </div>
 
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/shared/samples/spreadsheet_imports/_success.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_success.html.erb
@@ -6,23 +6,20 @@
 >
   <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= t(".description") %></p>
 
-  <%= viral_data_table(results, id: 'results_table') do |table| %>
-    <% table.with_column("Sample Name") do |row| %>
-      <%= row[:sample_name] %>
-    <% end %>
-    <% table.with_column("Completed") do |row| %>
-      <% if row[:completed] == true %>
-        <%= viral_icon(name: "check", classes: "w-2 h-2 text-green-500 dark:text-green-400") %>
-      <% else %>
-        <%= viral_icon(name: "x_mark", classes: "h-2 w-2 text-red-500 dark:text-red-400") %>
+  <% unless problems.empty? %>
+    <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= t(".problems") %></p>
+
+    <%= viral_data_table(problems, id: 'problems_table') do |table| %>
+      <% table.with_column("Sample Name") do |row| %>
+        <%= row[:sample_name] %>
+      <% end %>
+      <% table.with_column("Messages") do |row| %>
+        <% row[:message].each do |msg| %>
+          <%= t(".problem_message", path: msg[:path].join(" "), message: msg[:message]) %>
+        <% end %>
       <% end %>
     <% end %>
-    <% table.with_column("Sample ID") do |row| %>
-      <%= row[:sample_id] %>
-    <% end %>
-    <% table.with_column("message") do |row| %>
-      <%= row[:message] %>
-    <% end %>
+
   <% end %>
 
   <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>

--- a/app/views/shared/samples/spreadsheet_imports/_success.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_success.html.erb
@@ -14,6 +14,12 @@
     <span class="sr-only"><%= t(".success") %></span>
   </div>
   <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= t(".description") %></p>
+
+  <% results.each do |result|
+    # <%= viral_alert(type: :info, message: result) %>
+    <p class="mb-4 text-slate-900 dark:text-white"><%= result %></p>
+  <% end %>
+
   <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
     <%= t(".ok_button") %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1975,7 +1975,6 @@ en:
           ok_button: OK
           problem_message: "%{path} %{message}"
           problems: Errors were encountered while importing the following samples.
-          success: Success
     workflow_executions:
       destroy_multiple_confirmation_dialog:
         description:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1950,7 +1950,6 @@ en:
         tooltip: Metadata display settings
       spreadsheet_imports:
         dialog:
-          available: Available
           description: Importing a sample spreadsheet allows multiple samples with or without metadata fields to be added at once.
           file: File
           file_help: CSV, TSV, XLS or XLSX.
@@ -1965,7 +1964,6 @@ en:
           select_project_puid_column: Select a Project ID Column
           select_sample_description_column: Select a Sample Description Column
           select_sample_name_column: Select a Sample Name Column
-          selected: Selected
           spinner_message: Importing samples, this might take a while...
           submit_button: Import Samples
           title: Upload Samples

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1973,7 +1973,9 @@ en:
           description: 'The sample import completed with the following errors:'
           ok_button: OK
         success:
-          description: The sample spreadsheet has been processed. See the response table for details.
+          description: The sample spreadsheet has been processed.
+          problems: The following samples had problems while processing.
+          problem_message: '%{path} %{message}'
           ok_button: OK
           success: Success
     workflow_executions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1963,7 +1963,7 @@ en:
           select_sample_name_column: Select a Sample Name Column
           project_puid_column: Project ID Column
           select_project_puid_column: Select a Project ID Column
-          sample_description_column: Sample Description Column
+          sample_description_column: Sample Description Column (Optional)
           select_sample_description_column: Select a Sample Description Column
           selected: Selected
           spinner_message: Importing samples, this might take a while...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1973,7 +1973,7 @@ en:
           description: 'The sample import completed with the following errors:'
           ok_button: OK
         success:
-          description: The samples were imported successfully!
+          description: The sample spreadsheet has been processed. See the response table for details.
           ok_button: OK
           success: Success
     workflow_executions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1959,12 +1959,12 @@ en:
               description_html: The spreadsheet is required to have columns for <b>Sample Name</b> and <b>Project PUID</b>, and optionally <b>Sample Description</b>.
             project:
               description_html: The spreadsheet is required to have a column for <b>Sample Name</b>, and optionally <b>Sample Description</b>.
-          sample_name_column: Sample Name Column
-          select_sample_name_column: Select a Sample Name Column
           project_puid_column: Project ID Column
-          select_project_puid_column: Select a Project ID Column
           sample_description_column: Sample Description Column (Optional)
+          sample_name_column: Sample Name Column
+          select_project_puid_column: Select a Project ID Column
           select_sample_description_column: Select a Sample Description Column
+          select_sample_name_column: Select a Sample Name Column
           selected: Selected
           spinner_message: Importing samples, this might take a while...
           submit_button: Import Samples
@@ -1974,9 +1974,9 @@ en:
           ok_button: OK
         success:
           description: The sample spreadsheet has been processed.
-          problems: The following samples had problems while processing.
-          problem_message: '%{path} %{message}'
           ok_button: OK
+          problem_message: "%{path} %{message}"
+          problems: The following samples had problems while processing.
           success: Success
     workflow_executions:
       destroy_multiple_confirmation_dialog:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1974,7 +1974,7 @@ en:
           description: The sample spreadsheet has been processed.
           ok_button: OK
           problem_message: "%{path} %{message}"
-          problems: The following samples had problems while processing.
+          problems: Errors were encountered while importing the following samples.
           success: Success
     workflow_executions:
       destroy_multiple_confirmation_dialog:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -908,6 +908,7 @@ en:
           sample_export: Sample Export
         deselect_all_button: Deselect All
         import_metadata_button: Import metadata
+        import_samples_button: Import samples
         select_all_button: Select All
         subtitle: These are the samples in %{namespace_type} %{namespace_name}
         title: Samples
@@ -1574,6 +1575,7 @@ en:
         delete_samples_button: Delete Samples
         deselect_all_button: Deselect All
         import_metadata_button: Import metadata
+        import_samples_button: Import samples
         new_button: New sample
         no_associated_samples: There are no samples associated with this project.
         no_samples: No Samples
@@ -1948,7 +1950,32 @@ en:
         tooltip: Metadata display settings
       spreadsheet_imports:
         dialog:
+          available: Available
+          description: Importing a sample spreadsheet allows multiple samples with or without metadata fields to be added at once.
+          file: File
+          file_help: CSV, TSV, XLS or XLSX.
+          namespace:
+            group:
+              description_html: The spreadsheet is required to have columns for <b>Sample Name</b> and <b>Project PUID</b>, and optionally <b>Sample Description</b>.
+            project:
+              description_html: The spreadsheet is required to have a column for <b>Sample Name</b>, and optionally <b>Sample Description</b>.
+          sample_name_column: Sample Name Column
+          select_sample_name_column: Select a Sample Name Column
+          project_puid_column: Project ID Column
+          select_project_puid_column: Select a Project ID Column
+          sample_description_column: Sample Description Column
+          select_sample_description_column: Select a Sample Description Column
+          selected: Selected
           spinner_message: Importing samples, this might take a while...
+          submit_button: Import Samples
+          title: Upload Samples
+        errors:
+          description: 'The sample import completed with the following errors:'
+          ok_button: OK
+        success:
+          description: The samples were imported successfully!
+          ok_button: OK
+          success: Success
     workflow_executions:
       destroy_multiple_confirmation_dialog:
         description:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1970,7 +1970,7 @@ fr:
           description: The sample spreadsheet has been processed.
           ok_button: OK
           problem_message: "%{path} %{message}"
-          problems: The following samples had problems while processing.
+          problems: Errors were encountered while importing the following samples.
     workflow_executions:
       destroy_multiple_confirmation_dialog:
         description:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1946,7 +1946,6 @@ fr:
         tooltip: Paramètres d’affichage des métadonnées
       spreadsheet_imports: # TODO: translate section
         dialog:
-          available: Available
           description: Importing a sample spreadsheet allows multiple samples with or without metadata fields to be added at once.
           file: File
           file_help: CSV, TSV, XLS or XLSX.
@@ -1961,7 +1960,6 @@ fr:
           select_project_puid_column: Select a Project ID Column
           select_sample_description_column: Select a Sample Description Column
           select_sample_name_column: Select a Sample Name Column
-          selected: Selected
           spinner_message: Importing samples, this might take a while...
           submit_button: Import Samples
           title: Upload Samples

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -906,7 +906,7 @@ fr:
           sample_export: Exportation d’échantillons
         deselect_all_button: Désélectionner tout
         import_metadata_button: Importer des métadonnées
-        import_samples_button: Import samples # TODO: translate section
+        import_samples_button: Import samples
         select_all_button: Tout sélectionner
         subtitle: Voici les échantillons dans %{namespace_type} %{namespace_name}
         title: Échantillons
@@ -1571,7 +1571,7 @@ fr:
         delete_samples_button: Supprimer les échantillons
         deselect_all_button: Désélectionner tout
         import_metadata_button: Importer des métadonnées
-        import_samples_button: Import samples # TODO: translate section
+        import_samples_button: Import samples
         new_button: Nouvel échantillon
         no_associated_samples: Il n’y a aucun échantillon associé à ce projet.
         no_samples: Aucun échantillon
@@ -1944,7 +1944,7 @@ fr:
         templates:
           label: Modèles de métadonnées
         tooltip: Paramètres d’affichage des métadonnées
-      spreadsheet_imports: # TODO: translate section
+      spreadsheet_imports:
         dialog:
           description: Importing a sample spreadsheet allows multiple samples with or without metadata fields to be added at once.
           file: File

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -906,6 +906,7 @@ fr:
           sample_export: Exportation d’échantillons
         deselect_all_button: Désélectionner tout
         import_metadata_button: Importer des métadonnées
+        import_samples_button: Import samples # TODO: translate section
         select_all_button: Tout sélectionner
         subtitle: Voici les échantillons dans %{namespace_type} %{namespace_name}
         title: Échantillons
@@ -1570,6 +1571,7 @@ fr:
         delete_samples_button: Supprimer les échantillons
         deselect_all_button: Désélectionner tout
         import_metadata_button: Importer des métadonnées
+        import_samples_button: Import samples # TODO: translate section
         new_button: Nouvel échantillon
         no_associated_samples: Il n’y a aucun échantillon associé à ce projet.
         no_samples: Aucun échantillon
@@ -1942,9 +1944,35 @@ fr:
         templates:
           label: Modèles de métadonnées
         tooltip: Paramètres d’affichage des métadonnées
-      spreadsheet_imports:
+      spreadsheet_imports: # TODO: translate section
         dialog:
+          available: Available
+          description: Importing a sample spreadsheet allows multiple samples with or without metadata fields to be added at once.
+          file: File
+          file_help: CSV, TSV, XLS or XLSX.
+          namespace:
+            group:
+              description_html: The spreadsheet is required to have columns for <b>Sample Name</b> and <b>Project PUID</b>, and optionally <b>Sample Description</b>.
+            project:
+              description_html: The spreadsheet is required to have a column for <b>Sample Name</b>, and optionally <b>Sample Description</b>.
+          project_puid_column: Project ID Column
+          sample_description_column: Sample Description Column (Optional)
+          sample_name_column: Sample Name Column
+          select_project_puid_column: Select a Project ID Column
+          select_sample_description_column: Select a Sample Description Column
+          select_sample_name_column: Select a Sample Name Column
+          selected: Selected
           spinner_message: Importing samples, this might take a while...
+          submit_button: Import Samples
+          title: Upload Samples
+        errors:
+          description: 'The sample import completed with the following errors:'
+          ok_button: OK
+        success:
+          description: The sample spreadsheet has been processed.
+          ok_button: OK
+          problem_message: "%{path} %{message}"
+          problems: The following samples had problems while processing.
     workflow_executions:
       destroy_multiple_confirmation_dialog:
         description:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,7 @@ Flipper.enable(:progress_bars)
 Flipper.enable(:update_nextflow_metadata_param)
 Flipper.enable(:attachments_preview)
 Flipper.enable(:delete_multiple_workflows)
+Flipper.enable(:batch_sample_spreadsheet_import)
 
 @namespace_group_link_expiry_date = (Time.zone.today + 14).strftime('%Y-%m-%d')
 

--- a/test/fixtures/files/batch_sample_import/project/invalid_duplicate_header.csv
+++ b/test/fixtures/files/batch_sample_import/project/invalid_duplicate_header.csv
@@ -1,0 +1,3 @@
+sample_name,sample_name,description,metadata1,metadata2
+my new sample,mynewsample,my description,a,b
+my new sample 2,mynewsample1,my description 2,c,d

--- a/test/services/samples/group_batch_sample_import_service_test.rb
+++ b/test/services/samples/group_batch_sample_import_service_test.rb
@@ -79,11 +79,11 @@ module Samples
       assert_equal I18n.t('services.samples.batch_import.project_puid_not_in_namespace',
                           project_puid: @project.puid,
                           namespace: @group2.full_path),
-                   response['my new sample'][:message]
+                   response['my new sample'][0][:message]
       assert_equal I18n.t('services.samples.batch_import.project_puid_not_in_namespace',
                           project_puid: @project.puid,
                           namespace: @group2.full_path),
-                   response['my new sample 2'][:message]
+                   response['my new sample 2'][0][:message]
     end
 
     test 'import with bad data invalid project' do
@@ -105,7 +105,7 @@ module Samples
 
       assert_equal I18n.t('services.samples.batch_import.project_puid_not_found',
                           project_puid: 'invalid_puid'),
-                   response['my new sample 2'][:message]
+                   response['my new sample 2'][0][:message]
     end
 
     test 'import with bad data missing puid' do
@@ -127,7 +127,7 @@ module Samples
 
       assert_equal I18n.t('services.spreadsheet_import.missing_field',
                           index: 2),
-                   response['index 2'][:message]
+                   response['index 2'][0][:message]
     end
 
     test 'import with bad data blank line' do
@@ -149,7 +149,7 @@ module Samples
 
       assert_equal I18n.t('services.spreadsheet_import.missing_field',
                           index: 2),
-                   response['index 2'][:message]
+                   response['index 2'][0][:message]
     end
 
     test 'import with bad data short sample name' do
@@ -213,7 +213,7 @@ module Samples
 
       assert_equal I18n.t('services.samples.batch_import.duplicate_sample_name',
                           index: 2),
-                   response['index 2'][:message]
+                   response['index 2'][0][:message]
     end
 
     test 'import samples with metadata' do

--- a/test/services/samples/project_batch_sample_import_service_test.rb
+++ b/test/services/samples/project_batch_sample_import_service_test.rb
@@ -89,6 +89,27 @@ module Samples
                    response['index 2'][0][:message]
     end
 
+    test 'import with bad data duplicate header' do
+      assert_equal 3, @project.samples.count
+
+      file = Rack::Test::UploadedFile.new(
+        Rails.root.join('test/fixtures/files/batch_sample_import/project/invalid_duplicate_header.csv')
+      )
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: file,
+        filename: file.original_filename,
+        content_type: file.content_type
+      )
+
+      Samples::BatchFileImportService.new(@project.namespace, @john_doe, blob.id,
+                                                     @default_params).execute
+
+      assert_equal 3, @project.samples.count
+
+      assert_equal I18n.t('services.spreadsheet_import.duplicate_column_names'),
+                   @project.namespace.errors.errors[0].type
+    end
+
     test 'import with bad data short sample name' do
       assert_equal 3, @project.samples.count
 

--- a/test/services/samples/project_batch_sample_import_service_test.rb
+++ b/test/services/samples/project_batch_sample_import_service_test.rb
@@ -102,7 +102,7 @@ module Samples
       )
 
       Samples::BatchFileImportService.new(@project.namespace, @john_doe, blob.id,
-                                                     @default_params).execute
+                                          @default_params).execute
 
       assert_equal 3, @project.samples.count
 

--- a/test/services/samples/project_batch_sample_import_service_test.rb
+++ b/test/services/samples/project_batch_sample_import_service_test.rb
@@ -86,7 +86,7 @@ module Samples
 
       assert_equal I18n.t('services.spreadsheet_import.missing_field',
                           index: 2),
-                   response['index 2'][:message]
+                   response['index 2'][0][:message]
     end
 
     test 'import with bad data short sample name' do
@@ -150,7 +150,7 @@ module Samples
 
       assert_equal I18n.t('services.samples.batch_import.duplicate_sample_name',
                           index: 2),
-                   response['index 2'][:message]
+                   response['index 2'][0][:message]
     end
 
     test 'import samples with metadata' do

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -8,6 +8,7 @@ module Groups
 
     def setup
       Flipper.enable(:metadata_import_field_selection)
+      Flipper.enable(:batch_sample_spreadsheet_import)
 
       @user = users(:john_doe)
       login_as @user
@@ -1192,6 +1193,112 @@ module Groups
       ### VERIFY START ###
       within('table tbody tr:first-child td:nth-child(7)') do
         assert_no_selector "form[method='get']"
+      end
+      ### VERIFY END ###
+    end
+
+    test 'should import samples' do
+      ### SETUP START ###
+      visit group_samples_url(@group)
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 26,
+                                                                           locale: @user.locale))
+      within('table tbody') do
+        assert_selector 'tr', count: 20
+        assert_no_text 'my new sample'
+        assert_no_text 'my new sample 2'
+      end
+      ### SETUP END ###
+
+      ### ACTIONS START ###
+      # start import
+      click_link I18n.t('groups.samples.index.import_samples_button')
+      within('#dialog') do
+        attach_file('spreadsheet_import[file]',
+                    Rails.root.join('test/fixtures/files/batch_sample_import/group/valid.csv'))
+        find('#spreadsheet_import_sample_name_column', wait: 1).find(:xpath, 'option[2]').select_option
+        # sample name column is "consumed" by first selection,
+        # so select option 2 again for project puid and sample description
+        find('#spreadsheet_import_project_puid_column', wait: 1).find(:xpath, 'option[2]').select_option
+        find('#spreadsheet_import_sample_description_column', wait: 1).find(:xpath, 'option[2]').select_option
+
+        click_on I18n.t('shared.samples.spreadsheet_imports.dialog.submit_button')
+        ### ACTIONS END ###
+      end
+
+      ### VERIFY START ###
+      assert_text I18n.t('shared.progress_bar.in_progress')
+      perform_enqueued_jobs only: [::Samples::BatchSampleImportJob]
+
+      # success msg
+      assert_text I18n.t('shared.samples.spreadsheet_imports.success.description')
+      click_on I18n.t('shared.samples.spreadsheet_imports.success.ok_button')
+
+      # refresh to see new samples
+      visit group_samples_url(@group)
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 28,
+                                                                           locale: @user.locale))
+      within('table tbody') do
+        # added 2 new samples
+        assert_text 'my new sample'
+        assert_text 'my new sample 2'
+      end
+      ### VERIFY END ###
+    end
+
+    test 'should not import sample missing project puid' do
+      ### SETUP START ###
+      visit group_samples_url(@group)
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 26,
+                                                                           locale: @user.locale))
+      within('table tbody') do
+        assert_selector 'tr', count: 20
+        assert_no_text 'my new sample'
+        assert_no_text 'my new sample 2'
+      end
+      ### SETUP END ###
+
+      ### ACTIONS START ###
+      # start import
+      click_link I18n.t('groups.samples.index.import_samples_button')
+      within('#dialog') do
+        attach_file('spreadsheet_import[file]',
+                    Rails.root.join('test/fixtures/files/batch_sample_import/group/invalid_missing_puid.csv'))
+        find('#spreadsheet_import_sample_name_column', wait: 1).find(:xpath, 'option[2]').select_option
+        # sample name column is "consumed" by first selection,
+        # so select option 2 again for project puid and sample description
+        find('#spreadsheet_import_project_puid_column', wait: 1).find(:xpath, 'option[2]').select_option
+        find('#spreadsheet_import_sample_description_column', wait: 1).find(:xpath, 'option[2]').select_option
+
+        click_on I18n.t('shared.samples.spreadsheet_imports.dialog.submit_button')
+        ### ACTIONS END ###
+      end
+
+      ### VERIFY START ###
+      assert_text I18n.t('shared.progress_bar.in_progress')
+      perform_enqueued_jobs only: [::Samples::BatchSampleImportJob]
+
+      # success msg
+      assert_text I18n.t('shared.samples.spreadsheet_imports.success.description')
+      # problem message
+      assert_text I18n.t('shared.samples.spreadsheet_imports.success.problems')
+      # problem table
+      within('#problems_table table tbody') do
+        # has 1 problem
+        assert_selector 'tr', count: 1
+        assert_text "Row with index '2' is missing required fields"
+      end
+      click_on I18n.t('shared.samples.spreadsheet_imports.success.ok_button')
+
+      # refresh to see new samples
+      visit group_samples_url(@group)
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 27,
+                                                                           locale: @user.locale))
+      within('table tbody') do
+        # added 2 new samples
+        assert_text 'my new sample'
+        assert_no_text 'my new sample 2'
       end
       ### VERIFY END ###
     end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

* Adds "Import samples" button to Project Samples and Group Samples pages.
* Adds form for importing samples, similar to the Import metadata form
   * includes form field filtering to prevent duplicate headers being selected
* Connect turbo streams for progress bars, errors, success, etc
* Features are behind `Flipper.enable(:batch_sample_spreadsheet_import)`

Note: Metadata importing alongside sample importing will be in a separate PR

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Start irida next, sign in, navigate to a project where you have permissions to create samples.
2. Click the [Import samples] button
3. Select a file from test/fixtures/batch_sample_import/project/
4. test that headers can be selected, and submission works.
5. test that success is shown, that malformed sample sheets return errors to the users, that partial success is displayed when multiple are created but some have issues.
6. Repeat the above but on a group samples page instead of a project samples page, and files from test/fixtures/batch_sample_import/group/

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
