### PR TITLE
Accessibility: Add hover to breadcrumbs

### DIFF
--- a/app/assets/icons/heroicons/ellipsis_horizontal.svg
+++ b/app/assets/icons/heroicons/ellipsis_horizontal.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+</svg>

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -74,7 +74,7 @@
   & button.navbar-button {
     @apply rounded-md p-1 text-sm text-slate-500 hover:bg-slate-300 focus:ring-4 focus:ring-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-700;
   }
-  @apply rounded-md p-2.5 text-sm text-slate-500 hover:bg-slate-100 focus:ring-4 focus:ring-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-700;
+  @apply rounded-md p-1 text-sm text-slate-500 hover:bg-slate-300 focus:ring-4 focus:ring-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 dark:focus:ring-slate-700;
 }
 
 @utility link {

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -20,7 +20,10 @@
 >
   <%= sidebar %>
   <div class="relative content" data-layout-target="content">
-    <nav class="flex px-5" style="height: 50px">
+    <nav
+      class="flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0"
+      style="height: 50px"
+    >
       <div class=" flex flex-row shrink-0 justify-end items-center space-x-1">
         <button
           data-layout-target="expandButton"

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -21,10 +21,10 @@
   <%= sidebar %>
   <div class="relative content" data-layout-target="content">
     <nav
-      class="flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0"
+      class="flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0 z-50"
       style="height: 50px"
     >
-      <div class=" flex flex-row shrink-0 justify-end items-center space-x-1">
+      <div class="flex flex-row shrink-0 justify-end items-center space-x-1">
         <button
           data-layout-target="expandButton"
           data-action="click->layout#expand"

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -20,7 +20,7 @@
 >
   <%= sidebar %>
   <div class="relative content" data-layout-target="content">
-    <nav class="@container/nav flex px-5" style="height: 50px">
+    <nav class="flex px-5" style="height: 50px">
       <div class=" flex flex-row shrink-0 justify-end items-center space-x-1">
         <button
           data-layout-target="expandButton"

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -20,7 +20,7 @@
 >
   <%= sidebar %>
   <div class="relative content" data-layout-target="content">
-    <nav class="flex px-5" style="height: 50px">
+    <nav class="@container/nav flex px-5" style="height: 50px">
       <div class=" flex flex-row shrink-0 justify-end items-center space-x-1">
         <button
           data-layout-target="expandButton"

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -21,7 +21,7 @@
   <%= sidebar %>
   <div class="relative content" data-layout-target="content">
     <nav
-      class="flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0 z-50"
+      class="flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0 z-20"
       style="height: 50px"
     >
       <div class="flex flex-row shrink-0 justify-end items-center space-x-1">

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -5,24 +5,28 @@
   "
   style="height: 50px"
 >
-  <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: "Organism dropdown list" }) do |dropdown| %>
-    <% links.each_with_index do |link, index| %>
-      <% if index < links.length - 1 %>
-        <%= link_to link[:name],
-        URI.join(root_url, link[:path]).to_s,
-        data: {
-          turbo_frame: "_top",
-        },
-        class:
-          "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
-
-        <% dropdown.with_item(
-          label: link[:name],
-          url: URI.join(root_url, link[:path]).to_s,
-        ) %>
+  <li class="inline-flex items-center">
+    <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }) do |dropdown| %>
+      <% links.each_with_index do |link, index| %>
+        <% if index < links.length - 1 %>
+          <%= link_to link[:name],
+          URI.join(root_url, link[:path]).to_s,
+          data: {
+            turbo_frame: "_top",
+          },
+          class:
+            "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
+          <% dropdown.with_item(
+            label: link[:name],
+            url: URI.join(root_url, link[:path]).to_s,
+            data: {
+              turbo_frame: "_top",
+            },
+          ) %>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
+  </li>
 
   <li class="inline-flex items-center">
     <div class="flex items-center">

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -15,14 +15,16 @@
           data: {
             turbo_frame: "_top",
           },
-          class: "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400" %>
+          class:
+            "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
         <% else %>
           <%= link_to link[:name],
           URI.join(root_url, link[:path]).to_s,
           data: {
             turbo_frame: "_top",
           },
-          class: "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400" %>
+          class:
+            "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400 hover:underline" %>
         <% end %>
 
       </div>

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -1,17 +1,59 @@
 <ol
   aria-label="Breadcrumb"
-  class="inline-flex items-center space-x-1 md:space-x-3"
+  class="
+    max-md:visible md:hidden inline-flex items-center space-x-1 md:space-x-3
+  "
   style="height: 50px"
 >
