### PR TITLE
Bug: Create sample error increasing samples count

### DIFF
--- a/app/services/samples/create_service.rb
+++ b/app/services/samples/create_service.rb
@@ -17,7 +17,7 @@ module Samples
 
       if sample.save
 
-        update_samples_count if @project.parent.type == Group.sti_name
+        update_samples_count if @project.parent.group_namespace?
 
         if @include_activity
           @project.namespace.create_activity key: 'namespaces_project_namespace.samples.create',

--- a/app/services/samples/create_service.rb
+++ b/app/services/samples/create_service.rb
@@ -15,17 +15,20 @@ module Samples
     def execute
       authorize! @project, to: :create_sample? unless @project.nil?
 
-      if sample.save && @include_activity
-        @project.namespace.create_activity key: 'namespaces_project_namespace.samples.create',
-                                           owner: current_user,
-                                           parameters:
-                                             {
-                                               sample_id: sample.id,
-                                               sample_puid: sample.puid,
-                                               action: 'sample_create'
-                                             }
+      if sample.save
 
-        update_samples_count if @project.parent.type == 'Group'
+        update_samples_count if @project.parent.type == Group.sti_name
+
+        if @include_activity
+          @project.namespace.create_activity key: 'namespaces_project_namespace.samples.create',
+                                             owner: current_user,
+                                             parameters:
+                                               {
+                                                 sample_id: sample.id,
+                                                 sample_puid: sample.puid,
+                                                 action: 'sample_create'
+                                               }
+        end
       end
 
       sample

--- a/app/services/samples/create_service.rb
+++ b/app/services/samples/create_service.rb
@@ -24,9 +24,9 @@ module Samples
                                                sample_puid: sample.puid,
                                                action: 'sample_create'
                                              }
-      end
 
-      update_samples_count if @project.parent.type == 'Group'
+        update_samples_count if @project.parent.type == 'Group'
+      end
 
       sample
     end

--- a/db/migrate/20250416191422_recalculate_group_samples_count.rb
+++ b/db/migrate/20250416191422_recalculate_group_samples_count.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# migration to recalculate group.samples_count after a bug was found where samples failing to create still increased
+# samples_count
+class RecalculateGroupSamplesCount < ActiveRecord::Migration[8.0]
+  def change
+    Group.all.each do |group|
+      group.samples_count = 0
+      group.save
+    end
+
+    Project.all.each do |project|
+      next unless project.parent.group_namespace?
+
+      project.parent.self_and_ancestors.each do |group|
+        group.samples_count += project.samples_count
+        group.save
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_19_172718) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_16_191422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"

--- a/test/controllers/projects/samples_controller_test.rb
+++ b/test/controllers/projects/samples_controller_test.rb
@@ -65,7 +65,7 @@ module Projects
 
     test 'should not create a sample with short sample name parameter' do
       assert_difference -> { Sample.count } => 0,
