### PR TITLE
Advanced search: Add sections to field dropdown

### DIFF
--- a/app/components/advanced_search/condition.html.erb
+++ b/app/components/advanced_search/condition.html.erb
@@ -6,7 +6,10 @@
     <% invalid_field = @condition.errors.include?(:field) %>
     <div class="form-field w-1/3 <%= 'invalid' if invalid_field %>">
       <%= conditions_form.select :field,
-                             grouped_options_for_select(@fields),
+                             grouped_options_for_select(
+                               @fields,
+                               selected_key = @condition.field,
+                             ),
                              { include_blank: t("advanced_search_component.field") },
                              { "aria-label": t("advanced_search_component.field") } %>
       <%= render "shared/form/field_errors",
@@ -15,7 +18,10 @@
     <% invalid_operator = @condition.errors.include?(:operator) %>
     <div class="form-field w-1/6 <%= 'invalid' if invalid_operator %>">
       <%= conditions_form.select :operator,
-                             options_for_select(@operations),
+                             options_for_select(
+                               @operations,
+                               selected = @condition.operator,
+                             ),
                              {
                                include_blank: t("advanced_search_component.operator"),
                              },

--- a/app/components/advanced_search/condition.html.erb
+++ b/app/components/advanced_search/condition.html.erb
@@ -6,9 +6,14 @@
     <% invalid_field = @condition.errors.include?(:field) %>
     <div class="form-field w-1/3 <%= 'invalid' if invalid_field %>">
       <%= conditions_form.select :field,
-                             grouped_options_for_select(
-                               @fields,
+                             options_for_select(
+                               @sample_fields,
                                selected_key = @condition.field,
+                             ).concat(
+                               grouped_options_for_select(
+                                 @metadata_fields,
+                                 selected_key = @condition.field,
+                               ),
                              ),
                              { include_blank: t("advanced_search_component.field") },
                              { "aria-label": t("advanced_search_component.field") } %>

--- a/app/components/advanced_search/condition.html.erb
+++ b/app/components/advanced_search/condition.html.erb
@@ -15,7 +15,7 @@
     <% invalid_operator = @condition.errors.include?(:operator) %>
     <div class="form-field w-1/6 <%= 'invalid' if invalid_operator %>">
       <%= conditions_form.select :operator,
-                             @operations,
+                             options_for_select(@operations),
                              {
                                include_blank: t("advanced_search_component.operator"),
                              },

--- a/app/components/advanced_search/condition.html.erb
+++ b/app/components/advanced_search/condition.html.erb
@@ -6,7 +6,7 @@
     <% invalid_field = @condition.errors.include?(:field) %>
     <div class="form-field w-1/3 <%= 'invalid' if invalid_field %>">
       <%= conditions_form.select :field,
-                             @fields,
+                             grouped_options_for_select(@fields),
                              { include_blank: t("advanced_search_component.field") },
                              { "aria-label": t("advanced_search_component.field") } %>
       <%= render "shared/form/field_errors",

--- a/app/components/advanced_search/condition.rb
+++ b/app/components/advanced_search/condition.rb
@@ -3,12 +3,13 @@
 module AdvancedSearch
   # Component for rendering an advanced search condition
   class Condition < Component
-    def initialize(groups_form:, group_index:, condition:, condition_index:, fields: [], operations: []) # rubocop:disable Metrics/ParameterLists
+    def initialize(groups_form:, group_index:, condition:, condition_index:, sample_fields: [], metadata_fields: [], operations: []) # rubocop:disable Metrics/ParameterLists
       @groups_form = groups_form
       @group_index = group_index
       @condition = condition
       @condition_index = condition_index
-      @fields = fields
+      @sample_fields = sample_fields
+      @metadata_fields = metadata_fields
       @operations = operations
     end
   end

--- a/app/components/advanced_search/condition.rb
+++ b/app/components/advanced_search/condition.rb
@@ -3,7 +3,9 @@
 module AdvancedSearch
   # Component for rendering an advanced search condition
   class Condition < Component
-    def initialize(groups_form:, group_index:, condition:, condition_index:, sample_fields: [], metadata_fields: [], operations: []) # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(groups_form:, group_index:, condition:, condition_index:, sample_fields: [], metadata_fields: [],
+                   operations: [])
       @groups_form = groups_form
       @group_index = group_index
       @condition = condition
