### PR TITLE
Updated sample metadata template dropdown to act like a normal dropdown

### DIFF
--- a/app/javascript/controllers/metadata_template_dd_controller.js
+++ b/app/javascript/controllers/metadata_template_dd_controller.js
@@ -1,0 +1,72 @@
+import { Controller } from "@hotwired/stimulus";
+
+/**
+ * MetadataTemplateDropdownController
+ *
+ * Handles a Flowbite dropdown for metadata template selection.
+ * - Submits the form when the dropdown is shown (for live filtering or updating)
+ * - Hides the dropdown when a successful Turbo form submission occurs elsewhere
+ *
+ * Stimulus Targets:
+ * - trigger: The element that toggles the dropdown
+ * - menu: The dropdown menu element
+ * - form: The form to submit on dropdown show
+ *
+ * Usage:
+ * <div data-controller="metadata-template-dd">
+ *   <button data-metadata-template-dd-target="trigger">Open</button>
+ *   <div data-metadata-template-dd-target="menu">
+ *     <form data-metadata-template-dd-target="form">...</form>
+ *   </div>
+ * </div>
+ */
+export default class extends Controller {
+  static targets = ["trigger", "menu", "form"];
+
+  /** @type {Dropdown} Flowbite dropdown instance */
+  #dropdown;
+  /** @type {Function} Bound event handler for turbo:submit-end */
+  #turboSubmitEndListener = this.#handleTurboSubmitEnd.bind(this);
+
+  /**
+   * Connects the controller, initializes the dropdown, and sets up event listeners.
+   */
+  connect() {
+    this.#dropdown = new Dropdown(this.menuTarget, this.triggerTarget, {
+      onShow: () => {
+        // Auto-submit the form when dropdown is shown
+        this.formTarget.requestSubmit();
+      },
+    });
+
+    document.addEventListener("turbo:submit-end", this.#turboSubmitEndListener);
+    this.element.setAttribute("data-controller-connected", "true");
+  }
+
+  /**
+   * Disconnects the controller and cleans up event listeners.
+   */
+  disconnect() {
+    document.removeEventListener(
+      "turbo:submit-end",
+      this.#turboSubmitEndListener,
+    );
+    if (this.#dropdown) {
+      this.#dropdown.hide();
+      this.#dropdown = null;
+    }
+  }
+
+  /**
+   * Handles Turbo form submission events.
+   * Hides the dropdown if a successful submission occurs outside this form.
+   *
+   * @param {CustomEvent} event - The turbo:submit-end event
+   * @private
+   */
+  #handleTurboSubmitEnd(event) {
+    if (event.detail.success && event.target !== this.formTarget) {
+      this.#dropdown?.hide();
+    }
+  }
+}

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -1,76 +1,46 @@
-<%= form_with url: url, data: { turbo_frame: "metadata_templates_dropdown", turbo_stream: true }, method: :get do |f| %>
-  <input type="hidden" name="format" value="turbo_stream"/>
-  <input type="hidden" name="limit" value="<%= pagy&.limit %>"/>
-  <input type="hidden" name="page" value="<%= pagy&.page %>"/>
-  <%= f.hidden_field :metadata_template, value: metadata_template[:id] %>
-  <%= f.button type: :submit,
-    class: "inline-flex items-center justify-center
-            sm:w-auto
-            px-5 py-2.5
-            text-sm
-            border rounded-md
-            cursor-pointer
-            focus:z-10
-            bg-white text-slate-900 border-slate-200
-            hover:bg-slate-100 hover:text-slate-950
-            dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600
-            dark:hover:text-white dark:hover:bg-slate-700",
-    title: t("shared.samples.metadata_templates.tooltip"),
-    data: {
-      'dropdown-toggle': "dd-metadata_templates_dropdown",
-      "dropdown-offset-skidding": 150,
-    } do %>
-    <span class="text-sm">
+<div data-controller="metadata-template-dd">
+  <%= form_with url: url, data: { turbo_frame: "metadata_templates_dropdown", turbo_stream: true, "metadata-template-dd-target": "form" }, method: :get do |f| %>
+    <input type="hidden" name="format" value="turbo_stream"/>
+    <input type="hidden" name="limit" value="<%= pagy&.limit %>"/>
+    <input type="hidden" name="page" value="<%= pagy&.page %>"/>
+    <%= f.hidden_field :metadata_template, value: metadata_template[:id] %>
+  <% end %>
+  <button
+    data-metadata-template-dd-target="trigger"
+    id="metadata-template-dd-trigger"
+    class="
+      text-slate-900 bg-white border border-slate-300 hover:bg-slate-100 rounded-lg
+      text-sm px-5 py-2.5 dark:bg-slate-800 dark:text-white dark:border-slate-600
+      dark:hover:bg-slate-700 dark:hover:border-slate-600 cursor-pointer inline-flex
+      items-center justify-center
+    "
+    type="button"
+    aria-haspopup="listbox"
+    aria-expanded="false"
+    aria-controls="metadata-template-dd-menu"
+  >
+    <span class="text-sm" id="metadata-template-dd-label">
       <%= t("shared.samples.metadata_templates.label") %>
     </span>
     <%= viral_icon(name: "adjustment_horizontal", classes: "w-4 h-4 ml-2 flex-none") %>
