### PR TITLE
Faster/dashboards

### DIFF
--- a/app/components/namespace_tree/row/row_contents_component.html.erb
+++ b/app/components/namespace_tree/row/row_contents_component.html.erb
@@ -18,7 +18,7 @@
     data: {
       turbo: false,
     },
-    url: project_path(@namespace.project),
+    url: namespace_project_path(@namespace.parent, @namespace.project),
   ) %>
 <% end %>
 
@@ -37,7 +37,7 @@
               ) %>
             <% end %>
           <% else %>
-            <%= link_to project_path(@namespace.project),
+            <%= link_to namespace_project_path(@namespace.parent, @namespace.project),
             data: {
               turbo: false,
             } do %>

--- a/app/components/project_dashboard/samples_component.html.erb
+++ b/app/components/project_dashboard/samples_component.html.erb
@@ -10,7 +10,7 @@
       </div>
       <p class="mb-4 text-base font-normal text-slate-500 dark:text-slate-400">
         <%= link_to sample.name,
-        namespace_project_sample_path(@project.namespace.parent, @project, sample),
+        sample_path(sample),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline" %>
         -
         <%= viral_pill(text: sample.puid, color: :green) %>

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -39,7 +39,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
     if @project.persisted?
       flash[:success] = t('.success', project_name: @project.name)
       redirect_to(
-        project_path(@project)
+        namespace_project_path(@project.namespace.parent, @project)
       )
     else
       render :new, status: :unprocessable_entity
@@ -52,7 +52,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
       if @updated
         if project_params[:namespace_attributes][:path]
           flash[:success] = t('.success', project_name: @project.name)
-          format.turbo_stream { redirect_to(project_edit_path(@project)) }
+          format.turbo_stream { redirect_to(namespace_project_edit_path(@project.namespace.parent, @project)) }
         else
           format.turbo_stream do
             render status: :ok, locals: { type: 'success', message: t('.success', project_name: @project.name) }
@@ -81,11 +81,11 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
     end
   end
 
-  def transfer
+  def transfer # rubocop:disable Metrics/AbcSize
     if Projects::TransferService.new(@project, current_user).execute(new_namespace)
       flash[:success] = t('.success', project_name: @project.name)
       respond_to do |format|
-        format.turbo_stream { redirect_to project_path(@project) }
+        format.turbo_stream { redirect_to namespace_project_path(@project.namespace.parent, @project) }
       end
     else
       @error = @project.errors.messages.values.flatten.first
@@ -102,7 +102,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
       redirect_to dashboard_projects_path(format: :html)
     else
       flash[:error] = error_message(@project)
-      redirect_to project_path(@project)
+      redirect_to namespace_project_path(@project.namespace.parent, @project)
     end
   end
 

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -191,7 +191,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def children_allowed?
-    false if project_namespace?
+    return false if project_namespace?
 
     ancestors.count >= Namespace::MAX_ANCESTORS - 2
   end

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -28,6 +28,7 @@ class NamespaceGroupLink < ApplicationRecord
   after_save :send_access_granted_emails, if: :previously_new_record?
 
   scope :not_expired, -> { where('expires_at IS NULL OR expires_at > ?', Time.zone.now.beginning_of_day) }
+  scope :with_access, -> { where.not(group_access_level: Member::AccessLevel::NO_ACCESS) }
   scope :for_namespace_and_ancestors, lambda { |namespace = nil|
                                         where(namespace:).or(where(namespace: namespace.parent&.self_and_ancestors))
                                       }

