### PR TITLE
Add file preview to workflow execution files for project & groups

### DIFF
--- a/app/views/groups/workflow_executions/_attachment.html.erb
+++ b/app/views/groups/workflow_executions/_attachment.html.erb
@@ -75,4 +75,14 @@
   <td class="px-6 py-4">
     <%= local_time_ago(attachment.created_at) %>
   </td>
+
+  <td class="px-6 py-4">
+    <%= render partial: "attachment_actions", locals: { attachment: attachment } %>
+    <% if attachment.associated_attachment %>
+      <%= render partial: "attachment_actions",
+      locals: {
+        attachment: attachment.associated_attachment,
+      } %>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/groups/workflow_executions/_attachment_actions.html.erb
+++ b/app/views/groups/workflow_executions/_attachment_actions.html.erb
@@ -1,0 +1,17 @@
+<div
+  class="<%= class_names('flex justify-end', 'mb-4': attachment.metadata['direction'] == 'forward') %>"
+>
+  <% if Flipper.enabled?(:attachments_preview) && attachment.previewable? %>
+    <%= link_to attachment_path(attachment), class: "text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer" do %>
+      <%= t("workflow_executions.attachment.preview") %>
+    <% end %>
+  <% end %>
+
+  <%= link_to t("workflow_executions.attachment.download"),
+  rails_blob_path(attachment.file),
+  data: {
+    turbo: false,
+  },
+  class:
+    "text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer ml-2" %>
+</div>

--- a/app/views/groups/workflow_executions/_files.html.erb
+++ b/app/views/groups/workflow_executions/_files.html.erb
@@ -24,6 +24,7 @@
         <th scope="col" class="px-6 py-3"><%= t(:".table_header.type") %></th>
         <th scope="col" class="px-6 py-3"><%= t(:".table_header.size") %></th>
         <th scope="col" class="px-6 py-3"><%= t(:".table_header.created_at") %></th>
+        <th scope="col" class="px-6 py-3 text-right"><%= t(:".table_header.actions") %></th>
       </tr>
     </thead>
     <tbody

--- a/app/views/projects/workflow_executions/_attachment.html.erb
+++ b/app/views/projects/workflow_executions/_attachment.html.erb
@@ -75,4 +75,14 @@
   <td class="px-6 py-4">
     <%= local_time_ago(attachment.created_at) %>
   </td>
+
+  <td class="px-6 py-4">
+    <%= render partial: "attachment_actions", locals: { attachment: attachment } %>
+    <% if attachment.associated_attachment %>
+      <%= render partial: "attachment_actions",
+      locals: {
+        attachment: attachment.associated_attachment,
+      } %>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/projects/workflow_executions/_attachment_actions.html.erb
+++ b/app/views/projects/workflow_executions/_attachment_actions.html.erb
@@ -1,0 +1,17 @@
+<div
+  class="<%= class_names('flex justify-end', 'mb-4': attachment.metadata['direction'] == 'forward') %>"
+>
+  <% if Flipper.enabled?(:attachments_preview) && attachment.previewable? %>
+    <%= link_to attachment_path(attachment), class: "text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer" do %>
+      <%= t("workflow_executions.attachment.preview") %>
+    <% end %>
+  <% end %>
+
+  <%= link_to t("workflow_executions.attachment.download"),
+  rails_blob_path(attachment.file),
+  data: {
+    turbo: false,
+  },
+  class:
+    "text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer ml-2" %>
+</div>

--- a/app/views/projects/workflow_executions/_files.html.erb
+++ b/app/views/projects/workflow_executions/_files.html.erb
@@ -24,6 +24,7 @@
         <th scope="col" class="px-6 py-3"><%= t(:".table_header.type") %></th>
         <th scope="col" class="px-6 py-3"><%= t(:".table_header.size") %></th>
         <th scope="col" class="px-6 py-3"><%= t(:".table_header.created_at") %></th>