-  <% end %>
-<% end %>
-<div
-  id="dd-metadata_templates_dropdown"
-  class="
-    z-50 hidden bg-white divide-y divide-slate-100 rounded-lg shadow-sm w-44
-    dark:bg-slate-700
-  "
->
-  <ul id="metadata_templates_dropdown">
-    <li>
-      <%= render SpinnerComponent.new(
-        message: t("shared.samples.metadata_templates.loading"),
-      ) %>
-    </li>
-  </ul>
-</div>
-
-<button
-  id="dropdownRadioBgHoverButton"
-  data-dropdown-toggle="dropdownRadioBgHover"
-  class="
-    text-slate-900 bg-white border border-slate-300 hover:bg-slate-100 rounded-lg
-    text-sm px-5 py-2.5 me-2 mb-2 dark:bg-slate-800 dark:text-white
-    dark:border-slate-600 dark:hover:bg-slate-700 dark:hover:border-slate-600
-    cursor-pointer inline-flex items-center justify-center
-  "
-  type="button"
->
-  <span class="text-sm">
-    <%= t("shared.samples.metadata_templates.label") %>
-  </span>
-  <%= viral_icon(name: "adjustment_horizontal", classes: "w-4 h-4 ml-2 flex-none") %>
-</button>
-<!-- Dropdown menu -->
-<div
-  id="dropdownRadioBgHover"
-  class="
-    z-10 hidden w-48 bg-white divide-y divide-slate-100 rounded-lg shadow-sm
-    dark:bg-slate-700 dark:divide-slate-600 z-30
-  "
->
-  <ul id="metadata_templates_dropdown">
-    <li>
-      <%= render SpinnerComponent.new(
-        message: t("shared.samples.metadata_templates.loading"),
-      ) %>
-    </li>
-  </ul>
+  </button>
+  <!-- Dropdown menu -->
+  <div
+    data-metadata-template-dd-target="menu"
+    id="metadata-template-dd-menu"
+    class="
+      hidden w-48 bg-white divide-y divide-slate-100 rounded-lg shadow-sm
+      dark:bg-slate-700 dark:divide-slate-600 z-30
+    "
+    aria-labelledby="metadata-template-dd-trigger"
+    tabindex="-1"
+  >
+    <ul id="metadata_templates_dropdown" role="listbox">
+      <li role="option">
+        <%= render SpinnerComponent.new(
+          message: t("shared.samples.metadata_templates.loading"),
+        ) %>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -29,8 +29,41 @@
 <div
   id="dd-metadata_templates_dropdown"
   class="