-                        -> { @namespace.reload.aggregated_samples_count } => 0,
+                        -> { @namespace.reload.samples_count } => 0,
                         -> { @project.reload.samples_count } => 0 do
         post namespace_project_samples_url(@namespace, @project),
              params: { sample: {
@@ -78,7 +78,7 @@ module Projects
 
     test 'should not create a sample with same sample name parameter' do
       assert_difference -> { Sample.count } => 0,
-                        -> { @namespace.reload.aggregated_samples_count } => 0,
+                        -> { @namespace.reload.samples_count } => 0,
                         -> { @project.reload.samples_count } => 0 do
         post namespace_project_samples_url(@namespace, @project),
              params: { sample: {

--- a/test/controllers/projects/samples_controller_test.rb
+++ b/test/controllers/projects/samples_controller_test.rb
@@ -63,13 +63,29 @@ module Projects
       assert_redirected_to namespace_project_sample_url(id: Sample.last.id)
     end
 
-    test 'should not create a sample with wrong parameters' do
-      post namespace_project_samples_url(@namespace, @project),
-           params: { sample: {
-             description: @sample1.description,
-             name: '?'
-           } }
+    test 'should not create a sample with short sample name parameter' do
+      assert_difference -> { Sample.count } => 0,
+                        -> { @namespace.reload.aggregated_samples_count } => 0,
+                        -> { @project.reload.samples_count } => 0 do
+        post namespace_project_samples_url(@namespace, @project),
+             params: { sample: {
+               description: @sample1.description,
+               name: '?'
+             } }
+      end
+      assert_response :unprocessable_entity
+    end
 
+    test 'should not create a sample with same sample name parameter' do
+      assert_difference -> { Sample.count } => 0,
+                        -> { @namespace.reload.aggregated_samples_count } => 0,
+                        -> { @project.reload.samples_count } => 0 do
+        post namespace_project_samples_url(@namespace, @project),
+             params: { sample: {
+               description: @sample1.description,
+               name: 'Project 1 Sample 1'
+             } }
+      end
       assert_response :unprocessable_entity
     end
 

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -151,7 +151,8 @@ module Samples
 
       assert_difference -> { Sample.count } => 1,
                         -> { project1.reload.samples_count } => 1,
-                        -> { group1.reload.aggregated_samples_count } => 1 do
+                        -> { group1.reload.aggregated_samples_count } => 1,
+                        -> { PublicActivity::Activity.count } => 0 do
         Samples::CreateService.new(@user, project1, valid_params).execute
       end
     end

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -118,5 +118,29 @@ module Samples
         Samples::CreateService.new(@user, project31, valid_params).execute
       end
     end
+
+    test 'samples count does not update if sample is not saved due to same name' do
+      project1 = projects(:project1)
+      group1 = groups(:group_one)
+      same_name_params = { name: 'Project 1 Sample 1', description: 'sample with already existing name' }
+
+      assert_difference -> { Sample.count } => 0,
+                        -> { project1.reload.samples_count } => 0,
+                        -> { group1.reload.aggregated_samples_count } => 0 do
+        Samples::CreateService.new(@user, project1, same_name_params).execute
+      end
+    end
+
+    test 'samples count does not update if sample is not saved due too short name' do
+      project1 = projects(:project1)
+      group1 = groups(:group_one)
+      short_name_params = { name: 'a', description: 'sample with already existing name' }
+
+      assert_difference -> { Sample.count } => 0,
+                        -> { project1.reload.samples_count } => 0,
+                        -> { group1.reload.aggregated_samples_count } => 0 do
+        Samples::CreateService.new(@user, project1, short_name_params).execute
+      end
+    end
   end
 end

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -142,5 +142,18 @@ module Samples
         Samples::CreateService.new(@user, project1, short_name_params).execute
       end
     end
+
+    test 'sample count increases when activity is not written' do
+      project1 = projects(:project1)
+      group1 = groups(:group_one)
+      valid_params = { name: 'a new sample', description: 'sample with already existing name',
+                       include_activity: false }
+
+      assert_difference -> { Sample.count } => 1,
+                        -> { project1.reload.samples_count } => 1,
+                        -> { group1.reload.aggregated_samples_count } => 1 do
+        Samples::CreateService.new(@user, project1, valid_params).execute
+      end
+    end
   end
 end

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -157,7 +157,7 @@ module Samples
       end
     end
 
-    test 'activity increases when sample is created' do
+    test 'activity occurs when sample is created' do
       project1 = projects(:project1)
       group1 = groups(:group_one)
       valid_params = { name: 'a new sample', description: 'sample with already existing name',

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -156,5 +156,19 @@ module Samples
         Samples::CreateService.new(@user, project1, valid_params).execute
       end
     end
+
+    test 'activity increases when sample is created' do
+      project1 = projects(:project1)
+      group1 = groups(:group_one)
+      valid_params = { name: 'a new sample', description: 'sample with already existing name',
+                       include_activity: true }
+
+      assert_difference -> { Sample.count } => 1,
+                        -> { project1.reload.samples_count } => 1,
+                        -> { group1.reload.aggregated_samples_count } => 1,
+                        -> { PublicActivity::Activity.count } => 1 do
+        Samples::CreateService.new(@user, project1, valid_params).execute
+      end
+    end
   end
 end

--- a/test/services/samples/create_service_test.rb
+++ b/test/services/samples/create_service_test.rb
@@ -126,7 +126,7 @@ module Samples
 
       assert_difference -> { Sample.count } => 0,
                         -> { project1.reload.samples_count } => 0,
-                        -> { group1.reload.aggregated_samples_count } => 0 do
+                        -> { group1.reload.samples_count } => 0 do
         Samples::CreateService.new(@user, project1, same_name_params).execute
       end
     end
@@ -138,7 +138,7 @@ module Samples
 
       assert_difference -> { Sample.count } => 0,
                         -> { project1.reload.samples_count } => 0,
-                        -> { group1.reload.aggregated_samples_count } => 0 do
+                        -> { group1.reload.samples_count } => 0 do
         Samples::CreateService.new(@user, project1, short_name_params).execute
       end
     end
@@ -151,7 +151,7 @@ module Samples
 
       assert_difference -> { Sample.count } => 1,
                         -> { project1.reload.samples_count } => 1,
-                        -> { group1.reload.aggregated_samples_count } => 1,
+                        -> { group1.reload.samples_count } => 1,
                         -> { PublicActivity::Activity.count } => 0 do
         Samples::CreateService.new(@user, project1, valid_params).execute
       end
@@ -165,7 +165,7 @@ module Samples
 
       assert_difference -> { Sample.count } => 1,
                         -> { project1.reload.samples_count } => 1,
-                        -> { group1.reload.aggregated_samples_count } => 1,
+                        -> { group1.reload.samples_count } => 1,
                         -> { PublicActivity::Activity.count } => 1 do
         Samples::CreateService.new(@user, project1, valid_params).execute
       end


### PR DESCRIPTION
## What does this PR do and why?
A bug was found where if an error occurred during sample creation, the associated group sample count would still increment.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
Test the issue on `main` first
1. Create a group then create a project under that group
2. Create a new sample, then create another sample with the same name. You should get a same name error and the second sample should not be created
3. Navigate back to project samples to verify only your first sample exists
4. Navigate to the groups dashboard. Your group should have a samples_count of 2

Test the fix on this branch
5. Repeat the above with a new group/project/samples. On the group's dashboard, the samples_count should only be 1.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