@@ -12,5 +14,6 @@ module AdvancedSearch
       @metadata_fields = metadata_fields
       @operations = operations
     end
+    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/app/components/advanced_search/group.html.erb
+++ b/app/components/advanced_search/group.html.erb
@@ -9,7 +9,8 @@
         group_index: @group_index,
         condition: condition,
         condition_index: condition_index,
-        fields: @fields,
+        sample_fields: @sample_fields,
+        metadata_fields: @metadata_fields,
         operations: @operations,
       ) %>
     <% end %>

--- a/app/components/advanced_search/group.rb
+++ b/app/components/advanced_search/group.rb
@@ -3,12 +3,13 @@
 module AdvancedSearch
   # Component for rendering an advanced search group
   class Group < Component
-    def initialize(form:, group:, group_index:, show_remove_group_button:, fields: [], operations: []) # rubocop:disable Metrics/ParameterLists
+    def initialize(form:, group:, group_index:, show_remove_group_button:, sample_fields: [], metadata_fields: [], operations: []) # rubocop:disable Metrics/ParameterLists
       @form = form
       @group = group
       @group_index = group_index
       @show_remove_group_button = show_remove_group_button
-      @fields = fields
+      @sample_fields = sample_fields
+      @metadata_fields = metadata_fields
       @operations = operations
     end
   end

--- a/app/components/advanced_search/group.rb
+++ b/app/components/advanced_search/group.rb
@@ -3,7 +3,9 @@
 module AdvancedSearch
   # Component for rendering an advanced search group
   class Group < Component
-    def initialize(form:, group:, group_index:, show_remove_group_button:, sample_fields: [], metadata_fields: [], operations: []) # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(form:, group:, group_index:, show_remove_group_button:, sample_fields: [], metadata_fields: [],
+                   operations: [])
       @form = form
       @group = group
       @group_index = group_index
@@ -12,5 +14,6 @@ module AdvancedSearch
       @metadata_fields = metadata_fields
       @operations = operations
     end
+    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -116,6 +116,7 @@
           <% @fields.each do |fields_key, fields_value| %>
             <optgroup label="<%=fields_key%>">
               <% fields_value.each do |field_key, field_value| %>
+                <% field_value = field_key if field_value.nil? %>
                 <option value="<%=field_value%>"><%= field_key %></option>
               <% end %>
             </optgroup>

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -113,8 +113,12 @@
           name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][field]"
         >
           <option value="" selected><%= t(".field") %></option>
-          <% @fields.each do |field| %>
-            <option value="<%=field%>"><%= field %></option>
+          <% @fields.each do |key, array| %>
+            <optgroup label="<%=key%>">
+              <% array.each do |field| %>
+                <option value="<%=field%>"><%= field %></option>
+              <% end %>
+            </optgroup>
           <% end %>
         </select>
       </div>

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -113,10 +113,10 @@
           name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][field]"
         >
           <option value="" selected><%= t(".field") %></option>
-          <% @fields.each do |key, array| %>
-            <optgroup label="<%=key%>">
-              <% array.each do |field| %>
-                <option value="<%=field%>"><%= field %></option>
+          <% @fields.each do |fields_key, fields_value| %>
+            <optgroup label="<%=fields_key%>">
+              <% fields_value.each do |field_key, field_value| %>
+                <option value="<%=field_value%>"><%= field_key %></option>
               <% end %>
             </optgroup>
           <% end %>

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -66,7 +66,8 @@
             group: group,
             group_index: group_index,
             show_remove_group_button: @search.groups.count > 1,
