### PR TITLE
Samples table speedup

### DIFF
--- a/app/components/samples/editable_cell.html.erb
+++ b/app/components/samples/editable_cell.html.erb
@@ -1,27 +1,22 @@
 <td id="<%= dom_id(@sample, @field) %>" role="gridcell">
-  <%= form_with(
-              url: editable_namespace_project_sample_metadata_field_path(
+  <button
+    class="
+      w-full p-3 text-left cursor-pointer hover:bg-slate-50 focus:outline-hidden
+        dark:hover:bg-slate-600
+    "
+    data-action="click->projects--samples--metadata--editable-cell#submit"
+    data-field="<%= @field %>"
+    data-url="<%= editable_namespace_project_sample_metadata_field_path(
                 @sample.project.namespace.parent,
                 @sample.project,
                 @sample
-              ),
-              method: :get,
-              class: "w-full"
-            ) do |form| %>
-
-    <%= form.hidden_field :field, value: @field %>
-    <%= form.hidden_field :format, value: "turbo_stream" %>
-
-    <button
-      type="submit"
-      class="
-        w-full p-3 text-left cursor-pointer hover:bg-slate-50 focus:outline-hidden
-        dark:hover:bg-slate-600 truncate
-      "
-      aria-label="<%= t(:".aria_label", value: @sample.metadata[@field]) %> value"
-      <%= "autofocus" if @autofocus %>
+              ) %>"
+    aria-label="<%= t(:".aria_label", value: @sample.metadata[@field]) %> value"
+    <%= "autofocus" if @autofocus %>
     >
-      <%= @sample.metadata.fetch(@field, "") %>
+      <span class="block truncate">
+        <%= @sample.metadata.fetch(@field, "") %>
+      </span>
     </button>
   <% end %>
 </td>

--- a/app/components/samples/editable_cell.html.erb
+++ b/app/components/samples/editable_cell.html.erb
@@ -2,7 +2,7 @@
   <button
     class="
       w-full p-3 text-left cursor-pointer hover:bg-slate-50 focus:outline-hidden
-        dark:hover:bg-slate-600
+      dark:hover:bg-slate-600
     "
     data-action="click->projects--samples--metadata--editable-cell#submit"
     data-field="<%= @field %>"
@@ -13,10 +13,9 @@
               ) %>"
     aria-label="<%= t(:".aria_label", value: @sample.metadata[@field]) %> value"
     <%= "autofocus" if @autofocus %>
-    >
-      <span class="block truncate">
-        <%= @sample.metadata.fetch(@field, "") %>
-      </span>
-    </button>
-  <% end %>
+  >
+    <span class="block truncate pointer-events-none">
+      <%= @sample.metadata.fetch(@field, "") %>
+    </span>
+  </button>
 </td>

--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -129,7 +129,7 @@
                 <% end %>
               <% end %>
               <% @metadata_fields.each do |field| %>
-                <% if helpers.allowed_to?(:update_sample?, sample.project) %>
+                <% if @abilities[:edit_sample_metadata] %>
                   <%= render Samples::EditableCell.new(field: field, sample: sample) %>
                 <% else %>
                   <%= render_cell(

--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -212,17 +212,19 @@
       </table>
     <% end %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: t(".limit.item")) %>
-    <template data-projects--samples--metadata--editable-cell-target="formTemplate">
-      <%= form_with(
+    <% if @abilities[:edit_sample_metadata] %>
+      <template data-projects--samples--metadata--editable-cell-target="formTemplate">
+        <%= form_with(
               url: "URL_PLACEHOLDER",
               method: :get,
               class: "w-full"
             ) do |form| %>
 
-        <%= form.hidden_field :field, value: "FIELD_PLACEHOLDER" %>
-        <%= form.hidden_field :format, value: "turbo_stream" %>
-      <% end %>
-    </template>
+          <%= form.hidden_field :field, value: "FIELD_PLACEHOLDER" %>
+          <%= form.hidden_field :format, value: "turbo_stream" %>
+        <% end %>
+      </template>
+    <% end %>
   <% end %>
 
 <% else %>

--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -212,7 +212,19 @@
       </table>
     <% end %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: t(".limit.item")) %>