--- a/app/views/layouts/projects.html.erb
+++ b/app/views/layouts/projects.html.erb
@@ -7,7 +7,7 @@
         <%= navigation.with_header(label: t("projects.sidebar.label"), item: @project) %>
         <%= navigation.with_section do |section| %>
           <%= render section.with_item(
-            url: project_path(@project),
+            url: namespace_project_path,
             icon: "clipboard_document",
             label: t("projects.sidebar.details"),
             selected: @current_page == t(:"projects.sidebar.details"),
@@ -19,14 +19,14 @@
             selected: @current_page == t(:"projects.sidebar.members"),
           ) %>
           <%= render section.with_item(
-            url: project_samples_path(@project),
+            url: namespace_project_samples_path,
             icon: "beaker",
             label: t(:"projects.sidebar.samples"),
             selected: @current_page == t(:"projects.sidebar.samples"),
           ) %>
           <% if allowed_to?(:view_attachments?, @project) %>
             <%= render section.with_item(
-              url: namespace_project_attachments_path(@project.parent, @project),
+              url: namespace_project_attachments_path,
               icon: "document_text",
               label: t(:"projects.sidebar.files"),
               selected: @current_page == t(:"projects.sidebar.files"),
@@ -34,7 +34,7 @@
           <% end %>
           <% if allowed_to?(:view_history?, @project) %>
             <%= render section.with_item(
-              url: project_activity_path(@project),
+              url: namespace_project_activity_path,
               icon: "list_bullet",
               label: t(:"projects.sidebar.activity"),
               selected: @current_page == t(:"projects.sidebar.activity"),
@@ -42,7 +42,7 @@
           <% end %>
           <% if allowed_to?(:view_workflow_executions?, @project.namespace) && @pipelines_enabled %>
             <%= render section.with_item(
-              url: project_workflow_executions_path(@project),
+              url: namespace_project_workflow_executions_path,
               icon: "command_line",
               label: t(:"projects.sidebar.workflow_executions"),
               selected: @current_page == t(:"projects.sidebar.workflow_executions"),
@@ -62,30 +62,30 @@
               current_page: @current_page
             ) do |multi_level_menu| %>
               <% multi_level_menu.with_menu_item(
-                url: project_edit_path(@project),
+                url: namespace_project_edit_path,
                 label: t(:"projects.sidebar.general"),
                 selected: @current_page == t(:"projects.sidebar.general"),
               ) %>
               <% multi_level_menu.with_menu_item(
-                url: project_bots_path(@project),
+                url: namespace_project_bots_path,
                 label: t(:"projects.sidebar.bot_accounts"),
                 selected: @current_page == t(:"projects.sidebar.bot_accounts"),
               ) %>
               <% if @pipelines_enabled %>
                 <% multi_level_menu.with_menu_item(
-                  url: project_automated_workflow_executions_path(@project),
+                  url: namespace_project_automated_workflow_executions_path,
                   label: t(:"projects.sidebar.automated_workflow_executions"),
                   selected:
                     @current_page == t(:"projects.sidebar.automated_workflow_executions"),
                 ) %>
               <% end %>
               <% multi_level_menu.with_menu_item(
-                url: project_history_path(@project),
+                url: namespace_project_history_path,
                 label: t(:"projects.sidebar.history"),
                 selected: @current_page == t(:"projects.sidebar.history"),
               ) %>
               <% multi_level_menu.with_menu_item(
-                url: project_metadata_templates_path(@project),
+                url: namespace_project_metadata_templates_path,
                 label: t(:"projects.sidebar.metadata_templates"),
                 selected: @current_page == t(:"projects.sidebar.metadata_templates"),
               ) %>

--- a/app/views/projects/_destroy.html.erb
+++ b/app/views/projects/_destroy.html.erb
@@ -40,7 +40,7 @@
 
     <div class="mt-4">
       <%= button_to t(:"projects.edit.advanced.destroy.submit"),
-      @project,
+      namespace_project_path,
       method: :delete,
       data: {
         turbo_confirm: "",

--- a/app/views/projects/history/index.turbo_stream.erb
+++ b/app/views/projects/history/index.turbo_stream.erb
@@ -2,6 +2,6 @@
   <%= render HistoryComponent.new(
     data: @log_data.reverse,
     type: "Project",
-    url: project_view_history_path(@project),
+    url: namespace_project_view_history_path(@project.namespace.parent, @project),
   ) %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,16 +51,4 @@ Rails.application.routes.draw do
   draw :project
 
   draw :development
-
-  project_routes = Irida::Application.routes.set.filter_map do |route|
-    route.name if route.name&.include?('namespace_project')
-  end
-
-  project_routes.each do |name|
-    short_name = name.sub('namespace_project', 'project')
-
-    direct(short_name) do |project, *args|
-      send("#{name}_url", project&.namespace&.parent, project, *args)
-    end
-  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -15,7 +15,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test 'should show the project' do
     sign_in users(:john_doe)
 
-    get project_path(projects(:project1))
+    get namespace_project_path(projects(:project1).namespace.parent, projects(:project1))
     assert_response :success
 
     w3c_validate 'Project Show Page'
@@ -30,14 +30,14 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     project_member = members(:project_one_member_john_doe)
     project_member.expires_at = 10.days.ago.to_date
     project_member.save
-    get project_path(projects(:project1))
+    get namespace_project_path(projects(:project1).namespace.parent, projects(:project1))
     assert_response :unauthorized
   end
 
   test 'should not show the project' do
     sign_in users(:micha_doe)
 
-    get project_path(projects(:project1))
+    get namespace_project_path(projects(:project1).namespace.parent, projects(:project1))
     assert_response :unauthorized
   end
 
@@ -66,7 +66,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
                                                         parent_id: parent_namespace.id } } }
     end
 