-            fields: @fields,
+            sample_fields: @sample_fields,
+            metadata_fields: @metadata_fields,
             operations: @operations,
           ) %>
         <% end %>
@@ -113,13 +114,9 @@
           name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][field]"
         >
           <option value="" selected><%= t(".field") %></option>
-          <% @fields.each do |fields_key, fields_value| %>
-            <optgroup label="<%=fields_key%>">
-              <% fields_value.each do |field_key, field_value| %>
-                <% field_value = field_key if field_value.nil? %>
-                <option value="<%=field_value%>"><%= field_key %></option>
-              <% end %>
-            </optgroup>
+          <% @metadata_fields.each do |fields_key, fields_value| %>
+            <%= options_for_select(@sample_fields) %>
+            <%= grouped_options_for_select(@metadata_fields) %>
           <% end %>
         </select>
       </div>

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -114,10 +114,8 @@
           name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][field]"
         >
           <option value="" selected><%= t(".field") %></option>
-          <% @metadata_fields.each do |fields_key, fields_value| %>
-            <%= options_for_select(@sample_fields) %>
-            <%= grouped_options_for_select(@metadata_fields) %>
-          <% end %>
+          <%= options_for_select(@sample_fields) %>
+          <%= grouped_options_for_select(@metadata_fields) %>
         </select>
       </div>
       <div class="form-field w-1/6">

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -125,9 +125,7 @@
           name="q[groups_attributes][GROUP_INDEX_PLACEHOLDER][conditions_attributes][CONDITION_INDEX_PLACEHOLDER][operator]"
         >
           <option value="" selected><%= t(".operator") %></option>
-          <% @operations.each do |operation| %>
-            <option value="<%=operation%>"><%= operation %></option>
-          <% end %>
+          <%= options_for_select(@operations) %>
         </select>
       </div>
       <div class="form-field w-6/12 value invisible">

--- a/app/components/advanced_search_component.rb
+++ b/app/components/advanced_search_component.rb
@@ -16,11 +16,14 @@ class AdvancedSearchComponent < Component
   def field_options(fields)
     prefix = 'metadata.'
     metadata_fields, sample_fields = fields.partition { |field| field.start_with?(prefix) }
+    sample_field_options = sample_fields.map do |sample_field|
+      [I18n.t("samples.table_component.#{sample_field}"), sample_field]
+    end
     metadata_field_options = metadata_fields.map do |metadata_field|
       [metadata_field.delete_prefix(prefix), metadata_field]
     end
     {
-      I18n.t('advanced_search_component.operation.sample_fields') => sample_fields,
+      I18n.t('advanced_search_component.operation.sample_fields') => sample_field_options,
       I18n.t('advanced_search_component.operation.metadata_fields') => metadata_field_options
     }
   end

--- a/app/components/advanced_search_component.rb
+++ b/app/components/advanced_search_component.rb
@@ -2,10 +2,11 @@
 
 # View component for advanced search component
 class AdvancedSearchComponent < Component
-  def initialize(form:, search:, fields: [], open: false, status: true)
+  def initialize(form:, search:, sample_fields: [], metadata_fields: [], open: false, status: true) # rubocop: disable Metrics/ParameterLists
     @form = form
     @search = search
-    @fields = field_options(fields)
+    @sample_fields = sample_field_options(sample_fields)
+    @metadata_fields = metadata_field_options(metadata_fields)
     @operations = operation_options
     @open = open
     @status = status
@@ -13,17 +14,17 @@ class AdvancedSearchComponent < Component
 
   private
 
-  def field_options(fields)
-    prefix = 'metadata.'
-    metadata_fields, sample_fields = fields.partition { |field| field.start_with?(prefix) }
-    sample_field_options = sample_fields.map do |sample_field|
+  def sample_field_options(sample_fields)
+    sample_fields.map do |sample_field|
       [I18n.t("samples.table_component.#{sample_field}"), sample_field]
     end
