### PR TITLE
Fix for importing malformed files

### DIFF
--- a/app/services/base_spreadsheet_import_service.rb
+++ b/app/services/base_spreadsheet_import_service.rb
@@ -41,7 +41,7 @@ class BaseSpreadsheetImportService < BaseService
     raise FileImportError, I18n.t('services.spreadsheet_import.invalid_file_extension')
   end
 
-  def download_batch_import_file(extension)
+  def download_batch_import_file(extension) # rubocop:disable Metrics/MethodLength
     begin
       @temp_import_file.binmode
       @file.download do |chunk|

--- a/app/services/base_spreadsheet_import_service.rb
+++ b/app/services/base_spreadsheet_import_service.rb
@@ -50,13 +50,18 @@ class BaseSpreadsheetImportService < BaseService
     ensure
       @temp_import_file.close
     end
+
     @spreadsheet = if extension.eql? '.tsv'
                      Roo::Spreadsheet.open(@temp_import_file.path,
                                            { extension: '.csv', csv_options: { col_sep: "\t" } })
                    else
                      Roo::Spreadsheet.open(@temp_import_file.path, extension:)
                    end
-    @spreadsheet.parse(clean: true)
+    begin
+      @spreadsheet.parse(clean: true)
+    rescue CSV::MalformedCSVError
+      raise FileImportError, I18n.t('services.spreadsheet_import.csv_file_malformed')
+    end
   end
 
   def validate_file_headers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1933,6 +1933,7 @@ en:
         sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
         samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
     spreadsheet_import:
+      csv_file_malformed: The CSV file is malformed. New line characters must be either '\r\n' (DOS) or '\n' (Unix).
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
       invalid_file_extension: The file can only be a csv, tsv or excel.
       missing_data_columns: File is missing data columns. Please add additional data columns and headers and retry uploading.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1933,7 +1933,7 @@ en:
         sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
         samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
     spreadsheet_import:
-      csv_file_malformed: The CSV file is malformed. New line characters must be either '\r\n' (DOS) or '\n' (Unix).
+      csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
       invalid_file_extension: The file can only be a csv, tsv or excel.
       missing_data_columns: File is missing data columns. Please add additional data columns and headers and retry uploading.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1929,7 +1929,7 @@ fr:
         sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
         samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
     spreadsheet_import:
-      csv_file_malformed: The CSV file is malformed. New line characters must be either '\r\n' (DOS) or '\n' (Unix).
+      csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
       invalid_file_extension: Le fichier ne peut être qu’un fichier csv, tsv ou excel.
       missing_data_columns: Il manque des colonnes de données au fichier. Veuillez ajouter des colonnes de données et des en-têtes supplémentaires et réessayer le téléchargement.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1929,6 +1929,7 @@ fr:
         sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
         samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
     spreadsheet_import:
+      csv_file_malformed: The CSV file is malformed. New line characters must be either '\r\n' (DOS) or '\n' (Unix).
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
       invalid_file_extension: Le fichier ne peut être qu’un fichier csv, tsv ou excel.
       missing_data_columns: Il manque des colonnes de données au fichier. Veuillez ajouter des colonnes de données et des en-têtes supplémentaires et réessayer le téléchargement.

--- a/test/fixtures/files/metadata/malformed.csv
+++ b/test/fixtures/files/metadata/malformed.csv
@@ -1,0 +1,1 @@
+sample_name,metadatafield1,metadatafield2,metadatafield3Project 1 Sample 1,10,20,30Project 1 Sample 2,15,25,35 

--- a/test/services/samples/metadata/file_import_service_test.rb
+++ b/test/services/samples/metadata/file_import_service_test.rb
@@ -313,6 +313,21 @@ module Samples
                      I18n.t('services.spreadsheet_import.missing_data_row'))
       end
 
+      test 'import sample metadata with malformed file' do
+        file = Rack::Test::UploadedFile.new(Rails.root.join('test/fixtures/files/metadata/malformed.csv'))
+
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: file,
+          filename: file.original_filename,
+          content_type: file.content_type
+        )
+
+        params = { sample_id_column: 'sample_name' }
+        assert_empty Samples::Metadata::FileImportService.new(@project.namespace, @john_doe, blob.id, params).execute
+        assert_equal(@project.namespace.errors.full_messages_for(:base).first,
+                     I18n.t('services.spreadsheet_import.csv_file_malformed'))
+      end
+
       test 'import sample metadata with an empty header' do
         assert_equal({}, @sample1.metadata)
         assert_equal({}, @sample2.metadata)


### PR DESCRIPTION
## What does this PR do and why?
It appears that a user tried importing a file with a combination of different line endings, causing the file to be malformed.

The accepted EOL characters:
- Windows uses carriage return and line feed ("\r\n") 
- Macintosh uses just carriage return ("\r")
- Unix uses just line feed ("\n")

This PR displays an error message when the imported file is malformed.

STRY0016977

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/3bac0a2c-73b9-4210-aec0-12cd4d812bfa)

## How to set up and validate locally
1. Navigate to a samples page that the logged in user has access to update.
2. From the `Sample Actions` dropdown, under the `Import` section, hit the `Import Metadata` button.
3. Select a file that has a combination of different line endings. (Verify with Notepad++ or `cat -e`)
4. Select the `Sample ID Column`.
5. Hit the `Import Metadata` button.
6. Verify the sample metadata updated successfully.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
