### PR TITLE
Share & unshare pipeline results post run

### DIFF
--- a/app/controllers/concerns/workflow_execution_actions.rb
+++ b/app/controllers/concerns/workflow_execution_actions.rb
@@ -266,9 +266,9 @@ module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
   end
 
   def namespace_path
-    if @workflow_execution.namespace.type == 'Group'
+    if @workflow_execution.namespace.group_namespace?
       group_path(@workflow_execution.namespace)
-    elsif @workflow_execution.namespace.type == 'Project'
+    elsif @workflow_execution.namespace.project_namespace?
       namespace_project_path(@workflow_execution.namespace.parent, @workflow_execution.namespace.project)
     end
   end

--- a/app/controllers/concerns/workflow_execution_actions.rb
+++ b/app/controllers/concerns/workflow_execution_actions.rb
@@ -71,6 +71,8 @@ module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
                                                              'available')
     when 'samplesheet'
       format_samplesheet_params
+    when 'summary'
+      @namespace_path = namespace_path
     end
   end
 
@@ -261,5 +263,13 @@ module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
     search_params = {}
     search_params[:name_or_id_cont] = params.dig(:q, :name_or_id_cont)
     search_params
+  end
+
+  def namespace_path
+    if @workflow_execution.namespace.type == 'Group'
+      group_path(@workflow_execution.namespace)
+    elsif @workflow_execution.namespace.type == 'Project'
+      namespace_project_path(@workflow_execution.namespace.parent, @workflow_execution.namespace.project)
+    end
   end
 end

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -32,7 +32,7 @@ class WorkflowExecutionsController < ApplicationController
   end
 
   def workflow_execution_update_params
-    params.expect(workflow_execution: [:name])
+    params.expect(workflow_execution: [:name, :shared_with_namespace])
   end
 
   def workflow_execution_params_attributes

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -32,7 +32,7 @@ class WorkflowExecutionsController < ApplicationController
   end
 
   def workflow_execution_update_params
-    params.expect(workflow_execution: [:name, :shared_with_namespace])
+    params.expect(workflow_execution: %i[name shared_with_namespace])
   end
 
   def workflow_execution_params_attributes

--- a/app/views/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/workflow_executions/_edit_dialog.html.erb
@@ -24,6 +24,18 @@
 
     </div>
 
+    <% if Flipper.enabled?(:workflow_execution_sharing) %>
+      <div class="flex items-center h-5">
+        <%= form.check_box :shared_with_namespace,
+                       { checked: @workflow_execution["shared_with_namespace"] } %>
+        <%= form.label :shared_with_namespace,
+                   t(
+                     :"workflow_executions.edit_dialog.shared_with_namespace.#{@workflow_execution.namespace.type.downcase}",
+                   ),
+                   class: "mr-2 text-sm font-medium text-slate-900 dark:text-white" %>
+      </div>
+    <% end %>
+
     <div class="mt-4 space-x-2">
       <%= form.submit t("workflow_executions.edit_dialog.submit_button"),
                   class:

--- a/app/views/workflow_executions/_summary.html.erb
+++ b/app/views/workflow_executions/_summary.html.erb
@@ -33,6 +33,19 @@
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".workflow_version") %></dt>
       <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= @workflow_execution.metadata["workflow_version"] %></dd>
     </div>
+    <% if @workflow_execution.shared_with_namespace %>
+      <div class="flex flex-col py-3">
+        <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".shared_with_namespace.#{@workflow_execution.namespace.type.downcase}") %></dt>
+        <dd class="text-lg font-semibold text-slate-900 dark:text-white">
+          <%= link_to @workflow_execution.namespace.name,
+          @namespace_path,
+          data: {
+            turbo: false,
+          },
+          class: "hover:underline" %>
+        </dd>
+      </div>
+    <% end %>
     <div class="flex flex-col py-3">
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".created_at") %></dt>
       <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= local_time(@workflow_execution.created_at, :full_date) %></dd>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2189,6 +2189,9 @@ en:
       created_at: Created
       name: Name
       run_id: Run ID