+    <template data-projects--samples--metadata--editable-cell-target="formTemplate">
+      <%= form_with(
+              url: "URL_PLACEHOLDER",
+              method: :get,
+              class: "w-full"
+            ) do |form| %>
+
+        <%= form.hidden_field :field, value: "FIELD_PLACEHOLDER" %>
+        <%= form.hidden_field :format, value: "turbo_stream" %>
+      <% end %>
+    </template>
   <% end %>
+
 <% else %>
   <div class="empty_state_message">
     <%= viral_empty(

--- a/app/components/samples/table_component.rb
+++ b/app/components/samples/table_component.rb
@@ -56,7 +56,8 @@ module Samples
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('table-container flex flex-col shrink min-h-0')
+        classes: class_names('table-container flex flex-col shrink min-h-0'),
+        'data-controller' => 'projects--samples--metadata--editable-cell'
       }
     end
 

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -13,6 +13,7 @@ module Groups
     def index
       @timestamp = DateTime.current
       @pagy, @samples = @query.results(limit: params[:limit] || 20, page: params[:page] || 1)
+      @samples = @samples.includes(project: { namespace: :parent })
       @has_samples = @group.has_samples?
     end
 

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -15,6 +15,7 @@ module Projects
     def index
       @timestamp = DateTime.current
       @pagy, @samples = @query.results(limit: params[:limit] || 20, page: params[:page] || 1)
+      @samples = @samples.includes(project: { namespace: :parent })
       @has_samples = @project.samples.size.positive?
     end
 

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -5,7 +5,12 @@ import { Controller } from "@hotwired/stimulus";
  * @extends Controller
  */
 export default class extends Controller {
-  static targets = ["input", "newValue", "descriptionWith", "descriptionWithout"];
+  static targets = [
+    "input",
+    "newValue",
+    "descriptionWith",
+    "descriptionWithout",
+  ];
   static values = {
     original: String,
   };
@@ -53,8 +58,6 @@ export default class extends Controller {
   }
 
   async showConfirmDialog(dialog) {
-    console.log(this.descriptionWithTarget, this.descriptionWithoutTarget);
-
     dialog.showModal();
     if (this.inputTarget.value.trim() === "") {
       this.descriptionWithoutTarget.classList.remove("hidden");

--- a/app/javascript/controllers/projects/samples/metadata/editable_cell_controller.js
+++ b/app/javascript/controllers/projects/samples/metadata/editable_cell_controller.js
@@ -4,10 +4,11 @@ export default class extends Controller {
   static targets = ["formTemplate"];
 
   submit(event) {
+    let tableCell = event.target.parentNode;
     let form = this.formTemplateTarget.innerHTML
       .replace(/URL_PLACEHOLDER/g, event.target.dataset.url)
       .replace(/FIELD_PLACEHOLDER/g, event.target.dataset.field);
-    event.target.parentNode.insertAdjacentHTML("beforeend", form);
-    this.element.getElementsByTagName("form")[0].requestSubmit();
+    tableCell.insertAdjacentHTML("beforeend", form);
+    tableCell.getElementsByTagName("form")[0].requestSubmit();
   }
 }

--- a/app/javascript/controllers/projects/samples/metadata/editable_cell_controller.js
+++ b/app/javascript/controllers/projects/samples/metadata/editable_cell_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["formTemplate"];
+
+  submit(event) {
+    let form = this.formTemplateTarget.innerHTML
+      .replace(/URL_PLACEHOLDER/g, event.target.dataset.url)
+      .replace(/FIELD_PLACEHOLDER/g, event.target.dataset.field);
+    event.target.parentNode.insertAdjacentHTML("beforeend", form);
+    this.element.getElementsByTagName("form")[0].requestSubmit();
+  }
+}

--- a/app/views/groups/samples/_table.html.erb
+++ b/app/views/groups/samples/_table.html.erb
@@ -8,6 +8,7 @@
     select_samples:
       allowed_to?(:submit_workflow?, group) ||
         allowed_to?(:export_data?, group),
+    edit_sample_metadata: allowed_to?(:update_sample_metadata?, group),
   },
   metadata_fields: @fields,
   search_params: @search_params,

--- a/app/views/projects/samples/_table.html.erb
+++ b/app/views/projects/samples/_table.html.erb
@@ -10,6 +10,7 @@
         allowed_to?(:clone_sample?, project) ||
         allowed_to?(:transfer_sample?, project) ||
         allowed_to?(:export_data?, project),
+    edit_sample_metadata: allowed_to?(:update_sample?, project),
   },
   metadata_fields: @fields,
   search_params: @search_params,

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -1142,9 +1142,7 @@ module Groups
 
       ### ACTIONS START ###
       within('table tbody tr:first-child td:nth-child(7)') do