+  end
+
+  def metadata_field_options(metadata_fields)
     metadata_field_options = metadata_fields.map do |metadata_field|
-      [metadata_field.delete_prefix(prefix), metadata_field]
+      [metadata_field, "metadata.#{metadata_field}"]
     end
     {
-      I18n.t('advanced_search_component.operation.sample_fields') => sample_field_options,
       I18n.t('advanced_search_component.operation.metadata_fields') => metadata_field_options
     }
   end

--- a/app/components/advanced_search_component.rb
+++ b/app/components/advanced_search_component.rb
@@ -5,13 +5,21 @@ class AdvancedSearchComponent < Component
   def initialize(form:, search:, fields: [], open: false, status: true)
     @form = form
     @search = search
-    @fields = fields
+    @fields = field_options(fields)
     @operations = operation_options
     @open = open
     @status = status
   end
 
   private
+
+  def field_options(fields)
+    metadata_fields, sample_fields = fields.partition { |field| field.start_with?('metadata.') }
+    {
+      I18n.t('advanced_search_component.operation.sample_fields') => sample_fields,
+      I18n.t('advanced_search_component.operation.metadata_fields') => metadata_fields
+    }
+  end
 
   def operation_options
     {

--- a/app/components/advanced_search_component.rb
+++ b/app/components/advanced_search_component.rb
@@ -14,10 +14,14 @@ class AdvancedSearchComponent < Component
   private
 
   def field_options(fields)
-    metadata_fields, sample_fields = fields.partition { |field| field.start_with?('metadata.') }
+    prefix = 'metadata.'
+    metadata_fields, sample_fields = fields.partition { |field| field.start_with?(prefix) }
+    metadata_field_options = metadata_fields.map do |metadata_field|
+      [metadata_field.delete_prefix(prefix), metadata_field]
+    end
     {
       I18n.t('advanced_search_component.operation.sample_fields') => sample_fields,
-      I18n.t('advanced_search_component.operation.metadata_fields') => metadata_fields
+      I18n.t('advanced_search_component.operation.metadata_fields') => metadata_field_options
     }
   end
 

--- a/app/components/advanced_search_component.rb
+++ b/app/components/advanced_search_component.rb
@@ -2,12 +2,28 @@
 
 # View component for advanced search component
 class AdvancedSearchComponent < Component
-  def initialize(form:, search:, fields: [], operations: [], open: false, status: true) # rubocop:disable Metrics/ParameterLists
+  def initialize(form:, search:, fields: [], open: false, status: true)
     @form = form
     @search = search
     @fields = fields
     @operations = operations
     @open = open
     @status = status
+  end
+
+  private
+
+  def operations
+    {
+      I18n.t('advanced_search_component.operation.equals') => '=',
+      I18n.t('advanced_search_component.operation.not_equals') => '!=',
+      I18n.t('advanced_search_component.operation.less_than') => '<=',
+      I18n.t('advanced_search_component.operation.greater_than') => '>=',
+      I18n.t('advanced_search_component.operation.contains') => 'contains',
+      I18n.t('advanced_search_component.operation.exists') => 'exists',
+      I18n.t('advanced_search_component.operation.not_exists') => 'not_exists',
+      I18n.t('advanced_search_component.operation.in') => 'in',
+      I18n.t('advanced_search_component.operation.not_in') => 'not_in'
+    }
   end
 end

--- a/app/components/advanced_search_component.rb
+++ b/app/components/advanced_search_component.rb
@@ -6,14 +6,14 @@ class AdvancedSearchComponent < Component
     @form = form
     @search = search
     @fields = fields
-    @operations = operations
+    @operations = operation_options
     @open = open
     @status = status
   end
 
   private
 
-  def operations
+  def operation_options
     {
       I18n.t('advanced_search_component.operation.equals') => '=',
       I18n.t('advanced_search_component.operation.not_equals') => '!=',

--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -30,10 +30,8 @@ module Metadata
 
   # Builds list of fields available for advanced search
   def advanced_search_fields(namespace)
-    sample_fields = %w[name puid created_at updated_at attachments_updated_at]
-    metadata_fields = namespace.metadata_fields
-    metadata_fields.map! { |field| "metadata.#{field}" }
-    @advanced_search_fields = sample_fields.concat(metadata_fields)
+    @sample_fields = %w[name puid created_at updated_at attachments_updated_at]
+    @metadata_fields = namespace.metadata_fields
   end
 
   # Sets default metadata template if none selected

--- a/app/views/groups/samples/_table_filter.html.erb
+++ b/app/views/groups/samples/_table_filter.html.erb
@@ -24,7 +24,6 @@
     form: f,
     search: @query,
     fields: @advanced_search_fields,
-    # operations: %w[= != <= >= contains exists not_exists in not_in],
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/app/views/groups/samples/_table_filter.html.erb
+++ b/app/views/groups/samples/_table_filter.html.erb
@@ -24,7 +24,7 @@
     form: f,
     search: @query,
     fields: @advanced_search_fields,
-    operations: %w[= != <= >= contains exists not_exists in not_in],
+    # operations: %w[= != <= >= contains exists not_exists in not_in],
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/app/views/groups/samples/_table_filter.html.erb
+++ b/app/views/groups/samples/_table_filter.html.erb
@@ -23,7 +23,8 @@
   <%= render AdvancedSearchComponent.new(
     form: f,
     search: @query,
-    fields: @advanced_search_fields,
+    sample_fields: @sample_fields,
+    metadata_fields: @metadata_fields,
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -23,7 +23,7 @@
     form: f,
     search: @query,
     fields: @advanced_search_fields,
-    operations: %w[= != <= >= contains exists not_exists in not_in],
+    # operations: %w[= != <= >= contains exists not_exists in not_in],
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -23,7 +23,6 @@
     form: f,
     search: @query,
     fields: @advanced_search_fields,
-    # operations: %w[= != <= >= contains exists not_exists in not_in],
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -22,7 +22,8 @@
   <%= render AdvancedSearchComponent.new(
     form: f,
     search: @query,
-    fields: @advanced_search_fields,
+    sample_fields: @sample_fields,
+    metadata_fields: @metadata_fields,
     open: @query.errors.any?,
     status: @query.advanced_query?,
   ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,6 +368,16 @@ en:
     confirm_close_text: Are you sure that you want to discard your filter modifications and close the advanced search dialog?
     description: This advanced search uses fields, operators and values to filter samples. Add groups with conditions to define the search criteria.
     field: Field
+    operation:
+      contains: contains
+      equals: "="
+      exists: exists
+      greater_than: ">="
+      in: in
+      less_than: "<="
+      not_equals: "!="
+      not_exists: not exists
+      not_in: not in
     operator: Operator
     remove_condition_aria_label: Remove condition
     remove_group_button: Remove group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,9 +375,11 @@ en:
       greater_than: ">="
       in: in
       less_than: "<="
+      metadata_fields: Metadata fields
       not_equals: "!="
       not_exists: not exists
       not_in: not in
+      sample_fields: Sample fields
     operator: Operator
     remove_condition_aria_label: Remove condition
     remove_group_button: Remove group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,7 +379,6 @@ en:
       not_equals: "!="
       not_exists: not exists
       not_in: not in
-      sample_fields: Sample fields
     operator: Operator
     remove_condition_aria_label: Remove condition
     remove_group_button: Remove group

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -368,6 +368,16 @@ fr:
     confirm_close_text: Êtes-vous sûr de vouloir éliminer vos modifications de filtre et fermer la boîte de dialogue de recherche avancée?
     description: Cette recherche avancée utilise des champs, des opérateurs et des valeurs pour filtrer les échantillons. Ajoutez des groupes avec des conditions pour définir les critères de recherche.
     field: Champ
+    operation:
+      contains: contains
+      equals: "="
+      exists: exists
+      greater_than: ">="
+      in: in
+      less_than: "<="
+      not_equals: "!="
+      not_exists: not exists
+      not_in: not in
     operator: Opérateur
     remove_condition_aria_label: Supprimer la condition
     remove_group_button: Supprimer le groupe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -375,9 +375,11 @@ fr:
       greater_than: ">="
       in: in
       less_than: "<="
+      metadata_fields: Metadata fields
       not_equals: "!="
       not_exists: not exists
       not_in: not in
+      sample_fields: Sample fields
     operator: Opérateur
     remove_condition_aria_label: Supprimer la condition
     remove_group_button: Supprimer le groupe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -379,7 +379,6 @@ fr:
       not_equals: "!="
       not_exists: not exists
       not_in: not in
-      sample_fields: Sample fields
     operator: Opérateur
     remove_condition_aria_label: Supprimer la condition
     remove_group_button: Supprimer le groupe

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -21,9 +21,13 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
           assert_selector "div[data-advanced-search-target='conditionsContainer']", count: 1
         end
 
-        # verify the field list option group elements are localized
+        # verify the field list & option group elements are localized
         within first("select[name$='[field]']") do
-          assert_selector "optgroup[label='#{I18n.t('advanced_search_component.operation.sample_fields')}']", count: 1
+          assert_text I18n.t('samples.table_component.name')
+          assert_text I18n.t('samples.table_component.puid')
+          assert_text I18n.t('samples.table_component.created_at')
+          assert_text I18n.t('samples.table_component.updated_at')
+          assert_text I18n.t('samples.table_component.attachments_updated_at')
           assert_selector "optgroup[label='#{I18n.t('advanced_search_component.operation.metadata_fields')}']", count: 1
         end
 

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -21,6 +21,25 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
           assert_selector "div[data-advanced-search-target='conditionsContainer']", count: 1
         end
 
+        # verify the field list option group elements are localized
+        within first("select[name$='[field]']") do
+          assert_selector "optgroup[label='#{I18n.t('advanced_search_component.operation.sample_fields')}']", count: 1
+          assert_selector "optgroup[label='#{I18n.t('advanced_search_component.operation.metadata_fields')}']", count: 1
+        end
+
+        # verify the operator list is localized
+        within first("select[name$='[operator]']") do
+          assert_text I18n.t('advanced_search_component.operation.equals')
+          assert_text I18n.t('advanced_search_component.operation.not_equals')
+          assert_text I18n.t('advanced_search_component.operation.less_than')
+          assert_text I18n.t('advanced_search_component.operation.greater_than')
+          assert_text I18n.t('advanced_search_component.operation.contains')
+          assert_text I18n.t('advanced_search_component.operation.exists')
+          assert_text I18n.t('advanced_search_component.operation.not_exists')
+          assert_text I18n.t('advanced_search_component.operation.in')
+          assert_text I18n.t('advanced_search_component.operation.not_in')
+        end
+
         # verify removing a condition
         within all("div[data-advanced-search-target='groupsContainer']")[0] do
           within all("div[data-advanced-search-target='conditionsContainer']")[0] do

--- a/test/components/previews/advanced_search_component_preview.rb
+++ b/test/components/previews/advanced_search_component_preview.rb
@@ -20,12 +20,10 @@ class AdvancedSearchComponentPreview < ViewComponent::Preview
     )
     fields = %w[name puid created_at updated_at attachments_updated_at metadata.age metadata.country
                 metadata.collection_date metadata.food metadata.subject_type metadata.outbreak_code]
-    operations = %w[= != <= >= contains exists not_exists in not_in]
 
     render_with_template(locals: {
                            search: search,
-                           fields: fields,
-                           operations: operations
+                           fields: fields
                          })
   end
 
@@ -33,12 +31,10 @@ class AdvancedSearchComponentPreview < ViewComponent::Preview
     search = Sample::Query.new
     fields = %w[name puid created_at updated_at attachments_updated_at metadata.age metadata.country
                 metadata.collection_date metadata.food metadata.subject_type metadata.outbreak_code]
-    operations = %w[= != <= >= contains exists not_exists in not_in]
 
     render_with_template(template: 'advanced_search_component_preview/default', locals: {
                            search: search,
-                           fields: fields,
-                           operations: operations
+                           fields: fields
                          })
   end
 end

--- a/test/components/previews/advanced_search_component_preview.rb
+++ b/test/components/previews/advanced_search_component_preview.rb
@@ -18,23 +18,25 @@ class AdvancedSearchComponentPreview < ViewComponent::Preview
         )
       ]
     )
