### PR TITLE
Refactor Spinner Component ID

### DIFF
--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -17,6 +17,7 @@
             <% @columns.each_with_index do |column, index| %>
               <%= render_cell(
               tag: 'th',
+              **helpers.aria_sort(column, @q.sorts[0].name, @q.sorts[0].dir),
               scope: 'col',
               classes: class_names('px-3 py-3')
             ) do %>

--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -17,7 +17,6 @@
             <% @columns.each_with_index do |column, index| %>
               <%= render_cell(
               tag: 'th',
-              **helpers.aria_sort(column, @q.sorts[0].name, @q.sorts[0].dir),
               scope: 'col',
               classes: class_names('px-3 py-3')
             ) do %>

--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -155,7 +155,10 @@
       class="flex items-center p-4 space-x-4"
       data-nextflow--samplesheet-target="spinner"
     >
-      <%= render SpinnerComponent.new(message: t(".processing_samplesheet")) %>
+      <%= render SpinnerComponent.new(
+        message: t(".processing_samplesheet"),
+        id: "nextflow-spinner",
+      ) %>
     </div>
   <% end %>
 </div>

--- a/app/components/spinner_component.html.erb
+++ b/app/components/spinner_component.html.erb
@@ -1,5 +1,9 @@
 <div
-  id="spinner"
+  <% if id %>
+  id="<%= id %>"
+  <% else %>
+  data-testid="spinner"
+  <% end %>
   class="
     absolute z-50 grid w-full h-full -translate-x-1/2 -translate-y-1/2
     backdrop-blur-xs top-2/4 left-1/2 place-items-center
@@ -15,7 +19,12 @@
       role="status"
     >
       <%= viral_icon(name: :loading, classes: "animate-spin text-primary-500") %>
-      <span id="spinner-message" class="text-sm font-normal ps-4"><%= message %></span>
+      <span
+        <% if id %>
+        id="<%= id %>-message"
+        <% end %>
+        class="text-sm font-normal ps-4"
+      ><%= message %></span>
     </div>
   </div>
 </div>

--- a/app/components/spinner_component.html.erb
+++ b/app/components/spinner_component.html.erb
@@ -2,7 +2,7 @@
   <% if id %>
   id="<%= id %>"
   <% else %>
-  data-testid="spinner"
+  data-test-selector="spinner"
   <% end %>
   class="
     absolute z-50 grid w-full h-full -translate-x-1/2 -translate-y-1/2

--- a/app/components/spinner_component.rb
+++ b/app/components/spinner_component.rb
@@ -2,9 +2,10 @@
 
 # Component for displaying spinner when loading
 class SpinnerComponent < Component
-  attr_reader :message
+  attr_reader :message, :id
 
-  def initialize(message:)
+  def initialize(message:, id: nil)
     @message = message
+    @id = id
   end
 end

--- a/app/javascript/controllers/nextflow/samplesheet_controller.js
+++ b/app/javascript/controllers/nextflow/samplesheet_controller.js
@@ -240,7 +240,7 @@ export default class extends Controller {
   }
 
   #enableProcessingState(message) {
-    document.getElementById("spinner-message").innerHTML = message;
+    document.getElementById("nextflow-spinner-message").innerHTML = message;
     this.submitTarget.disabled = true;
     this.spinnerTarget.classList.remove("hidden");
   }

--- a/test/components/spinner_component_test.rb
+++ b/test/components/spinner_component_test.rb
@@ -5,7 +5,7 @@ require 'view_component_test_case'
 class SpinnerComponentTest < ViewComponentTestCase
   test 'default' do
     render_inline SpinnerComponent.new(message: 'Still loading..please wait...')
-    assert_selector 'div[id="spinner"]', count: 1
+    assert_selector 'div[data-testid="spinner"]', count: 1
     assert_text 'Still loading..please wait...'
   end
 end

--- a/test/components/spinner_component_test.rb
+++ b/test/components/spinner_component_test.rb
@@ -5,7 +5,7 @@ require 'view_component_test_case'
 class SpinnerComponentTest < ViewComponentTestCase
   test 'default' do
     render_inline SpinnerComponent.new(message: 'Still loading..please wait...')
