### PR TITLE
Bug: Samplesheet Default PE file selection

### DIFF
--- a/app/models/concerns/file_selector.rb
+++ b/app/models/concerns/file_selector.rb
@@ -10,7 +10,7 @@ module FileSelector
     @sorted_files || sort_files
   end
 
-  def sort_files # rubocop:disable Metrics/MethodLength
+  def sort_files # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     singles = []
     pe_forward = []
     pe_reverse = []


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where when a user uploads multiple sets of PE files to a sample in a single upload, the nextflow samplesheet didn't properly select a pair. This sometimes happens as the PE files getting attached to the sample out of order. eg if you upload 2 sets of PE files (pe1 and pe2), they could be attached to the sample in order of [pe1-fwd, pe2-fwd, pe2-rev, pe1-rev]. The samplesheet then pulls the most recent fwd and rev attachments, resulting in pe2-fwd/pe1-rev being default selected.

Now when building the files hash in `concerns/file_selector`, we go through `single` and `forward` attachments, and when a `forward` attachment is encountered, we retrieve its `.associated_attachment` to ensure pairs are listed at the same index.

## Screenshots or screen recordings
[Screencast from 2025-04-02 10:57:03 AM.webm](https://github.com/user-attachments/assets/5b8a747d-1fc6-4f40-9ff7-dcc3691688b9)

## How to set up and validate locally
1. Verify file attachments in samplesheet still behave as expected

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