-    fields = %w[name puid created_at updated_at attachments_updated_at metadata.age metadata.country
-                metadata.collection_date metadata.food metadata.subject_type metadata.outbreak_code]
+    sample_fields = %w[name puid created_at updated_at attachments_updated_at]
+    metadata_fields = %w[age country collection_date food subject_type outbreak_code]
 
     render_with_template(locals: {
                            search: search,
-                           fields: fields
+                           sample_fields: sample_fields,
+                           metadata_fields: metadata_fields
                          })
   end
 
   def empty
     search = Sample::Query.new
-    fields = %w[name puid created_at updated_at attachments_updated_at metadata.age metadata.country
-                metadata.collection_date metadata.food metadata.subject_type metadata.outbreak_code]
+    sample_fields = %w[name puid created_at updated_at attachments_updated_at]
+    metadata_fields = %w[age country collection_date food subject_type outbreak_code]
 
     render_with_template(template: 'advanced_search_component_preview/default', locals: {
                            search: search,
-                           fields: fields
+                           sample_fields: sample_fields,
+                           metadata_fields: metadata_fields
                          })
   end
 end

--- a/test/components/previews/advanced_search_component_preview/default.html.erb
+++ b/test/components/previews/advanced_search_component_preview/default.html.erb
@@ -1,3 +1,3 @@
 <%= form_with model: search, scope: :q, url: "#" do |form| %>