-    assert_selector 'div[data-testid="spinner"]', count: 1
+    assert_selector 'div[data-test-selector="spinner"]', count: 1
     assert_text 'Still loading..please wait...'
   end
 end

--- a/test/system/groups/metadata_templates_test.rb
+++ b/test/system/groups/metadata_templates_test.rb
@@ -183,9 +183,9 @@ module Groups
         )
       end
 
-      assert_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       table_row = find(:table_row, ['Group Template011'])
 
@@ -233,7 +233,7 @@ module Groups
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -276,7 +276,7 @@ module Groups
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -324,9 +324,9 @@ module Groups
         )
       end
 
-      assert_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       table_row = find(:table_row, ['Group Template011'])
 
@@ -364,7 +364,7 @@ module Groups
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -513,9 +513,9 @@ module Groups
         )
       end
 
-      assert_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_equal 6, metadata_template.reload.fields.length
       assert_equal 'Group Template011', metadata_template.name

--- a/test/system/groups/metadata_templates_test.rb
+++ b/test/system/groups/metadata_templates_test.rb
@@ -183,9 +183,9 @@ module Groups
         )
       end
 
-      assert_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       table_row = find(:table_row, ['Group Template011'])
 
@@ -233,7 +233,7 @@ module Groups
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -276,7 +276,7 @@ module Groups
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -324,9 +324,9 @@ module Groups
         )
       end
 
-      assert_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       table_row = find(:table_row, ['Group Template011'])
 
@@ -364,7 +364,7 @@ module Groups
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -513,9 +513,9 @@ module Groups
         )
       end
 
-      assert_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_equal 6, metadata_template.reload.fields.length
       assert_equal 'Group Template011', metadata_template.name

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -129,8 +129,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text 'Samples: 13'
       within('table tbody') do
@@ -210,8 +210,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text 'Samples: 13'
       within('table tbody') do
@@ -248,8 +248,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -288,8 +288,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -323,8 +323,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 10, count: 26,
                                                                            locale: @user.locale))
@@ -372,8 +372,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text '1-13 of 13'
       within('table tbody') do
@@ -419,8 +419,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -448,8 +448,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -467,8 +467,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'none'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_selector 'table thead tr th', count: 6
     end
@@ -484,8 +484,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -506,8 +506,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'none'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 6
@@ -761,8 +761,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text 'Samples: 1'
       assert_selector 'table tbody tr', count: 1
@@ -785,8 +785,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: ' '
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_text 'Samples: 26'
       assert_selector 'tfoot strong[data-selection-target="selected"]', text: '0'
@@ -1031,8 +1031,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_selector '#samples-table table thead tr th', count: 9
       click_link I18n.t('groups.samples.index.import_metadata_button'), match: :first
@@ -1124,14 +1124,14 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -1174,8 +1174,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -1184,8 +1184,8 @@ module Groups
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample28.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       ### SETUP END ###
 

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -129,8 +129,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text 'Samples: 13'
       within('table tbody') do
@@ -210,8 +210,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text 'Samples: 13'
       within('table tbody') do
@@ -248,8 +248,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -288,8 +288,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -323,8 +323,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 10, count: 26,
                                                                            locale: @user.locale))
@@ -372,8 +372,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: 'Sample 1'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text '1-13 of 13'
       within('table tbody') do
@@ -419,8 +419,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
                                                                            locale: @user.locale))
@@ -448,8 +448,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -467,8 +467,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'none'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_selector 'table thead tr th', count: 6
     end
@@ -484,8 +484,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -506,8 +506,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'none'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 6
@@ -761,8 +761,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text 'Samples: 1'
       assert_selector 'table tbody tr', count: 1
@@ -785,8 +785,8 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: ' '
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_text 'Samples: 26'
       assert_selector 'tfoot strong[data-selection-target="selected"]', text: '0'
@@ -1031,8 +1031,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_selector '#samples-table table thead tr th', count: 9
       click_link I18n.t('groups.samples.index.import_metadata_button'), match: :first