+        <th scope="col" class="px-6 py-3 text-right"><%= t(:".table_header.actions") %></th>
       </tr>
     </thead>
     <tbody

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -978,6 +978,7 @@ en:
         title: Edit workflow execution
       files:
         table_header:
+          actions: Actions
           created_at: Created At
           filename: Filename
           format: Format
@@ -1725,6 +1726,7 @@ en:
         title: Edit automated workflow execution
       files:
         table_header:
+          actions: Actions
           created_at: Created At
           filename: Filename
           format: Format

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -976,6 +976,7 @@ fr:
         title: Edit workflow execution
       files:
         table_header:
+          actions: Actions
           created_at: Created At
           filename: Filename
           format: Format
@@ -1721,6 +1722,7 @@ fr:
         title: Modifier l’exécution automatisée du flux de travail
       files:
         table_header:
+          actions: Actions
           created_at: Créé à
           filename: Nom du fichier
           format: Format

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -976,7 +976,7 @@ fr:
         title: Edit workflow execution
       files:
         table_header:
-          actions: Actions
+          actions: Mesures
           created_at: Created At
           filename: Filename
           format: Format
@@ -1722,7 +1722,7 @@ fr:
         title: Modifier l’exécution automatisée du flux de travail
       files:
         table_header:
-          actions: Actions
+          actions: Mesures
           created_at: Créé à
           filename: Nom du fichier
           format: Format

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -282,3 +282,13 @@ attachment_tsv:
   name: file
   record: attachmentTSV (Attachment)
   blob: attachment_tsv_blob
+
+workflow_execution_group_shared_output_attachment:
+  name: file
+  record: workflow_execution_group_shared_output_attachment (Attachment)
+  blob: workflow_execution_group_shared_output_attachment_blob
+
+workflow_execution_shared_with_project_output_attachment:
+  name: file
+  record: workflow_execution_shared_with_project_output_attachment (Attachment)
+  blob: workflow_execution_shared_with_project_output_attachment_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -124,6 +124,9 @@ gasclustering_test_file_json_blob: <%= ActiveStorage::FixtureSet.blob filename: 
 
 metadata_valid_csv_blob: <%= ActiveStorage::FixtureSet.blob filename: "valid.csv", service_name: "test" %>
 
+workflow_execution_group_shared_output_attachment_blob: <%= ActiveStorage::FixtureSet.blob filename: "summary.txt.gz", service_name: "test" %>
+workflow_execution_shared_with_project_output_attachment_blob: <%= ActiveStorage::FixtureSet.blob filename: "summary.txt.gz", service_name: "test" %>
+
 # ⬇️ attachment_test.rb files ⬇️
 # --------------------------------
 attachment_csv_blob: <%= ActiveStorage::FixtureSet.blob filename: "attachment_preview.csv", service_name: "test" %>

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -124,8 +124,8 @@ gasclustering_test_file_json_blob: <%= ActiveStorage::FixtureSet.blob filename: 
 
 metadata_valid_csv_blob: <%= ActiveStorage::FixtureSet.blob filename: "valid.csv", service_name: "test" %>
 
-workflow_execution_group_shared_output_attachment_blob: <%= ActiveStorage::FixtureSet.blob filename: "summary.txt.gz", service_name: "test" %>
-workflow_execution_shared_with_project_output_attachment_blob: <%= ActiveStorage::FixtureSet.blob filename: "summary.txt.gz", service_name: "test" %>
+workflow_execution_group_shared_output_attachment_blob: <%= ActiveStorage::FixtureSet.blob filename: "s.mlst.json", service_name: "test" %>
+workflow_execution_shared_with_project_output_attachment_blob: <%= ActiveStorage::FixtureSet.blob filename: "s.mlst.json", service_name: "test" %>
 
 # ⬇️ attachment_test.rb files ⬇️
 # --------------------------------

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -429,11 +429,11 @@ attachmentTSV:
   created_at: <%= 2.hours.ago %>
 
 workflow_execution_group_shared_output_attachment:
-  metadata: { "compression": "gzip", "format": "unknown" }
+  metadata: { "compression": "none", "format": "csv" }
   attachable: workflow_execution_group_shared1 (WorkflowExecution)
   puid: INXT_ATT_ABAAAAAABG
 
 workflow_execution_shared_with_project_output_attachment:
-  metadata: { "compression": "gzip", "format": "unknown" }
+  metadata: { "compression": "none", "format": "csv" }
   attachable: workflow_execution_shared2 (WorkflowExecution)
   puid: INXT_ATT_ABAAAAAABH

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -423,7 +423,7 @@ attachmentImage:
   created_at: <%= 2.hours.ago %>
 
 attachmentTSV:
-  metadata: { "compression": "none", "format": "json" }
+  metadata: { "compression": "none", "format": "csv" }
   attachable: project2_namespace (Namespace)
   puid: INXT_ATT_ABAAAAAABF
   created_at: <%= 2.hours.ago %>
@@ -434,6 +434,6 @@ workflow_execution_group_shared_output_attachment:
   puid: INXT_ATT_ABAAAAAABG
 
 workflow_execution_shared_with_project_output_attachment:
-  metadata: { "compression": "none", "format": "csv" }
+  metadata: { "compression": "none", "format": "json" }
   attachable: workflow_execution_shared2 (WorkflowExecution)
   puid: INXT_ATT_ABAAAAAABH

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -427,3 +427,13 @@ attachmentTSV:
   attachable: project2_namespace (Namespace)
   puid: INXT_ATT_ABAAAAAABF
   created_at: <%= 2.hours.ago %>
+
+workflow_execution_group_shared_output_attachment:
+  metadata: { "compression": "gzip", "format": "unknown" }
+  attachable: workflow_execution_group_shared1 (WorkflowExecution)
+  puid: INXT_ATT_ABAAAAAABG
+
+workflow_execution_shared_with_project_output_attachment:
+  metadata: { "compression": "gzip", "format": "unknown" }
+  attachable: workflow_execution_shared2 (WorkflowExecution)
+  puid: INXT_ATT_ABAAAAAABH

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -423,7 +423,7 @@ attachmentImage:
   created_at: <%= 2.hours.ago %>
 
 attachmentTSV:
-  metadata: { "compression": "none", "format": "csv" }
+  metadata: { "compression": "none", "format": "tsv" }
   attachable: project2_namespace (Namespace)
   puid: INXT_ATT_ABAAAAAABF
   created_at: <%= 2.hours.ago %>

--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -423,13 +423,13 @@ attachmentImage:
   created_at: <%= 2.hours.ago %>
 
 attachmentTSV:
-  metadata: { "compression": "none", "format": "tsv" }
+  metadata: { "compression": "none", "format": "json" }
   attachable: project2_namespace (Namespace)
   puid: INXT_ATT_ABAAAAAABF
   created_at: <%= 2.hours.ago %>
 
 workflow_execution_group_shared_output_attachment:
-  metadata: { "compression": "none", "format": "csv" }
+  metadata: { "compression": "none", "format": "json" }
   attachable: workflow_execution_group_shared1 (WorkflowExecution)
   puid: INXT_ATT_ABAAAAAABG
 

--- a/test/system/groups/workflow_executions_test.rb
+++ b/test/system/groups/workflow_executions_test.rb
@@ -261,6 +261,9 @@ module Groups
         click_button I18n.t(:'components.confirmation.confirm', locale: user.locale)
       end
 
+      assert_text I18n.t(:'concerns.workflow_execution_actions.cancel.success',
+                         workflow_name: workflow_execution.metadata['workflow_name'], locale: user.locale)
+
       assert_text workflow_execution.id
       assert_equal workflow_execution.reload.state, 'canceled'
       assert_text I18n.t(:"workflow_executions.state.#{workflow_execution.state}", locale: user.locale)