-  <%= render AdvancedSearchComponent.new(search:, form:, fields:, operations:) %>
+  <%= render AdvancedSearchComponent.new(search:, form:, fields:) %>
 <% end %>

--- a/test/components/previews/advanced_search_component_preview/default.html.erb
+++ b/test/components/previews/advanced_search_component_preview/default.html.erb
@@ -1,3 +1,8 @@
 <%= form_with model: search, scope: :q, url: "#" do |form| %>
-  <%= render AdvancedSearchComponent.new(search:, form:, fields:) %>
+  <%= render AdvancedSearchComponent.new(
+    search:,
+    form:,
+    sample_fields:,
+    metadata_fields:,
+  ) %>
 <% end %>

--- a/test/controllers/concerns/metadata_concern_test.rb
+++ b/test/controllers/concerns/metadata_concern_test.rb
@@ -64,25 +64,27 @@ class MetadataConcernTest < ActionDispatch::IntegrationTest
   end
 
   test 'advanced_search_fields returns combined sample and metadata fields for group' do
-    expected_base_fields = %w[name puid created_at updated_at attachments_updated_at]
-    metadata_fields = @group.metadata_fields.map { |field| "metadata.#{field}" }
-    expected_fields = expected_base_fields.concat(metadata_fields)
+    expected_sample_fields = %w[name puid created_at updated_at attachments_updated_at]
+    expected_metadata_fields = @group.metadata_fields
 
     @controller.advanced_search_fields(@group)