@@ -1124,14 +1124,14 @@ module Groups
       fill_in placeholder: I18n.t(:'groups.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -1174,8 +1174,8 @@ module Groups
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 9
@@ -1184,8 +1184,8 @@ module Groups
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample28.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       ### SETUP END ###
 

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -186,9 +186,9 @@ module Projects
         )
       end
 
-      assert_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       table_row = find(:table_row, ['Project Template011'])
 
@@ -233,7 +233,7 @@ module Projects
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -275,7 +275,7 @@ module Projects
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -321,9 +321,9 @@ module Projects
         )
       end
 
-      assert_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       table_row = find(:table_row, ['Project Template011'])
 
@@ -359,7 +359,7 @@ module Projects
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -499,9 +499,9 @@ module Projects
         )
       end
 
-      assert_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_equal 5, metadata_template.reload.fields.length
       assert_equal 'Project Template011', metadata_template.name

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -186,9 +186,9 @@ module Projects
         )
       end
 
-      assert_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       table_row = find(:table_row, ['Project Template011'])
 
@@ -233,7 +233,7 @@ module Projects
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -275,7 +275,7 @@ module Projects
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -321,9 +321,9 @@ module Projects
         )
       end
 
-      assert_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       table_row = find(:table_row, ['Project Template011'])
 
@@ -359,7 +359,7 @@ module Projects
       end
 
       assert_no_selector "div[data-controller='viral--flash']"
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
       assert_no_text I18n.t('metadata_templates.table_component.spinner_message')
     end
 
@@ -499,9 +499,9 @@ module Projects
         )
       end
 
-      assert_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
       assert_text I18n.t('metadata_templates.table_component.spinner_message')
-      assert_no_selector 'div#spinner'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_equal 5, metadata_template.reload.fields.length
       assert_equal 'Project Template011', metadata_template.name

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -783,8 +783,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: sample3.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       # verify limit is still 10
       assert_selector 'div#limit-component button span', text: '10'
@@ -864,8 +864,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       # verify sort is still applied
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
@@ -888,8 +888,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -916,8 +916,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample2.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -939,8 +939,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: 'sample'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -963,8 +963,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -993,8 +993,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: filter_text
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_selector "tr[id='#{@sample1.id}']"
       assert_no_selector "tr[id='#{@sample2.id}']"
@@ -1046,8 +1046,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: filter_text
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -1113,8 +1113,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('#samples-table table thead tr') do
         assert_selector 'th', count: 7
@@ -1190,8 +1190,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('#samples-table table thead tr') do
         assert_selector 'th', count: 7
@@ -1278,8 +1278,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('#samples-table table thead tr') do
         assert_selector 'th', count: 7
@@ -1372,8 +1372,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_selector '#samples-table table thead tr th', count: 7
       within('#samples-table table') do
@@ -1516,8 +1516,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within("tr[id='#{@sample32.id}']") do
         # value for metadatafield1, which is blank on the csv to import and will be left unchanged after import
@@ -1577,8 +1577,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within("tr[id='#{@sample32.id}']") do
         # value for metadatafield1, which is blank on the csv to import and will be deleted by the import
@@ -1730,8 +1730,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_selector '#samples-table table thead tr th', count: 7
       within('#samples-table table thead') do
@@ -1805,8 +1805,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       # metadata that does not overwriting analysis values will still be added
       within('#samples-table table thead tr') do
@@ -2414,8 +2414,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: samples(:sample1).name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within 'tbody' do
         assert_selector 'input[name="sample_ids[]"]', count: 1
@@ -2436,8 +2436,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: ' '
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within 'tfoot' do
         assert_text "#{I18n.t('samples.table_component.counts.samples')}: 3"
@@ -2990,14 +2990,14 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7
@@ -3044,8 +3044,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       assert_selector 'table thead tr th', count: 7
 
@@ -3074,8 +3074,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7
@@ -3084,8 +3084,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample2.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
       ### SETUP END ###
 
       ### VERIFY START ###
