### PR TITLE
Sortable Lists Accessibility Improvements

### DIFF
--- a/app/components/viral/sortable_list/list_component.html.erb
+++ b/app/components/viral/sortable_list/list_component.html.erb
@@ -1,5 +1,5 @@
 <div class="<%= @system_arguments[:container_classes] %>">
-  <%= title %>
+  <div id="<%= id %>label" role="label"><%= title %></div>
   <ul
     id="<%= id %>"
     data-controller="viral--sortable-lists--list"
@@ -8,6 +8,7 @@
     tabindex="0"
     aria-label="<%= title %>"
     role="listbox"
+    aria-labelledby="<%= id %>label"
     aria-roledescription="<%= t('.aria_role_description', list: title)%>"
   >
     <%= render Viral::SortableList::ListItemComponent.with_collection(list_items) %>

--- a/app/components/viral/sortable_list/list_component.html.erb
+++ b/app/components/viral/sortable_list/list_component.html.erb
@@ -1,5 +1,5 @@
 <div class="<%= @system_arguments[:container_classes] %>">
-  <p id="<%= id %>label"><%= title %></p>
+  <p id="<%= id %>-list-label"><%= title %></p>
   <ul
     id="<%= id %>"
     data-controller="viral--sortable-lists--list"
@@ -8,7 +8,7 @@
     tabindex="0"
     aria-label="<%= title %>"
     role="listbox"
-    aria-labelledby="<%= id %>label"
+    aria-labelledby="<%= id %>-list-label"
     aria-roledescription="<%= t('.aria_role_description', list: title)%>"
   >
     <%= render Viral::SortableList::ListItemComponent.with_collection(list_items) %>

--- a/app/components/viral/sortable_list/list_component.html.erb
+++ b/app/components/viral/sortable_list/list_component.html.erb
@@ -6,6 +6,8 @@
     data-viral--sortable-lists--list-group-name-value="<%= group %>"
     class="<%= @system_arguments[:list_classes] %>"
     tabindex="0"
+    role="<%= t('.aria_role', list: title)%>"
+    aria-roledescription="<%= t('.aria_role_description', list: title)%>"
   >
     <%= render Viral::SortableList::ListItemComponent.with_collection(list_items) %>
   </ul>

--- a/app/components/viral/sortable_list/list_component.html.erb
+++ b/app/components/viral/sortable_list/list_component.html.erb
@@ -1,5 +1,5 @@
 <div class="<%= @system_arguments[:container_classes] %>">
-  <div id="<%= id %>label" role="label"><%= title %></div>
+  <p id="<%= id %>label"><%= title %></p>
   <ul
     id="<%= id %>"
     data-controller="viral--sortable-lists--list"

--- a/app/components/viral/sortable_list/list_component.html.erb
+++ b/app/components/viral/sortable_list/list_component.html.erb
@@ -6,6 +6,7 @@
     data-viral--sortable-lists--list-group-name-value="<%= group %>"
     class="<%= @system_arguments[:list_classes] %>"
     tabindex="0"
+    aria-label="<%= title %>"
     role="listbox"
     aria-roledescription="<%= t('.aria_role_description', list: title)%>"
   >

--- a/app/components/viral/sortable_list/list_component.html.erb
+++ b/app/components/viral/sortable_list/list_component.html.erb
@@ -6,7 +6,7 @@
     data-viral--sortable-lists--list-group-name-value="<%= group %>"
     class="<%= @system_arguments[:list_classes] %>"
     tabindex="0"
-    role="<%= t('.aria_role', list: title)%>"
+    role="listbox"
     aria-roledescription="<%= t('.aria_role_description', list: title)%>"
   >
     <%= render Viral::SortableList::ListItemComponent.with_collection(list_items) %>

--- a/app/components/viral/sortable_list/list_item_component.html.erb
+++ b/app/components/viral/sortable_list/list_item_component.html.erb
@@ -1,4 +1,10 @@
 <li
+  data-action="
+    keydown->viral--sortable-lists--two-lists-selection#navigateList
+  "
+  tabindex="0"
+  role="option"
+  aria-selected="false"
   id="<%= list_item %>"
   class="
     block w-full px-4 py-2 border-b cursor-move border-slate-200

--- a/app/components/viral/sortable_lists_component.html.erb
+++ b/app/components/viral/sortable_lists_component.html.erb
@@ -41,14 +41,18 @@
 </div>
 <div class="flex -mt-3 font-medium text-slate-900 dark:text-white">
   <button
-    class="mr-2 text-sm"
+    class="
+      mr-2 text-sm underline enabled:hover:no-underline enabled:cursor-pointer
+    "
     data-action="click->viral--sortable-lists--two-lists-selection#addAll"
     data-viral--sortable-lists--two-lists-selection-target="addAll"
   >
     <%= t(".add_all") %>
   </button>
   <button
-    class="ml-2 text-sm"
+    class="
+      ml-2 text-sm underline enabled:hover:no-underline enabled:cursor-pointer
+    "
     data-action="click->viral--sortable-lists--two-lists-selection#removeAll"
     data-viral--sortable-lists--two-lists-selection-target="removeAll"
   >

--- a/app/components/viral/sortable_lists_component.html.erb
+++ b/app/components/viral/sortable_lists_component.html.erb
@@ -43,6 +43,8 @@
   <button
     class="
       mr-2 text-sm underline enabled:hover:no-underline enabled:cursor-pointer
+      disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-slate-300
+      disabled:dark:text-slate-700
     "
     data-action="click->viral--sortable-lists--two-lists-selection#addAll"
     data-viral--sortable-lists--two-lists-selection-target="addAll"
@@ -52,6 +54,8 @@
   <button
     class="
       ml-2 text-sm underline enabled:hover:no-underline enabled:cursor-pointer
+      disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-slate-300
+      disabled:dark:text-slate-700
     "
     data-action="click->viral--sortable-lists--two-lists-selection#removeAll"
     data-viral--sortable-lists--two-lists-selection-target="removeAll"

--- a/app/components/viral/sortable_lists_component.html.erb
+++ b/app/components/viral/sortable_lists_component.html.erb
@@ -43,8 +43,8 @@
   <button
     class="
       mr-2 text-sm underline enabled:hover:no-underline enabled:cursor-pointer
-      disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-slate-300
-      disabled:dark:text-slate-700
+      disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-slate-500
+      disabled:dark:text-slate-400
     "
     data-action="click->viral--sortable-lists--two-lists-selection#addAll"
     data-viral--sortable-lists--two-lists-selection-target="addAll"
@@ -54,8 +54,8 @@
   <button
     class="
       ml-2 text-sm underline enabled:hover:no-underline enabled:cursor-pointer
-      disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-slate-300
-      disabled:dark:text-slate-700
+      disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-slate-500
+      disabled:dark:text-slate-400
     "
     data-action="click->viral--sortable-lists--two-lists-selection#removeAll"
     data-viral--sortable-lists--two-lists-selection-target="removeAll"

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -23,7 +23,7 @@ export default class extends Controller {
     "text-slate-300",
     "dark:text-slate-700",
   ];
-  #enabledClasses = ["underline", "hover:no-underline"];
+  #enabledClasses = ["underline", "hover:no-underline", "cursor-pointer"];
   #originalAvailableList;
 
   #selectedOption;