-  <div class="@max-md/nav:visible @md/nav:hidden flex items-center">
-    <button>
-      <%= viral_icon(name: "ellipsis_horizontal", classes: "w-6 h-6") %>
-    </button>
-  </div>
+  <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: "Organism dropdown list" }) do |dropdown| %>
+    <% links.each_with_index do |link, index| %>
+      <% if index < links.length - 1 %>
+        <%= link_to link[:name],
+        URI.join(root_url, link[:path]).to_s,
+        data: {
+          turbo_frame: "_top",
+        },
+        class:
+          "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
 
+        <% dropdown.with_item(
+          label: link[:name],
+          url: URI.join(root_url, link[:path]).to_s,
+        ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <li class="inline-flex items-center">
+    <div class="flex items-center">
+      <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
+    </div>
+  </li>
+
+  <li class="inline-flex items-center">
+    <div class="flex items-center">
+      <% link = links.last %>
+      <%= link_to link[:name],
+      URI.join(root_url, link[:path]).to_s,
+      data: {
+        turbo_frame: "_top",
+      },
+      class:
+        "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400 hover:underline" %>
+    </div>
+  </li>
+</ol>
+
+<ol
+  aria-label="Breadcrumb"
+  class="
+    max-md:hidden md:visible inline-flex items-center space-x-1 md:space-x-3
+  "
+  style="height: 50px"
+>
   <% links.each_with_index do |link, index| %>
     <li class="inline-flex items-center">
-      <div class="@max-md/nav:hidden @md/nav:visible flex items-center">
+      <div class="flex items-center">
         <% if index > 0 %>
           <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
         <% end %>
@@ -32,7 +74,6 @@
           class:
             "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400 hover:underline" %>
         <% end %>
-
       </div>
     </li>
   <% end %>

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -31,7 +31,7 @@
   <% end %>
 
   <li class="max-md:visible md:hidden inline-flex items-center">
-    <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }) do |dropdown| %>
+    <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }, classes: "cursor-pointer") do |dropdown| %>
       <% links.each_with_index do |link, index| %>
         <% if index < links.length - 1 %>
           <%= link_to link[:name],

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -1,5 +1,5 @@
 <ol
-  aria-label="Breadcrumb"
+  aria-label="<%=I18n.t(:'components.breadcrumb.aria_label')%>"
   class="
     max-md:visible md:hidden inline-flex items-center space-x-1 md:space-x-3
   "
@@ -49,7 +49,7 @@
 </ol>
 
 <ol
-  aria-label="Breadcrumb"
+  aria-label="<%=I18n.t(:'components.breadcrumb.aria_label')%>"
   class="
     max-md:hidden md:visible inline-flex items-center space-x-1 md:space-x-3
   "

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -30,9 +30,9 @@
     </li>
   <% end %>
 
-  <% unless links.empty? %>
+  <% if links.length > 1 %>
     <li class="max-md:visible md:hidden inline-flex items-center">
-      <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }, classes: "cursor-pointer") do |dropdown| %>
+      <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }, classes: "text-slate-500 cursor-pointer") do |dropdown| %>
         <% links.each_with_index do |link, index| %>
           <% if index < links.length - 1 %>
             <%= link_to link[:name],
@@ -53,10 +53,14 @@
         <% end %>
       <% end %>
     </li>
+  <% end %>
 
+  <% if links.length > 0 %>
     <li class="max-md:visible md:hidden inline-flex items-center">
       <div class="flex items-center">
-        <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
+        <% if links.length > 1 %>
+          <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
+        <% end %>
         <% link = links.last %>
         <%= link_to link[:name],
         URI.join(root_url, link[:path]).to_s,

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -3,9 +3,15 @@
   class="inline-flex items-center space-x-1 md:space-x-3"
   style="height: 50px"
 >
+  <div class="@max-md/nav:visible @md/nav:hidden flex items-center">
+    <button>
+      <%= viral_icon(name: "ellipsis_horizontal", classes: "w-6 h-6") %>
+    </button>
+  </div>
+
   <% links.each_with_index do |link, index| %>
     <li class="inline-flex items-center">
-      <div class="flex items-center">
+      <div class="@max-md/nav:hidden @md/nav:visible flex items-center">
         <% if index > 0 %>
           <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
         <% end %>

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -1,11 +1,36 @@
 <ol
   aria-label="<%=I18n.t(:'components.breadcrumb.aria_label')%>"
-  class="
-    max-md:visible md:hidden inline-flex items-center space-x-1 md:space-x-3
-  "
+  class="inline-flex items-center space-x-1 md:space-x-3"
   style="height: 50px"
 >
