### PR TITLE
Samples table accessibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,15 +215,8 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
-    ffi (1.17.1-aarch64-linux-gnu)
-    ffi (1.17.1-aarch64-linux-musl)
-    ffi (1.17.1-arm-linux-gnu)
-    ffi (1.17.1-arm-linux-musl)
     ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86-linux-gnu)
-    ffi (1.17.1-x86-linux-musl)
     ffi (1.17.1-x86_64-linux-gnu)
-    ffi (1.17.1-x86_64-linux-musl)
     fiber-storage (1.0.0)
     flipper (1.3.2)
       concurrent-ruby (< 2)
@@ -374,7 +367,6 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
     minitest (5.25.5)
     msgpack (1.8.0)
     multi_json (1.15.0)
@@ -396,24 +388,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.4)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.18.4-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.4-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.4-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.4-arm-linux-musl)
-      racc (~> 1.4)
     nokogiri (1.18.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.4-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.18.4-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.4-x86_64-linux-musl)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -608,14 +585,12 @@ GEM
     tailwindcss-rails (4.2.0)
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.0.9-arm64-darwin)
     tailwindcss-ruby (4.0.9-x86_64-linux-gnu)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.3.2)
-    thruster (0.1.11)
-    thruster (0.1.11-aarch64-linux)
     thruster (0.1.11-arm64-darwin)
-    thruster (0.1.11-x86_64-darwin)
     thruster (0.1.11-x86_64-linux)
     timecop (0.9.10)
     timeout (0.4.3)
@@ -665,19 +640,9 @@ GEM
     zip_kit (6.3.1)
 
 PLATFORMS
-  aarch64-linux
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux
-  arm-linux-gnu
-  arm-linux-musl
-  arm64-darwin
-  x86-linux
-  x86-linux-gnu
-  x86-linux-musl
+  arm64-darwin-24
   x86_64-linux
   x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   action_policy

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -813,6 +813,15 @@
   }
 }
 
