### PR TITLE
Automated workflow execution launch service set sample name in samplesheet params if required

### DIFF
--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -39,12 +39,16 @@ module AutomatedWorkflowExecutions
             sample_id: @sample.id,
             samplesheet_params: {
               sample: @sample.puid,
+              **(@workflow.samplesheet_headers.include?('sample_name') ? { sample_name: @sample.name } : {}),
               fastq_1: @pe_attachment_pair['forward'].to_global_id, # rubocop:disable Naming/VariableNumber
               fastq_2: @pe_attachment_pair['reverse'].to_global_id # rubocop:disable Naming/VariableNumber
             }
           }
         ]
       }.with_indifferent_access
+    end
+
+    def samples_workflow_executions_attributes
     end
 
     def name

--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -48,9 +48,6 @@ module AutomatedWorkflowExecutions
       }.with_indifferent_access
     end
 
-    def samples_workflow_executions_attributes
-    end
-
     def name
       if @automated_workflow_execution.name.blank?
         @sample.puid

--- a/app/views/projects/workflow_executions/_samplesheet.html.erb
+++ b/app/views/projects/workflow_executions/_samplesheet.html.erb
@@ -1,0 +1,54 @@
+<% if @samplesheet_headers.blank? || @samplesheet_rows.blank? %>
+  <%= viral_alert(message: t(:"workflow_executions.samples.empty"), type: :info) %>
+<% else %>
+  <div class="relative overflow-x-auto">
+    <table
+      class="
+        w-full text-sm text-left text-slate-500 rtl:text-right dark:text-slate-400
+      "
+    >
+      <thead
+        class="
+          text-xs uppercase text-slate-700 bg-slate-50 dark:bg-slate-700
+          dark:text-slate-400
+        "
+      >
+        <tr>
+          <% @samplesheet_headers.each do |header| %>
+            <th scope="col" class="px-6 py-3">
+              <%= header %>
+            </th>
+          <% end %>
+
+        </tr>
+      </thead>
+      <tbody>
+        <% @samplesheet_rows.each do |sample| %>
+          <tr class="bg-white border-b dark:bg-slate-800 dark:border-slate-700">
+            <% @samplesheet_headers.each do |header| %>
+              <% if header == "sample" %>
+                <th class="px-6 py-4">
+                  <div class="font-semibold text-slate-900 dark:text-white"><%= sample[header] %></div>
+                </th>
+
+              <% else %>
+                <% if sample[header].is_a?(Hash) %>
+                  <td class="px-6 py-4">
+                    <% unless sample[header].blank? %>
+                      <div class="font-semibold text-slate-900 dark:text-white"><%= sample[header][:puid] %></div>
+                      <div class="font-normal text-slate-500 dark:text-slate-400"><%= sample[header][:name] %></div>
+                    <% end %>
+                  </td>
+                <% else %>
+                  <td class="px-6 py-4">
+                    <%= sample[header] %>
+                  </td>
+                <% end %>
+              <% end %>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/projects/workflow_executions/show.html.erb
+++ b/app/views/projects/workflow_executions/show.html.erb
@@ -99,6 +99,9 @@
   <%= tabs.with_tab(url: namespace_project_workflow_execution_path(@namespace.parent, @namespace.project, @workflow_execution, tab: "params"), selected: @tab == "params", controls: "workflow-execution-tabs") do %>
     <%= t(:"workflow_executions.show.tabs.params") %>
   <% end %>
+  <%= tabs.with_tab(url: namespace_project_workflow_execution_path(@namespace.parent, @namespace.project, @workflow_execution, tab: "samplesheet"), selected: @tab == "samplesheet", controls: "workflow-execution-tabs") do %>
+    <%= t(:"workflow_executions.show.tabs.samplesheet") %>
+  <% end %>
   <%= tabs.with_tab(url: namespace_project_workflow_execution_path(@namespace.parent, @namespace.project, @workflow_execution, tab: "files"), selected: @tab == "files", controls: "workflow-execution-tabs") do %>
     <%= t(:"workflow_executions.show.tabs.files") %>
   <% end %>
@@ -108,6 +111,8 @@
       <%= render partial: "summary" %>
     <% elsif @tab == "params" %>
       <%= render partial: "params" %>
+    <% elsif @tab == 'samplesheet' %>
+      <%= render partial: "samplesheet" %>
     <% elsif @tab == 'files' %>
       <%= render partial: "files" %>
     <% end %>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Prior to this PR, any automated pipeline would only launch with `sample`, `fastq_1`, and `fastq_2` as entries in the samplesheet. With this PR, if a workflow has the column named `sample_name` in the samplesheet we will add that as a field.

Additionally this PR adds the `samplesheet` tab to Project Workflow Executions table, which makes it easier to verify that the field is present.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Add a pipeline to your `config/pipelines/development.json` that has `sample_name` in the samplesheet schema (E.g. mikrokondo)
```json
{
    "url": "https://github.com/phac-nml/mikrokondo",
    "name": "phac-nml/mikrokondo",
    "description": "mikrokondo",
    "versions": [
      {
        "name": "0.5.1",
        "automatable": true
      }
    ]
  }
```
2. Restart your server, so that the pipeline can be downloaded
3. Create a Project
4. Setup 2 automated pipelines, one for mikrokondo and one for iridanextexample
5. Create a Sample
6. Upload pair end data to the sample
7. See that 2 Workflow Executions have been created
8. Verify presence of `sample_name` in mikrokondo samplesheet, and verify absence in iridanextexample

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
