### PR TITLE
Fix: Samplesheet File selector and Metadata input box focus

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -39,6 +39,9 @@
   td[contenteditable="true"]:focus-visible {
     outline-offset: -2px;
   }
+  button.file-selector:focus-visible {
+    outline-offset: -2px;
+  }
 }
 
 @utility collapsed {
@@ -82,7 +85,7 @@
 }
 
 @utility card {
-  @apply rounded-md border border-slate-200 bg-slate-50 p-4 shadow-xs sm:p-6 dark:border-slate-700 dark:bg-slate-800;
+  @apply shadow-xs rounded-md border border-slate-200 bg-slate-50 p-4 sm:p-6 dark:border-slate-700 dark:bg-slate-800;
 }
 
 @utility form-field {
@@ -837,11 +840,11 @@
   }
 
   dialog::backdrop {
-    @apply bg-slate-200/40 backdrop-blur-xs;
+    @apply backdrop-blur-xs bg-slate-200/40;
   }
 
   .dark dialog::backdrop {
-    @apply bg-slate-600/40 backdrop-blur-xs;
+    @apply backdrop-blur-xs bg-slate-600/40;
   }
 
   .dialog--section {
@@ -855,7 +858,7 @@
 }
 
 .pagy-nav.pagination {
-  @apply isolate inline-flex -space-x-px rounded-md shadow-xs;
+  @apply shadow-xs isolate inline-flex -space-x-px rounded-md;
 }
 
 .page.next a {
@@ -904,7 +907,7 @@ div.field_with_errors > :is(select) {
 }
 
 input[type="checkbox"] {
-  @apply text-primary-600 checked:border-primary-500 dark:checked:border-primary-500 dark:checked:bg-primary-500 mt-0.5 mr-2 shrink-0 rounded-sm border-slate-200 disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800;
+  @apply text-primary-600 checked:border-primary-500 dark:checked:border-primary-500 dark:checked:bg-primary-500 mr-2 mt-0.5 shrink-0 rounded-sm border-slate-200 disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800;
 }
 
 input[type="radio"] {

--- a/app/components/nextflow/samplesheet/header_component.html.erb
+++ b/app/components/nextflow/samplesheet/header_component.html.erb
@@ -17,7 +17,7 @@
       include_blank: !@required_properties.include?(header),
       id: "field-#{header}",
       class:
-        "bg-slate-50 text-slate-900 text-sm border-none block min-w-56 w-full p-2.5 dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white font-semibold tracking-wider uppercase",
+        "bg-slate-50 text-inherit text-sm border-none block min-w-56 w-full p-2.5 dark:bg-slate-700 font-semibold tracking-wider uppercase",
       data: {
         action: "change->nextflow--samplesheet#handleMetadataSelection",
         "metadata-header": header,

--- a/app/components/nextflow/samplesheet_component.html.erb
+++ b/app/components/nextflow/samplesheet_component.html.erb
@@ -88,10 +88,7 @@
 </div>
 
 <template data-nextflow--samplesheet-target="cellContainer">
-  <div
-    style="content-visibility: auto;"
-    class="border table-td dark:border-slate-600 border-slate-100"
-  >
+  <div class="border table-td dark:border-slate-600 border-slate-100">
   </div>
 </template>
 
@@ -132,7 +129,7 @@
   },
   id: "ATTACHABLE_ID_PLACEHOLDER_PROPERTY_PLACEHOLDER",
   class:
-    "block p-2 text-sm border-2 border-transparent cursor-pointer bg-inherit text-inherit hover:border-slate-300" %>
+    "block p-2 text-sm border-2 border-transparent cursor-pointer bg-inherit text-inherit focus:-outline-offset-2" %>
 </template>
 
 <template data-nextflow--samplesheet-target="metadataCell">
@@ -145,8 +142,8 @@
   <label for="ID_PLACEHOLDER" class="sr-only">NAME_PLACEHOLDER</label>
   <input
     class="
-      bg-slate-50 border-0 text-slate-900 text-sm block w-full p-2.5 dark:bg-slate-700
-      dark:border-slate-600 dark:placeholder-slate-400 dark:text-white
+      block p-2 text-sm border-2 border-transparent bg-inherit text-inherit w-full
+      focus:-outline-offset-2
     "
     data-action="change->nextflow--samplesheet#updateEditableSamplesheetData"
     type="text"


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Prior to this PR, focus outline was not visible for file selector link or metadata input field in firefox. Now focus is indicating correctly.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/1932d2ee-a7e5-43a4-81ef-48af4ceafbc2)
![image](https://github.com/user-attachments/assets/caada51f-97a7-4de8-8f75-3d6d3e614b4d)

![image](https://github.com/user-attachments/assets/5294af31-9bb6-4860-951d-03ee6f3880c3)
![image](https://github.com/user-attachments/assets/d52d9ad3-551a-490c-94ff-18a537af2ce6)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Navigate to a Project of your choice that you can run an analysis on
3. Select a pipeline with both file inputs and metadata inputs
4. Tab through the page and ensure that focus is visible

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