-  <li class="inline-flex items-center">
+  <% links.each_with_index do |link, index| %>
+    <li class="max-md:hidden md:visible inline-flex items-center">
+      <div class="flex items-center">
+        <% if index > 0 %>
+          <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
+        <% end %>
+        <% if index < links.length - 1 %>
+          <%= link_to link[:name],
+          URI.join(root_url, link[:path]).to_s,
+          data: {
+            turbo_frame: "_top",
+          },
+          class:
+            "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
+        <% else %>
+          <%= link_to link[:name],
+          URI.join(root_url, link[:path]).to_s,
+          data: {
+            turbo_frame: "_top",
+          },
+          class:
+            "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400 hover:underline" %>
+        <% end %>
+      </div>
+    </li>
+  <% end %>
+
+  <li class="max-md:visible md:hidden inline-flex items-center">
     <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }) do |dropdown| %>
       <% links.each_with_index do |link, index| %>
         <% if index < links.length - 1 %>
@@ -28,56 +53,18 @@
     <% end %>
   </li>
 
-  <li class="inline-flex items-center">
-    <div class="flex items-center">
-      <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
-    </div>
-  </li>
-
-  <li class="inline-flex items-center">
-    <div class="flex items-center">
-      <% link = links.last %>
-      <%= link_to link[:name],
-      URI.join(root_url, link[:path]).to_s,
-      data: {
-        turbo_frame: "_top",
-      },
-      class:
-        "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400 hover:underline" %>
-    </div>
-  </li>
-</ol>
-
-<ol
-  aria-label="<%=I18n.t(:'components.breadcrumb.aria_label')%>"
-  class="
-    max-md:hidden md:visible inline-flex items-center space-x-1 md:space-x-3
-  "
-  style="height: 50px"
->
-  <% links.each_with_index do |link, index| %>
-    <li class="inline-flex items-center">
+  <% unless links.empty? %>
+    <li class="max-md:visible md:hidden inline-flex items-center">
       <div class="flex items-center">
-        <% if index > 0 %>
-          <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
-        <% end %>
-        <% if index < links.length - 1 %>
-          <%= link_to link[:name],
-          URI.join(root_url, link[:path]).to_s,
-          data: {
-            turbo_frame: "_top",
-          },
-          class:
-            "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
-        <% else %>
-          <%= link_to link[:name],
-          URI.join(root_url, link[:path]).to_s,
-          data: {
-            turbo_frame: "_top",
-          },
-          class:
-            "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400 hover:underline" %>
-        <% end %>
+        <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>
+        <% link = links.last %>
+        <%= link_to link[:name],
+        URI.join(root_url, link[:path]).to_s,
+        data: {
+          turbo_frame: "_top",
+        },
+        class:
+          "ml-1 text-sm font-medium text-slate-600 md:ml-2 dark:text-slate-400 hover:underline" %>
       </div>
     </li>
   <% end %>

--- a/app/components/viral/breadcrumb_component.html.erb
+++ b/app/components/viral/breadcrumb_component.html.erb
@@ -30,30 +30,30 @@
     </li>
   <% end %>
 