+@utility fixed-table-component {
+  @media screen and (min-height: 500px) {
+    height: calc(100vh - 50px - 32px);
+    max-height: calc(100vh - 50px - 32px);
+    display: flex;
+    flex-direction: column;
+  }
+}
+
 @layer utilities {
   body {
     height: 100vh;
@@ -925,13 +934,6 @@ div.field_with_errors > :is(select) {
 
 .table-container .empty_state_message {
   display: none;
-}
-
-.fixed-table-component {
-  height: calc(100vh - 50px - 32px);
-  max-height: calc(100vh - 50px - 32px);
-  display: flex;
-  flex-direction: column;
 }
 
 .scrollbar::-webkit-scrollbar {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -945,6 +945,7 @@ div.field_with_errors > :is(select) {
   --tw-bg-opacity: 1 !important;
   @apply bg-slate-300 dark:bg-slate-600;
   border-radius: 0.25rem;
+  min-width: 60px;
 }
 
 .scrollbar::-webkit-scrollbar-corner {

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -27,8 +27,8 @@
     </nav>
     <main
       class="
-        max-xl:fixed xl:absolute bottom-0 left-0 right-0 p-4 overflow-y-auto top-12
-        border-t border-slate-200 dark:border-slate-950
+        @container max-xl:fixed xl:absolute bottom-0 left-0 right-0 p-4 overflow-y-auto
+        top-12 border-t border-slate-200 dark:border-slate-950
       "
     >
       <div class="<%= @layout %>"><%= body %></div>

--- a/app/components/samples/editable_cell.html.erb
+++ b/app/components/samples/editable_cell.html.erb
@@ -1,8 +1,7 @@
 <td id="<%= dom_id(@sample, @field) %>">
   <button
     class="
-      w-full p-3 text-left cursor-pointer hover:bg-slate-50 focus:outline-hidden
-      dark:hover:bg-slate-600
+      w-full p-3 text-left cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-600
     "
     data-action="click->projects--samples--metadata--editable-cell#submit"
     data-field="<%= @field %>"

--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -7,7 +7,7 @@
           whitespace-nowrap
         '
       >
-        <thead class='sticky top-0 z-10 text-xs uppercase'>
+        <thead class='@2xl:sticky @2xl:top-0 z-10 text-xs uppercase'>
           <tr
             class="
               border-b dark:border-slate-900 border-slate-200 dark:text-slate-400
@@ -18,7 +18,7 @@
               <%= render_cell(
               tag: 'th',
               scope: 'col',
-              classes: class_names('sticky px-3 py-3 bg-slate-100 dark:bg-slate-900', 'left-0 min-w-56 max-w-56 z-10': index.zero?, 'left-56 z-10': index == 1)
+              classes: class_names('px-3 py-3 bg-slate-100 dark:bg-slate-900', '@2xl:sticky left-0 min-w-56 max-w-56 z-10': index.zero?, '@4xl:sticky left-56 z-10': index == 1)
                 ) do %>
                 <% if index.zero? and @abilities[:select_samples] %>
                   <%= check_box_tag "select-page",
@@ -63,7 +63,7 @@
               <%= render_cell(
               tag: 'th',
               scope: 'col',
-              classes: class_names('px-3 py-3 bg-slate-100 dark:bg-slate-900 sticky right-0')
+              classes: class_names('px-3 py-3 bg-slate-100 dark:bg-slate-900 @4xl:sticky right-0')
             ) do %>
                 <%= t(".action") %>
               <% end %>
@@ -82,7 +82,7 @@
                 <%= render_cell(
                 tag: index.zero? ? 'th' :'td',
                 scope: index.zero? ? 'row' : nil,
-                classes: class_names('px-3 py-3', 'sticky left-0 z-5 min-w-56 max-w-56 bg-slate-50 dark:bg-slate-900': index.zero?, 'sticky z-5 left-56 bg-slate-50 dark:bg-slate-900': index == 1)
+                classes: class_names('px-3 py-3', '@2xl:sticky left-0 z-5 min-w-56 max-w-56 bg-slate-50 dark:bg-slate-900': index.zero?, '@4xl:sticky z-5 left-56 bg-slate-50 dark:bg-slate-900': index == 1)
               ) do %>
                   <% if index.zero? && @abilities[:select_samples] %>
                     <%= check_box_tag "sample_ids[]",
@@ -144,7 +144,7 @@
               <% if @renders_row_actions %>
                 <%= render_cell(
                 tag: 'td',
-                classes: class_names('sticky right-0')
+                classes: class_names('@4xl:sticky right-0')
               ) do %>
                   <div class="px-3 py-2.5 bg-white dark:bg-slate-800 z-5 space-x-2 w-full">
                     <% if @row_actions[:edit] %>
@@ -183,7 +183,7 @@
           <% end %>
         </tbody>
         <% if @abilities[:select_samples] && @has_samples %>
-          <tfoot class="sticky bottom-0 z-10 bg-slate-100 dark:bg-slate-900">
+          <tfoot class="@2xl:sticky bottom-0 z-10 bg-slate-100 dark:bg-slate-900">
             <tr>
               <td
                 class="

--- a/app/components/samples/table_component.rb
+++ b/app/components/samples/table_component.rb
@@ -56,7 +56,7 @@ module Samples
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('table-container flex flex-col shrink min-h-0'),
+        classes: class_names('table-container @2xl:flex @2xl:flex-col @3xl:shrink @3xl:min-h-0'),
         'data-controller' => 'projects--samples--metadata--editable-cell'
       }
     end

--- a/app/components/viral/dropdown_component.rb
+++ b/app/components/viral/dropdown_component.rb
@@ -55,7 +55,7 @@ module Viral
     def system_arguments_for_button
       {
         classes: class_names(
-          'viral-dropdown--button cursor-pointer flex items-center w-full',
+          'viral-dropdown--button flex items-center w-full',
           system_arguments[:classes]
         )
       }
@@ -64,7 +64,7 @@ module Viral
     def system_arguments_for_icon
       {
         classes: class_names(
-          'viral-dropdown--icon cursor-pointer',
+          'viral-dropdown--icon',
           system_arguments[:classes]
         )
       }

--- a/app/components/viral/page_header_component.html.erb
+++ b/app/components/viral/page_header_component.html.erb
@@ -1,6 +1,6 @@
-<div class="justify-between w-full mb-4 page-header sm:flex">
-  <div class="flex items-start">
-    <% if icon.present? %>
+<div class="justify-between w-full mb-4 page-header flex @max-md:flex-col">
+  <div class="flex items-center">
+    <% if icon? %>
       <span class="mr-2"><%= icon %></span>
     <% end %>
 
@@ -26,7 +26,7 @@
       <% end %>
     </div>
   </div>
-  <div class="flex ml-auto space-x-2 whitespace-nowrap sm:space-x-3">
+  <div class=" flex @md:ml-auto space-x-2 whitespace-nowrap @max-md:mt-2">
     <div class="flex-none"><%= buttons %></div>
   </div>
 </div>

--- a/app/components/viral/page_header_component.rb
+++ b/app/components/viral/page_header_component.rb
@@ -5,7 +5,7 @@ module Viral
   class PageHeaderComponent < Component
     attr_reader :title, :subtitle, :id, :id_color
 
-    renders_one :icon
+    renders_one :icon, Viral::IconComponent
     renders_one :buttons
 
     def initialize(title:, id: nil, subtitle: nil, id_color: :primary)

--- a/app/components/viral/pagy/full_component.html.erb
+++ b/app/components/viral/pagy/full_component.html.erb
@@ -1,5 +1,9 @@
 <% if pagy.vars[:size].positive? && pagy.count.positive? %>
-  <div class="flex items-center justify-between">
+  <div
+    class="
+      flex items-center justify-between @max-3xl:flex-col @max-3xl:space-y-2 mt-2
+    "
+  >
     <%= render Viral::Pagy::LimitComponent.new(pagy, item: item) %>
     <%= render Viral::Pagy::PaginationComponent.new(pagy) %>
   </div>

--- a/app/components/viral/pagy/limit_component.html.erb
+++ b/app/components/viral/pagy/limit_component.html.erb
@@ -1,8 +1,6 @@
 <div
   id="limit-component"
-  class="
-    inline-flex items-center mt-4 space-x-2 text-slate-500 dark:text-slate-400
-  "
+  class="inline-flex items-center space-x-2 text-slate-500 dark:text-slate-400"
 >
   <span><%= t(".items", items: @item) %></span>
   <%= viral_dropdown(label: @pagy.limit) do |dropdown| %>

--- a/app/components/viral/pagy/limit_component.html.erb
+++ b/app/components/viral/pagy/limit_component.html.erb
@@ -1,12 +1,17 @@
 <div
   id="limit-component"
-  class="inline-flex items-center space-x-2 text-slate-500 dark:text-slate-400"
+  class="
+    @md:inline-flex @max-md:flex @max-md:flex-col items-center @md:space-x-2
+    text-slate-500 dark:text-slate-400
+  "
 >
-  <span><%= t(".items", items: @item) %></span>
-  <%= viral_dropdown(label: @pagy.limit) do |dropdown| %>
-    <% Pagy::DEFAULT[:limits].each do |limit| %>
-      <% dropdown.with_item(label: limit, url: current_url_with_limit(limit)) %>
+  <div class="inline-flex items-center space-x-2">
+    <span><%= t(".items", items: @item) %></span>
+    <%= viral_dropdown(label: @pagy.limit) do |dropdown| %>
+      <% Pagy::DEFAULT[:limits].each do |limit| %>
+        <% dropdown.with_item(label: limit, url: current_url_with_limit(limit)) %>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
   <span><%== t(".summary", to: @pagy.to, from: @pagy.from, count: @pagy.count) %></span>
 </div>

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -15,8 +15,8 @@
         nil,
         disabled: true,
         class: "#{disabled_link_classes} border-e-0 rounded-s-lg",
-        data: {
-          "aria-disabled": true,
+        aria: {
+          disabled: true,
         } %>
       <% end %>
     </li>
@@ -30,8 +30,8 @@
           nil,
           disabled: true,
           class: current_link_classes,
-          data: {
-            "aria-disabled": true,
+          aria: {
+            disabled: true,
           } %>
 
         <% elsif item == :gap %>
@@ -39,8 +39,8 @@
           nil,
           disabled: true,
           class: class_names(disabled_link_classes, invisible_link_classes),
-          data: {
-            "aria-disabled": true,
+          aria: {
+            disabled: true,
           } %>
         <% end %>
       </li>
@@ -54,8 +54,8 @@
         nil,
         disabled: true,
         class: "#{disabled_link_classes} rounded-e-lg cursor-default",
-        data: {
-          "aria-disabled": true,
+        aria: {
+          disabled: true,
         } %>
       <% end %>
     </li>

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -24,7 +24,7 @@
     <% @pagy.series.each do |item| %>
       <li>
         <% if item.is_a?(Integer) %>
-          <%== a.(item, classes: active_link_classes) %>
+          <%== a.(item, classes: class_names(active_link_classes, invisible_link_classes)) %>
         <% elsif item.is_a?(String) %>
           <%= button_to item,
           nil,
@@ -38,7 +38,7 @@
           <%= button_to "...",
           nil,
           disabled: true,
-          class: disabled_link_classes,
+          class: class_names(disabled_link_classes, invisible_link_classes),
           data: {
             "aria-disabled": true,
           } %>

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -11,13 +11,14 @@
           classes: "#{active_link_classes} border-e-0 rounded-s-lg",
         ) %>
       <% else %>
-        <%= button_to t(".previous"),
-        nil,
-        disabled: true,
-        class: "#{disabled_link_classes} border-e-0 rounded-s-lg",
-        aria: {
-          disabled: true,
-        } %>
+        <%= content_tag(
+          :a,
+          t(".previous"),
+          class: "#{disabled_link_classes} border-e-0 rounded-s-lg",
+          aria: {
+            disabled: true,
+          },
+        ) %>
       <% end %>
     </li>
     <%# Page links (series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]) %>
@@ -26,22 +27,16 @@
         <% if item.is_a?(Integer) %>
           <%== a.(item, classes: class_names(active_link_classes, invisible_link_classes)) %>
         <% elsif item.is_a?(String) %>
-          <%= button_to item,
-          nil,
-          disabled: true,
-          class: current_link_classes,
-          aria: {
-            disabled: true,
-          } %>
-
+          <%= content_tag(:a, item, class: current_link_classes, aria: { disabled: true }) %>
         <% elsif item == :gap %>
-          <%= button_to "...",
-          nil,
-          disabled: true,
-          class: class_names(disabled_link_classes, invisible_link_classes),
-          aria: {
-            disabled: true,
-          } %>
+          <%= content_tag(
+            :a,
+            "...",
+            class: class_names(disabled_link_classes, invisible_link_classes),
+            aria: {
+              disabled: true,
+            },
+          ) %>
         <% end %>
       </li>
     <% end %>
@@ -50,13 +45,14 @@
       <% if @pagy.next %>
         <%== a.(@pagy.next, t(".next"), classes: "#{active_link_classes} rounded-e-lg") %>
       <% else %>
-        <%= button_to t(".next"),
-        nil,
-        disabled: true,
-        class: "#{disabled_link_classes} rounded-e-lg cursor-default",
-        aria: {
-          disabled: true,
-        } %>
+        <%= content_tag(
+          :a,
+          t(".next"),
+          class: "#{disabled_link_classes} rounded-e-lg cursor-default",
+          aria: {
+            disabled: true,
+          },
+        ) %>
       <% end %>
     </li>
   </ul>

--- a/app/components/viral/pagy/pagination_component.rb
+++ b/app/components/viral/pagy/pagination_component.rb
@@ -21,6 +21,10 @@ module Viral
         "#{default_link_classes} text-primary-800 bg-primary-50 hover:bg-primary-100 hover:text-primary-700 dark:bg-slate-700 dark:text-white" # rubocop:disable Layout/LineLength
       end
 
+      def invisible_link_classes
+        '@max-md:invisible @max-md:w-0 @max-md:p-0 @max-md:border-none'
+      end
+
       private
 
       def default_link_classes

--- a/app/components/viral/pagy/pagination_component.rb
+++ b/app/components/viral/pagy/pagination_component.rb
@@ -18,11 +18,11 @@ module Viral
       end
 
       def disabled_link_classes
-        "#{default_link_classes} cursor-not-allowed opacity-50 text-slate-600 bg-slate-50 dark:bg-slate-700 dark:text-slate-400"
+        "#{default_link_classes} cursor-not-allowed opacity-50 text-slate-600 bg-slate-50 dark:bg-slate-700 dark:text-slate-400" # rubocop:disable Layout/LineLength
       end
 
       def current_link_classes
-        "#{default_link_classes} cursor-not-allowed text-primary-800 bg-primary-50 hover:bg-primary-100 hover:text-primary-700 dark:bg-slate-700 dark:text-white" # rubocop:disable Layout/LineLength
+        "#{default_link_classes} cursor-not-allowed text-primary-800 bg-primary-50 dark:bg-slate-700 dark:text-white"
       end
 
       def invisible_link_classes

--- a/app/components/viral/pagy/pagination_component.rb
+++ b/app/components/viral/pagy/pagination_component.rb
@@ -9,16 +9,20 @@ module Viral
         @data_string = data_string
       end
 
+      def render?
+        @pagy.next || @pagy.prev
+      end
+
       def active_link_classes
         "#{default_link_classes} text-slate-500 bg-white hover:bg-slate-100 hover:text-slate-700 dark:bg-slate-800  dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-white" # rubocop:disable Layout/LineLength
       end
 
       def disabled_link_classes
-        "#{default_link_classes} cursor-default text-slate-600 bg-slate-50 dark:bg-slate-700 dark:text-slate-400"
+        "#{default_link_classes} cursor-not-allowed opacity-50 text-slate-600 bg-slate-50 dark:bg-slate-700 dark:text-slate-400"
       end
 
       def current_link_classes
-        "#{default_link_classes} text-primary-800 bg-primary-50 hover:bg-primary-100 hover:text-primary-700 dark:bg-slate-700 dark:text-white" # rubocop:disable Layout/LineLength
+        "#{default_link_classes} cursor-not-allowed text-primary-800 bg-primary-50 hover:bg-primary-100 hover:text-primary-700 dark:bg-slate-700 dark:text-white" # rubocop:disable Layout/LineLength
       end
 
       def invisible_link_classes

--- a/app/views/groups/bots/index.html.erb
+++ b/app/views/groups/bots/index.html.erb
@@ -1,8 +1,7 @@
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
 <%= turbo_frame_tag "token_dialog" %>
 <%= render Viral::PageHeaderComponent.new(title: t('.title'), subtitle: t('.subtitle')) do |component| %>
-  <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
-  <%= component.with_buttons do %>
+  <% component.with_buttons do %>
     <% if allowed_to?(:create_bot_accounts?, @namespace) %>
       <%= link_to t(".add_new_bot"),
       new_group_bot_path(@namespace),

--- a/app/views/groups/history/index.html.erb
+++ b/app/views/groups/history/index.html.erb
@@ -1,6 +1,4 @@
-<%= render Viral::PageHeaderComponent.new(title: t(:".title")) do |component| %>
-  <%= component.with_icon(name: "list_bullet", classes: "h-14 w-14 text-primary-700") %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(title: t(:".title")) %>
 
 <div class="px-4">
   <%= turbo_frame_tag "history_modal" %>

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -2,8 +2,7 @@
 <%= turbo_frame_tag "member-update-alert" %>
 
 <%= render Viral::PageHeaderComponent.new(title: t(:'.title'), subtitle: t(:'.subtitle', namespace_type: @namespace.class.model_name.human, namespace_name: @namespace.name)) do |component| %>
-  <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
-  <%= component.with_buttons do %>
+  <% component.with_buttons do %>
     <% if allowed_to?(:link_namespace_with_group?, @namespace) %>
       <%= link_to I18n.t("groups.members.index.invite_group"),
       new_group_group_link_path(@namespace, tab: @tab),

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,6 +1,7 @@
-<%= render Viral::PageHeaderComponent.new(title: t(:"groups.create.title"), subtitle: t(:"groups.create.subtitle")) do |component| %>
-  <%= component.with_icon(name: "squares_plus", classes: "h-14 w-14 text-primary-700") %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(
+  title: t(:"groups.create.title"),
+  subtitle: t(:"groups.create.subtitle"),
+) %>
 <div data-controller="slugify" class="card">
   <%= form_with(model: @new_group, url: groups_path, method: :post) do |form| %>
     <div class="grid gap-4">

--- a/app/views/groups/new_subgroup.html.erb
+++ b/app/views/groups/new_subgroup.html.erb
@@ -1,6 +1,7 @@
-<%= render Viral::PageHeaderComponent.new(title: t(:'groups.new_subgroup.title'), subtitle: t(:'groups.new_subgroup.subtitle')) do |component| %>
-  <%= component.with_icon(name: "squares_plus", classes: "h-14 w-14 text-primary-700") %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(
+  title: t(:"groups.new_subgroup.title"),
+  subtitle: t(:"groups.new_subgroup.subtitle"),
+) %>
 
 <div
   data-controller="slugify"

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -28,7 +28,7 @@
                 },
                 class:
                   "flex items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
               ) %>
             <% else %>
               <% dropdown.with_item(
@@ -61,7 +61,7 @@
   <% end %>
 
   <% if @has_samples %>
-    <div class="flex mb-2">
+    <div class="flex @max-2xl:flex-col @max-2xl:space-y-2 mb-2">
       <div class="inline-flex grow space-x-2">
         <% if allowed_to?(:submit_workflow?, @group) || allowed_to?(:export_data?, @group) %>
           <%= form_with(

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -7,8 +7,7 @@
 
 <div class="fixed-table-component">
   <%= render Viral::PageHeaderComponent.new(title: t(:'.title'), subtitle: t(:'.subtitle', namespace_type: @group.class.model_name.human, namespace_name: @group.name)) do |component| %>
-    <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
-    <%= component.with_buttons do %>
+    <% component.with_buttons do %>
       <div class="flex items-center space-x-2">
         <% if allowed_to?(:submit_workflow?, @group) && @pipelines_enabled %>
           <%= link_to pipeline_selection_workflow_executions_submissions_path(namespace_id: @group.id),
@@ -29,7 +28,7 @@
                 },
                 class:
                   "flex items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
               ) %>
             <% else %>
               <% dropdown.with_item(

--- a/app/views/groups/workflow_executions/show.html.erb
+++ b/app/views/groups/workflow_executions/show.html.erb
@@ -8,8 +8,7 @@
 
 <%= render Viral::PageHeaderComponent.new(title: turbo_frame_tag('we_name_header') do @workflow_execution.name.blank? ? @workflow_execution.metadata["workflow_name"] :
    @workflow_execution.name end, id: @workflow_execution.id, id_color: find_pill_color_for_state(@workflow_execution.state)) do |component| %>
-  <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
-  <%= component.with_buttons do %>
+  <% component.with_buttons do %>
     <div class="flex flex-row">
       <% if allowed_to?(:export_data?, @namespace) %>
         <% if @workflow_execution.completed? %>

--- a/app/views/profiles/personal_access_tokens/index.html.erb
+++ b/app/views/profiles/personal_access_tokens/index.html.erb
@@ -1,7 +1,8 @@
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
-<%= render Viral::PageHeaderComponent.new(title: t("profiles.personal_access_tokens.index.title"), subtitle: t("profiles.personal_access_tokens.index.subtitle")) do |component| %>
-  <%= component.with_icon(name: "ticket", classes: "h-14 w-14 text-primary-700") %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(
+  title: t("profiles.personal_access_tokens.index.title"),
+  subtitle: t("profiles.personal_access_tokens.index.subtitle"),
+) %>
 
 <div class="grid gap-4 grid-cols-1">
   <%= turbo_frame_tag "access-token-section" %>

--- a/app/views/projects/bots/index.html.erb
+++ b/app/views/projects/bots/index.html.erb
@@ -1,7 +1,6 @@
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
 <%= turbo_frame_tag "token_dialog" %>
 <%= render Viral::PageHeaderComponent.new(title: t('.title'), subtitle: t('.subtitle')) do |component| %>
-  <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
   <% if allowed_to?(:create_bot_accounts?, @namespace) %>
     <%= component.with_buttons do %>
       <%= link_to t(".add_new_bot"),

--- a/app/views/projects/history/index.html.erb
+++ b/app/views/projects/history/index.html.erb
@@ -1,6 +1,7 @@
-<%= render Viral::PageHeaderComponent.new(title: t(:".title"), subtitle: t(:".subtitle")) do |component| %>
-  <%= component.with_icon(name: "list_bullet", classes: "h-14 w-14 text-primary-700") %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(
+  title: t(:".title"),
+  subtitle: t(:".subtitle"),
+) %>
 
 <div class="px-4">
   <%= turbo_frame_tag "history_modal" %>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -2,8 +2,7 @@
 <%= turbo_frame_tag "member-update-alert" %>
 
 <%= render Viral::PageHeaderComponent.new(title: t(:'.title'), subtitle: t(:'.subtitle', namespace_type: @namespace.class.model_name.human, namespace_name: @namespace.name)) do |component| %>
-  <%= component.with_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
-  <%= component.with_buttons do %>
+  <% component.with_buttons do %>
     <% if allowed_to?(:link_namespace_with_group?, @namespace) %>
       <%= link_to I18n.t("projects.members.index.invite_group"),
       new_namespace_project_group_link_path(

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,9 +1,7 @@
-<%= render Viral::PageHeaderComponent.new(title: t(:".title"), subtitle: t(:".subtitle")) do |component| %>
-  <%= component.with_icon(
-    name: "rectangle_stack",
-    classes: "h-14 w-14 text-primary-700",
-  ) %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(
+  title: t(:".title"),
+  subtitle: t(:".subtitle"),
+) %>
 
 <div class="p-4">
   <div class="mb-4 card" data-controller="slugify">

--- a/app/views/projects/samples/edit.html.erb
+++ b/app/views/projects/samples/edit.html.erb
@@ -1,6 +1,7 @@
-<%= render Viral::PageHeaderComponent.new(title: t("projects.samples.edit.title"), subtitle: t("projects.samples.edit.subtitle")) do |component| %>
-  <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(
+  title: t("projects.samples.edit.title"),
+  subtitle: t("projects.samples.edit.subtitle"),
+) %>
 <div class="p-4">
   <div class="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
     <div

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -9,8 +9,7 @@
 
 <div class="fixed-table-component">
   <%= render Viral::PageHeaderComponent.new(title: t('.title')) do |component| %>
-    <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
-    <%= component.with_buttons do %>
+    <% component.with_buttons do %>
       <div class="flex items-center space-x-2">
         <% if allowed_to?(:submit_workflow?, @project) && @pipelines_enabled %>
           <%= link_to pipeline_selection_workflow_executions_submissions_path(namespace_id: @project.namespace.id),

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -113,7 +113,7 @@
     <% end %>
   <% end %>
 
-  <div class="flex mb-2">
+  <div class="flex @max-2xl:flex-col @max-2xl:space-y-2 mb-2">
     <div class="inline-flex grow space-x-2">
       <% if allowed_to?(:submit_workflow?, @project) || allowed_to?(:clone_sample?, @project) || allowed_to?(:transfer_sample?, @project) || allowed_to?(:export_data?, @project) %>
         <%= form_with(

--- a/app/views/projects/samples/new.html.erb
+++ b/app/views/projects/samples/new.html.erb
@@ -1,6 +1,7 @@
-<%= render Viral::PageHeaderComponent.new(title: t("projects.samples.new.title"), subtitle: t("projects.samples.new.subtitle")) do |component| %>
-  <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
-<% end %>
+<%= render Viral::PageHeaderComponent.new(
+  title: t("projects.samples.new.title"),
+  subtitle: t("projects.samples.new.subtitle"),
+) %>
 <div class="p-4">
   <div class="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
     <div

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -2,8 +2,7 @@
 
 <%= render Viral::PageHeaderComponent.new(title: @sample.name, id: @sample.puid, subtitle: @sample.description) do |component| %>
   <%= viral_pill(text: @sample.puid, color: :blue) %>
-  <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
-  <%= component.with_buttons do %>
+  <% component.with_buttons do %>
     <div class="flex flex-row">
       <% if allowed_to?(:new?, @project) %>
         <%= link_to(

--- a/app/views/shared/metadata_templates/_header.html.erb
+++ b/app/views/shared/metadata_templates/_header.html.erb
@@ -1,6 +1,5 @@
 <%= render Viral::PageHeaderComponent.new(title: title, subtitle: subtitle) do |component| %>
-  <%= component.with_icon(name: "list_bullet", classes: "h-14 w-14 text-primary-700") %>
-  <%= component.with_buttons do %>
+  <% component.with_buttons do %>
     <% if namespace.metadata_fields.length.positive? && allowed_to?(:create_metadata_templates?, namespace) %>
       <%= link_to new_template_button_text,
       new_template_url,

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -5,8 +5,8 @@
   <%= f.hidden_field :metadata_template, value: metadata_template[:id] %>
   <%= f.button type: :submit,
     class: "inline-flex items-center justify-center
-            w-1/2 sm:w-auto
-            px-5 py-2.5 ml-2
+            sm:w-auto
+            px-5 py-2.5
             text-sm
             border rounded-md
             cursor-pointer

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -10,7 +10,7 @@
             text-sm
             border rounded-md
             cursor-pointer
-            focus:z-10 focus:outline-hidden focus:ring-slate-200
+            focus:z-10 focus:ring-slate-200
             bg-white text-slate-900 border-slate-200
             hover:bg-slate-100 hover:text-slate-950
             dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600

--- a/app/views/workflow_executions/show.html.erb
+++ b/app/views/workflow_executions/show.html.erb
@@ -8,8 +8,7 @@
 
 <%= render Viral::PageHeaderComponent.new(title: turbo_frame_tag('we_name_header') do @workflow_execution.name.blank? ? @workflow_execution.metadata["workflow_name"] :
    @workflow_execution.name end, id: @workflow_execution.id, id_color: find_pill_color_for_state(@workflow_execution.state)) do |component| %>
-  <%= component.with_icon(name: "beaker", classes: "h-14 w-14 text-primary-700") %>
-  <%= component.with_buttons do %>
+  <% component.with_buttons do %>
     <div class="flex flex-row">
       <% if @workflow_execution.completed? %>
         <%= link_to t(".create_export_button"),

--- a/test/components/viral/pagy_full_component_preview_test.rb
+++ b/test/components/viral/pagy_full_component_preview_test.rb
@@ -7,10 +7,10 @@ class PagyFullComponentPreviewTest < ApplicationSystemTestCase
     visit('/rails/view_components/viral_pagy_full_component/default')
 
     assert_selector 'nav.pagy.nav'
-    assert_selector 'li button[disabled]', text: 'Previous'
+    assert_selector 'li a[aria-disabled="true"]', text: 'Previous'
     assert_selector 'li > a', text: 'Next'
-    assert_selector 'li button[disabled]', text: '1'
-    assert_selector 'li > a:not([data-aria-disabled="true"])', count: '5'
+    assert_selector 'li a[aria-disabled="true"]', text: '1'
+    assert_selector 'li > a:not([aria-disabled="true"])', count: '5'
   end
 
   test 'renders empty state' do

--- a/test/components/viral/pagy_pagination_component_preview_test.rb
+++ b/test/components/viral/pagy_pagination_component_preview_test.rb
@@ -1,36 +1,38 @@
 # frozen_string_literal: true
 
-require 'application_system_test_case'
+require 'view_component_test_case'
 
-class PagyPaginationComponentPreviewTest < ApplicationSystemTestCase
-  test 'renders default' do
-    visit('/rails/view_components/viral_pagy_pagination_component/default')
+module Viral
+  class PagyPaginationComponentTest < ViewComponentTestCase
+    test 'renders default' do
+      render_preview(:default)
 
-    assert_selector 'nav.pagy.nav'
-    assert_selector 'li button[disabled]', text: 'Previous'
-    assert_selector 'li > a', text: 'Next'
-    assert_selector 'li button[disabled]', text: '1'
-    assert_selector 'li > a:not([data-aria-disabled="true"])', count: '5'
-  end
+      assert_selector 'nav.pagy.nav'
+      assert_selector 'li a[aria-disabled="true"]', text: 'Previous'
+      assert_selector 'li > a', text: 'Next'
+      assert_selector 'li a[aria-disabled="true"]', text: '1'
+      assert_selector 'li > a:not([aria-disabled="true"])', count: '5'
+    end
 
-  test 'renders with one item' do
-    visit('/rails/view_components/viral_pagy_pagination_component/only_one_page')
+    test 'does not render when only one page' do
+      render_preview(:only_one_page)
 
-    assert_selector 'nav.pagy.nav'
-    assert_selector 'li button[disabled]', text: 'Previous'
-    assert_selector 'li button[disabled]', text: 'Next'
-    assert_selector 'li button[disabled]', text: '1'
-    assert_no_selector 'li > a:not([data-aria-disabled="true"])'
-  end
+      assert_no_selector 'nav.pagy.nav'
+      assert_no_selector 'li a[aria-disabled="true"]', text: 'Previous'
+      assert_no_selector 'li a[aria-disabled="true"]', text: 'Next'
+      assert_no_selector 'li a[aria-disabled="true"]', text: '1'
+      assert_no_selector 'li > a:not([aria-disabled="true"])'
+    end
 
-  test 'renders many pages' do
-    visit('/rails/view_components/viral_pagy_pagination_component/many_pages')
+    test 'renders many pages' do
+      render_preview(:many_pages)
 
-    assert_selector 'nav.pagy.nav'
-    assert_selector 'li > a', text: 'Previous'
-    assert_selector 'li > a', text: 'Next'
-    assert_selector 'li button[disabled]', text: '5'
-    assert_selector 'li > a:not([data-aria-disabled="true"])', count: '6'
-    assert_selector 'li button[disabled]', text: '...', count: '2'
+      assert_selector 'nav.pagy.nav'
+      assert_selector 'li > a', text: 'Previous'
+      assert_selector 'li > a', text: 'Next'
+      assert_selector 'li a[aria-disabled="true"]', text: '5'
+      assert_selector 'li > a:not([aria-disabled="true"])', count: '6'
+      assert_selector 'li a[aria-disabled="true"]', text: '...', count: '2'
+    end
   end
 end

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -43,7 +43,7 @@ module Groups
       assert_selector 'tbody > tr', count: 20
       assert_text samples(:sample3).name
       assert_selector 'a', text: I18n.t(:'viral.pagy.pagination_component.next', locale: @user.locale)
-      assert_selector 'button[disabled="disabled"]',
+      assert_selector 'a[aria-disabled="true"]',
                       text: I18n.t(:'viral.pagy.pagination_component.previous', locale: @user.locale)
 
       click_on I18n.t(:'viral.pagy.pagination_component.next', locale: @user.locale)
@@ -72,7 +72,7 @@ module Groups
       assert_text samples(:sample1).name
       assert_text samples(:sample3).name
       assert_selector 'a', text: I18n.t(:'viral.pagy.pagination_component.next', locale: @user.locale)
-      assert_selector 'button[disabled="disabled"]',
+      assert_selector 'a[aria-disabled="true"]',
                       text: I18n.t(:'viral.pagy.pagination_component.previous', locale: @user.locale)
 
       click_on I18n.t(:'viral.pagy.pagination_component.next', locale: @user.locale)
@@ -96,7 +96,7 @@ module Groups
       visit group_samples_url(group)
 
       assert_selector 'a', text: I18n.t(:'viral.pagy.pagination_component.next', locale: @user.locale)
-      assert_selector 'button[disabled="disabled"]',
+      assert_selector 'a[aria-disabled="true"]',
                       text: I18n.t(:'viral.pagy.pagination_component.previous', locale: @user.locale)
 
       click_on I18n.t(:'viral.pagy.pagination_component.next', locale: @user.locale)


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the Samples::TableComponent and any components used one the Samples Indexes to be accessible at zoom level 400% at 1280px browser width and also indicate keyboard focus when tabbing through elements.

Elements not addressed in this PR:
Any buttons that launch dialogs on this page
Buttons in page header (this is being worked on by a different person in a different branch).
Breadcrumbs (this will need to be handled in a separate PR)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before:
![image](https://github.com/user-attachments/assets/7a26e1cb-21e4-48ef-8b28-9ef2cd3d599d)

After:
![image](https://github.com/user-attachments/assets/9b0d5b4d-6ccf-476b-929c-bc4182937ed5)
![image](https://github.com/user-attachments/assets/6b9e9466-63fe-4ab5-b394-eab1b702b80d)
![image](https://github.com/user-attachments/assets/5a921dc1-b40a-472c-8049-5c4cd8e3a3d0)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Restart server
2. Open a browser window and resize it so that it is roughly 1280px - 1024px.
3. Navigate to a Project Samples page with at least 10 samples
4. Toggle Metadata
5. Zoom in to 400%
6. Verify that user is able to navigate the page and see all content
7. Reconfirm on a Group Samples page

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