-    assert_redirected_to project_path(Project.last)
+    assert_redirected_to namespace_project_path(Project.last.namespace.parent, Project.last)
   end
 
   test 'should not create a new project under another user\'s namespace' do
@@ -105,11 +105,11 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test 'should update a project which is a part of a parent group and of which the user is a member' do
     sign_in users(:john_doe)
 
-    patch project_path(projects(:project2)),
+    patch namespace_project_path(projects(:project2).namespace.parent, projects(:project2)),
           params: { project: { namespace_attributes: { name: 'Awesome Project 2', path: 'awesome-project-2' } },
                     format: :turbo_stream }
 
-    assert_redirected_to project_edit_path(projects(:project2).reload)
+    assert_redirected_to namespace_project_edit_path(projects(:project2).namespace.parent, projects(:project2).reload)
   end
 
   test 'should update a project which which is under the user\'s namespace' do
@@ -117,11 +117,11 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     project = projects(:john_doe_project2)
 
-    patch project_path(project),
+    patch namespace_project_path(project.namespace.parent, project),
           params: { project: { namespace_attributes: { name: 'Awesome Project 2', path: 'awesome-project-2' } },
                     format: :turbo_stream }
 
-    assert_redirected_to project_edit_path(project.reload)
+    assert_redirected_to namespace_project_edit_path(project.namespace.parent, project.reload)
   end
 
   test 'should not update a project which which is under another user\'s namespace' do
@@ -129,7 +129,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     project = projects(:john_doe_project2)
 
-    patch project_path(project),
+    patch namespace_project_path(project.namespace.parent, project),
           params: { project: { namespace_attributes: { name: 'Awesome Project 2', path: 'awesome-project-2' } } }
 
     assert_response :unauthorized
@@ -140,7 +140,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     project = projects(:john_doe_project2)
 
-    patch project_path(project),
+    patch namespace_project_path(project.namespace.parent, project),
           params: { project: { namespace_attributes: { name: 'Awesome Project 2', path: 'VERY BAD PATH' } } }
 
     assert_response :unauthorized

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -203,7 +203,7 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   test '#metadata_summary incorporates fields from shared groups' do
-    assert_equal %w[unique.metadata.field metadatafield1 metadatafield2], groups(:david_doe_group_four).metadata_fields
+    assert_equal %w[metadatafield1 metadatafield2 unique.metadata.field], groups(:david_doe_group_four).metadata_fields
   end
 
   test '#metadata_summary incorporates fields from shared projects' do

--- a/test/system/projects/transfer_test.rb
+++ b/test/system/projects/transfer_test.rb
@@ -14,7 +14,7 @@ module Projects
     end
 
     test 'should transfer project' do
-      visit project_edit_path(@project)
+      visit namespace_project_edit_path(@project.namespace.parent, @project)
       find('input.select2-input').click
       find("button[data-viral--select2-primary-param='#{@namespace.full_path}']").click
       assert_selector 'input.select2-input', count: 1
@@ -30,7 +30,7 @@ module Projects
     end
 
     test 'empty state of transfer group' do
-      visit project_edit_path(@project)
+      visit namespace_project_edit_path(@project.namespace.parent, @project)
       find('input.select2-input').fill_in with: 'invalid project name or puid'
       assert_text I18n.t(:'projects.edit.advanced.transfer.empty_state')
     end
@@ -38,7 +38,7 @@ module Projects
     test 'should display error message when user attempts to transfer to namespace with same project name' do
       project2 = projects(:project2)
 