-  <li class="max-md:visible md:hidden inline-flex items-center">
-    <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }, classes: "cursor-pointer") do |dropdown| %>
-      <% links.each_with_index do |link, index| %>
-        <% if index < links.length - 1 %>
-          <%= link_to link[:name],
-          URI.join(root_url, link[:path]).to_s,
-          data: {
-            turbo_frame: "_top",
-          },
-          class:
-            "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
-          <% dropdown.with_item(
-            label: link[:name],
-            url: URI.join(root_url, link[:path]).to_s,
+  <% unless links.empty? %>
+    <li class="max-md:visible md:hidden inline-flex items-center">
+      <%= viral_dropdown(icon: "ellipsis_horizontal", aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') }, classes: "cursor-pointer") do |dropdown| %>
+        <% links.each_with_index do |link, index| %>
+          <% if index < links.length - 1 %>
+            <%= link_to link[:name],
+            URI.join(root_url, link[:path]).to_s,
             data: {
               turbo_frame: "_top",
             },
-          ) %>
+            class:
+              "ml-1 text-sm font-normal text-slate-500 md:ml-2 dark:text-slate-400 hover:underline" %>
+            <% dropdown.with_item(
+              label: link[:name],
+              url: URI.join(root_url, link[:path]).to_s,
+              data: {
+                turbo_frame: "_top",
+              },
+            ) %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-  </li>
+    </li>
 
-  <% unless links.empty? %>
     <li class="max-md:visible md:hidden inline-flex items-center">
       <div class="flex items-center">
         <%= viral_icon(name: "chevron_right", classes: "w-3 h-3 text-slate-300") %>

--- a/app/components/viral/dropdown/item_component.html.erb
+++ b/app/components/viral/dropdown/item_component.html.erb
@@ -1,6 +1,5 @@
 <li>
-  <%= link_to url, data: { turbo_frame: "_top" },
-          class: "flex items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white", **system_arguments do %>
+  <%= link_to url, class: "flex items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white", **system_arguments do %>
     <% if icon.present? %>
       <span class="grow-0 mr-2"><%= viral_icon(name: icon, color: :subdued, classes: "w-5 h-5") %></span>
     <% end %>

--- a/app/components/viral/dropdown/item_component.html.erb
+++ b/app/components/viral/dropdown/item_component.html.erb
@@ -1,5 +1,6 @@
 <li>
-  <%= link_to url, class: "flex items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white", **system_arguments do %>
+  <%= link_to url, data: { turbo_frame: "_top" },
+          class: "flex items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white", **system_arguments do %>
     <% if icon.present? %>
       <span class="grow-0 mr-2"><%= viral_icon(name: icon, color: :subdued, classes: "w-5 h-5") %></span>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,6 +477,7 @@ en:
       load_more: Load more
       more_details: More details
     breadcrumb:
+      aria_label: Breadcrumb
       dropdown:
         aria_label: Breadcrumb dropdown
     clipboard:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,6 +476,9 @@ en:
           title: Transferred Samples
       load_more: Load more
       more_details: More details
+    breadcrumb:
+      dropdown:
+        aria_label: Breadcrumb dropdown
     clipboard:
       copied: Copied!
       title: Copy to clipboard

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -477,6 +477,7 @@ fr:
       load_more: Charger plus
       more_details: More details
     breadcrumb:
+      aria_label: Breadcrumb
       dropdown:
         aria_label: Breadcrumb dropdown
     clipboard:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -476,6 +476,9 @@ fr:
           title: Transferred Samples
       load_more: Charger plus
       more_details: More details
+    breadcrumb:
+      dropdown:
+        aria_label: Breadcrumb dropdown
     clipboard:
       copied: Copié!
       title: Copier dans le presse-papiers

--- a/test/components/viral/breadcrumb_component_test.rb
+++ b/test/components/viral/breadcrumb_component_test.rb
@@ -16,8 +16,8 @@ module Viral
 
       render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
-      assert_selector 'a', count: 2
-      assert_selector 'svg', count: 1
+      assert_selector 'li[class~="md:visible"] a', count: 2
+      assert_selector 'li[class~="md:visible"] svg', count: 1
     end
 
     test 'compound path' do
@@ -32,8 +32,8 @@ module Viral
       render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
       assert_text I18n.t('groups.edit.title', raise: true)
-      assert_selector 'a', count: 2
-      assert_selector 'svg', count: 1
+      assert_selector 'li[class~="md:visible"] a', count: 2
+      assert_selector 'li[class~="md:visible"] svg', count: 1
     end
 
     test 'route with no extra crumbs' do
@@ -44,7 +44,7 @@ module Viral
 
       render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
-      assert_selector 'a', count: 1
+      assert_selector 'li[class~="md:visible"] a', count: 1
     end
 
     test 'compound path with missing translation' do
@@ -58,8 +58,8 @@ module Viral
 
       render_inline(Viral::BreadcrumbComponent.new(context_crumbs:))
       assert_text groups(:group_one).name
-      assert_selector 'a', count: 2
-      assert_selector 'svg', count: 1
+      assert_selector 'li[class~="md:visible"] a', count: 2
+      assert_selector 'li[class~="md:visible"] svg', count: 1
     end
 
     test 'context crumbs not an array' do


### PR DESCRIPTION
## What does this PR do and why?
Added a hover & collapsible (on zoom) state to breadcrumbs.  
STRY0017584

## Screenshots or screen recordings
Without Zoom:
![Screenshot from 2025-04-09 12-48-42](https://github.com/user-attachments/assets/4b9ca6c5-6fa6-4da4-8d5e-04f9775110fb)

With Zoom:
![image](https://github.com/user-attachments/assets/cfca7632-69a9-419f-93b0-1f7a8c0add56)

## How to set up and validate locally
1. Navigate to any page with breadcrumbs.
2. Verify the links are underlined on hover.
3. Zoom in 400%.
4. Verify the breadcrumb parent items collapse into a `...` icon button with dropdown.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
