### PR TITLE
Nextflow: Improve File Selector Accessbility

### DIFF
--- a/app/components/nextflow/samplesheet_component.html.erb
+++ b/app/components/nextflow/samplesheet_component.html.erb
@@ -15,10 +15,8 @@
         data-action="search->nextflow--samplesheet#filter"
         class="
           t-search-component block w-full p-2.5 pl-10 text-sm text-slate-900 border
-          border-slate-300 rounded-lg bg-slate-50 focus:ring-primary-500
-          focus:border-primary-500 dark:bg-slate-700 dark:border-slate-600
-          dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500
-          dark:focus:border-primary-500
+          border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600
+          dark:placeholder-slate-400 dark:text-white
         "
         placeholder="<%= t('.filter_placeholder')%>"
         type="search"
@@ -107,9 +105,8 @@
   <select
     aria-label="COLUMN_NAME_PLACEHOLDER"
     class="
-      w-full focus:ring-primary-500 focus:border-primary-500 p-2.5 dark:bg-slate-700
-      bg-slate-50 border-none dark:border-none dark:placeholder-slate-400 text-inherit
-      text-sm dark:focus:ring-primary-500 dark:focus:border-primary-500 cursor-pointer
+      w-full p-2.5 dark:bg-slate-700 bg-slate-50 border-none dark:border-none
+      dark:placeholder-slate-400 text-inherit text-sm cursor-pointer
     "
     data-action="change->nextflow--samplesheet#updateEditableSamplesheetData"
     name="workflow_execution[samples_workflow_executions_attributes][INDEX_PLACEHOLDER][samplesheet_params][COLUMN_NAME_PLACEHOLDER]"
@@ -135,7 +132,7 @@
   },
   id: "ATTACHABLE_ID_PLACEHOLDER_PROPERTY_PLACEHOLDER",
   class:
-    "block p-2 text-sm border-2 border-transparent focus:ring-primary-500 focus:border-primary-500 cursor-pointer bg-inherit text-inherit dark:focus:border-primary-500 hover:border-slate-300" %>
+    "block p-2.5 text-sm cursor-pointer bg-inherit text-inherit focus:underline hover:underline" %>
 </template>
 
 <template data-nextflow--samplesheet-target="metadataCell">
@@ -148,9 +145,8 @@
   <label for="ID_PLACEHOLDER" class="sr-only">NAME_PLACEHOLDER</label>
   <input
     class="
-      bg-slate-50 border-0 text-slate-900 text-sm focus:ring-primary-500 block w-full
-      p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400
-      dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500
+      bg-slate-50 border-0 text-slate-900 text-sm block w-full p-2.5 dark:bg-slate-700
+      dark:border-slate-600 dark:placeholder-slate-400 dark:text-white
     "
     data-action="change->nextflow--samplesheet#updateEditableSamplesheetData"
     type="text"
@@ -182,8 +178,7 @@
             flex items-center justify-center h-10 px-4 leading-tight bg-white border
             cursor-pointer ms-0 border-slate-300 dark:border-slate-700 text-slate-500
             hover:bg-slate-100 hover:text-slate-700 dark:bg-slate-800 dark:text-slate-400
-            dark:hover:bg-slate-700 dark:hover:text-white focus:ring-0
-            focus:border-primary-500 dark:focus:border-primary-500
+            dark:hover:bg-slate-700 dark:hover:text-white
           "
           data-nextflow--samplesheet-target="pageNum"
           data-action="change->nextflow--samplesheet#pageSelected"

--- a/app/components/nextflow/samplesheet_component.html.erb
+++ b/app/components/nextflow/samplesheet_component.html.erb
@@ -15,8 +15,10 @@
         data-action="search->nextflow--samplesheet#filter"
         class="
           t-search-component block w-full p-2.5 pl-10 text-sm text-slate-900 border
