### PR TITLE
Feat: Compose blob retry

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,7 @@ Flipper.enable(:update_nextflow_metadata_param)
 Flipper.enable(:attachments_preview)
 Flipper.enable(:delete_multiple_workflows)
 Flipper.enable(:batch_sample_spreadsheet_import)
+Flipper.enable(:compose_with_retry)
 
 @namespace_group_link_expiry_date = (Time.zone.today + 14).strftime('%Y-%m-%d')
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates `compose_blob_with_custom_key` to have optional retry when `compose_with_retry` feature is enabled. This allows compose to recover from `Errno::ECONNRESET` when storage endpoint connection is unsuccessful.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
