### PR TITLE
Nextflow: Refactor metadata header selection

### DIFF
--- a/app/components/nextflow/samplesheet/header_component.html.erb
+++ b/app/components/nextflow/samplesheet/header_component.html.erb
@@ -11,35 +11,17 @@
         dark:bg-slate-700 bg-slate-50
       "
     >
-      <%= form_with url: fields_workflow_executions_metadata_path do |f| %>
-        <%= f.hidden_field :format, value: "turbo_stream", id: "field_#{header}_turbo" %>
-        <%= f.hidden_field :namespace_id, value: namespace_id, id: "namespace_#{header}" %>
-        <%= f.hidden_field :header, value: header, id: "header_#{header}" %>
-        <%= f.hidden_field :name_format,
-                       value:
-                         "workflow_execution[samples_workflow_executions_attributes][INDEX][samplesheet_params]",
-                       id: "format_#{header}" %>
-        <% samples.each do |sample| %>
-          <%= f.hidden_field :sample_ids,
-                         value: sample.id,
-                         id: "sample-#{sample.id}-#{header}",
-                         multiple: true %>
-        <% end %>
-        <%= f.select :field,
-                 options_for_select(metadata_fields_for_field(header), header),
-                 { include_blank: !@required_properties.include?(header) },
-                 {
-                   id: "field-#{header}",
-                   "aria-label": header,
-                   class:
-                     "bg-slate-50 text-slate-900 text-sm border-none focus:ring-primary-500 focus:border-primary-500 block min-w-56 w-full p-2.5 dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500 font-semibold tracking-wider uppercase",
-                   onchange: "Turbo.navigator.submitForm(this.form)",
-                   data: {
-                     action: "change->nextflow--samplesheet#setMetadataParam",
-                     "metadata-header": header,
-                   },
-                 } %>
-      <% end %>
+      <%= select_tag :field,
+      options_for_select(metadata_fields_for_field(header), header),
+      include_blank: !@required_properties.include?(header),
+      id: "field-#{header}",
+      "aria-label": header,
+      class:
+        "bg-slate-50 text-slate-900 text-sm border-none focus:ring-primary-500 focus:border-primary-500 block min-w-56 w-full p-2.5 dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500 font-semibold tracking-wider uppercase",
+      data: {
+        action: "change->nextflow--samplesheet#handleMetadataSelection",
+        "metadata-header": header,
+      } %>
     </div>
   <% else %>
     <div

--- a/app/components/nextflow/samplesheet_component.html.erb
+++ b/app/components/nextflow/samplesheet_component.html.erb
@@ -212,3 +212,28 @@ data: {
     </ul>
   </nav>
 </template>
+
+<template data-nextflow--samplesheet-target="metadataHeaderForm">
+  <%= form_with url: fields_workflow_executions_metadata_path do |f| %>
+    <%= f.hidden_field :format,
+                   value: "turbo_stream",
+                   id: "field_HEADER_PLACEHOLDER_turbo" %>
+    <%= f.hidden_field :namespace_id,
+                   value: namespace_id,
+                   id: "namespace_HEADER_PLACEHOLDER" %>
+    <%= f.hidden_field :header,
+                   value: "HEADER_PLACEHOLDER",
+                   id: "header_HEADER_PLACEHOLDER" %>
+    <%= f.hidden_field :name_format,
+                   value:
+                     "workflow_execution[samples_workflow_executions_attributes][INDEX][samplesheet_params]",
+                   id: "format_HEADER_PLACEHOLDER" %>
+    <% @samples.each do |sample| %>
+      <%= f.hidden_field :sample_ids,
+                     value: sample.id,
+                     id: "sample-#{sample.id}-HEADER_PLACEHOLDER",
+                     multiple: true %>
+    <% end %>
+    <%= f.hidden_field :field, value: "FIELD_PLACEHOLDER" %>
+  <% end %>
+</template>

--- a/app/javascript/controllers/nextflow/metadata_controller.js
+++ b/app/javascript/controllers/nextflow/metadata_controller.js
@@ -12,6 +12,8 @@ export default class extends Controller {
   }
 
   sendMetadata() {
+    console.log(this.metadataValue);
+    console.log(this.propertyValue);
     this.dispatch("sendMetadata", {
       detail: {
         content: { metadata: this.metadataValue, property: this.propertyValue },

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -26,6 +26,7 @@ export default class extends Controller {
     "pagination",
     "paginationContainer",
     "emptyState",
+    "metadataHeaderForm",
   ];
 
   static values = {
@@ -606,7 +607,7 @@ export default class extends Controller {
     }
   }
 
-  setMetadataParam(event) {
+  handleMetadataSelection(event) {
     const metadataSamplesheetColumn = event.target.getAttribute(
       "data-metadata-header",
     );
@@ -627,5 +628,13 @@ export default class extends Controller {
         );
       }, 1000);
     }
+
+    const metadataForm = this.metadataHeaderFormTarget.innerHTML
+      .replace(/HEADER_PLACEHOLDER/g, metadataSamplesheetColumn)
+      .replace(/FIELD_PLACEHOLDER/g, metadataField);
+
+    this.element.insertAdjacentHTML("beforeend", metadataForm);
+    this.element.lastElementChild.requestSubmit();
+    this.element.lastElementChild.remove();
   }
 }


### PR DESCRIPTION
## What does this PR do and why?
This PR refactors the metadata headers for the nextflow samplesheet, as it originally had forms within a form, which fails W3C validation. Now, the selection will be handled by stimulus controller.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
If you don't already have a pipeline set up with metadata:
1. Add the file `development.json` to `config/pipelines`
2. Add the `SNVPhyl` pipeline to `development.json`
```
{
      "url": "https://github.com/phac-nml/snvphylnfc",
      "name": "phac-nml/snvphylnfc",
      "description": "SNVPhyl nf-core pipeline",
      "versions": [
        {
          "name": "2.2.0"
        }
      ]
    }
```
--------
3. Restart your server
4. Start the workflow with metadata, and verify metadata selection behaves as expected
- Metadata fields update for samples
- Metadata parameter below samplesheet updates
- After submission, the workflow's parameter values match your selections.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