-    actual_fields = @controller.instance_variable_get(:@advanced_search_fields)
+    actual_sample_fields = @controller.instance_variable_get(:@sample_fields)
+    actual_metadata_fields = @controller.instance_variable_get(:@metadata_fields)
 
-    assert_equal expected_fields.sort, actual_fields.sort
+    assert_equal expected_sample_fields.sort, actual_sample_fields.sort
+    assert_equal expected_metadata_fields.sort, actual_metadata_fields.sort
   end
 
   test 'advanced_search_fields returns combined sample and metadata fields for project' do
-    expected_base_fields = %w[name puid created_at updated_at attachments_updated_at]
-    metadata_fields = @project.namespace.metadata_fields.map { |field| "metadata.#{field}" }
-    expected_fields = expected_base_fields.concat(metadata_fields)
+    expected_sample_fields = %w[name puid created_at updated_at attachments_updated_at]
+    expected_metadata_fields = @project.namespace.metadata_fields
 
     @controller.advanced_search_fields(@project.namespace)
-    actual_fields = @controller.instance_variable_get(:@advanced_search_fields)
+    actual_sample_fields = @controller.instance_variable_get(:@sample_fields)
+    actual_metadata_fields = @controller.instance_variable_get(:@metadata_fields)
 
-    assert_equal expected_fields.sort, actual_fields.sort
+    assert_equal expected_sample_fields.sort, actual_sample_fields.sort
+    assert_equal expected_metadata_fields.sort, actual_metadata_fields.sort
   end
 
   test 'metadata_templates_for_namespace returns formatted template options for group' do

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -448,8 +448,8 @@ module Groups
       end
 
       # confirm destroy bot