-      visit project_edit_path(project2)
+      visit namespace_project_edit_path(project2.namespace.parent, project2)
       find('input.select2-input').click
       find("button[data-viral--select2-primary-param='#{@namespace.full_path}']").click
       assert_selector 'input.select2-input', count: 1

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -146,7 +146,7 @@ class ProjectsTest < ApplicationSystemTestCase
     project_name = 'New Project'
     project_description = 'New Project Description'
 
-    visit project_edit_path(projects(:project1))
+    visit namespace_project_edit_path(projects(:project1).namespace.parent, projects(:project1))
     assert_text I18n.t(:'projects.edit.general.title')
 
     fill_in I18n.t(:'activerecord.attributes.namespaces/project_namespace.name'), with: project_name
@@ -191,7 +191,7 @@ class ProjectsTest < ApplicationSystemTestCase
   end
 
   test 'can access edit project' do
-    visit project_edit_path(projects(:project1))
+    visit namespace_project_edit_path(projects(:project1).namespace.parent, projects(:project1))
 
     assert_text I18n.t(:'projects.edit.general.title')
   end
@@ -200,14 +200,14 @@ class ProjectsTest < ApplicationSystemTestCase
     login_as users(:david_doe)
 
     project = projects(:project1)
-    visit project_edit_path(project)
+    visit namespace_project_edit_path(project.namespace.parent, project)
 
     assert_text I18n.t(:'action_policy.policy.project.edit?', name: project.name)
   end
 
   test 'can delete a project' do
     project = projects(:project1)
-    visit project_edit_path(project)
+    visit namespace_project_edit_path(project.namespace.parent, project)
     click_on I18n.t(:'projects.edit.advanced.destroy.submit')
 
     within('#turbo-confirm') do
@@ -223,7 +223,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
   test 'can edit a project path' do
     project = projects(:project1)
-    visit project_edit_path(project)
+    visit namespace_project_edit_path(project.namespace.parent, project)
 
     fill_in 'Path', with: 'project-1-edited'
     click_on I18n.t(:'projects.edit.advanced.path.submit')
@@ -242,7 +242,7 @@ class ProjectsTest < ApplicationSystemTestCase
 
   test 'show error when editing a project path to an existing namespace' do
     project = projects(:project1)
-    visit project_edit_path(project)
+    visit namespace_project_edit_path(project.namespace.parent, project)
 
     fill_in 'Path', with: 'project-2'
     click_on I18n.t(:'projects.edit.advanced.path.submit')
@@ -262,7 +262,7 @@ class ProjectsTest < ApplicationSystemTestCase
   test 'show error when editing a project with a short name' do
     project_name = 'a'
     project = projects(:project1)
-    visit project_edit_path(project)
+    visit namespace_project_edit_path(project.namespace.parent, project)
 
     fill_in 'Name', with: project_name
     click_on I18n.t('projects.edit.general.submit')
@@ -282,7 +282,7 @@ class ProjectsTest < ApplicationSystemTestCase
   test 'show error when editing a project with a same name' do
     project1 = projects(:project1)
     project2 = projects(:project2)
-    visit project_edit_path(project1)
+    visit namespace_project_edit_path(project1.namespace.parent, project1)
 
     fill_in 'Name', with: project2.name
     click_on I18n.t('projects.edit.general.submit')
@@ -302,7 +302,7 @@ class ProjectsTest < ApplicationSystemTestCase
   test 'show error when editing a project with a long description' do
     project_description = 'a' * 256
     project = projects(:project1)
-    visit project_edit_path(project)
+    visit namespace_project_edit_path(project.namespace.parent, project)
 
     fill_in 'Description', with: project_description
     click_on I18n.t('projects.edit.general.submit')


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates `metadata_fields` and `aggregrated_samples_count` methods in `app/models/group.rb` to use more efficient queries. In addtion `app/models/namespace_group_link.rb` has been updated to add a `with_access` scope, which limits the results to only ones with access level higher than `no_access`.

Additionally I have removed the shorter `project*_path` methods and now `namespace_project*_path` methods have to be used.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Ensure that Group Dashboard and Namespace Tree Component is till rendering as expected
2. Ensure that metadata_fields from namespace_group_links that are expired are not included in `metadata_fields` response for a Group.
3. Ensure that `aggregated_samples_count` is still reporting the correct number, and this time does not include counst from expired namespace_group_links.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