-    z-50 hidden bg-white divide-y divide-gray-100 rounded-lg shadow-sm w-44
-    dark:bg-gray-700
+    z-50 hidden bg-white divide-y divide-slate-100 rounded-lg shadow-sm w-44
+    dark:bg-slate-700
+  "
+>
+  <ul id="metadata_templates_dropdown">
+    <li>
+      <%= render SpinnerComponent.new(
+        message: t("shared.samples.metadata_templates.loading"),
+      ) %>
+    </li>
+  </ul>
+</div>
+
+<button
+  id="dropdownRadioBgHoverButton"
+  data-dropdown-toggle="dropdownRadioBgHover"
+  class="
+    text-slate-900 bg-white border border-slate-300 hover:bg-slate-100 rounded-lg
+    text-sm px-5 py-2.5 me-2 mb-2 dark:bg-slate-800 dark:text-white
+    dark:border-slate-600 dark:hover:bg-slate-700 dark:hover:border-slate-600
+    cursor-pointer inline-flex items-center justify-center
+  "
+  type="button"
+>
+  <span class="text-sm">
+    <%= t("shared.samples.metadata_templates.label") %>
+  </span>
+  <%= viral_icon(name: "adjustment_horizontal", classes: "w-4 h-4 ml-2 flex-none") %>
+</button>
+<!-- Dropdown menu -->
+<div
+  id="dropdownRadioBgHover"
+  class="
+    z-10 hidden w-48 bg-white divide-y divide-slate-100 rounded-lg shadow-sm
+    dark:bg-slate-700 dark:divide-slate-600 z-30
   "
 >
   <ul id="metadata_templates_dropdown">

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <button
     data-metadata-template-dd-target="trigger"
-    tooltip="<%= t("shared.samples.metadata_templates.tooltip") %>
+    tooltip="<%= t("shared.samples.metadata_templates.tooltip") %>"
     id="metadata-template-dd-trigger"
     class="
       text-slate-900 bg-white border border-slate-300 hover:bg-slate-100 rounded-lg

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <button
     data-metadata-template-dd-target="trigger"
-    tooltip="<%= t("shared.samples.metadata_templates.tooltip") %>"
+    title="<%= t("shared.samples.metadata_templates.tooltip") %>"
     id="metadata-template-dd-trigger"
     class="
       text-slate-900 bg-white border border-slate-300 hover:bg-slate-100 rounded-lg

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -7,6 +7,7 @@
   <% end %>
   <button
     data-metadata-template-dd-target="trigger"
+    tooltip="<%= t("shared.samples.metadata_templates.tooltip") %>
     id="metadata-template-dd-trigger"
     class="
       text-slate-900 bg-white border border-slate-300 hover:bg-slate-100 rounded-lg

--- a/app/views/shared/samples/_metadata_template_item.html.erb
+++ b/app/views/shared/samples/_metadata_template_item.html.erb
@@ -1,0 +1,20 @@
+<li
+  class="
+    w-full border-b border-slate-200 dark:border-slate-600 hover:bg-slate-100
+    dark:hover:bg-slate-600
+  "
+>
+  <button
+    type="submit"
+    value="<%= value %>"
+    name="q[metadata_template]"
+    class="w-full flex py-2.5 px-3 cursor-pointer"
+  >
+    <span class="size-5 mr-2">
+      <% if selected %>
+        <%= viral_icon(name: "check", classes: "flex-none") %>
+      <% end %>
+    </span>
+    <%= label %>
+  </button>
+</li>