-      assert_selector 'dialog[open]'
-      within('dialog[open]') do
+      assert_selector '#dialog'
+      within('#dialog') do
         assert_text I18n.t('bots.destroy_confirmation.description', bot_name: @group_bot.user.email)
         click_button I18n.t('bots.destroy_confirmation.submit_button')
       end

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -453,8 +453,8 @@ module Projects
       end
 
       # confirm destroy bot
-      assert_selector 'dialog[open]'
-      within('dialog[open]') do
+      assert_selector '#dialog'
+      within('#dialog') do
         assert_text I18n.t('bots.destroy_confirmation.description', bot_name: @project_bot.user.email)
         click_button I18n.t('bots.destroy_confirmation.submit_button')
       end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -3124,7 +3124,7 @@ module Projects
         assert_selector 'h1', text: I18n.t(:'advanced_search_component.title')
         within all("div[data-advanced-search-target='groupsContainer']")[0] do
           within all("div[data-advanced-search-target='conditionsContainer']")[0] do
-            find("select[name$='[field]']").find("option[value='name").select_option
+            find("select[name$='[field]']").find("option[value='name']").select_option
             find("select[name$='[operator]']").find("option[value='=']").select_option
             find("input[name$='[value]']").fill_in with: @sample1.name
           end
@@ -3133,7 +3133,7 @@ module Projects
         assert_selector "div[data-advanced-search-target='groupsContainer']", count: 2
         within all("div[data-advanced-search-target='groupsContainer']")[1] do
           within all("div[data-advanced-search-target='conditionsContainer']")[0] do
-            find("select[name$='[field]']").find("option[value='name").select_option
+            find("select[name$='[field]']").find("option[value='name']").select_option
             find("select[name$='[operator]']").find("option[value='=']").select_option
             find("input[name$='[value]']").fill_in with: @sample2.name
           end


### PR DESCRIPTION
## What does this PR do and why?
- The metadata keys should not be prefixed with `metadata.*`.
- There should be a new metadata section within the fields dropdown that lists all the metadata fields.
- The sample fields within the fields dropdown should be localized.
- The operator dropdown should be localized.
 
STRY0017732

## Screenshots or screen recordings
Light mode:
![image](https://github.com/user-attachments/assets/ef5bc09a-799e-4f0f-be28-50809aa2ca33)

Dark mode:
![image](https://github.com/user-attachments/assets/356c50da-bb05-4125-a754-cb5dadd77cab)

## How to set up and validate locally
Please see https://github.com/phac-nml/irida-next/pull/887 for instructions on how to test the advanced search feature. 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