-          border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600
-          dark:placeholder-slate-400 dark:text-white
+          border-slate-300 rounded-lg bg-slate-50 focus:ring-primary-500
+          focus:border-primary-500 dark:bg-slate-700 dark:border-slate-600
+          dark:placeholder-slate-400 dark:text-white dark:focus:ring-primary-500
+          dark:focus:border-primary-500
         "
         placeholder="<%= t('.filter_placeholder')%>"
         type="search"
@@ -105,8 +107,9 @@
   <select
     aria-label="COLUMN_NAME_PLACEHOLDER"
     class="
-      w-full p-2.5 dark:bg-slate-700 bg-slate-50 border-none dark:border-none
-      dark:placeholder-slate-400 text-inherit text-sm cursor-pointer
+      w-full focus:ring-primary-500 focus:border-primary-500 p-2.5 dark:bg-slate-700
+      bg-slate-50 border-none dark:border-none dark:placeholder-slate-400 text-inherit
+      text-sm dark:focus:ring-primary-500 dark:focus:border-primary-500 cursor-pointer
     "
     data-action="change->nextflow--samplesheet#updateEditableSamplesheetData"
     name="workflow_execution[samples_workflow_executions_attributes][INDEX_PLACEHOLDER][samplesheet_params][COLUMN_NAME_PLACEHOLDER]"
@@ -132,7 +135,7 @@
   },
   id: "ATTACHABLE_ID_PLACEHOLDER_PROPERTY_PLACEHOLDER",
   class:
-    "block p-2.5 text-sm cursor-pointer bg-inherit text-inherit focus:underline hover:underline" %>
+    "block p-2 text-sm border-2 border-transparent focus:ring-primary-500 focus:border-primary-500 cursor-pointer bg-inherit text-inherit dark:focus:border-primary-500 hover:border-slate-300" %>
 </template>
 
 <template data-nextflow--samplesheet-target="metadataCell">
@@ -145,8 +148,9 @@
   <label for="ID_PLACEHOLDER" class="sr-only">NAME_PLACEHOLDER</label>
   <input
     class="
-      bg-slate-50 border-0 text-slate-900 text-sm block w-full p-2.5 dark:bg-slate-700
-      dark:border-slate-600 dark:placeholder-slate-400 dark:text-white
+      bg-slate-50 border-0 text-slate-900 text-sm focus:ring-primary-500 block w-full
+      p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400
+      dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500
     "
     data-action="change->nextflow--samplesheet#updateEditableSamplesheetData"
     type="text"
@@ -178,7 +182,8 @@
             flex items-center justify-center h-10 px-4 leading-tight bg-white border
             cursor-pointer ms-0 border-slate-300 dark:border-slate-700 text-slate-500
             hover:bg-slate-100 hover:text-slate-700 dark:bg-slate-800 dark:text-slate-400
