### PR TITLE
Fix: Pagy OverflowError

### DIFF
--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -11,6 +11,8 @@ module Groups
     before_action :current_metadata_template, only: %i[index]
     before_action :index_view_authorizations, only: %i[index]
 
+    rescue_from Pagy::OverflowError, with: :redirect_to_first_page
+
     def index
       @timestamp = DateTime.current
       @pagy, @samples = @query.results(limit: params[:limit] || 20, page: params[:page] || 1)
@@ -117,6 +119,10 @@ module Groups
 
     def search_key
       :"#{controller_name}_#{group.id}_search_params"
+    end
+
+    def redirect_to_first_page
+      redirect_to url_for(page: 1)
     end
   end
 end

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -122,7 +122,7 @@ module Groups
     end
 
     def redirect_to_first_page
-      redirect_to url_for(page: 1)
+      redirect_to url_for(page: 1, limit: params[:limit] || 20)
     end
   end
 end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -14,6 +14,8 @@ module Projects
     before_action :index_view_authorizations, only: %i[index]
     before_action :show_view_authorizations, only: %i[show]
 
+    rescue_from Pagy::OverflowError, with: :redirect_to_first_page
+
     def index
       @timestamp = DateTime.current
       @pagy, @samples = @query.results(limit: params[:limit] || 20, page: params[:page] || 1)
@@ -195,6 +197,10 @@ module Projects
         update_store(search_key, updated_params)
       end
       updated_params
+    end
+
+    def redirect_to_first_page
+      redirect_to url_for(page: 1)
     end
   end
 end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -200,7 +200,7 @@ module Projects
     end
 
     def redirect_to_first_page
-      redirect_to url_for(page: 1)
+      redirect_to url_for(page: 1, limit: params[:limit] || 20)
     end
   end
 end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -146,7 +146,7 @@ require 'pagy/extras/limit'
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/docs/extras/overflow
 # require 'pagy/extras/overflow'
-# Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
+Pagy::DEFAULT[:overflow] = :exception # default  (other options: :last_page and :exception)
 
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/docs/extras/trim

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -1318,7 +1318,7 @@ module Groups
 
     test 'pagy overflow redirects to first page' do
       group = groups(:group_seventeen)
-      sample = samples(:bulk_sample25)
+      sample = samples(:bulk_sample19)
 
       visit group_samples_url(group)
 
@@ -1357,17 +1357,13 @@ module Groups
       #        within('#samples-table table') do
       within('tbody') do
         # rows
-        assert_selector '#samples-table table tbody tr', count: 1
+        assert_selector 'tr', count: 11
 
         within("tr[id='#{dom_id(sample)}']") do
           assert_selector 'th:first-child', text: sample.puid
           assert_selector 'td:nth-child(2)', text: sample.name
         end
       end
-
-      # verify url contains page=1
-      url = URI.parse(current_url).to_s
-      assert url.include?('?page=1')
     end
   end
 end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -3427,7 +3427,7 @@ module Projects
 
     test 'pagy overflow redirects to first page' do
       project = projects(:project38)
-      sample = samples(:bulk_sample25)
+      sample = samples(:bulk_sample19)
 
       visit namespace_project_samples_url(project.namespace.parent, project)
 
@@ -3466,17 +3466,13 @@ module Projects
       #        within('#samples-table table') do
       within('tbody') do
         # rows
-        assert_selector '#samples-table table tbody tr', count: 1
+        assert_selector '#samples-table table tbody tr', count: 11
 
         within("tr[id='#{dom_id(sample)}']") do
           assert_selector 'th:first-child', text: sample.puid
           assert_selector 'td:nth-child(2)', text: sample.name
         end
       end
-
-      # verify url contains page=1
-      url = URI.parse(current_url).to_s
-      assert url.include?('?page=1')
     end
 
     def long_filter_text


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates pagy to redirect to the first page if a `Pagy::OverflowError` is encountered for the project and group samples tables.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

[Screencast from 2025-04-24 15-36-24.webm](https://github.com/user-attachments/assets/306b0e2f-92c2-4888-b050-f7ff57b57ad7)

[Screencast from 2025-04-24 15-34-47.webm](https://github.com/user-attachments/assets/66b051de-6968-4c93-a799-f4467948cd5d)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

**On Main:**

1) Go to a group which has > 20 samples
2) From the first page of the group samples table, copy a sample PUID
3) Go to another page in the samples table
4) In the search box, paste the PUID, and hit the `Enter` to search
5) Verify that you get an error page
6) Retry steps 1 through 5 for a project


**On this branch:**

1) Go to a group which has > 20 samples
2) From the first page of the group samples table, copy a sample PUID
3) Go to another page in the samples table
4) In the search box, paste the PUID, and hit the `Enter` to search
5) Verify that you get the search result instead of an error page
6) Retry steps 1 through 5 for a project

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
