### PR TITLE
Fixed bad rebase which reverted displaying of the Launch Workflow tex…

### DIFF
--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -49,7 +49,8 @@ module Groups
       @allowed_to = {
         submit_workflow: allowed_to?(:submit_workflow?, @group),
         export_data: allowed_to?(:export_data?, @group),
-        update_sample_metadata: allowed_to?(:update_sample_metadata?, @group)
+        update_sample_metadata: allowed_to?(:update_sample_metadata?, @group),
+        import_samples_and_metadata: allowed_to?(:import_samples_and_metadata?, @group)
       }
     end
 

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -112,7 +112,8 @@ module Projects
         update_sample_metadata: allowed_to?(:update_sample_metadata?, @project.namespace),
         create_sample: allowed_to?(:create_sample?, @project),
         destroy_sample: allowed_to?(:destroy_sample?, @project),
-        update_sample: allowed_to?(:update_sample?, @project)
+        update_sample: allowed_to?(:update_sample?, @project),
+        import_samples_and_metadata: allowed_to?(:import_samples_and_metadata?, @project.namespace)
       }
     end
 

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -14,35 +14,39 @@
         data: { turbo_stream: true, controller: "action-button", action_button_required_value: 1, action: "turbo:morph-element->action-button#idempotentConnect " },
                   class: "button button--size-default button--state-default action-button" do %>
             <%= viral_icon(name: :rocket_launch, classes: "w-5 h-5 inline-block") %>
-            <span class="sr-only"><%= t(".workflows.button_sr") %></span>
+            <span><%= t(".workflows.button_sr") %></span>
           <% end %>
         <% end %>
         <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, classes: "font-normal button button--size-default button--state-default") do |dropdown| %>
-          <% if @allowed_to[:update_sample_metadata] && @has_samples %>
+
+          <% if @allowed_to[:update_sample_metadata] || @allowed_to[:import_samples_and_metadata] %>
+
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.import"),
               section_header: true,
             ) %>
 
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.import_metadata"),
-              url: new_group_samples_file_import_path,
-              disableable: true,
-              data: {
-                turbo_stream: true,
-              },
-            ) %>
-          <% end %>
+            <% if @allowed_to[:update_sample_metadata] && @has_samples %>
+              <% dropdown.with_item(
+                label: t("shared.samples.actions_dropdown.import_metadata"),
+                url: new_group_samples_file_import_path,
+                disableable: true,
+                data: {
+                  turbo_stream: true,
+                },
+              ) %>
+            <% end %>
 
-          <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && allowed_to?(:import_samples_and_metadata?, @group) %>
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.import_samples"),
-              url: new_group_samples_spreadsheet_import_path,
-              disableable: true,
-              data: {
-                turbo_stream: true,
-              },
-            ) %>
+            <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && @allowed_to[:import_samples_and_metadata] %>
+              <% dropdown.with_item(
+                label: t("shared.samples.actions_dropdown.import_samples"),
+                url: new_group_samples_spreadsheet_import_path,
+                disableable: true,
+                data: {
+                  turbo_stream: true,
+                },
+              ) %>
+            <% end %>
           <% end %>
 
           <% if @allowed_to[:export_data] %>

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -16,12 +16,12 @@
         data: { action: "turbo:morph-element->action-button#idempotentConnect ", turbo_stream: true, controller: "action-button", action_button_required_value: 1 },
                   class: "button button--size-default button--state-default action-button" do %>
             <%= viral_icon(name: :rocket_launch, classes: "w-5 h-5 inline-block") %>
-            <span class="sr-only"><%= t(:".workflows.button_sr") %></span>
+            <span><%= t(:".workflows.button_sr") %></span>
           <% end %>
         <% end %>
 
         <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, classes: "font-normal button button--size-default button--state-default") do |dropdown| %>
-          <% if allowed_to?(:create_sample?, @project) %>
+          <% if @allowed_to[:create_sample] %>
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.new_sample"),
               url: new_namespace_project_sample_path,