--- a/test/system/groups/workflow_executions_test.rb
+++ b/test/system/groups/workflow_executions_test.rb
@@ -21,6 +21,7 @@ module Groups
       @created_at_col = '7'
 
       Flipper.enable(:workflow_execution_sharing)
+      Flipper.enable(:attachments_preview)
     end
 
     test 'should display a list of workflow executions' do
@@ -191,7 +192,7 @@ module Groups
       within('table tbody') do
         assert_text attachment.puid
         assert_text attachment.file.filename.to_s
-        assert I18n.t('workflow_executions.attachment.preview', locale: user.locale)
+        assert_text I18n.t('workflow_executions.attachment.preview', locale: user.locale)
       end
 
       within %(div[id="workflow-execution-tabs"]) do

--- a/test/system/groups/workflow_executions_test.rb
+++ b/test/system/groups/workflow_executions_test.rb
@@ -187,7 +187,12 @@ module Groups
         click_on I18n.t('workflow_executions.show.tabs.files', locale: user.locale)
       end
 
-      assert_text 'FILENAME'
+      attachment = attachments(:workflow_execution_group_shared_output_attachment)
+      within('table tbody') do
+        assert_text attachment.puid
+        assert_text attachment.file.filename.to_s
+        assert I18n.t('workflow_executions.attachment.preview', locale: user.locale)
+      end
 
       within %(div[id="workflow-execution-tabs"]) do
         click_on I18n.t('workflow_executions.show.tabs.params', locale: user.locale)

--- a/test/system/projects/workflow_executions_test.rb
+++ b/test/system/projects/workflow_executions_test.rb
@@ -456,6 +456,17 @@ module Projects
       assert_no_link I18n.t(:'workflow_executions.show.cancel_button')
       assert_no_link I18n.t(:'workflow_executions.show.edit_button')
       assert_no_link I18n.t(:'workflow_executions.show.remove_button')
+
+      within %(div[id="workflow-execution-tabs"]) do
+        click_on I18n.t('workflow_executions.show.tabs.files')
+      end
+
+      attachment = attachments(:workflow_execution_shared_with_project_output_attachment)
+      within('table tbody') do
+        assert_text attachment.puid
+        assert_text attachment.file.filename.to_s
+        assert I18n.t('workflow_executions.attachment.preview')
+      end
     end
 
     test 'can successfully delete multiple workflows at once' do

--- a/test/system/projects/workflow_executions_test.rb
+++ b/test/system/projects/workflow_executions_test.rb
@@ -21,6 +21,7 @@ module Projects
       @created_at_col = '7'
 
       Flipper.enable(:delete_multiple_workflows)
+      Flipper.enable(:attachments_preview)
     end
 
     test 'should display a list of workflow executions' do
@@ -465,7 +466,7 @@ module Projects
       within('table tbody') do
         assert_text attachment.puid
         assert_text attachment.file.filename.to_s
-        assert I18n.t('workflow_executions.attachment.preview')
+        assert_text I18n.t('workflow_executions.attachment.preview')
       end
     end
 


### PR DESCRIPTION
## What does this PR do and why?
Updated workflow executions for project & groups to enable preview of pipeline result files, like it is currently enabled for user workflow executions.

## Screenshots or screen recordings
Workflow execution files that are shared with a project::
![image](https://github.com/user-attachments/assets/a1d15762-aadb-40c9-9d41-c83eaf563c91)

Workflow execution files that are shared with a group:
![image](https://github.com/user-attachments/assets/316373e2-ce4e-4483-8d1b-f0fb2551a86d)

## How to set up and validate locally
1. Setup a pipeline that produces output files that can be previewed.
1. Follow the instructions from [PR895](https://github.com/phac-nml/irida-next/pull/895), to test workflow executions shared with a project.
1. Follow the instructions from [PR948](https://github.com/phac-nml/irida-next/pull/948), to test workflow executions shared with a group.
1. Navigate to the workflow execution and click the `Files` tab.
1. Verify there is a new `Actions` column. Click the `Preview` link.
1. Verify the pipeline output files can be previewed.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