-            dark:hover:bg-slate-700 dark:hover:text-white
+            dark:hover:bg-slate-700 dark:hover:text-white focus:ring-0
+            focus:border-primary-500 dark:focus:border-primary-500
           "
           data-nextflow--samplesheet-target="pageNum"
           data-action="change->nextflow--samplesheet#pageSelected"

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -273,7 +273,6 @@ export default class extends Controller {
   // handles changes to file cells; triggered by nextflow/file_controller.js
   updateFileData({ detail: { content } }) {
     content["files"].forEach((file, index) => {
-      console.log(index);
       this.#setFormData(
         `workflow_execution[samples_workflow_executions_attributes][${content["index"]}][samplesheet_params][${file["property"]}]`,
         file["global_id"],

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -272,7 +272,8 @@ export default class extends Controller {
 
   // handles changes to file cells; triggered by nextflow/file_controller.js
   updateFileData({ detail: { content } }) {
-    content["files"].forEach((file) => {
+    content["files"].forEach((file, index) => {
+      console.log(index);
       this.#setFormData(
         `workflow_execution[samples_workflow_executions_attributes][${content["index"]}][samplesheet_params][${file["property"]}]`,
         file["global_id"],
@@ -293,7 +294,12 @@ export default class extends Controller {
         file["property"]
       ]["attachment_id"] = file["id"];
 
-      this.#updateCell(file["property"], content["index"], "file_cell");
+      this.#updateCell(
+        file["property"],
+        content["index"],
+        "file_cell",
+        index === 0,
+      );
     });
     this.#clearPayload();
   }
@@ -305,7 +311,7 @@ export default class extends Controller {
         `workflow_execution[samples_workflow_executions_attributes][${index}][samplesheet_params][${content["property"]}]`,
         content["metadata"][index],
       );
-      this.#updateCell(content["property"], index, "metadata_cell");
+      this.#updateCell(content["property"], index, "metadata_cell", false);
     }
     this.#clearPayload();
   }
@@ -539,7 +545,7 @@ export default class extends Controller {
     }
   }
 
-  #updateCell(columnName, index, cell_type) {
+  #updateCell(columnName, index, cell_type, focusCell) {
     let container = document.getElementById(`${index}_${columnName}`);
     if (container) {
       container.innerHTML = "";
@@ -547,6 +553,9 @@ export default class extends Controller {
         this.#generateFileCell(container, columnName, index);
       } else {
         this.#generateMetadataCell(container, columnName, index);
+      }
+      if (focusCell) {
+        container.firstElementChild.focus();
       }
     }
   }

--- a/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
+++ b/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
@@ -26,12 +26,7 @@
               '
             >
               <tr>
-                <th
-                  class="sticky left-0 px-3 py-3 bg-slate-50 dark:bg-slate-700"
-                  aria-hidden="true"
-                >
-                </th>
-                <th class="px-3 py-3">
+                <th class="pr-3 pl-10.5 py-3 bg-slate-50 dark:bg-slate-700">
                   <%= t(".headers.filename") %>
                 </th>
                 <th class="px-3 py-3">
@@ -61,19 +56,13 @@
                     bg-white border-b border-slate-200 dark:bg-slate-800 dark:border-slate-700
                   "
                 >
-                  <td class="sticky left-0 px-3 py-3 bg-white dark:bg-slate-800">
+                  <td class="px-3 py-3 bg-white dark:bg-slate-800">
                     <%= form.radio_button "attachment_id",
                                       attachment[:id],
                                       checked:
                                         file_selector_params["selected_id"] &&
                                           file_selector_params["selected_id"] == attachment[:id] %>
-
-                  </td>
-                  <td class="px-3 py-3">
-                    <label
-                      class="hover:underline cursor-pointer"
-                      for="attachment_id_<%= attachment[:id] %>"
-                    ><%= attachment[:filename] %></label>
+                    <label class="cursor-pointer ml-2.5" for="attachment_id_<%= attachment[:id] %>"><%= attachment[:filename] %></label>
                   </td>
                   <td class="px-3 py-3"><%= viral_pill(
                       text: attachment[:metadata]["format"],
@@ -93,14 +82,12 @@
               <% end %>
               <% unless file_selector_params["required_properties"].present? && file_selector_params["required_properties"].include?(file_selector_params["property"]) %>
                 <tr class="bg-white border-b dark:bg-slate-800 dark:border-slate-700">
-                  <td class="sticky left-0 px-3 py-3 bg-white dark:bg-slate-800">
+                  <td class="px-3 py-3 bg-white dark:bg-slate-800">
                     <%= form.radio_button "attachment_id",
                                       "no_attachment",
                                       checked: file_selector_params["selected_id"].empty? %>
 
-                  </td>
-                  <td class="px-3 py-3">
-                    <label class="hover:underline cursor-pointer" for="attachment_id_no_attachment">
+                    <label class="cursor-pointer ml-2.5" for="attachment_id_no_attachment">
                       <%= t(".no_file") %>
                     </label>
                   </td>

--- a/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
+++ b/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
@@ -100,7 +100,12 @@
 
                   </td>
                   <td class="px-3 py-3">
-                    <%= t(".no_file") %>
+                    <label
+                      class="hover:underline hover:cursor-pointer"
+                      for="attachment_id_no_attachment"
+                    >
+                      <%= t(".no_file") %>
+                    </label>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
+++ b/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
@@ -71,7 +71,7 @@
                   </td>
                   <td class="px-3 py-3">
                     <label
-                      class="hover:underline hover:cursor-pointer"
+                      class="hover:underline cursor-pointer"
                       for="attachment_id_<%= attachment[:id] %>"
                     ><%= attachment[:filename] %></label>
                   </td>
@@ -100,10 +100,7 @@
 
                   </td>
                   <td class="px-3 py-3">
-                    <label
-                      class="hover:underline hover:cursor-pointer"
-                      for="attachment_id_no_attachment"
-                    >
+                    <label class="hover:underline cursor-pointer" for="attachment_id_no_attachment">
                       <%= t(".no_file") %>
                     </label>
                   </td>
@@ -116,7 +113,7 @@
       <% unless @listing_attachments.empty? %>
         <%= form.submit t(".submit_button"),
                     class:
-                      "inline-flex items-center justify-center text-sm border rounded-md cursor-pointer sm:w-auto focus:z-10 text-white bg-primary-700 hover:bg-primary-800 rounded-md px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700 focus:ring-primary-300 dark:focus:ring-primary-700" %>
+                      "inline-flex items-center justify-center text-sm border rounded-md cursor-pointer sm:w-auto text-white bg-primary-700 hover:bg-primary-800 rounded-md px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700" %>
 
       <% end %>
     <% end %>

--- a/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
+++ b/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
@@ -70,7 +70,10 @@
 
                   </td>
                   <td class="px-3 py-3">
-                    <%= attachment[:filename] %>
+                    <label
+                      class="hover:underline hover:cursor-pointer"
+                      for="attachment_id_<%= attachment[:id] %>"
+                    ><%= attachment[:filename] %></label>
                   </td>
                   <td class="px-3 py-3"><%= viral_pill(
                       text: attachment[:metadata]["format"],
@@ -108,7 +111,7 @@
       <% unless @listing_attachments.empty? %>
         <%= form.submit t(".submit_button"),
                     class:
-                      "inline-flex items-center justify-center text-sm border rounded-md cursor-pointer sm:w-auto focus:z-10 focus:outline-none text-white bg-primary-700 hover:bg-primary-800 focus:ring-0 rounded-md px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700" %>
+                      "inline-flex items-center justify-center text-sm border rounded-md cursor-pointer sm:w-auto focus:z-10 text-white bg-primary-700 hover:bg-primary-800 rounded-md px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700 focus:ring-primary-300 dark:focus:ring-primary-700" %>
 
       <% end %>
     <% end %>

--- a/test/system/workflow_executions/submissions_test.rb
+++ b/test/system/workflow_executions/submissions_test.rb
@@ -611,7 +611,7 @@ module WorkflowExecutions
         within('#file_selector_form') do
           # verify no file option exists in non-required field
           assert_selector '#attachment_id_no_attachment'
-          find('#attachment_id_no_attachment').click
+          find('label[for="attachment_id_no_attachment"]').click
         end
         click_button I18n.t('workflow_executions.file_selector.file_selector_dialog.submit_button')
       end


### PR DESCRIPTION
## What does this PR do and why?
This PR is for [STRY0017589](https://publichealthprod.service-now.com/rm_story.do?sys_id=a4b0d3f13b2c6a10d0d23a0eb3e45aee) to improve the nextflow dialog.

File cell focus was fixed in [PR1008](https://github.com/phac-nml/irida-next/pull/1008).

In this PR, the actual file selector modal has been improved:
- Submit button now displays focus indicator
- Filenames are now labels for their associated radio button, and clickable to select.

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/b02185f2-59f4-47d0-9e54-2e42d7c71178)

## How to set up and validate locally
1. Navigate to a project.
2. Select a sample and add extra PE files to it.
3. Launch the `iridanextexample` workflow with this sample
4. Click a file cell for this sample.
5. In the file selector dialog, verify:
- Tab through and make sure the submit button highlights when focused.
- Clicking the filename selects that file.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