--- a/app/views/shared/samples/_metadata_templates_list.html.erb
+++ b/app/views/shared/samples/_metadata_templates_list.html.erb
@@ -8,9 +8,8 @@ data: {
   <ul
     id="metadata_templates"
     class="py-2 text-sm text-slate-700 dark:text-slate-200"
-    aria-labelledby="dropdownDefault"
+    aria-labelledby="metadata-template-dd-trigger"
   >
-
     <li
       class="
         w-full px-3 py-2 text-xs font-bold tracking-wider uppercase bg-slate-200
@@ -32,6 +31,8 @@ data: {
           value="all"
           name="q[metadata_template]"
           onchange="this.form.requestSubmit()"
+          aria-checked="<%= @current_metadata_template_id == 'all' ? 'true' : 'false' %>"
+          tabindex="<%= @current_metadata_template_id == 'all' ? '0' : '-1' %>"
           <%= @current_metadata_template_id == "all" ? "checked" : "" %>
         >
         <label
@@ -55,7 +56,8 @@ data: {
           value="none"
           onchange="this.form.requestSubmit()"
           name="q[metadata_template]"
-          <%= @current_metadata_template_id == "none" ? "checked" : "" %>
+          aria-checked="<%= @current_metadata_template_id == 'none' ? 'true' : 'false' %>"
+          tabindex="<%= @current_metadata_template_id == 'none' ? '0' : '-1' %>"
         >
         <label
           for="rl-none"
@@ -88,6 +90,8 @@ data: {
               value="<%= metadata_template.id %>"
               onchange="this.form.requestSubmit()"
               name="q[metadata_template]"
+              aria-checked="<%= @current_metadata_template_id == metadata_template.id ? 'true' : 'false' %>"
+              tabindex="<%= @current_metadata_template_id == metadata_template.id ? '0' : '-1' %>"
               <%= @current_metadata_template_id == metadata_template.id ? "checked" : "" %>
             >
             <label

--- a/app/views/shared/samples/_metadata_templates_list.html.erb
+++ b/app/views/shared/samples/_metadata_templates_list.html.erb
@@ -18,55 +18,18 @@ data: {
     >
       <%= t("shared.samples.metadata_templates.fields.label") %>
     </li>
-    <li
-      class="
-        w-full border-b border-slate-200 dark:border-slate-600 hover:bg-slate-100
-        dark:hover:bg-slate-600
-      "
-    >
-      <div class="flex items-center ps-3">
-        <input
-          id="rl-all"
-          type="radio"
-          value="all"
-          name="q[metadata_template]"
-          onchange="this.form.requestSubmit()"
-          aria-checked="<%= @current_metadata_template_id == 'all' ? 'true' : 'false' %>"
-          tabindex="<%= @current_metadata_template_id == 'all' ? '0' : '-1' %>"
-          <%= @current_metadata_template_id == "all" ? "checked" : "" %>
-        >
-        <label
-          for="rl-all"
-          class="
-            w-full py-3 text-sm font-medium text-slate-900 ms-2 dark:text-slate-300
-          "
-        ><%= t("shared.samples.metadata_templates.fields.all") %></label>
-      </div>
-    </li>
-    <li
-      class="
-        w-full border-b border-slate-200 dark:border-slate-600 hover:bg-slate-100
-        dark:hover:bg-slate-600
-      "
-    >
-      <div class="flex items-center ps-3">
-        <input
-          id="rl-none"
-          type="radio"
-          value="none"
-          onchange="this.form.requestSubmit()"
-          name="q[metadata_template]"
-          aria-checked="<%= @current_metadata_template_id == 'none' ? 'true' : 'false' %>"
-          tabindex="<%= @current_metadata_template_id == 'none' ? '0' : '-1' %>"
-        >
-        <label
-          for="rl-none"
-          class="
-            w-full py-3 text-sm font-medium text-slate-900 ms-2 dark:text-slate-300
-          "
-        ><%= t("shared.samples.metadata_templates.fields.none") %></label>
-      </div>
-    </li>
+    <%= render partial: "shared/samples/metadata_template_item",
+    locals: {
+      selected: @current_metadata_template_id == "all",
+      label: t("shared.samples.metadata_templates.fields.all"),
+      value: "all",
+    } %>
+    <%= render partial: "shared/samples/metadata_template_item",
+    locals: {
+      selected: @current_metadata_template_id == "none",
+      label: t("shared.samples.metadata_templates.fields.none"),
+      value: "none",
+    } %>
     <%- if @metadata_templates.any? %>
       <li
         class="
@@ -77,31 +40,13 @@ data: {
         <%= t("shared.samples.metadata_templates.templates.label") %>
       </li>
       <% @metadata_templates.each do |metadata_template| %>
-        <li
-          class="
-            w-full border-b border-slate-200 dark:border-slate-600 hover:bg-slate-100
-            dark:hover:bg-slate-600
-          "
-        >
-          <div class="flex items-center ps-3">
-            <input
-              id="rl-<%= metadata_template.id %>"
-              type="radio"
-              value="<%= metadata_template.id %>"
-              onchange="this.form.requestSubmit()"
-              name="q[metadata_template]"
-              aria-checked="<%= @current_metadata_template_id == metadata_template.id ? 'true' : 'false' %>"
-              tabindex="<%= @current_metadata_template_id == metadata_template.id ? '0' : '-1' %>"
-              <%= @current_metadata_template_id == metadata_template.id ? "checked" : "" %>
-            >
-            <label
-              for="rl-<%= metadata_template.id %>"
-              class="
-                w-full py-3 text-sm font-medium text-slate-900 ms-2 dark:text-slate-300
-              "
-            ><%= metadata_template.name %></label>
-          </div>
-        </li>
+        <%= render partial: "shared/samples/metadata_template_item",
+        locals: {
+          selected: @current_metadata_template_id == metadata_template.id,
+          label: metadata_template.name,
+          value: metadata_template.id,
+        } %>
+
       <% end %>
     <% end %>
   </ul>

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -322,7 +322,7 @@ module Groups
       end
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -447,7 +447,7 @@ module Groups
       assert_selector 'table thead th:nth-child(5) svg.icon-arrow_up'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -466,7 +466,7 @@ module Groups
       end
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'none'
+      click_button I18n.t("shared.samples.metadata_templates.fields.none")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -483,7 +483,7 @@ module Groups
       end
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -505,7 +505,7 @@ module Groups
       assert_selector 'tbody tr:first-child td:nth-child(2)', text: @sample30.name
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'none'
+      click_button I18n.t("shared.samples.metadata_templates.fields.none")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1038,7 +1038,7 @@ module Groups
       visit group_samples_url(@group)
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1140,7 +1140,7 @@ module Groups
       assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1184,7 +1184,7 @@ module Groups
 
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -322,7 +322,7 @@ module Groups
       end
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -447,7 +447,7 @@ module Groups
       assert_selector 'table thead th:nth-child(5) svg.icon-arrow_up'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -466,7 +466,7 @@ module Groups
       end
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.none")
+      click_button I18n.t('shared.samples.metadata_templates.fields.none')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -483,7 +483,7 @@ module Groups
       end
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -505,7 +505,7 @@ module Groups
       assert_selector 'tbody tr:first-child td:nth-child(2)', text: @sample30.name
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.none")
+      click_button I18n.t('shared.samples.metadata_templates.fields.none')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1038,7 +1038,7 @@ module Groups
       visit group_samples_url(@group)
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1140,7 +1140,7 @@ module Groups
       assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1184,7 +1184,7 @@ module Groups
 
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -1130,7 +1130,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1208,7 +1208,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1297,7 +1297,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1392,7 +1392,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1539,7 +1539,7 @@ module Projects
                                                                                locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1601,7 +1601,7 @@ module Projects
                                                                                locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1758,7 +1758,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1834,7 +1834,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3178,7 +3178,7 @@ module Projects
       assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3226,7 +3226,7 @@ module Projects
       assert_selector 'table thead tr th', count: 5
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3256,7 +3256,7 @@ module Projects
       assert_selector 'table thead tr th', count: 5
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3294,7 +3294,7 @@ module Projects
       assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3347,7 +3347,7 @@ module Projects
 
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      click_button I18n.t("shared.samples.metadata_templates.fields.all")
+      click_button I18n.t('shared.samples.metadata_templates.fields.all')
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -1130,7 +1130,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1208,7 +1208,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1297,7 +1297,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1392,7 +1392,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1539,7 +1539,7 @@ module Projects
                                                                                locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1601,7 +1601,7 @@ module Projects
                                                                                locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1758,7 +1758,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -1834,7 +1834,7 @@ module Projects
                                                                            locale: @user.locale))
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3178,7 +3178,7 @@ module Projects
       assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3226,7 +3226,7 @@ module Projects
       assert_selector 'table thead tr th', count: 5
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3256,7 +3256,7 @@ module Projects
       assert_selector 'table thead tr th', count: 5
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3294,7 +3294,7 @@ module Projects
       assert_no_selector 'div[data-test-selector="spinner"]'
 
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'
@@ -3347,7 +3347,7 @@ module Projects
 
       # toggle metadata on for samples table
       click_button I18n.t('shared.samples.metadata_templates.label')
-      choose 'q[metadata_template]', option: 'all'
+      click_button I18n.t("shared.samples.metadata_templates.fields.all")
 
       assert_selector 'div[data-test-selector="spinner"]'
       assert_no_selector 'div[data-test-selector="spinner"]'


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Fixes issue where the metadata template dropdown was inaccessible and did not close when the button was pressed a second time.

- Replaced the metadata template dropdown with a proper flowbite dropdown
- Replace the radio buttons with actual buttons, a checkmark shows the selected value

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/9b1bbd62-f2cf-4ed7-bf96-23965a1e2c1a)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Go to a project samples page
2. If there are no templates create on in the project settings
3. Try toggling all types of templates (all fields, no fields, and random templates)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