@@ -3106,14 +3106,14 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7
@@ -3158,15 +3158,15 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div[data-testid="spinner"]'
-      assert_no_selector 'div[data-testid="spinner"]'
+      assert_selector 'div[data-test-selector="spinner"]'
+      assert_no_selector 'div[data-test-selector="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -783,8 +783,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: sample3.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       # verify limit is still 10
       assert_selector 'div#limit-component button span', text: '10'
@@ -864,8 +864,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       # verify sort is still applied
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
@@ -888,8 +888,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -916,8 +916,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample2.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -939,8 +939,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: 'sample'
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -963,8 +963,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.puid
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -993,8 +993,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: filter_text
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_selector "tr[id='#{@sample1.id}']"
       assert_no_selector "tr[id='#{@sample2.id}']"
@@ -1046,8 +1046,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: filter_text
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
       ### ACTIONS END ###
 
       ### VERIFY START ###
@@ -1113,8 +1113,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('#samples-table table thead tr') do
         assert_selector 'th', count: 7
@@ -1190,8 +1190,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('#samples-table table thead tr') do
         assert_selector 'th', count: 7
@@ -1278,8 +1278,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('#samples-table table thead tr') do
         assert_selector 'th', count: 7
@@ -1372,8 +1372,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_selector '#samples-table table thead tr th', count: 7
       within('#samples-table table') do
@@ -1516,8 +1516,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within("tr[id='#{@sample32.id}']") do
         # value for metadatafield1, which is blank on the csv to import and will be left unchanged after import
@@ -1577,8 +1577,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within("tr[id='#{@sample32.id}']") do
         # value for metadatafield1, which is blank on the csv to import and will be deleted by the import
@@ -1730,8 +1730,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_selector '#samples-table table thead tr th', count: 7
       within('#samples-table table thead') do
@@ -1805,8 +1805,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       # metadata that does not overwriting analysis values will still be added
       within('#samples-table table thead tr') do
@@ -2414,8 +2414,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: samples(:sample1).name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within 'tbody' do
         assert_selector 'input[name="sample_ids[]"]', count: 1
@@ -2436,8 +2436,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: ' '
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within 'tfoot' do
         assert_text "#{I18n.t('samples.table_component.counts.samples')}: 3"
@@ -2990,14 +2990,14 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7
@@ -3044,8 +3044,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       assert_selector 'table thead tr th', count: 7
 
@@ -3074,8 +3074,8 @@ module Projects
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7
@@ -3084,8 +3084,8 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample2.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
       ### SETUP END ###
 
       ### VERIFY START ###
@@ -3106,14 +3106,14 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7
@@ -3158,15 +3158,15 @@ module Projects
       fill_in placeholder: I18n.t(:'projects.samples.table_filter.search.placeholder'), with: @sample1.name
       find('input.t-search-component').native.send_keys(:return)
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
       choose 'q[metadata_template]', option: 'all'
 
-      assert_selector 'div#spinner'
-      assert_no_selector 'div#spinner'
+      assert_selector 'div[data-testid="spinner"]'
+      assert_no_selector 'div[data-testid="spinner"]'
 
       within('table thead tr') do
         assert_selector 'th', count: 7

--- a/test/system/workflow_executions/submissions_test.rb
+++ b/test/system/workflow_executions/submissions_test.rb
@@ -1057,8 +1057,8 @@ module WorkflowExecutions
         ### ACTIONS END ###
 
         ### VERIFY START ###
-        assert_selector 'div#spinner'
-        assert_no_selector 'div#spinner'
+        assert_selector 'div#nextflow-spinner'
+        assert_no_selector 'div#nextflow-spinner'
         assert_selector %(input#samplesheet-filter) do |input|
           assert_equal 'inxt_sam_', input['value']
         end


### PR DESCRIPTION
## What does this PR do and why?
This PR refactors the spinner component to receive an optional ID rather than setting a default ID. This required fixing as there are instances in the DOM where multiple spinner components are present, with overlapping IDs

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Verify tests pass locally

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