@@ -48,6 +48,11 @@ export default class extends Controller {
 
       this.#setInitialSelectAllState(this.availableList, this.addAllTarget);
       this.#setInitialSelectAllState(this.selectedList, this.removeAllTarget);
+
+      // require specific submit button logic for edit metadata template
+      if (this.selectedList.querySelectorAll("li").length > 0) {
+        this.#setSubmitButtonDisableState(false);
+      }
 
       this.buttonStateListener = this.#checkStates.bind(this);
       this.selectedList.addEventListener("drop", this.buttonStateListener);

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -49,9 +49,12 @@ export default class extends Controller {
       this.#setInitialSelectAllState(this.availableList, this.addAllTarget);
       this.#setInitialSelectAllState(this.selectedList, this.removeAllTarget);
 
-      // require specific submit button logic for edit metadata template
+      // require specific submit button logic for lists that can vary
+      // between states upon loading (such as edit metadata template)
       if (this.selectedList.querySelectorAll("li").length > 0) {
         this.#setSubmitButtonDisableState(false);
+      } else {
+        this.#setSubmitButtonDisableState(true);
       }
 
       this.buttonStateListener = this.#checkStates.bind(this);
@@ -267,7 +270,6 @@ export default class extends Controller {
         // set option when no option was selected
         this.#setSelectedOption(event.target);
       }
-      this.#checkStates();
     } else if (event.key === "ArrowRight") {
       // navigate to right side list
       event.preventDefault();
@@ -296,7 +298,13 @@ export default class extends Controller {
           ? event.target.previousElementSibling
           : event.target.nextElementSibling;
       this.#navigateListUpAndDown(event.key, nextOption);
+    } else if (event.key === "Tab" && this.#selectedOption) {
+      // de-select option and allow tab to function as expected
+      event.preventDefault();
+      this.#removeSelectedAttributes();
     }
+    console.log("hi?");
+    this.#checkStates();
   }
 
   #navigateListUpAndDown(eventKey, nextOption) {

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -26,6 +26,9 @@ export default class extends Controller {
   #enabledClasses = ["underline", "hover:no-underline"];
   #originalAvailableList;
 
+  #optionSelected = null;
+  #optionSelectedClasses = ["bg-primary-600", "dark:bg-primary-500"];
+
   connect() {
     this.idempotentConnect();
   }
@@ -50,6 +53,24 @@ export default class extends Controller {
       this.selectedList.addEventListener("drop", this.buttonStateListener);
       this.availableList.addEventListener("drop", this.buttonStateListener);
     }
+
+    window.addEventListener("click", () => {
+      if (this.#optionSelected) {
+        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
+        this.#optionSelected.setAttribute("aria-selected", "false");
+        this.#optionSelected = null;
+      }
+    });
+  }
+
+  disconnect() {
+    window.removeEventListener("click", () => {
+      if (this.#optionSelected) {
+        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
+        this.#optionSelected.setAttribute("aria-selected", "false");
+        this.#optionSelected = null;
+      }
+    });
   }
 
   addAll(event) {
@@ -237,6 +258,75 @@ export default class extends Controller {
       this.#checkButtonStates();
     } catch (error) {
       console.error("Error setting template:", error);
+    }
+  }
+
+  navigateList(event) {
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
+      if (this.#optionSelected === event.target) {
+        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
+        this.#optionSelected.setAttribute("aria-selected", "false");
+        this.#optionSelected = null;
+      } else if (this.#optionSelected) {
+        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
+        this.#optionSelected.setAttribute("aria-selected", "false");
+        this.#optionSelected = event.target;
+        this.#optionSelected.classList.add(...this.#optionSelectedClasses);
+        this.#optionSelected.setAttribute("aria-selected", "true");
+      } else {
+        this.#optionSelected = event.target;
+        this.#optionSelected.classList.add(...this.#optionSelectedClasses);
+        this.#optionSelected.setAttribute("aria-selected", "true");
+      }
+      this.#checkStates();
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      let selectedListFirstChild = this.selectedList.firstElementChild;
+      if (event.target.parentNode === this.availableList) {
+        if (this.#optionSelected) {
+          this.#optionSelected.remove();
+          this.selectedList.prepend(this.#optionSelected);
+          this.#optionSelected.focus();
+        } else if (selectedListFirstChild) {
+          selectedListFirstChild.focus();
+        }
+      }
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      let availableListFirstChild = this.availableList.firstElementChild;
+      if (event.target.parentNode === this.selectedList) {
+        if (this.#optionSelected) {
+          this.#optionSelected.remove();
+          this.availableList.prepend(this.#optionSelected);
+          this.#optionSelected.focus();
+        } else if (availableListFirstChild) {
+          availableListFirstChild.focus();
+        }
+      }
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      let previousOption = event.target.previousElementSibling;
+      if (previousOption && this.#optionSelected) {
+        this.#optionSelected.remove();
+        previousOption.insertAdjacentElement(
+          "beforebegin",
+          this.#optionSelected,
+        );
+        this.#optionSelected.focus();
+      } else if (previousOption) {
+        previousOption.focus();
+      }
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      let nextOption = event.target.nextElementSibling;
+      if (nextOption && this.#optionSelected) {
+        this.#optionSelected.remove();
+        nextOption.insertAdjacentElement("afterend", this.#optionSelected);
+        this.#optionSelected.focus();
+      } else if (nextOption) {
+        nextOption.focus();
+      }
     }
   }
 }

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -26,8 +26,8 @@ export default class extends Controller {
   #enabledClasses = ["underline", "hover:no-underline"];
   #originalAvailableList;
 
-  #optionSelected = null;
-  #optionSelectedClasses = ["bg-primary-600", "dark:bg-primary-500"];
+  #selectedOption = null;
+  #selectedOptionClasses = ["bg-primary-600", "dark:bg-primary-500"];
 
   connect() {
     this.idempotentConnect();
@@ -55,20 +55,20 @@ export default class extends Controller {
     }
 
     window.addEventListener("click", () => {
-      if (this.#optionSelected) {
-        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
-        this.#optionSelected.setAttribute("aria-selected", "false");
-        this.#optionSelected = null;
+      if (this.#selectedOption) {
+        this.#selectedOption.classList.remove(...this.#selectedOptionClasses);
+        this.#selectedOption.setAttribute("aria-selected", "false");
+        this.#selectedOption = null;
       }
     });
   }
 
   disconnect() {
     window.removeEventListener("click", () => {
-      if (this.#optionSelected) {
-        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
-        this.#optionSelected.setAttribute("aria-selected", "false");
-        this.#optionSelected = null;
+      if (this.#selectedOption) {
+        this.#selectedOption.classList.remove(...this.#selectedOptionClasses);
+        this.#selectedOption.setAttribute("aria-selected", "false");
+        this.#selectedOption = null;
       }
     });
   }
@@ -264,69 +264,71 @@ export default class extends Controller {
   navigateList(event) {
     if (event.key === " " || event.key === "Enter") {
       event.preventDefault();
-      if (this.#optionSelected === event.target) {
-        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
-        this.#optionSelected.setAttribute("aria-selected", "false");
-        this.#optionSelected = null;
-      } else if (this.#optionSelected) {
-        this.#optionSelected.classList.remove(...this.#optionSelectedClasses);
-        this.#optionSelected.setAttribute("aria-selected", "false");
-        this.#optionSelected = event.target;
-        this.#optionSelected.classList.add(...this.#optionSelectedClasses);
-        this.#optionSelected.setAttribute("aria-selected", "true");
+      if (this.#selectedOption === event.target) {
+        this.#selectedOption.classList.remove(...this.#selectedOptionClasses);
+        this.#selectedOption.setAttribute("aria-selected", "false");
+        this.#selectedOption = null;
+      } else if (this.#selectedOption) {
+        this.#selectedOption.classList.remove(...this.#selectedOptionClasses);
+        this.#selectedOption.setAttribute("aria-selected", "false");
+        this.#selectedOption = event.target;
+        this.#selectedOption.classList.add(...this.#selectedOptionClasses);
+        this.#selectedOption.setAttribute("aria-selected", "true");
       } else {
-        this.#optionSelected = event.target;
-        this.#optionSelected.classList.add(...this.#optionSelectedClasses);
-        this.#optionSelected.setAttribute("aria-selected", "true");
+        this.#selectedOption = event.target;
+        this.#selectedOption.classList.add(...this.#selectedOptionClasses);
+        this.#selectedOption.setAttribute("aria-selected", "true");
       }
       this.#checkStates();
     } else if (event.key === "ArrowRight") {
       event.preventDefault();
       let selectedListFirstChild = this.selectedList.firstElementChild;
       if (event.target.parentNode === this.availableList) {
-        if (this.#optionSelected) {
-          this.#optionSelected.remove();
-          this.selectedList.prepend(this.#optionSelected);
-          this.#optionSelected.focus();
-        } else if (selectedListFirstChild) {
-          selectedListFirstChild.focus();
-        }
+        this.#navigateListLeftAndRight(
+          this.selectedList,
+          selectedListFirstChild,
+        );
       }
     } else if (event.key === "ArrowLeft") {
       event.preventDefault();
       let availableListFirstChild = this.availableList.firstElementChild;
       if (event.target.parentNode === this.selectedList) {
-        if (this.#optionSelected) {
-          this.#optionSelected.remove();
-          this.availableList.prepend(this.#optionSelected);
-          this.#optionSelected.focus();
-        } else if (availableListFirstChild) {
-          availableListFirstChild.focus();
-        }
-      }
-    } else if (event.key === "ArrowUp") {
-      event.preventDefault();
-      let previousOption = event.target.previousElementSibling;
-      if (previousOption && this.#optionSelected) {
-        this.#optionSelected.remove();
-        previousOption.insertAdjacentElement(
-          "beforebegin",
-          this.#optionSelected,
+        this.#navigateListLeftAndRight(
+          this.availableList,
+          availableListFirstChild,
         );
-        this.#optionSelected.focus();
-      } else if (previousOption) {
-        previousOption.focus();
       }
-    } else if (event.key === "ArrowDown") {
+    } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
       event.preventDefault();
-      let nextOption = event.target.nextElementSibling;
-      if (nextOption && this.#optionSelected) {
-        this.#optionSelected.remove();
-        nextOption.insertAdjacentElement("afterend", this.#optionSelected);
-        this.#optionSelected.focus();
-      } else if (nextOption) {
-        nextOption.focus();
+      let nextOption =
+        event.key === "ArrowUp"
+          ? event.target.previousElementSibling
+          : event.target.nextElementSibling;
+      this.#navigateListUpAndDown(event.key, nextOption);
+    }
+  }
+
+  #navigateListUpAndDown(eventKey, nextOption) {
+    if (nextOption && this.#selectedOption) {
+      this.#selectedOption.remove();
+      if (eventKey === "ArrowUp") {
+        nextOption.insertAdjacentElement("beforebegin", this.#selectedOption);
+      } else {
+        nextOption.insertAdjacentElement("afterend", this.#selectedOption);
       }
+      this.#selectedOption.focus();
+    } else if (nextOption) {
+      nextOption.focus();
+    }
+  }
+
+  #navigateListLeftAndRight(targetList, targetListFirstChild) {
+    if (this.#selectedOption) {
+      this.#selectedOption.remove();
+      targetList.prepend(this.#selectedOption);
+      this.#selectedOption.focus();
+    } else if (targetListFirstChild) {
+      targetListFirstChild.focus();
     }
   }
 }

--- a/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
+++ b/app/javascript/controllers/viral/sortable_lists/two_lists_selection_controller.js
@@ -17,12 +17,6 @@ export default class extends Controller {
     fieldName: String,
   };
 
-  #disabledClasses = [
-    "pointer-events-none",
-    "cursor-not-allowed",
-    "text-slate-300",
-    "dark:text-slate-700",
-  ];
   #originalAvailableList;
 
   #selectedOption;
@@ -136,14 +130,11 @@ export default class extends Controller {
   }
 
   #setAddOrRemoveButtonDisableState(button, disableState) {
-    if (disableState && !button.classList.contains("pointer-events-none")) {
-      button.classList.add(...this.#disabledClasses);
+    if (disableState && !button.disabled) {
+      button.disabled = true;
       button.setAttribute("aria-disabled", "true");
-    } else if (
-      !disableState &&
-      button.classList.contains("pointer-events-none")
-    ) {
-      button.classList.remove(...this.#disabledClasses);
+    } else if (!disableState && button.disabled) {
+      button.disabled = false;
       button.removeAttribute("aria-disabled");
     }
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,7 +369,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -454,7 +454,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -493,7 +493,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -605,14 +605,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -680,7 +680,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -713,7 +713,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -787,18 +787,18 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1003,10 +1003,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1014,11 +1014,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1029,15 +1029,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1054,7 +1054,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -1133,7 +1133,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: "The following samples are missing required data: "
+    data_missing_error: 'The following samples are missing required data: '
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1164,8 +1164,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1229,7 +1229,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1257,7 +1257,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1335,20 +1335,20 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1466,11 +1466,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1478,20 +1478,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1564,7 +1564,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1604,7 +1604,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1656,8 +1656,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
     spreadsheet_import:
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
       invalid_file_extension: The file can only be a csv, tsv or excel.
@@ -1906,7 +1906,7 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -1926,11 +1926,11 @@ en:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: "Failed to parse spreadsheet file: %{error}"
+    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
-    unknown_file_format: "Unknown file type: %{extension}"
+    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
+    unknown_file_format: 'Unknown file type: %{extension}'
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1981,7 +1981,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: "The following errors prevented the Workflow Execution from being created:"
+      error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,7 +369,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -454,7 +454,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -493,7 +493,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -605,14 +605,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -680,7 +680,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -713,7 +713,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -787,18 +787,18 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1003,10 +1003,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1014,11 +1014,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1029,15 +1029,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1054,7 +1054,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -1133,7 +1133,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: 'The following samples are missing required data: '
+    data_missing_error: "The following samples are missing required data: "
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1164,8 +1164,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1229,7 +1229,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1257,7 +1257,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1335,20 +1335,20 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1466,11 +1466,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1478,20 +1478,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1564,7 +1564,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1604,7 +1604,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1656,8 +1656,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
     spreadsheet_import:
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
       invalid_file_extension: The file can only be a csv, tsv or excel.
@@ -1906,7 +1906,7 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -1926,11 +1926,11 @@ en:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
+    failed_parsing: "Failed to parse spreadsheet file: %{error}"
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
-    unknown_file_format: 'Unknown file type: %{extension}'
+    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
+    unknown_file_format: "Unknown file type: %{extension}"
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1968,6 +1968,10 @@ en:
         aria-label: Pagination
         next: Next
         previous: Previous
+    sortable_list:
+      list_component:
+        aria_role: "%{list} listbox"
+        aria_role_description: "%{list} listbox drag and drop"
     sortable_lists_component:
       add_all: Add all
       no_template: No template
@@ -1977,7 +1981,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: 'The following errors prevented the Workflow Execution from being created:'
+      error_message: "The following errors prevented the Workflow Execution from being created:"
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,7 +369,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -454,7 +454,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -493,7 +493,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -605,14 +605,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -680,7 +680,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -713,7 +713,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -787,18 +787,18 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1003,10 +1003,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1014,11 +1014,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1029,15 +1029,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1054,7 +1054,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -1133,7 +1133,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: "The following samples are missing required data: "
+    data_missing_error: 'The following samples are missing required data: '
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1164,8 +1164,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1229,7 +1229,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1257,7 +1257,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1335,20 +1335,20 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1466,11 +1466,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1478,20 +1478,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1564,7 +1564,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1604,7 +1604,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1656,8 +1656,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
     spreadsheet_import:
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
       invalid_file_extension: The file can only be a csv, tsv or excel.
@@ -1906,7 +1906,7 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -1926,11 +1926,11 @@ en:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: "Failed to parse spreadsheet file: %{error}"
+    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
-    unknown_file_format: "Unknown file type: %{extension}"
+    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
+    unknown_file_format: 'Unknown file type: %{extension}'
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1980,7 +1980,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: "The following errors prevented the Workflow Execution from being created:"
+      error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,7 +369,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -454,7 +454,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     list_filter:
       apply: Apply filter
@@ -493,7 +493,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -605,14 +605,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -680,7 +680,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -713,7 +713,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -787,18 +787,18 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1003,10 +1003,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1014,11 +1014,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1029,15 +1029,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1054,7 +1054,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -1133,7 +1133,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: 'The following samples are missing required data: '
+    data_missing_error: "The following samples are missing required data: "
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1164,8 +1164,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1229,7 +1229,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1257,7 +1257,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1335,20 +1335,20 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1466,11 +1466,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1478,20 +1478,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1564,7 +1564,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1604,7 +1604,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1656,8 +1656,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
     spreadsheet_import:
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
       invalid_file_extension: The file can only be a csv, tsv or excel.
@@ -1906,7 +1906,7 @@ en:
             submit_button: Import Metadata
             title: Upload Sample Metadata
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -1926,11 +1926,11 @@ en:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
+    failed_parsing: "Failed to parse spreadsheet file: %{error}"
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
-    unknown_file_format: 'Unknown file type: %{extension}'
+    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
+    unknown_file_format: "Unknown file type: %{extension}"
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1970,7 +1970,6 @@ en:
         previous: Previous
     sortable_list:
       list_component:
-        aria_role: "%{list} listbox"
         aria_role_description: "%{list} listbox drag and drop"
     sortable_lists_component:
       add_all: Add all
@@ -1981,7 +1980,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: 'The following errors prevented the Workflow Execution from being created:'
+      error_message: "The following errors prevented the Workflow Execution from being created:"
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -369,7 +369,7 @@ fr:
         title: Supprimer un fichier
       new_attachment_component:
         files: Fichiers
-        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
+        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
         upload: Télécharger
         upload_files: Télécharger des fichiers
         uploading: Téléchargement
@@ -454,7 +454,7 @@ fr:
       transferred_by: "%{type} transféré par %{user}"
     history_version:
       current_version: Actuel (Version %{version})
-      keys_deleted: "Clés supprimées :"
+      keys_deleted: 'Clés supprimées :'
       previous_version: Précédent (Version %{version})
     list_filter:
       apply: Appliquer un filtre
@@ -493,7 +493,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+        error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
     bot_actions:
       create:
         success: Le compte de bot a été ajouté avec succès
@@ -605,14 +605,14 @@ fr:
         status: Statut
       title: Exportations de données
     list_workflow_execution:
-      id: "ID:"
-      name: "Nom:"
-      run_id: "Exécuter l’identifiant:"
-      workflow: "Flux de travail :"
+      id: 'ID:'
+      name: 'Nom:'
+      run_id: 'Exécuter l’identifiant:'
+      workflow: 'Flux de travail :'
     new:
       after_submission_description_html: Après la soumission, vous serez redirigé vers la page d’exportation. Pendant que le statut de l’exportation est <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">en cours de traitement</span>, le contenu de l’exportation est créé. Une fois que le statut de l’exportation sera <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">prêt</span>, il sera disponible pour téléchargement. Vous aurez 3 jours ouvrables pour télécharger l’exportation avant qu’elle ne soit supprimée.
       email_label: Vous recevez une notification par courriel lorsque votre exportation est prête à être téléchargée?
-      name_label: "Nom d’exportation (facultatif) :"
+      name_label: 'Nom d’exportation (facultatif) :'
       sample_description:
         plural: Cette exportation contiendra les échantillons COUNT_PLACEHOLDER.
         singular: Cette exportation contiendra 1 échantillon.
@@ -680,8 +680,8 @@ fr:
   errors:
     messages:
       not_saved:
-        one: "1 erreur a empêché cette %{resource} d’être sauvegardée :"
-        other: "Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :"
+        one: '1 erreur a empêché cette %{resource} d’être sauvegardée :'
+        other: 'Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :'
   general:
     default_sidebar:
       data_exports: Exportations de données
@@ -713,7 +713,7 @@ fr:
       title: Activité en groupe
     attachments:
       create:
-        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -787,18 +787,18 @@ fr:
         transfer:
           confirm:
             points_html:
-              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-              - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+            - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{group_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-            - Transférer le groupe à un autre groupe parent
+          - Transférer le groupe à un autre groupe parent
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Choisissez un groupe parent
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce groupe
           points:
-            - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
-            - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
-            - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
+          - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
+          - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
+          - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
           select_group: Sélectionner un groupe
           submit: Groupe de transfert
           title: Groupe de transfert
@@ -1003,10 +1003,10 @@ fr:
       export_ready:
         download_before_html: Veuillez télécharger l’exportation avant <strong>%{date}</strong>, car elle sera supprimée après cette période.
         ready_for_download_html: Votre exportation <strong>%{name}</strong> est prête à être téléchargée.
-        view_exports: "Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :"
+        view_exports: 'Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :'
     email_template:
       automated_message: Ce courriel a été envoyé à partir d’un système automatisé. Veuillez ne pas répondre à ce courriel.
-      copy_paste: "Ou copiez-collez ce lien dans votre navigateur :"
+      copy_paste: 'Ou copiez-collez ce lien dans votre navigateur :'
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -1014,11 +1014,11 @@ fr:
       access_granted_manager_email:
         body_html: Le groupe '%{group_name}' a <strong>obtenu</strong> l’accès à %{namespace_type} '%{namespace_name}'
         subject: Le groupe '%{group_name}' a obtenu l’accès à %{namespace_type} '%{namespace_name}'
-        view_details: "Pour voir tous les membres de %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "Pour voir %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_manager_email:
         body_html: L’accès à %{namespace_type} '%{namespace_name}' a été <strong>révoqué</strong> pour le groupe '%{group_name}'
         subject: L’accès à %{namespace_type} '%{namespace_name}' a été révoqué pour le groupe '%{group_name}'
@@ -1029,15 +1029,15 @@ fr:
       access_granted_manager_email:
         body_html: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu <strong></strong> l’accès à %{type} '%{name}'
         subject: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu l’accès à %{type} '%{name}'
-        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_granted_user_email:
         body_html: Vous avez <strong>obtenu</strong> l’accès à %{type} '%{name}'
         subject: Vous avez obtenu l’accès à %{type} '%{name}'
-        view_details: "Pour voir %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_manager_email:
         body_html: L’accès à %{type} '%{name}' a été <strong>révoqué</strong> pour l’utilisateur '%{first_name} %{last_name}' (%{email})
         subject: L’accès à %{type} '%{name}' a été révoqué pour l’utilisateur '%{first_name} %{last_name}' (%{email})
-        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_user_email:
         body_html: Votre accès à %{type} '%{name}' a été <strong>révoqué</strong>
         subject: Votre accès à %{type} '%{name}' a été révoqué
@@ -1054,7 +1054,7 @@ fr:
       error_user_email:
         body_html: Votre pipeline <strong>%{id}</strong> n’a pas été complété avec succès en raison d’erreurs.
         subject: Pipeline erroné – %{id}
-      view_details: "Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :"
+      view_details: 'Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :'
   members:
     access_levels:
       level_0: Pas d’accès
@@ -1133,7 +1133,7 @@ fr:
         aria_label: Sélecteur de page de pagination
       previous: Précédent
   nextflow_component:
-    data_missing_error: "Les échantillons suivants manquent de données requises : "
+    data_missing_error: 'Les échantillons suivants manquent de données requises : '
     filtering_samples: Le filtrage des échantillons peut prendre un certain temps.
     name:
       helper: Un nom personnalisé facilitera la recherche à l’avenir.
@@ -1164,8 +1164,8 @@ fr:
         confirm: Êtes-vous sûr de vouloir supprimer votre compte?
         description: La suppression de votre compte a les effets suivants
         effects:
-          - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
-          - Tous les projets et groupes dont vous êtes membre seront laissés intacts
+        - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
+        - Tous les projets et groupes dont vous êtes membre seront laissés intacts
     passwords:
       update:
         forgot: Vous avez oublié votre mot de passe?
@@ -1229,7 +1229,7 @@ fr:
       title: Activité du projet
     attachments:
       create:
-        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -1257,7 +1257,7 @@ fr:
       edit:
         error: Impossible de modifier le pipeline automatisé %{workflow_name}
       edit_dialog:
-        title: "Modification du pipeline automatisé : %{workflow_name}"
+        title: 'Modification du pipeline automatisé : %{workflow_name}'
       index:
         add_new_automated_workflow_execution: Nouveau pipeline automatisé
         subtitle: Configurer des pipelines automatisés à lancer lorsque les données jumelées sont téléchargées dans le projet
@@ -1335,20 +1335,20 @@ fr:
         transfer:
           confirm:
             points_html:
-              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-              - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+            - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{project_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-            - Transférer votre projet dans un autre espace de noms.
-            - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
-            - Ce qu’il faut savoir avant de transférer votre projet:
+          - Transférer votre projet dans un autre espace de noms.
+          - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
+          - Ce qu’il faut savoir avant de transférer votre projet:
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Sélectionnez un nouvel espace de noms
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce projet
           points:
-            - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
-            - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
-            - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
+          - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
+          - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
+          - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
           select_namespace: Sélectionnez l’espace de noms
           submit: Projet de transfert
           title: Projet de transfert
@@ -1466,11 +1466,11 @@ fr:
             success: Les dossiers ont été concaténés avec succès.
           modal:
             basename: Nom du fichier
-            description: "Les fichiers suivants ont été sélectionnés pour être concaténés :"
+            description: 'Les fichiers suivants ont été sélectionnés pour être concaténés :'
             submit_button: Concaténer
             title: Concaténer les fichiers
         create:
-          failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+          failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
           success: Le fichier %{filename} a été téléchargé avec succès.
         delete_attachment_modal:
           description: Êtes-vous sûr de vouloir supprimer ce fichier de l’échantillon?
@@ -1478,20 +1478,20 @@ fr:
           title: Supprimer un fichier
         deletions:
           destroy:
-            error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+            error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
             partial_success: Certains fichiers ont été supprimés avec succès.
             success: Les fichiers ont été supprimés avec succès.
           modal:
-            description: "Les fichiers suivants ont été sélectionnés pour suppression :"
+            description: 'Les fichiers suivants ont été sélectionnés pour suppression :'
             submit_button: Supprimer
             title: Supprimer des fichiers
         destroy:
-          error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+          error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
           success: Le fichier %{filename} a été supprimé avec succès.
       clones:
         create:
-          error: "La liste suivante des échantillons n’a pas été copiée :"
-          no_samples_cloned_error: "Les échantillons n’ont pas été copiés pour les raisons suivantes :"
+          error: 'La liste suivante des échantillons n’a pas été copiée :'
+          no_samples_cloned_error: 'Les échantillons n’ont pas été copiés pour les raisons suivantes :'
           success: Les échantillons ont été copiés avec succès.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ fr:
           title: Supprimer l’échantillon
         new_multiple_deletions_dialog:
           description:
-            plural: "Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :"
-            singular: "L’échantillon suivant a été sélectionné aux fins de suppression :"
+            plural: 'Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :'
+            singular: 'L’échantillon suivant a été sélectionné aux fins de suppression :'
             zero: Aucun échantillon n’a été sélectionné pour être supprimer
           loading: Chargement...
           samples: Échantillons
@@ -1564,7 +1564,7 @@ fr:
             multi_success: Les clés de métadonnées '%{deleted_keys}' ont été supprimées avec succès.
             single_success: La clé de métadonnées '%{deleted_key}' a été supprimée avec succès.
           modal:
-            description: "Champs de métadonnées sélectionnés pour suppression :"
+            description: 'Champs de métadonnées sélectionnés pour suppression :'
             key_header: Clé
             submit_button: Supprimer
             title: Supprimer les métadonnées
@@ -1604,7 +1604,7 @@ fr:
         delete_metadata_button: Supprimer les métadonnéesDelete Metadata
         edit_button: Modifier cet échantillon
         files: FichiersFiles
-        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
+        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
         history:
           modal:
             created_by: Échantillon créé par %{user}
@@ -1656,8 +1656,8 @@ fr:
           placeholder: Filtrer par ID ou nom
       transfers:
         create:
-          error: "La liste suivante des échantillons n’a pas été transférée :"
-          no_samples_transferred_error: "Les échantillons n’ont pas été transférés pour les raisons suivantes :"
+          error: 'La liste suivante des échantillons n’a pas été transférée :'
+          no_samples_transferred_error: 'Les échantillons n’ont pas été transférés pour les raisons suivantes :'
           success: Les échantillons ont été transférés avec succès.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ fr:
         empty_new_project_id: Le projet de destination n’a pas été sélectionné.
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         same_project: Les projets sources et de destination sont les mêmes. Veuillez sélectionner un autre projet de destination.
-        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
-        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
+        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
+        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
       metadata:
         empty_metadata: Aucune métadonnée n’a été reçue pour mettre à jour l’échantillon '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ fr:
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         maintainer_transfer_not_allowed: Un responsable ne peut transférer des échantillons qu’à d’autres projets dans la même hiérarchie avec un ancêtre commun
         same_project: Les échantillons existent déjà dans le projet. Veuillez sélectionner un autre projet.
-        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
-        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
+        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
+        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
     spreadsheet_import:
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
       invalid_file_extension: Le fichier ne peut être qu’un fichier csv, tsv ou excel.
@@ -1894,7 +1894,7 @@ fr:
               description: Si cette option est sélectionnée, les champs de métadonnées sans valeur associée seront ignorés et ces clés de métadonnées ne seront pas supprimées de l’échantillon si elles sont présentes. Cependant, si cette option n’est pas sélectionnée, tous les échantillons avec la clé de métadonnées et la valeur vide seront supprimés.
             metadata_columns: Metadata Columns
             namespace:
-              description: "La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. "
+              description: 'La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. '
               group:
                 description_html: L’identificateur est sensible à la casse et doit contenir l’<b>identifiant de l’échantillon</b>.
               project:
@@ -1906,7 +1906,7 @@ fr:
             submit_button: Import Metadata
             title: Télécharger des échantillons de métadonnées
           errors:
-            description: "L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :"
+            description: 'L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :'
             ok_button: OK
           success:
             description: Les métadonnées ont été importées avec succès!
@@ -1926,11 +1926,11 @@ fr:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: "Failed to parse spreadsheet file: %{error}"
+    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
-    unknown_file_format: "Unknown file type: %{extension}"
+    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
+    unknown_file_format: 'Unknown file type: %{extension}'
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1980,7 +1980,7 @@ fr:
       download: Télécharger
       preview: Aperçu
     create:
-      error_message: "Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :"
+      error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
     edit_dialog:
       cancel_button: Annuler
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -369,7 +369,7 @@ fr:
         title: Supprimer un fichier
       new_attachment_component:
         files: Fichiers
-        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
+        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
         upload: Télécharger
         upload_files: Télécharger des fichiers
         uploading: Téléchargement
@@ -454,7 +454,7 @@ fr:
       transferred_by: "%{type} transféré par %{user}"
     history_version:
       current_version: Actuel (Version %{version})
-      keys_deleted: "Clés supprimées :"
+      keys_deleted: 'Clés supprimées :'
       previous_version: Précédent (Version %{version})
     list_filter:
       apply: Appliquer un filtre
@@ -493,7 +493,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+        error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
     bot_actions:
       create:
         success: Le compte de bot a été ajouté avec succès
@@ -605,14 +605,14 @@ fr:
         status: Statut
       title: Exportations de données
     list_workflow_execution:
-      id: "ID:"
-      name: "Nom:"
-      run_id: "Exécuter l’identifiant:"
-      workflow: "Flux de travail :"
+      id: 'ID:'
+      name: 'Nom:'
+      run_id: 'Exécuter l’identifiant:'
+      workflow: 'Flux de travail :'
     new:
       after_submission_description_html: Après la soumission, vous serez redirigé vers la page d’exportation. Pendant que le statut de l’exportation est <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">en cours de traitement</span>, le contenu de l’exportation est créé. Une fois que le statut de l’exportation sera <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">prêt</span>, il sera disponible pour téléchargement. Vous aurez 3 jours ouvrables pour télécharger l’exportation avant qu’elle ne soit supprimée.
       email_label: Vous recevez une notification par courriel lorsque votre exportation est prête à être téléchargée?
-      name_label: "Nom d’exportation (facultatif) :"
+      name_label: 'Nom d’exportation (facultatif) :'
       sample_description:
         plural: Cette exportation contiendra les échantillons COUNT_PLACEHOLDER.
         singular: Cette exportation contiendra 1 échantillon.
@@ -680,8 +680,8 @@ fr:
   errors:
     messages:
       not_saved:
-        one: "1 erreur a empêché cette %{resource} d’être sauvegardée :"
-        other: "Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :"
+        one: '1 erreur a empêché cette %{resource} d’être sauvegardée :'
+        other: 'Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :'
   general:
     default_sidebar:
       data_exports: Exportations de données
@@ -713,7 +713,7 @@ fr:
       title: Activité en groupe
     attachments:
       create:
-        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -787,18 +787,18 @@ fr:
         transfer:
           confirm:
             points_html:
-              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-              - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+            - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{group_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-            - Transférer le groupe à un autre groupe parent
+          - Transférer le groupe à un autre groupe parent
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Choisissez un groupe parent
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce groupe
           points:
-            - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
-            - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
-            - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
+          - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
+          - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
+          - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
           select_group: Sélectionner un groupe
           submit: Groupe de transfert
           title: Groupe de transfert
@@ -1003,10 +1003,10 @@ fr:
       export_ready:
         download_before_html: Veuillez télécharger l’exportation avant <strong>%{date}</strong>, car elle sera supprimée après cette période.
         ready_for_download_html: Votre exportation <strong>%{name}</strong> est prête à être téléchargée.
-        view_exports: "Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :"
+        view_exports: 'Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :'
     email_template:
       automated_message: Ce courriel a été envoyé à partir d’un système automatisé. Veuillez ne pas répondre à ce courriel.
-      copy_paste: "Ou copiez-collez ce lien dans votre navigateur :"
+      copy_paste: 'Ou copiez-collez ce lien dans votre navigateur :'
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -1014,11 +1014,11 @@ fr:
       access_granted_manager_email:
         body_html: Le groupe '%{group_name}' a <strong>obtenu</strong> l’accès à %{namespace_type} '%{namespace_name}'
         subject: Le groupe '%{group_name}' a obtenu l’accès à %{namespace_type} '%{namespace_name}'
-        view_details: "Pour voir tous les membres de %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "Pour voir %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_manager_email:
         body_html: L’accès à %{namespace_type} '%{namespace_name}' a été <strong>révoqué</strong> pour le groupe '%{group_name}'
         subject: L’accès à %{namespace_type} '%{namespace_name}' a été révoqué pour le groupe '%{group_name}'
@@ -1029,15 +1029,15 @@ fr:
       access_granted_manager_email:
         body_html: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu <strong></strong> l’accès à %{type} '%{name}'
         subject: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu l’accès à %{type} '%{name}'
-        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_granted_user_email:
         body_html: Vous avez <strong>obtenu</strong> l’accès à %{type} '%{name}'
         subject: Vous avez obtenu l’accès à %{type} '%{name}'
-        view_details: "Pour voir %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_manager_email:
         body_html: L’accès à %{type} '%{name}' a été <strong>révoqué</strong> pour l’utilisateur '%{first_name} %{last_name}' (%{email})
         subject: L’accès à %{type} '%{name}' a été révoqué pour l’utilisateur '%{first_name} %{last_name}' (%{email})
-        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_user_email:
         body_html: Votre accès à %{type} '%{name}' a été <strong>révoqué</strong>
         subject: Votre accès à %{type} '%{name}' a été révoqué
@@ -1054,7 +1054,7 @@ fr:
       error_user_email:
         body_html: Votre pipeline <strong>%{id}</strong> n’a pas été complété avec succès en raison d’erreurs.
         subject: Pipeline erroné – %{id}
-      view_details: "Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :"
+      view_details: 'Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :'
   members:
     access_levels:
       level_0: Pas d’accès
@@ -1133,7 +1133,7 @@ fr:
         aria_label: Sélecteur de page de pagination
       previous: Précédent
   nextflow_component:
-    data_missing_error: "Les échantillons suivants manquent de données requises : "
+    data_missing_error: 'Les échantillons suivants manquent de données requises : '
     filtering_samples: Le filtrage des échantillons peut prendre un certain temps.
     name:
       helper: Un nom personnalisé facilitera la recherche à l’avenir.
@@ -1164,8 +1164,8 @@ fr:
         confirm: Êtes-vous sûr de vouloir supprimer votre compte?
         description: La suppression de votre compte a les effets suivants
         effects:
-          - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
-          - Tous les projets et groupes dont vous êtes membre seront laissés intacts
+        - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
+        - Tous les projets et groupes dont vous êtes membre seront laissés intacts
     passwords:
       update:
         forgot: Vous avez oublié votre mot de passe?
@@ -1229,7 +1229,7 @@ fr:
       title: Activité du projet
     attachments:
       create:
-        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -1257,7 +1257,7 @@ fr:
       edit:
         error: Impossible de modifier le pipeline automatisé %{workflow_name}
       edit_dialog:
-        title: "Modification du pipeline automatisé : %{workflow_name}"
+        title: 'Modification du pipeline automatisé : %{workflow_name}'
       index:
         add_new_automated_workflow_execution: Nouveau pipeline automatisé
         subtitle: Configurer des pipelines automatisés à lancer lorsque les données jumelées sont téléchargées dans le projet
@@ -1335,20 +1335,20 @@ fr:
         transfer:
           confirm:
             points_html:
-              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-              - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+            - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{project_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-            - Transférer votre projet dans un autre espace de noms.
-            - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
-            - Ce qu’il faut savoir avant de transférer votre projet:
+          - Transférer votre projet dans un autre espace de noms.
+          - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
+          - Ce qu’il faut savoir avant de transférer votre projet:
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Sélectionnez un nouvel espace de noms
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce projet
           points:
-            - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
-            - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
-            - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
+          - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
+          - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
+          - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
           select_namespace: Sélectionnez l’espace de noms
           submit: Projet de transfert
           title: Projet de transfert
@@ -1466,11 +1466,11 @@ fr:
             success: Les dossiers ont été concaténés avec succès.
           modal:
             basename: Nom du fichier
-            description: "Les fichiers suivants ont été sélectionnés pour être concaténés :"
+            description: 'Les fichiers suivants ont été sélectionnés pour être concaténés :'
             submit_button: Concaténer
             title: Concaténer les fichiers
         create:
-          failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+          failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
           success: Le fichier %{filename} a été téléchargé avec succès.
         delete_attachment_modal:
           description: Êtes-vous sûr de vouloir supprimer ce fichier de l’échantillon?
@@ -1478,20 +1478,20 @@ fr:
           title: Supprimer un fichier
         deletions:
           destroy:
-            error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+            error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
             partial_success: Certains fichiers ont été supprimés avec succès.
             success: Les fichiers ont été supprimés avec succès.
           modal:
-            description: "Les fichiers suivants ont été sélectionnés pour suppression :"
+            description: 'Les fichiers suivants ont été sélectionnés pour suppression :'
             submit_button: Supprimer
             title: Supprimer des fichiers
         destroy:
-          error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+          error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
           success: Le fichier %{filename} a été supprimé avec succès.
       clones:
         create:
-          error: "La liste suivante des échantillons n’a pas été copiée :"
-          no_samples_cloned_error: "Les échantillons n’ont pas été copiés pour les raisons suivantes :"
+          error: 'La liste suivante des échantillons n’a pas été copiée :'
+          no_samples_cloned_error: 'Les échantillons n’ont pas été copiés pour les raisons suivantes :'
           success: Les échantillons ont été copiés avec succès.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ fr:
           title: Supprimer l’échantillon
         new_multiple_deletions_dialog:
           description:
-            plural: "Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :"
-            singular: "L’échantillon suivant a été sélectionné aux fins de suppression :"
+            plural: 'Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :'
+            singular: 'L’échantillon suivant a été sélectionné aux fins de suppression :'
             zero: Aucun échantillon n’a été sélectionné pour être supprimer
           loading: Chargement...
           samples: Échantillons
@@ -1564,7 +1564,7 @@ fr:
             multi_success: Les clés de métadonnées '%{deleted_keys}' ont été supprimées avec succès.
             single_success: La clé de métadonnées '%{deleted_key}' a été supprimée avec succès.
           modal:
-            description: "Champs de métadonnées sélectionnés pour suppression :"
+            description: 'Champs de métadonnées sélectionnés pour suppression :'
             key_header: Clé
             submit_button: Supprimer
             title: Supprimer les métadonnées
@@ -1604,7 +1604,7 @@ fr:
         delete_metadata_button: Supprimer les métadonnéesDelete Metadata
         edit_button: Modifier cet échantillon
         files: FichiersFiles
-        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
+        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
         history:
           modal:
             created_by: Échantillon créé par %{user}
@@ -1656,8 +1656,8 @@ fr:
           placeholder: Filtrer par ID ou nom
       transfers:
         create:
-          error: "La liste suivante des échantillons n’a pas été transférée :"
-          no_samples_transferred_error: "Les échantillons n’ont pas été transférés pour les raisons suivantes :"
+          error: 'La liste suivante des échantillons n’a pas été transférée :'
+          no_samples_transferred_error: 'Les échantillons n’ont pas été transférés pour les raisons suivantes :'
           success: Les échantillons ont été transférés avec succès.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ fr:
         empty_new_project_id: Le projet de destination n’a pas été sélectionné.
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         same_project: Les projets sources et de destination sont les mêmes. Veuillez sélectionner un autre projet de destination.
-        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
-        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
+        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
+        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
       metadata:
         empty_metadata: Aucune métadonnée n’a été reçue pour mettre à jour l’échantillon '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ fr:
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         maintainer_transfer_not_allowed: Un responsable ne peut transférer des échantillons qu’à d’autres projets dans la même hiérarchie avec un ancêtre commun
         same_project: Les échantillons existent déjà dans le projet. Veuillez sélectionner un autre projet.
-        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
-        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
+        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
+        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
     spreadsheet_import:
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
       invalid_file_extension: Le fichier ne peut être qu’un fichier csv, tsv ou excel.
@@ -1894,7 +1894,7 @@ fr:
               description: Si cette option est sélectionnée, les champs de métadonnées sans valeur associée seront ignorés et ces clés de métadonnées ne seront pas supprimées de l’échantillon si elles sont présentes. Cependant, si cette option n’est pas sélectionnée, tous les échantillons avec la clé de métadonnées et la valeur vide seront supprimés.
             metadata_columns: Metadata Columns
             namespace:
-              description: "La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. "
+              description: 'La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. '
               group:
                 description_html: L’identificateur est sensible à la casse et doit contenir l’<b>identifiant de l’échantillon</b>.
               project:
@@ -1906,7 +1906,7 @@ fr:
             submit_button: Import Metadata
             title: Télécharger des échantillons de métadonnées
           errors:
-            description: "L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :"
+            description: 'L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :'
             ok_button: OK
           success:
             description: Les métadonnées ont été importées avec succès!
@@ -1926,11 +1926,11 @@ fr:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: "Failed to parse spreadsheet file: %{error}"
+    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
-    unknown_file_format: "Unknown file type: %{extension}"
+    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
+    unknown_file_format: 'Unknown file type: %{extension}'
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1981,7 +1981,7 @@ fr:
       download: Télécharger
       preview: Aperçu
     create:
-      error_message: "Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :"
+      error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
     edit_dialog:
       cancel_button: Annuler
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -369,7 +369,7 @@ fr:
         title: Supprimer un fichier
       new_attachment_component:
         files: Fichiers
-        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
+        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
         upload: Télécharger
         upload_files: Télécharger des fichiers
         uploading: Téléchargement
@@ -454,7 +454,7 @@ fr:
       transferred_by: "%{type} transféré par %{user}"
     history_version:
       current_version: Actuel (Version %{version})
-      keys_deleted: 'Clés supprimées :'
+      keys_deleted: "Clés supprimées :"
       previous_version: Précédent (Version %{version})
     list_filter:
       apply: Appliquer un filtre
@@ -493,7 +493,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+        error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
     bot_actions:
       create:
         success: Le compte de bot a été ajouté avec succès
@@ -605,14 +605,14 @@ fr:
         status: Statut
       title: Exportations de données
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Nom:'
-      run_id: 'Exécuter l’identifiant:'
-      workflow: 'Flux de travail :'
+      id: "ID:"
+      name: "Nom:"
+      run_id: "Exécuter l’identifiant:"
+      workflow: "Flux de travail :"
     new:
       after_submission_description_html: Après la soumission, vous serez redirigé vers la page d’exportation. Pendant que le statut de l’exportation est <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">en cours de traitement</span>, le contenu de l’exportation est créé. Une fois que le statut de l’exportation sera <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">prêt</span>, il sera disponible pour téléchargement. Vous aurez 3 jours ouvrables pour télécharger l’exportation avant qu’elle ne soit supprimée.
       email_label: Vous recevez une notification par courriel lorsque votre exportation est prête à être téléchargée?
-      name_label: 'Nom d’exportation (facultatif) :'
+      name_label: "Nom d’exportation (facultatif) :"
       sample_description:
         plural: Cette exportation contiendra les échantillons COUNT_PLACEHOLDER.
         singular: Cette exportation contiendra 1 échantillon.
@@ -680,8 +680,8 @@ fr:
   errors:
     messages:
       not_saved:
-        one: '1 erreur a empêché cette %{resource} d’être sauvegardée :'
-        other: 'Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :'
+        one: "1 erreur a empêché cette %{resource} d’être sauvegardée :"
+        other: "Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :"
   general:
     default_sidebar:
       data_exports: Exportations de données
@@ -713,7 +713,7 @@ fr:
       title: Activité en groupe
     attachments:
       create:
-        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -787,18 +787,18 @@ fr:
         transfer:
           confirm:
             points_html:
-            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-            - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+              - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{group_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-          - Transférer le groupe à un autre groupe parent
+            - Transférer le groupe à un autre groupe parent
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Choisissez un groupe parent
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce groupe
           points:
-          - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
-          - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
-          - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
+            - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
+            - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
+            - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
           select_group: Sélectionner un groupe
           submit: Groupe de transfert
           title: Groupe de transfert
@@ -1003,10 +1003,10 @@ fr:
       export_ready:
         download_before_html: Veuillez télécharger l’exportation avant <strong>%{date}</strong>, car elle sera supprimée après cette période.
         ready_for_download_html: Votre exportation <strong>%{name}</strong> est prête à être téléchargée.
-        view_exports: 'Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :'
+        view_exports: "Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :"
     email_template:
       automated_message: Ce courriel a été envoyé à partir d’un système automatisé. Veuillez ne pas répondre à ce courriel.
-      copy_paste: 'Ou copiez-collez ce lien dans votre navigateur :'
+      copy_paste: "Ou copiez-collez ce lien dans votre navigateur :"
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -1014,11 +1014,11 @@ fr:
       access_granted_manager_email:
         body_html: Le groupe '%{group_name}' a <strong>obtenu</strong> l’accès à %{namespace_type} '%{namespace_name}'
         subject: Le groupe '%{group_name}' a obtenu l’accès à %{namespace_type} '%{namespace_name}'
-        view_details: 'Pour voir tous les membres de %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'Pour voir %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
       access_revoked_manager_email:
         body_html: L’accès à %{namespace_type} '%{namespace_name}' a été <strong>révoqué</strong> pour le groupe '%{group_name}'
         subject: L’accès à %{namespace_type} '%{namespace_name}' a été révoqué pour le groupe '%{group_name}'
@@ -1029,15 +1029,15 @@ fr:
       access_granted_manager_email:
         body_html: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu <strong></strong> l’accès à %{type} '%{name}'
         subject: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu l’accès à %{type} '%{name}'
-        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_granted_user_email:
         body_html: Vous avez <strong>obtenu</strong> l’accès à %{type} '%{name}'
         subject: Vous avez obtenu l’accès à %{type} '%{name}'
-        view_details: 'Pour voir %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_revoked_manager_email:
         body_html: L’accès à %{type} '%{name}' a été <strong>révoqué</strong> pour l’utilisateur '%{first_name} %{last_name}' (%{email})
         subject: L’accès à %{type} '%{name}' a été révoqué pour l’utilisateur '%{first_name} %{last_name}' (%{email})
-        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_revoked_user_email:
         body_html: Votre accès à %{type} '%{name}' a été <strong>révoqué</strong>
         subject: Votre accès à %{type} '%{name}' a été révoqué
@@ -1054,7 +1054,7 @@ fr:
       error_user_email:
         body_html: Votre pipeline <strong>%{id}</strong> n’a pas été complété avec succès en raison d’erreurs.
         subject: Pipeline erroné – %{id}
-      view_details: 'Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :'
+      view_details: "Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :"
   members:
     access_levels:
       level_0: Pas d’accès
@@ -1133,7 +1133,7 @@ fr:
         aria_label: Sélecteur de page de pagination
       previous: Précédent
   nextflow_component:
-    data_missing_error: 'Les échantillons suivants manquent de données requises : '
+    data_missing_error: "Les échantillons suivants manquent de données requises : "
     filtering_samples: Le filtrage des échantillons peut prendre un certain temps.
     name:
       helper: Un nom personnalisé facilitera la recherche à l’avenir.
@@ -1164,8 +1164,8 @@ fr:
         confirm: Êtes-vous sûr de vouloir supprimer votre compte?
         description: La suppression de votre compte a les effets suivants
         effects:
-        - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
-        - Tous les projets et groupes dont vous êtes membre seront laissés intacts
+          - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
+          - Tous les projets et groupes dont vous êtes membre seront laissés intacts
     passwords:
       update:
         forgot: Vous avez oublié votre mot de passe?
@@ -1229,7 +1229,7 @@ fr:
       title: Activité du projet
     attachments:
       create:
-        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -1257,7 +1257,7 @@ fr:
       edit:
         error: Impossible de modifier le pipeline automatisé %{workflow_name}
       edit_dialog:
-        title: 'Modification du pipeline automatisé : %{workflow_name}'
+        title: "Modification du pipeline automatisé : %{workflow_name}"
       index:
         add_new_automated_workflow_execution: Nouveau pipeline automatisé
         subtitle: Configurer des pipelines automatisés à lancer lorsque les données jumelées sont téléchargées dans le projet
@@ -1335,20 +1335,20 @@ fr:
         transfer:
           confirm:
             points_html:
-            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-            - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+              - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{project_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-          - Transférer votre projet dans un autre espace de noms.
-          - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
-          - Ce qu’il faut savoir avant de transférer votre projet:
+            - Transférer votre projet dans un autre espace de noms.
+            - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
+            - Ce qu’il faut savoir avant de transférer votre projet:
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Sélectionnez un nouvel espace de noms
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce projet
           points:
-          - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
-          - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
-          - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
+            - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
+            - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
+            - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
           select_namespace: Sélectionnez l’espace de noms
           submit: Projet de transfert
           title: Projet de transfert
@@ -1466,11 +1466,11 @@ fr:
             success: Les dossiers ont été concaténés avec succès.
           modal:
             basename: Nom du fichier
-            description: 'Les fichiers suivants ont été sélectionnés pour être concaténés :'
+            description: "Les fichiers suivants ont été sélectionnés pour être concaténés :"
             submit_button: Concaténer
             title: Concaténer les fichiers
         create:
-          failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+          failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
           success: Le fichier %{filename} a été téléchargé avec succès.
         delete_attachment_modal:
           description: Êtes-vous sûr de vouloir supprimer ce fichier de l’échantillon?
@@ -1478,20 +1478,20 @@ fr:
           title: Supprimer un fichier
         deletions:
           destroy:
-            error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+            error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
             partial_success: Certains fichiers ont été supprimés avec succès.
             success: Les fichiers ont été supprimés avec succès.
           modal:
-            description: 'Les fichiers suivants ont été sélectionnés pour suppression :'
+            description: "Les fichiers suivants ont été sélectionnés pour suppression :"
             submit_button: Supprimer
             title: Supprimer des fichiers
         destroy:
-          error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+          error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
           success: Le fichier %{filename} a été supprimé avec succès.
       clones:
         create:
-          error: 'La liste suivante des échantillons n’a pas été copiée :'
-          no_samples_cloned_error: 'Les échantillons n’ont pas été copiés pour les raisons suivantes :'
+          error: "La liste suivante des échantillons n’a pas été copiée :"
+          no_samples_cloned_error: "Les échantillons n’ont pas été copiés pour les raisons suivantes :"
           success: Les échantillons ont été copiés avec succès.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ fr:
           title: Supprimer l’échantillon
         new_multiple_deletions_dialog:
           description:
-            plural: 'Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :'
-            singular: 'L’échantillon suivant a été sélectionné aux fins de suppression :'
+            plural: "Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :"
+            singular: "L’échantillon suivant a été sélectionné aux fins de suppression :"
             zero: Aucun échantillon n’a été sélectionné pour être supprimer
           loading: Chargement...
           samples: Échantillons
@@ -1564,7 +1564,7 @@ fr:
             multi_success: Les clés de métadonnées '%{deleted_keys}' ont été supprimées avec succès.
             single_success: La clé de métadonnées '%{deleted_key}' a été supprimée avec succès.
           modal:
-            description: 'Champs de métadonnées sélectionnés pour suppression :'
+            description: "Champs de métadonnées sélectionnés pour suppression :"
             key_header: Clé
             submit_button: Supprimer
             title: Supprimer les métadonnées
@@ -1604,7 +1604,7 @@ fr:
         delete_metadata_button: Supprimer les métadonnéesDelete Metadata
         edit_button: Modifier cet échantillon
         files: FichiersFiles
-        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
+        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
         history:
           modal:
             created_by: Échantillon créé par %{user}
@@ -1656,8 +1656,8 @@ fr:
           placeholder: Filtrer par ID ou nom
       transfers:
         create:
-          error: 'La liste suivante des échantillons n’a pas été transférée :'
-          no_samples_transferred_error: 'Les échantillons n’ont pas été transférés pour les raisons suivantes :'
+          error: "La liste suivante des échantillons n’a pas été transférée :"
+          no_samples_transferred_error: "Les échantillons n’ont pas été transférés pour les raisons suivantes :"
           success: Les échantillons ont été transférés avec succès.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ fr:
         empty_new_project_id: Le projet de destination n’a pas été sélectionné.
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         same_project: Les projets sources et de destination sont les mêmes. Veuillez sélectionner un autre projet de destination.
-        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
-        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
+        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
+        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
       metadata:
         empty_metadata: Aucune métadonnée n’a été reçue pour mettre à jour l’échantillon '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ fr:
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         maintainer_transfer_not_allowed: Un responsable ne peut transférer des échantillons qu’à d’autres projets dans la même hiérarchie avec un ancêtre commun
         same_project: Les échantillons existent déjà dans le projet. Veuillez sélectionner un autre projet.
-        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
-        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
+        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
+        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
     spreadsheet_import:
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
       invalid_file_extension: Le fichier ne peut être qu’un fichier csv, tsv ou excel.
@@ -1894,7 +1894,7 @@ fr:
               description: Si cette option est sélectionnée, les champs de métadonnées sans valeur associée seront ignorés et ces clés de métadonnées ne seront pas supprimées de l’échantillon si elles sont présentes. Cependant, si cette option n’est pas sélectionnée, tous les échantillons avec la clé de métadonnées et la valeur vide seront supprimés.
             metadata_columns: Metadata Columns
             namespace:
-              description: 'La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. '
+              description: "La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. "
               group:
                 description_html: L’identificateur est sensible à la casse et doit contenir l’<b>identifiant de l’échantillon</b>.
               project:
@@ -1906,7 +1906,7 @@ fr:
             submit_button: Import Metadata
             title: Télécharger des échantillons de métadonnées
           errors:
-            description: 'L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :'
+            description: "L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :"
             ok_button: OK
           success:
             description: Les métadonnées ont été importées avec succès!
@@ -1926,11 +1926,11 @@ fr:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
+    failed_parsing: "Failed to parse spreadsheet file: %{error}"
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
-    unknown_file_format: 'Unknown file type: %{extension}'
+    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
+    unknown_file_format: "Unknown file type: %{extension}"
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1970,7 +1970,6 @@ fr:
         previous: Précédent
     sortable_list:
       list_component:
-        aria_role: "%{list} listbox"
         aria_role_description: "%{list} listbox drag and drop"
     sortable_lists_component:
       add_all: Ajouter tout
@@ -1981,7 +1980,7 @@ fr:
       download: Télécharger
       preview: Aperçu
     create:
-      error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
+      error_message: "Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :"
     edit_dialog:
       cancel_button: Annuler
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -369,7 +369,7 @@ fr:
         title: Supprimer un fichier
       new_attachment_component:
         files: Fichiers
-        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
+        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
         upload: Télécharger
         upload_files: Télécharger des fichiers
         uploading: Téléchargement
@@ -454,7 +454,7 @@ fr:
       transferred_by: "%{type} transféré par %{user}"
     history_version:
       current_version: Actuel (Version %{version})
-      keys_deleted: 'Clés supprimées :'
+      keys_deleted: "Clés supprimées :"
       previous_version: Précédent (Version %{version})
     list_filter:
       apply: Appliquer un filtre
@@ -493,7 +493,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+        error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
     bot_actions:
       create:
         success: Le compte de bot a été ajouté avec succès
@@ -605,14 +605,14 @@ fr:
         status: Statut
       title: Exportations de données
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Nom:'
-      run_id: 'Exécuter l’identifiant:'
-      workflow: 'Flux de travail :'
+      id: "ID:"
+      name: "Nom:"
+      run_id: "Exécuter l’identifiant:"
+      workflow: "Flux de travail :"
     new:
       after_submission_description_html: Après la soumission, vous serez redirigé vers la page d’exportation. Pendant que le statut de l’exportation est <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">en cours de traitement</span>, le contenu de l’exportation est créé. Une fois que le statut de l’exportation sera <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">prêt</span>, il sera disponible pour téléchargement. Vous aurez 3 jours ouvrables pour télécharger l’exportation avant qu’elle ne soit supprimée.
       email_label: Vous recevez une notification par courriel lorsque votre exportation est prête à être téléchargée?
-      name_label: 'Nom d’exportation (facultatif) :'
+      name_label: "Nom d’exportation (facultatif) :"
       sample_description:
         plural: Cette exportation contiendra les échantillons COUNT_PLACEHOLDER.
         singular: Cette exportation contiendra 1 échantillon.
@@ -680,8 +680,8 @@ fr:
   errors:
     messages:
       not_saved:
-        one: '1 erreur a empêché cette %{resource} d’être sauvegardée :'
-        other: 'Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :'
+        one: "1 erreur a empêché cette %{resource} d’être sauvegardée :"
+        other: "Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :"
   general:
     default_sidebar:
       data_exports: Exportations de données
@@ -713,7 +713,7 @@ fr:
       title: Activité en groupe
     attachments:
       create:
-        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -787,18 +787,18 @@ fr:
         transfer:
           confirm:
             points_html:
-            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-            - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+              - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{group_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-          - Transférer le groupe à un autre groupe parent
+            - Transférer le groupe à un autre groupe parent
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Choisissez un groupe parent
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce groupe
           points:
-          - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
-          - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
-          - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
+            - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
+            - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
+            - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
           select_group: Sélectionner un groupe
           submit: Groupe de transfert
           title: Groupe de transfert
@@ -1003,10 +1003,10 @@ fr:
       export_ready:
         download_before_html: Veuillez télécharger l’exportation avant <strong>%{date}</strong>, car elle sera supprimée après cette période.
         ready_for_download_html: Votre exportation <strong>%{name}</strong> est prête à être téléchargée.
-        view_exports: 'Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :'
+        view_exports: "Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :"
     email_template:
       automated_message: Ce courriel a été envoyé à partir d’un système automatisé. Veuillez ne pas répondre à ce courriel.
-      copy_paste: 'Ou copiez-collez ce lien dans votre navigateur :'
+      copy_paste: "Ou copiez-collez ce lien dans votre navigateur :"
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -1014,11 +1014,11 @@ fr:
       access_granted_manager_email:
         body_html: Le groupe '%{group_name}' a <strong>obtenu</strong> l’accès à %{namespace_type} '%{namespace_name}'
         subject: Le groupe '%{group_name}' a obtenu l’accès à %{namespace_type} '%{namespace_name}'
-        view_details: 'Pour voir tous les membres de %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'Pour voir %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
       access_revoked_manager_email:
         body_html: L’accès à %{namespace_type} '%{namespace_name}' a été <strong>révoqué</strong> pour le groupe '%{group_name}'
         subject: L’accès à %{namespace_type} '%{namespace_name}' a été révoqué pour le groupe '%{group_name}'
@@ -1029,15 +1029,15 @@ fr:
       access_granted_manager_email:
         body_html: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu <strong></strong> l’accès à %{type} '%{name}'
         subject: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu l’accès à %{type} '%{name}'
-        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_granted_user_email:
         body_html: Vous avez <strong>obtenu</strong> l’accès à %{type} '%{name}'
         subject: Vous avez obtenu l’accès à %{type} '%{name}'
-        view_details: 'Pour voir %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_revoked_manager_email:
         body_html: L’accès à %{type} '%{name}' a été <strong>révoqué</strong> pour l’utilisateur '%{first_name} %{last_name}' (%{email})
         subject: L’accès à %{type} '%{name}' a été révoqué pour l’utilisateur '%{first_name} %{last_name}' (%{email})
-        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_revoked_user_email:
         body_html: Votre accès à %{type} '%{name}' a été <strong>révoqué</strong>
         subject: Votre accès à %{type} '%{name}' a été révoqué
@@ -1054,7 +1054,7 @@ fr:
       error_user_email:
         body_html: Votre pipeline <strong>%{id}</strong> n’a pas été complété avec succès en raison d’erreurs.
         subject: Pipeline erroné – %{id}
-      view_details: 'Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :'
+      view_details: "Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :"
   members:
     access_levels:
       level_0: Pas d’accès
@@ -1133,7 +1133,7 @@ fr:
         aria_label: Sélecteur de page de pagination
       previous: Précédent
   nextflow_component:
-    data_missing_error: 'Les échantillons suivants manquent de données requises : '
+    data_missing_error: "Les échantillons suivants manquent de données requises : "
     filtering_samples: Le filtrage des échantillons peut prendre un certain temps.
     name:
       helper: Un nom personnalisé facilitera la recherche à l’avenir.
@@ -1164,8 +1164,8 @@ fr:
         confirm: Êtes-vous sûr de vouloir supprimer votre compte?
         description: La suppression de votre compte a les effets suivants
         effects:
-        - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
-        - Tous les projets et groupes dont vous êtes membre seront laissés intacts
+          - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
+          - Tous les projets et groupes dont vous êtes membre seront laissés intacts
     passwords:
       update:
         forgot: Vous avez oublié votre mot de passe?
@@ -1229,7 +1229,7 @@ fr:
       title: Activité du projet
     attachments:
       create:
-        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -1257,7 +1257,7 @@ fr:
       edit:
         error: Impossible de modifier le pipeline automatisé %{workflow_name}
       edit_dialog:
-        title: 'Modification du pipeline automatisé : %{workflow_name}'
+        title: "Modification du pipeline automatisé : %{workflow_name}"
       index:
         add_new_automated_workflow_execution: Nouveau pipeline automatisé
         subtitle: Configurer des pipelines automatisés à lancer lorsque les données jumelées sont téléchargées dans le projet
@@ -1335,20 +1335,20 @@ fr:
         transfer:
           confirm:
             points_html:
-            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-            - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+              - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{project_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-          - Transférer votre projet dans un autre espace de noms.
-          - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
-          - Ce qu’il faut savoir avant de transférer votre projet:
+            - Transférer votre projet dans un autre espace de noms.
+            - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
+            - Ce qu’il faut savoir avant de transférer votre projet:
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Sélectionnez un nouvel espace de noms
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce projet
           points:
-          - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
-          - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
-          - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
+            - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
+            - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
+            - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
           select_namespace: Sélectionnez l’espace de noms
           submit: Projet de transfert
           title: Projet de transfert
@@ -1466,11 +1466,11 @@ fr:
             success: Les dossiers ont été concaténés avec succès.
           modal:
             basename: Nom du fichier
-            description: 'Les fichiers suivants ont été sélectionnés pour être concaténés :'
+            description: "Les fichiers suivants ont été sélectionnés pour être concaténés :"
             submit_button: Concaténer
             title: Concaténer les fichiers
         create:
-          failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+          failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
           success: Le fichier %{filename} a été téléchargé avec succès.
         delete_attachment_modal:
           description: Êtes-vous sûr de vouloir supprimer ce fichier de l’échantillon?
@@ -1478,20 +1478,20 @@ fr:
           title: Supprimer un fichier
         deletions:
           destroy:
-            error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+            error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
             partial_success: Certains fichiers ont été supprimés avec succès.
             success: Les fichiers ont été supprimés avec succès.
           modal:
-            description: 'Les fichiers suivants ont été sélectionnés pour suppression :'
+            description: "Les fichiers suivants ont été sélectionnés pour suppression :"
             submit_button: Supprimer
             title: Supprimer des fichiers
         destroy:
-          error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+          error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
           success: Le fichier %{filename} a été supprimé avec succès.
       clones:
         create:
-          error: 'La liste suivante des échantillons n’a pas été copiée :'
-          no_samples_cloned_error: 'Les échantillons n’ont pas été copiés pour les raisons suivantes :'
+          error: "La liste suivante des échantillons n’a pas été copiée :"
+          no_samples_cloned_error: "Les échantillons n’ont pas été copiés pour les raisons suivantes :"
           success: Les échantillons ont été copiés avec succès.
         dialog:
           description:
@@ -1522,8 +1522,8 @@ fr:
           title: Supprimer l’échantillon
         new_multiple_deletions_dialog:
           description:
-            plural: 'Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :'
-            singular: 'L’échantillon suivant a été sélectionné aux fins de suppression :'
+            plural: "Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :"
+            singular: "L’échantillon suivant a été sélectionné aux fins de suppression :"
             zero: Aucun échantillon n’a été sélectionné pour être supprimer
           loading: Chargement...
           samples: Échantillons
@@ -1564,7 +1564,7 @@ fr:
             multi_success: Les clés de métadonnées '%{deleted_keys}' ont été supprimées avec succès.
             single_success: La clé de métadonnées '%{deleted_key}' a été supprimée avec succès.
           modal:
-            description: 'Champs de métadonnées sélectionnés pour suppression :'
+            description: "Champs de métadonnées sélectionnés pour suppression :"
             key_header: Clé
             submit_button: Supprimer
             title: Supprimer les métadonnées
@@ -1604,7 +1604,7 @@ fr:
         delete_metadata_button: Supprimer les métadonnéesDelete Metadata
         edit_button: Modifier cet échantillon
         files: FichiersFiles
-        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
+        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
         history:
           modal:
             created_by: Échantillon créé par %{user}
@@ -1656,8 +1656,8 @@ fr:
           placeholder: Filtrer par ID ou nom
       transfers:
         create:
-          error: 'La liste suivante des échantillons n’a pas été transférée :'
-          no_samples_transferred_error: 'Les échantillons n’ont pas été transférés pour les raisons suivantes :'
+          error: "La liste suivante des échantillons n’a pas été transférée :"
+          no_samples_transferred_error: "Les échantillons n’ont pas été transférés pour les raisons suivantes :"
           success: Les échantillons ont été transférés avec succès.
         dialog:
           description:
@@ -1831,8 +1831,8 @@ fr:
         empty_new_project_id: Le projet de destination n’a pas été sélectionné.
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         same_project: Les projets sources et de destination sont les mêmes. Veuillez sélectionner un autre projet de destination.
-        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
-        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
+        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
+        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
       metadata:
         empty_metadata: Aucune métadonnée n’a été reçue pour mettre à jour l’échantillon '%{sample_name}'
         fields:
@@ -1855,8 +1855,8 @@ fr:
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         maintainer_transfer_not_allowed: Un responsable ne peut transférer des échantillons qu’à d’autres projets dans la même hiérarchie avec un ancêtre commun
         same_project: Les échantillons existent déjà dans le projet. Veuillez sélectionner un autre projet.
-        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
-        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
+        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
+        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
     spreadsheet_import:
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
       invalid_file_extension: Le fichier ne peut être qu’un fichier csv, tsv ou excel.
@@ -1894,7 +1894,7 @@ fr:
               description: Si cette option est sélectionnée, les champs de métadonnées sans valeur associée seront ignorés et ces clés de métadonnées ne seront pas supprimées de l’échantillon si elles sont présentes. Cependant, si cette option n’est pas sélectionnée, tous les échantillons avec la clé de métadonnées et la valeur vide seront supprimés.
             metadata_columns: Metadata Columns
             namespace:
-              description: 'La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. '
+              description: "La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. "
               group:
                 description_html: L’identificateur est sensible à la casse et doit contenir l’<b>identifiant de l’échantillon</b>.
               project:
@@ -1906,7 +1906,7 @@ fr:
             submit_button: Import Metadata
             title: Télécharger des échantillons de métadonnées
           errors:
-            description: 'L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :'
+            description: "L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :"
             ok_button: OK
           success:
             description: Les métadonnées ont été importées avec succès!
@@ -1926,11 +1926,11 @@ fr:
         dialog:
           spinner_message: Importing samples, this might take a while...
   spreadsheet_helper:
-    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
+    failed_parsing: "Failed to parse spreadsheet file: %{error}"
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
-    unknown_file_format: 'Unknown file type: %{extension}'
+    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
+    unknown_file_format: "Unknown file type: %{extension}"
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -1968,6 +1968,10 @@ fr:
         aria-label: Pagination
         next: Suivant
         previous: Précédent
+    sortable_list:
+      list_component:
+        aria_role: "%{list} listbox"
+        aria_role_description: "%{list} listbox drag and drop"
     sortable_lists_component:
       add_all: Ajouter tout
       no_template: Pas de modèle
@@ -1977,7 +1981,7 @@ fr:
       download: Télécharger
       preview: Aperçu
     create:
-      error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
+      error_message: "Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :"
     edit_dialog:
       cancel_button: Annuler
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -221,7 +221,7 @@ class DataExportsTest < ApplicationSystemTestCase
 
     visit data_export_path(@data_export2)
 
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t(:'data_exports.show.download')
     assert_no_text I18n.t(:'data_exports.show.tabs.preview')
   end
@@ -278,14 +278,14 @@ class DataExportsTest < ApplicationSystemTestCase
     end
     # project samples page
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample1.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     assert_accessible
@@ -335,7 +335,7 @@ class DataExportsTest < ApplicationSystemTestCase
     # project samples page
     visit group_samples_url(@group1)
     assert_text '1-20 of 26'
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
@@ -343,7 +343,7 @@ class DataExportsTest < ApplicationSystemTestCase
       find("input[type='checkbox'][value='#{@sample2.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.sample_export'), match: :first
@@ -391,25 +391,25 @@ class DataExportsTest < ApplicationSystemTestCase
     sample32 = samples(:sample32)
 
     visit namespace_project_samples_url(subgroup12a, project29)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{sample32.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
 
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample1.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
 
     click_button I18n.t('projects.samples.index.create_export_button.label')
@@ -892,14 +892,14 @@ class DataExportsTest < ApplicationSystemTestCase
     sample3 = samples(:sample3)
 
     visit namespace_project_samples_url(@group1, project)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{sample3.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
 
@@ -912,14 +912,14 @@ class DataExportsTest < ApplicationSystemTestCase
     sample43 = samples(:sample43)
 
     visit group_samples_url(group)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{sample43.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
 
@@ -929,14 +929,14 @@ class DataExportsTest < ApplicationSystemTestCase
 
   test 'new linelist export dialog' do
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample30.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -951,9 +951,9 @@ class DataExportsTest < ApplicationSystemTestCase
                          selected: I18n.t('data_exports.new_linelist_export_dialog.selected').downcase)
       assert_text I18n.t('data_exports.new_linelist_export_dialog.available')
       assert_text I18n.t('data_exports.new_linelist_export_dialog.selected')
-      assert_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_selector 'bbutton[disabled]',
                       text: I18n.t('viral.sortable_lists_component.remove_all')
-      assert_no_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_no_selector 'bbutton[disabled]',
                          text: I18n.t('viral.sortable_lists_component.add_all')
       assert_text I18n.t('data_exports.new_linelist_export_dialog.format')
       assert_text I18n.t('data_exports.new_linelist_export_dialog.csv')
@@ -997,14 +997,14 @@ class DataExportsTest < ApplicationSystemTestCase
 
   test 'add all and remove all buttons in new linelist export dialog' do
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample30.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -1023,9 +1023,9 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_selector 'input[disabled]'
-      assert_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.remove_all')
-      assert_no_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_no_selector 'button[disabled]',
                          text: I18n.t('viral.sortable_lists_component.add_all')
 
       click_button I18n.t('viral.sortable_lists_component.add_all')
@@ -1043,9 +1043,9 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_no_selector 'input[disabled]'
-      assert_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.add_all')
-      assert_no_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_no_selector 'button[disabled]',
                          text: I18n.t('viral.sortable_lists_component.remove_all')
 
       click_button I18n.t('viral.sortable_lists_component.remove_all')
@@ -1063,23 +1063,23 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_selector 'input[disabled]'
-      assert_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.remove_all')
-      assert_no_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_no_selector 'button[disabled]',
                          text: I18n.t('viral.sortable_lists_component.add_all')
     end
   end
 
   test 'create csv export from project samples page' do
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within('tbody') do
       find("input[type='checkbox'][value='#{@sample30.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -1098,14 +1098,14 @@ class DataExportsTest < ApplicationSystemTestCase
 
   test 'create xlsx export from group samples page' do
     visit group_samples_url(@group1)
-    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_selector 'button[disabled]',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within('tbody') do
       find("input[type='checkbox'][value='#{@sample1.id}']").click
     end
 
-    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
+    assert_no_selector 'button[disabled]',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -1154,9 +1154,9 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_no_selector 'input[disabled]'
-      assert_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.add_all')
-      assert_no_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_no_selector 'bbutton[disabled]',
                          text: I18n.t('viral.sortable_lists_component.remove_all')
 
       click_button I18n.t('viral.sortable_lists_component.remove_all')
@@ -1172,9 +1172,9 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_selector 'input[disabled]'
-      assert_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_selector 'bbutton[disabled]',
                       text: I18n.t('viral.sortable_lists_component.remove_all')
-      assert_no_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_no_selector 'bbutton[disabled]',
                          text: I18n.t('viral.sortable_lists_component.add_all')
 
       click_button I18n.t('viral.sortable_lists_component.add_all')
@@ -1190,9 +1190,9 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_no_selector 'input[disabled]'
-      assert_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_selector 'bbutton[disabled]',
                       text: I18n.t('viral.sortable_lists_component.add_all')
-      assert_no_selector 'button.pointer-events-none.cursor-not-allowed',
+      assert_no_selector 'bbutton[disabled]',
                          text: I18n.t('viral.sortable_lists_component.remove_all')
     end
   end

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -221,7 +221,7 @@ class DataExportsTest < ApplicationSystemTestCase
 
     visit data_export_path(@data_export2)
 
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t(:'data_exports.show.download')
     assert_no_text I18n.t(:'data_exports.show.tabs.preview')
   end
@@ -278,14 +278,14 @@ class DataExportsTest < ApplicationSystemTestCase
     end
     # project samples page
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample1.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     assert_accessible
@@ -335,7 +335,7 @@ class DataExportsTest < ApplicationSystemTestCase
     # project samples page
     visit group_samples_url(@group1)
     assert_text '1-20 of 26'
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
@@ -343,7 +343,7 @@ class DataExportsTest < ApplicationSystemTestCase
       find("input[type='checkbox'][value='#{@sample2.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.sample_export'), match: :first
@@ -391,25 +391,25 @@ class DataExportsTest < ApplicationSystemTestCase
     sample32 = samples(:sample32)
 
     visit namespace_project_samples_url(subgroup12a, project29)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{sample32.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
 
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample1.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
 
     click_button I18n.t('projects.samples.index.create_export_button.label')
@@ -892,14 +892,14 @@ class DataExportsTest < ApplicationSystemTestCase
     sample3 = samples(:sample3)
 
     visit namespace_project_samples_url(@group1, project)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{sample3.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
 
@@ -912,14 +912,14 @@ class DataExportsTest < ApplicationSystemTestCase
     sample43 = samples(:sample43)
 
     visit group_samples_url(group)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{sample43.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
 
@@ -929,14 +929,14 @@ class DataExportsTest < ApplicationSystemTestCase
 
   test 'new linelist export dialog' do
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample30.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -951,9 +951,9 @@ class DataExportsTest < ApplicationSystemTestCase
                          selected: I18n.t('data_exports.new_linelist_export_dialog.selected').downcase)
       assert_text I18n.t('data_exports.new_linelist_export_dialog.available')
       assert_text I18n.t('data_exports.new_linelist_export_dialog.selected')
-      assert_selector 'bbutton[disabled]',
+      assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.remove_all')
-      assert_no_selector 'bbutton[disabled]',
+      assert_no_selector 'button[disabled]',
                          text: I18n.t('viral.sortable_lists_component.add_all')
       assert_text I18n.t('data_exports.new_linelist_export_dialog.format')
       assert_text I18n.t('data_exports.new_linelist_export_dialog.csv')
@@ -997,14 +997,14 @@ class DataExportsTest < ApplicationSystemTestCase
 
   test 'add all and remove all buttons in new linelist export dialog' do
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within %(#samples-table) do
       find("input[type='checkbox'][value='#{@sample30.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -1072,14 +1072,14 @@ class DataExportsTest < ApplicationSystemTestCase
 
   test 'create csv export from project samples page' do
     visit namespace_project_samples_url(@group1, @project1)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within('tbody') do
       find("input[type='checkbox'][value='#{@sample30.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -1098,14 +1098,14 @@ class DataExportsTest < ApplicationSystemTestCase
 
   test 'create xlsx export from group samples page' do
     visit group_samples_url(@group1)
-    assert_selector 'button[disabled]',
+    assert_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                     text: I18n.t('projects.samples.index.create_export_button.label')
 
     within('tbody') do
       find("input[type='checkbox'][value='#{@sample1.id}']").click
     end
 
-    assert_no_selector 'button[disabled]',
+    assert_no_selector 'button.pointer-events-none.cursor-not-allowed.bg-slate-100.text-slate-600',
                        text: I18n.t('projects.samples.index.create_export_button.label')
     click_button I18n.t('projects.samples.index.create_export_button.label')
     click_link I18n.t('projects.samples.index.create_export_button.linelist_export')
@@ -1156,7 +1156,7 @@ class DataExportsTest < ApplicationSystemTestCase
       assert_no_selector 'input[disabled]'
       assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.add_all')
-      assert_no_selector 'bbutton[disabled]',
+      assert_no_selector 'button[disabled]',
                          text: I18n.t('viral.sortable_lists_component.remove_all')
 
       click_button I18n.t('viral.sortable_lists_component.remove_all')
@@ -1172,9 +1172,9 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_selector 'input[disabled]'
-      assert_selector 'bbutton[disabled]',
+      assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.remove_all')
-      assert_no_selector 'bbutton[disabled]',
+      assert_no_selector 'button[disabled]',
                          text: I18n.t('viral.sortable_lists_component.add_all')
 
       click_button I18n.t('viral.sortable_lists_component.add_all')
@@ -1190,9 +1190,9 @@ class DataExportsTest < ApplicationSystemTestCase
       end
 
       assert_no_selector 'input[disabled]'
-      assert_selector 'bbutton[disabled]',
+      assert_selector 'button[disabled]',
                       text: I18n.t('viral.sortable_lists_component.add_all')
-      assert_no_selector 'bbutton[disabled]',
+      assert_no_selector 'button[disabled]',
                          text: I18n.t('viral.sortable_lists_component.remove_all')
     end
   end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds accessibility to the sortable lists component, enabling keyboard commands to be usable with the lists.

## Screenshots or screen recordings
[Screencast from 2025-03-24 04:19:37 PM.webm](https://github.com/user-attachments/assets/676a93ef-b742-425f-9c5b-132ddc81dbdd)

## How to set up and validate locally
1. Navigate to any dialog with the sortable lists (like creating a linelist export).
2. Tab into the metadata list, and use the keyboard to move the items around.
3. Up/Down to navigate up and down the list, Left/Right to navigate between lists, and Space/Enter to select/de-select an item.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