@@ -32,7 +32,7 @@
             ) %>
           <% end %>
 
-          <% if allowed_to?(:clone_sample?, @project) %>
+          <% if @allowed_to[:clone_sample] %>
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.clone"),
               url: new_namespace_project_samples_clone_path,
@@ -47,7 +47,7 @@
                 "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white action-button",
             ) %>
           <% end %>
-          <% if allowed_to?(:transfer_sample?, @project) %>
+          <% if @allowed_to[:transfer_sample] %>
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.transfer"),
               url: new_namespace_project_samples_transfer_path,
@@ -63,7 +63,7 @@
             ) %>
           <% end %>
 
-          <% if allowed_to?(:destroy_sample?, @project) %>
+          <% if @allowed_to[:destroy_sample] %>
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.delete_samples"),
               url: new_namespace_project_samples_deletion_path,
@@ -82,34 +82,36 @@
             ) %>
           <% end %>
 
-          <% if allowed_to?(:update_sample_metadata?, @project.namespace) && @has_samples %>
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.import"),
-              section_header: true,
-            ) %>
+          <% dropdown.with_item(
+            label: t("shared.samples.actions_dropdown.import"),
+            section_header: true,
+          ) %>
 
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.import_metadata"),
-              url: new_namespace_project_samples_file_import_path,
-              disableable: true,
-              data: {
-                turbo_stream: true,
-              },
-            ) %>
+          <% if @allowed_to[:update_sample_metadata] || @allowed_to[:import_samples_and_metadata] %>
+            <% if @allowed_to[:update_sample_metadata] && @has_samples %>
+              <% dropdown.with_item(
+                label: t("shared.samples.actions_dropdown.import_metadata"),
+                url: new_namespace_project_samples_file_import_path,
+                disableable: true,
+                data: {
+                  turbo_stream: true,
+                },
+              ) %>
+            <% end %>
+
+            <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && @allowed_to[:import_samples_and_metadata] %>
+              <% dropdown.with_item(
+                label: t("shared.samples.actions_dropdown.import_samples"),
+                url: new_namespace_project_samples_spreadsheet_import_path,
+                disableable: true,
+                data: {
+                  turbo_stream: true,
+                },
+              ) %>
+            <% end %>
           <% end %>
 
-          <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && allowed_to?(:import_samples_and_metadata?, @project.namespace) %>
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.import_samples"),
-              url: new_namespace_project_samples_spreadsheet_import_path,
-              disableable: true,
-              data: {
-                turbo_stream: true,
-              },
-            ) %>
-          <% end %>
-
-          <% if allowed_to?(:export_data?, @project) %>
+          <% if @allowed_to[:export_data] %>
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.export"),
               section_header: true,

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -110,7 +110,7 @@ module Projects
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
                                                                            locale: user.locale))
 
-      assert_selector 'span[class="sr-only"]',
+      assert_selector 'span',
                       text: I18n.t('projects.samples.index.workflows.button_sr', locale: user.locale)
     end
 
@@ -122,7 +122,7 @@ module Projects
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
                                                                            locale: user.locale))
 
-      assert_no_selector 'span[class="sr-only"]', text: I18n.t('projects.samples.index.workflows.button_sr')
+      assert_no_selector 'span', text: I18n.t('projects.samples.index.workflows.button_sr')
     end
 
     test 'User with role >= Analyst sees create export button' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR reverts a change which hid the `Launch Workflow` text for the rocket ship button on the samples pages unless viewed by a screenreader. Updated the sample actions dropdowns to show the `Import` header 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/70297b4c-0d70-4c66-9455-b43bbe5589e6)

![image](https://github.com/user-attachments/assets/bbb67667-9bed-4ef9-bf95-ab7ca8bf25a9)

![image](https://github.com/user-attachments/assets/feff9e6b-8851-4ede-9377-cc364f5cbd96)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