-        within('form[method="get"]') do
-          find('button').click
-        end
+        find('button[data-field="metadatafield1"]').click
         assert_selector "form[data-controller='inline-edit']"
 
         within('form[data-controller="inline-edit"]') do
@@ -1155,7 +1153,7 @@ module Groups
 
         ### VERIFY START ###
         assert_no_selector "form[data-controller='inline-edit']"
-        assert_selector 'form[method="get"]'
+        assert_selector 'button[data-field="metadatafield1"]'
         assert_selector 'button', text: 'value2'
         ### VERIFY END ###
       end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -3161,9 +3161,7 @@ module Projects
 
       within('table tbody tr:first-child td:nth-child(7)') do
         ### ACTIONS START ###
-        within('form[method="get"]') do
-          find('button').click
-        end
+        find('button[data-field="metadatafield2"]').click
         assert_selector "form[data-controller='inline-edit']"
 
         within('form[data-controller="inline-edit"]') do
@@ -3174,7 +3172,7 @@ module Projects
 
         ### VERIFY START ###
         assert_no_selector "form[data-controller='inline-edit']"
-        assert_selector 'form[method="get"]'
+        assert_selector 'button[data-field="metadatafield2"]'
         assert_selector 'button', text: 'value2'
       end
       assert_text I18n.t('samples.editable_cell.update_success')

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -3205,9 +3205,7 @@ module Projects
 
       within('table tbody tr:nth-child(1) td:nth-child(6)') do
         ### ACTIONS START ###
-        within('form[method="get"]') do
-          find('button').click
-        end
+        find('button[data-field="metadatafield1"]').click
         ### ACTIONS END ###
 
         ### VERIFY START ###
@@ -3281,9 +3279,7 @@ module Projects
 
       within('table tbody tr:first-child td:nth-child(7)') do
         ### ACTIONS START ###
-        within('form[method="get"]') do
-          find('button').click
-        end
+        find('button[data-field="metadatafield2"]').click
         assert_selector "form[data-controller='inline-edit']"
 
         within('form[data-controller="inline-edit"]') do
@@ -3342,9 +3338,7 @@ module Projects
 
       within('table tbody tr:first-child td:nth-child(7)') do
         ### ACTIONS START ###
-        within('form[method="get"]') do
-          find('button').click
-        end
+        find('button[data-field="metadatafield2"]').click
         assert_selector "form[data-controller='inline-edit']"
 
         within('form[data-controller="inline-edit"]') do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the samples table component to display editable metadata cell using an abilities check (set once) rather than checking permission for each cell, and updates samples controllers to include the namespace parent for each sample to cut down on queries

The metadata editable cells have also been refactored so fewer DOM elements are loaded into the table.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

**On main:**

1. Create a project, and 100 samples with ~20 pieces of metadata each
2. Visit the project samples page, and change to displaying 100 samples and showing all metadata fields
3. Inspect element, click the network tab, clear the log
4. Refresh the page and make a note of the response time for at the `samples?limit=100` 
5. Verify editing metadata within the table functions as expected

**On this branch:**

Follow steps 2 through 4 and verify that the response time has improved by ~1 second or so


## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