+      shared_with_namespace:
+        group: Shared with Group
+        project: Shared with Project
       state: State
       updated_at: Last Updated
       workflow_name: Workflow Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2112,6 +2112,9 @@ en:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'
       name_placeholder: Enter workflow execution name (optional)
+      shared_with_namespace:
+        group: Share results with group members?
+        project: Share results with project members?
       submit_button: Submit
       title: Edit workflow execution
     file_selector:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2108,6 +2108,9 @@ fr:
       cancel_button: Annuler
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'
       name_placeholder: Entrez le nom d’exécution du flux de travail (facultatif)
+      shared_with_namespace:
+        group: Share results with group members?
+        project: Share results with project members?
       submit_button: Envoyer
       title: Modifier l’exécution du flux de travail
     file_selector:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2185,6 +2185,9 @@ fr:
       created_at: Créé
       name: Nom
       run_id: Exécuter l’identifiant
+      shared_with_namespace:
+        group: Shared with Group
+        project: Shared with Project
       state: État
       updated_at: Dernière mise à jour
       workflow_name: Nom du flux de travail

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -230,6 +230,16 @@ class WorkflowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'Submitter can share the pipeline results post launch' do
+    workflow_execution = workflow_executions(:irida_next_example_new)
+
+    update_params = { workflow_execution: { shared_with_namespace: true } }
+
+    put workflow_execution_path(workflow_execution, format: :turbo_stream), params: update_params
+
+    assert_response :success
+  end
+
   test 'Cannot update another user\'s personal workflow execution name' do
     sign_in users(:ryan_doe)
 
@@ -241,6 +251,7 @@ class WorkflowExecutionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
   end
+
 
   test 'should open destroy_multiple_confirmation' do
     get destroy_multiple_confirmation_workflow_executions_path(format: :turbo_stream)

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -252,7 +252,6 @@ class WorkflowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-
   test 'should open destroy_multiple_confirmation' do
     get destroy_multiple_confirmation_workflow_executions_path(format: :turbo_stream)
 

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -448,6 +448,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
   test 'submitter can edit workflow execution post launch from workflow execution page' do
     ### SETUP START ###
+    Flipper.enable(:workflow_execution_sharing)
     workflow_execution = workflow_executions(:irida_next_example_new)
     visit workflow_execution_path(workflow_execution)
     dt_value = I18n.t('projects.workflow_executions.summary.name', locale: @user.locale)
@@ -471,6 +472,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       fill_in placeholder: I18n.t('workflow_executions.edit_dialog.name_placeholder'),
               with: new_we_name
 
+      assert_not find("input[type='checkbox']").checked?
+      check I18n.t(:"workflow_executions.edit_dialog.shared_with_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
+
       click_button I18n.t(:'workflow_executions.edit_dialog.submit_button')
     end
     ### ACTIONS END ###
@@ -479,6 +483,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'h1', text: new_we_name
     assert_selector 'dt', text: dt_value
     assert_selector 'dd', text: new_we_name
+
     ### VERIFY END ###
   end
 

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -483,6 +483,8 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'h1', text: new_we_name
     assert_selector 'dt', text: dt_value
     assert_selector 'dd', text: new_we_name
+    assert_selector 'dt', text: I18n.t(:"workflow_executions.summary.shared_with_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
+    assert_selector 'dd', text: workflow_execution.namespace.name
 
     ### VERIFY END ###
   end


### PR DESCRIPTION
## What does this PR do and why?
Added the ability to share/unshare pipeline results post run.
STRY0017632 & STRY0017633

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/5f602a53-8e59-4f5a-ba17-de633d4e891e)
![image](https://github.com/user-attachments/assets/7b2acb5a-a253-4c3a-8474-2f83fe855e1d)

## How to set up and validate locally
Please see https://github.com/phac-nml/irida-next/pull/948 & https://github.com/phac-nml/irida-next/pull/895 for  instructions on how to share pipeline results with group & project members.

To share/unshare pipeline results post run:
1. Select `Workflow Executions` from the `Go To` side menu .
2. Click on the ID of the workflow execution which was just launched.
3. Verify if the results are shared within the `Summary` section.
4. Click on the `Edit` button on the top right.
5. Check or uncheck share results.
6. Click Submit.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
