### PR TITLE
Enhance accessibility for pagy components with ARIA labels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,19 +27,20 @@
   "files.insertFinalNewline": true,
   "editor.rulers": [120],
   "cSpell.words": [
-    "micha",
-    "irida",
-    "nofork",
-    "logfile",
-    "createuser",
-    "headful",
-    "tailwindcss",
-    "colour",
-    "datetime",
-    "keyfile",
-    "flowbite",
-    "checkin",
     "activerecord",
-    "rubocop"
+    "checkin",
+    "colour",
+    "createuser",
+    "datetime",
+    "describedby",
+    "flowbite",
+    "headful",
+    "irida",
+    "keyfile",
+    "logfile",
+    "micha",
+    "nofork",
+    "rubocop",
+    "tailwindcss"
   ]
 }

--- a/app/components/nextflow/samplesheet_component.html.erb
+++ b/app/components/nextflow/samplesheet_component.html.erb
@@ -100,7 +100,7 @@
 
 <template data-nextflow--samplesheet-target="dropdownCell">
   <select
-    aria-label="COLUMN_NAME_PLACEHOLDER"
+    aria_label="COLUMN_NAME_PLACEHOLDER"
     class="
       w-full p-2.5 dark:bg-slate-700 bg-slate-50 border-none dark:border-none
       dark:placeholder-slate-400 text-inherit text-sm cursor-pointer
@@ -153,7 +153,7 @@
 </template>
 
 <template data-nextflow--samplesheet-target="pagination">
-  <nav aria-label="<%= t("viral.pagy.pagination_component.aria-label") %>">
+  <nav aria_label="<%= t("viral.pagy.pagination_component.aria_label") %>">
     <ul class="inline-flex h-10 text-base">
       <li><button
           type="button"

--- a/app/components/nextflow/samplesheet_component.html.erb
+++ b/app/components/nextflow/samplesheet_component.html.erb
@@ -100,7 +100,7 @@
 
 <template data-nextflow--samplesheet-target="dropdownCell">
   <select
-    aria_label="COLUMN_NAME_PLACEHOLDER"
+    aria-label="COLUMN_NAME_PLACEHOLDER"
     class="
       w-full p-2.5 dark:bg-slate-700 bg-slate-50 border-none dark:border-none
       dark:placeholder-slate-400 text-inherit text-sm cursor-pointer
@@ -153,7 +153,7 @@
 </template>
 
 <template data-nextflow--samplesheet-target="pagination">
-  <nav aria_label="<%= t("viral.pagy.pagination_component.aria_label") %>">
+  <nav aria-label="<%= t("viral.pagy.pagination_component.aria_label") %>">
     <ul class="inline-flex h-10 text-base">
       <li><button
           type="button"

--- a/app/components/pagination_component.html.erb
+++ b/app/components/pagination_component.html.erb
@@ -1,33 +1,48 @@
-<div class="flex items-center justify-center space-x-2 mt-4">
+<nav
+  class="flex items-center justify-center space-x-2 mt-4"
+  role="navigation"
+  aria-label="<%= t("viral.pagy.pagination_component.aria_label") %>"
+  aria-describedby="pagination-info"
+  aria-live="polite"
+>
   <% if prev_url %>
     <%= link_to t("viral.pagy.pagination_component.previous"),
     prev_url,
     **link_arguments,
     class:
-      "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium rounded text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white" %>
+      "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium rounded text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
+    aria_label: t("viral.pagy.pagination_component.previous_aria_label") %>
   <% else %>
-    <span
+    <a
+      href="javascript:void(0);"
+      aria-label="<%= t("viral.pagy.pagination_component.at_first_aria_label") %>"
       class="
-        flex items-center justify-center px-4 h-10 ms-0 leading-tight rounded border
-        border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
-        dark:bg-slate-800 cursor-not-allowed
+        flex items-center justify-center px-4 h-10 ms-0 leading-tight border
+        border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-300
+        dark:bg-slate-800 cursor-not-allowed rounded
       "
-    ><%= t("viral.pagy.pagination_component.previous") %></span>
+    ><%= t("viral.pagy.pagination_component.previous") %></a>
   <% end %>
   <% if next_url %>
     <%= link_to t("viral.pagy.pagination_component.next"),
     next_url,
     **link_arguments,
     class:
-      "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium rounded text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white" %>
+      "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium rounded text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
+    aria_label: t("viral.pagy.pagination_component.next_aria_label") %>
   <% else %>
-    <span
+    <a
+      href="javascript:void(0);"
+      aria-label="<%= t("viral.pagy.pagination_component.at_last_aria_label") %>"
       class="
-        flex items-center justify-center px-4 h-10 leading-tight rounded border
-        border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
-        dark:bg-slate-800 cursor-not-allowed
+        flex items-center justify-center px-4 h-10 ms-0 leading-tight border
+        border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-300
+        dark:bg-slate-800 cursor-not-allowed rounded
       "
-    ><%= t("viral.pagy.pagination_component.next") %></span>
+    ><%= t("viral.pagy.pagination_component.next") %></a>
   <% end %>
-</div>
-<p class="text-center m-4 text-slate-700 dark:text-slate-200"><%== info %></p>
+</nav>
+<p
+  id="pagination-info"
+  class="text-center m-4 text-slate-700 dark:text-slate-200"
+><%== info %></p>

--- a/app/components/pagination_component.html.erb
+++ b/app/components/pagination_component.html.erb
@@ -11,7 +11,7 @@
     **link_arguments,
     class:
       "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium rounded text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
-    aria_label: t("viral.pagy.pagination_component.previous_aria_label") %>
+    "aria-label": t("viral.pagy.pagination_component.previous_aria_label") %>
   <% else %>
     <a
       href="javascript:void(0);"
@@ -29,7 +29,7 @@
     **link_arguments,
     class:
       "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium rounded text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
-    aria_label: t("viral.pagy.pagination_component.next_aria_label") %>
+    "aria-label": t("viral.pagy.pagination_component.next_aria_label") %>
   <% else %>
     <a
       href="javascript:void(0);"

--- a/app/components/viral/pagy/limit_component.html.erb
+++ b/app/components/viral/pagy/limit_component.html.erb
@@ -7,9 +7,13 @@
 >
   <div class="inline-flex items-center space-x-2">
     <span><%= t(".items", items: @item) %></span>
-    <%= viral_dropdown(label: @pagy.limit) do |dropdown| %>
+    <%= viral_dropdown(label: @pagy.limit, "aria-label": t(".aria_label")) do |dropdown| %>
       <% Pagy::DEFAULT[:limits].each do |limit| %>
-        <% dropdown.with_item(label: limit, url: current_url_with_limit(limit)) %>
+        <% dropdown.with_item(
+          label: limit,
+          url: current_url_with_limit(limit),
+          "aria-label": t(".item_aria_label", items: limit),
+        ) %>
       <% end %>
     <% end %>
   </div>

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -1,5 +1,9 @@
 <% a = helpers.pagy_anchor(@pagy, anchor_string: @data_string) %>
-<nav class="pagy nav" aria-label="<%= t(".aria-label") %>">
+<nav
+  class="pagy nav"
+  aria-role="navigation"
+  aria-label="<%= t(".aria_label") %>"
+>
   <ul class="inline-flex h-10 -space-x-px text-base">
     <%# Previous page link %>
     <li>
@@ -8,13 +12,14 @@
           @pagy.prev,
           t(".previous"),
           aria_label: t(".previous_aria_label"),
-          classes: "#{active_link_classes} border-e-0 rounded-s-lg",
+          classes:
+            "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white border-e-0 rounded-s-md",
         ) %>
       <% else %>
         <span
           class="
             flex items-center justify-center px-4 h-10 ms-0 leading-tight border
-            border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
+            border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-300
             dark:bg-slate-800 cursor-not-allowed rounded-s-lg
           "
         ><%= t(".previous") %></span>
@@ -26,7 +31,8 @@
         <% if item.is_a?(Integer) %>
           <%== a.(
             item,
-            classes: class_names(active_link_classes, invisible_link_classes),
+            classes:
+              "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
             aria_label: t(".item_aria_label", number: item),
           ) %>
         <% elsif item.is_a?(String) %>
@@ -35,7 +41,7 @@
             aria-current="page"
             class="
               flex items-center justify-center px-4 h-10 ms-0 leading-tight border
-              border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
+              border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-300
               dark:bg-slate-800 cursor-not-allowed
             "
           ><%= item %></a>
@@ -43,7 +49,7 @@
           <span
             class="
               flex items-center justify-center px-4 h-10 ms-0 leading-tight border
-              border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
+              border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-300
               dark:bg-slate-800 cursor-not-allowed
             "
           >...</span>
@@ -56,15 +62,15 @@
         <%== a.(
           @pagy.next,
           t(".next"),
-          classes: "#{active_link_classes} rounded-e-lg",
+          classes: "#{active_link_classes} rounded-e-md",
           aria_label: t(".next_aria_label"),
         ) %>
       <% else %>
         <span
           class="
             flex items-center justify-center px-4 h-10 ms-0 leading-tight border
-            border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
-            dark:bg-slate-800 cursor-not-allowed rounded-e-lg
+            border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-300
+            dark:bg-slate-800 cursor-not-allowed rounded-e-md
           "
         ><%= t(".next") %></span>
       <% end %>

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -7,9 +7,9 @@
         <%== a.(
           @pagy.prev,
           t(".previous"),
-          "aria-label": t(".previous_aria_label"),
           classes:
             "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white border-e-0 rounded-s-md",
+          aria_label: t(".previous_aria_label"),
         ) %>
       <% else %>
         <span
@@ -29,7 +29,7 @@
             item,
             classes:
               "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
-            "aria-label": t(".item_aria_label", number: item),
+            aria_label: t(".item_aria_label", number: item),
           ) %>
         <% elsif item.is_a?(String) %>
           <a
@@ -58,8 +58,9 @@
         <%== a.(
           @pagy.next,
           t(".next"),
-          classes: "#{active_link_classes} rounded-e-md",
-          "aria-label": t(".next_aria_label"),
+          classes:
+            "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white rounded-e-md",
+          aria_label: t(".next_aria_label"),
         ) %>
       <% else %>
         <span

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -7,7 +7,7 @@
         <%== a.(
           @pagy.prev,
           t(".previous"),
-          aria_label: t(".previous"),
+          aria_label: t(".previous_aria_label"),
           classes: "#{active_link_classes} border-e-0 rounded-s-lg",
         ) %>
       <% else %>
@@ -24,20 +24,26 @@
     <% @pagy.series.each do |item| %>
       <li>
         <% if item.is_a?(Integer) %>
-          <%== a.(item, classes: class_names(active_link_classes, invisible_link_classes)) %>
+          <%== a.(
+            item,
+            classes: class_names(active_link_classes, invisible_link_classes),
+            aria_label: t(".item_aria_label", number: item),
+          ) %>
         <% elsif item.is_a?(String) %>
-          <span
+          <a
+            href="javascript:void(0);"
+            aria-current="page"
             class="
               flex items-center justify-center px-4 h-10 ms-0 leading-tight border
-              border-slate-300 dark:border-slate-600 text-slate-400 bg-slate-100
+              border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
               dark:bg-slate-800 cursor-not-allowed
             "
-          ><%= item %></span>
+          ><%= item %></a>
         <% elsif item == :gap %>
           <span
             class="
               flex items-center justify-center px-4 h-10 ms-0 leading-tight border
-              border-slate-300 dark:border-slate-600 text-slate-400 bg-slate-100
+              border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-100
               dark:bg-slate-800 cursor-not-allowed
             "
           >...</span>
@@ -47,7 +53,12 @@
     <%# Next page link %>
     <li>
       <% if @pagy.next %>
-        <%== a.(@pagy.next, t(".next"), classes: "#{active_link_classes} rounded-e-lg") %>
+        <%== a.(
+          @pagy.next,
+          t(".next"),
+          classes: "#{active_link_classes} rounded-e-lg",
+          aria_label: t(".next_aria_label"),
+        ) %>
       <% else %>
         <span
           class="

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -7,7 +7,7 @@
         <%== a.(
           @pagy.prev,
           t(".previous"),
-          aria_label: t(".previous_aria_label"),
+          "aria-label": t(".previous_aria_label"),
           classes:
             "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white border-e-0 rounded-s-md",
         ) %>
@@ -29,7 +29,7 @@
             item,
             classes:
               "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
-            aria_label: t(".item_aria_label", number: item),
+            "aria-label": t(".item_aria_label", number: item),
           ) %>
         <% elsif item.is_a?(String) %>
           <a
@@ -59,7 +59,7 @@
           @pagy.next,
           t(".next"),
           classes: "#{active_link_classes} rounded-e-md",
-          aria_label: t(".next_aria_label"),
+          "aria-label": t(".next_aria_label"),
         ) %>
       <% else %>
         <span

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -1,9 +1,5 @@
 <% a = helpers.pagy_anchor(@pagy, anchor_string: @data_string) %>
-<nav
-  class="pagy nav"
-  aria-role="navigation"
-  aria-label="<%= t(".aria_label") %>"
->
+<nav class="pagy nav" aria-label="<%= t(".aria_label") %>">
   <ul class="inline-flex h-10 -space-x-px text-base">
     <%# Previous page link %>
     <li>

--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -8,7 +8,7 @@
           @pagy.prev,
           t(".previous"),
           classes:
-            "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white border-e-0 rounded-s-md",
+            "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white border-e-0 rounded-s-md focus:relative",
           aria_label: t(".previous_aria_label"),
         ) %>
       <% else %>
@@ -28,7 +28,7 @@
           <%== a.(
             item,
             classes:
-              "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white",
+              "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white focus:relative",
             aria_label: t(".item_aria_label", number: item),
           ) %>
         <% elsif item.is_a?(String) %>
@@ -38,7 +38,7 @@
             class="
               flex items-center justify-center px-4 h-10 ms-0 leading-tight border
               border-slate-300 dark:border-slate-600 text-slate-600 bg-slate-300
-              dark:bg-slate-800 cursor-not-allowed
+              dark:bg-slate-800 cursor-not-allowed focus:relative
             "
           ><%= item %></a>
         <% elsif item == :gap %>
@@ -59,7 +59,7 @@
           @pagy.next,
           t(".next"),
           classes:
-            "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white rounded-e-md",
+            "flex items-center justify-center text-slate-700 bg-slate-200 border border-slate-300 font-medium text-sm px-4 h-10 hover:bg-slate-300 hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-600 dark:hover:text-white rounded-e-md focus:relative",
           aria_label: t(".next_aria_label"),
         ) %>
       <% else %>

--- a/app/components/viral/pagy/pagination_component.rb
+++ b/app/components/viral/pagy/pagination_component.rb
@@ -12,33 +12,6 @@ module Viral
       def render?
         @pagy.next || @pagy.prev
       end
-
-      def active_link_classes
-        "#{default_link_classes} text-slate-700 bg-slate-200 hover:bg-slate-300 " \
-          'hover:text-slate-900 dark:bg-slate-700 dark:text-slate-200 ' \
-          'dark:hover:bg-slate-600 dark:hover:text-white'
-      end
-
-      def disabled_link_classes
-        "#{default_link_classes} cursor-not-allowed text-slate-600 bg-slate-300 " \
-          'dark:bg-slate-800 dark:text-slate-500 dark:border-slate-600'
-      end
-
-      def current_link_classes
-        "#{default_link_classes} text-white bg-primary-600 dark:bg-primary-700 " \
-          'dark:text-white'
-      end
-
-      def invisible_link_classes
-        '@max-md:invisible @max-md:w-0 @max-md:p-0 @max-md:border-none'
-      end
-
-      private
-
-      def default_link_classes
-        'flex items-center justify-center px-4 h-10 ms-0 leading-tight ' \
-          'border border-slate-300 dark:border-slate-600'
-      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2093,14 +2093,19 @@ en:
         action: Action
     pagy:
       limit_component:
+        aria_label: Select the number of items to display
+        item_aria_label: Show %{items} items per page
         items: "%{items} per page:"
         summary:
           one: Displaying <span class='font-bold'>%{count}</span> item
           other: Displaying <span class='font-bold'>%{from}-%{to}</span> of <span class='font-bold'>%{count}</span> items
       pagination_component:
-        aria-label: Pagination
+        aria-label: Pagination Navigation
+        item_aria_label: Go to Page %{number}
         next: Next
+        next_aria_label: Go to next page
         previous: Previous
+        previous_aria_label: Go to previous page
     sortable_list:
       list_component:
         aria_role_description: "%{list} listbox drag and drop"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2100,7 +2100,9 @@ en:
           one: Displaying <span class='font-bold'>%{count}</span> item
           other: Displaying <span class='font-bold'>%{from}-%{to}</span> of <span class='font-bold'>%{count}</span> items
       pagination_component:
-        aria-label: Pagination Navigation
+        aria_label: Pagination Navigation
+        at_first_aria_label: You are on the first page
+        at_last_aria_label: You are on the last page
         item_aria_label: Go to Page %{number}
         next: Next
         next_aria_label: Go to next page

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2096,7 +2096,9 @@ fr:
           one: Afficher l’élément <span class='font-bold'>%{count}</span>
           other: Afficher les éléments <span class='font-bold'>%{from}-%{to}</span> de <span class='font-bold'>%{count}</span>
       pagination_component:
-        aria-label: Pagination
+        aria_label: Pagination
+        at_first_aria_label: You are on the first page
+        at_last_aria_label: You are on the last page
         item_aria_label: Go to Page %{number}
         next: Suivant
         next_aria_label: Go to next page

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2089,14 +2089,19 @@ fr:
         action: Mesure
     pagy:
       limit_component:
+        aria_label: Select the number of items to display
+        item_aria_label: Show %{items} items per page
         items: "%{items} par page :"
         summary:
           one: Afficher l’élément <span class='font-bold'>%{count}</span>
           other: Afficher les éléments <span class='font-bold'>%{from}-%{to}</span> de <span class='font-bold'>%{count}</span>
       pagination_component:
         aria-label: Pagination
+        item_aria_label: Go to Page %{number}
         next: Suivant
+        next_aria_label: Go to next page
         previous: Précédent
+        previous_aria_label: Go to previous page
     sortable_list:
       list_component:
         aria_role_description: "%{list} listbox drag and drop"

--- a/test/components/pagination_component_test.rb
+++ b/test/components/pagination_component_test.rb
@@ -42,9 +42,9 @@ class PaginationComponentTest < ViewComponent::TestCase
       next_url: '/-/projects?page=2',
       info: '<span class="pagy-info">Displaying items <b>1-20</b> of <b>114</b> in total</span>'
     )
-
-    assert_selector 'span.cursor-not-allowed.text-slate-600.bg-slate-100',
-                    text: I18n.t('viral.pagy.pagination_component.previous')
+    assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                    '.cursor-not-allowed',
+                    exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
   end
 
   test 'renders disabled next link' do
@@ -53,8 +53,8 @@ class PaginationComponentTest < ViewComponent::TestCase
       next_url: nil,
       info: '<span class="pagy-info">Displaying items <b>101-114</b> of <b>114</b> in total</span>'
     )
-
-    assert_selector 'span.cursor-not-allowed.text-slate-600.bg-slate-100',
-                    text: I18n.t('viral.pagy.pagination_component.next')
+    assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                    '.cursor-not-allowed',
+                    exact_text: I18n.t(:'viral.pagy.pagination_component.next')
   end
 end

--- a/test/components/viral/pagy_full_component_preview_test.rb
+++ b/test/components/viral/pagy_full_component_preview_test.rb
@@ -9,8 +9,9 @@ class PagyFullComponentPreviewTest < ApplicationSystemTestCase
     assert_selector 'nav.pagy.nav'
     assert_selector 'li span.cursor-not-allowed', text: I18n.t('viral.pagy.pagination_component.previous')
     assert_selector 'li > a', text: I18n.t('viral.pagy.pagination_component.next')
-    assert_selector 'li span.cursor-not-allowed', text: '1'
-    assert_selector 'li > a', count: '5'
+    assert_selector 'li span.cursor-not-allowed', text: I18n.t('viral.pagy.pagination_component.previous')
+    assert_selector 'li a[aria-current="page"]', text: '1', count: 1
+    assert_selector 'li > a', count: '6'
   end
 
   test 'renders empty state' do

--- a/test/components/viral/pagy_pagination_component_preview_test.rb
+++ b/test/components/viral/pagy_pagination_component_preview_test.rb
@@ -10,18 +10,14 @@ module Viral
       assert_selector 'nav.pagy.nav'
       assert_selector 'li span.cursor-not-allowed', text: I18n.t('viral.pagy.pagination_component.previous')
       assert_selector 'li > a', text: I18n.t('viral.pagy.pagination_component.next')
-      assert_selector 'li span.cursor-not-allowed', text: '1', count: 1
-      assert_selector 'li > a:not([aria-disabled="true"])', count: 5
+      assert_selector 'li a.cursor-not-allowed', text: '1', count: 1
+      assert_selector 'li > a:not([aria-disabled="true"])', count: 6
     end
 
     test 'does not render when only one page' do
       render_preview(:only_one_page)
 
       assert_no_selector 'nav.pagy.nav'
-      assert_no_selector 'li span.cursor-not-allowed', text: I18n.t('viral.pagy.pagination_component.previous')
-      assert_no_selector 'li span.cursor-not-allowed', text: I18n.t('viral.pagy.pagination_component.next')
-      assert_no_selector 'li span.cursor-not-allowed', text: '1'
-      assert_no_selector 'li > a:not([aria-disabled="true"])'
     end
 
     test 'renders many pages' do
@@ -30,8 +26,8 @@ module Viral
       assert_selector 'nav.pagy.nav'
       assert_selector 'li > a', text: I18n.t('viral.pagy.pagination_component.previous')
       assert_selector 'li > a', text: I18n.t('viral.pagy.pagination_component.next')
-      assert_selector 'li span.cursor-not-allowed', text: '5', count: 1
-      assert_selector 'li > a:not([aria-disabled="true"])', count: 6
+      assert_selector 'li a.cursor-not-allowed', text: '5', count: 1
+      assert_selector 'li > a:not([aria-disabled="true"])', count: 7
       assert_selector 'li span.cursor-not-allowed', text: '...', count: 2
     end
   end

--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -23,8 +23,9 @@ module Dashboard
       assert_selector 'tr', count: 20
       assert_text @project.human_name
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
-
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
       click_on I18n.t(:'viral.pagy.pagination_component.next')
       assert_text 'Displaying items 21-39 of 39 in total'
       assert_selector 'tr', count: 19
@@ -46,7 +47,9 @@ module Dashboard
       assert_selector 'tr', count: 20
       assert_text @project.human_name
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
 
       click_on I18n.t(:'viral.pagy.pagination_component.next')
       assert_text 'Displaying items 21-22 of 22 in total'
@@ -69,8 +72,12 @@ module Dashboard
       assert_text 'Displaying 4 items'
       assert_selector 'tr', count: 4
       assert_text projects(:john_doe_project2).human_name
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
     end
 
     test 'can search the list of projects by name' do
@@ -84,8 +91,12 @@ module Dashboard
       find('input.t-search-component').native.send_keys(:return)
 
       assert_selector 'tr', count: 12
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
 
       assert_selector %(input.t-search-component) do |input|
         assert_equal @project.name, input['value']
@@ -139,8 +150,12 @@ module Dashboard
       find('input.t-search-component').native.send_keys(:return)
       assert_text 'Displaying 12 items'
       assert_selector 'tr', count: 12
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
 
       click_on I18n.t(:'dashboard.projects.index.sorting.updated_at_desc')
       click_on I18n.t(:'dashboard.projects.index.sorting.namespace_name_desc')
@@ -179,8 +194,12 @@ module Dashboard
 
       assert_text 'Displaying 12 items'
       assert_selector 'tr', count: 12
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
 
       within('tbody tr:first-child') do
         assert_text projects(:project19).human_name

--- a/test/system/groups/members_test.rb
+++ b/test/system/groups/members_test.rb
@@ -30,12 +30,16 @@ module Groups
       assert_selector 'tr', count: 20 + header_row_count
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
       click_on I18n.t(:'viral.pagy.pagination_component.next')
       assert_selector 'tr', count: 6 + header_row_count
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
 
       click_on I18n.t(:'viral.pagy.pagination_component.previous')
       assert_selector 'tr', count: 20 + header_row_count

--- a/test/system/groups/metadata_templates_test.rb
+++ b/test/system/groups/metadata_templates_test.rb
@@ -28,7 +28,8 @@ module Groups
       end
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']",
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
 
       click_on I18n.t(:'viral.pagy.pagination_component.next')
 
@@ -37,7 +38,8 @@ module Groups
       end
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']",
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
 
       click_on I18n.t(:'viral.pagy.pagination_component.previous')
 

--- a/test/system/projects/members_test.rb
+++ b/test/system/projects/members_test.rb
@@ -31,13 +31,17 @@ module Projects
       assert_selector 'tr', count: 20 + header_row_count
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
 
       click_on I18n.t(:'viral.pagy.pagination_component.next')
       assert_selector 'tr', count: 6 + header_row_count
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
 
       click_on I18n.t(:'viral.pagy.pagination_component.previous')
       assert_selector 'tr', count: 20 + header_row_count
@@ -170,7 +174,9 @@ module Projects
       project_member = members(:project_twenty_six_group_member25)
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
 
       assert_selector 'th', text: I18n.t(:'members.table_component.user_email').upcase
 

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -28,7 +28,9 @@ module Projects
       end
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
 
       click_on I18n.t(:'viral.pagy.pagination_component.next')
 
@@ -37,7 +39,9 @@ module Projects
       end
 
       assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
-      assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
+      assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']" \
+                      '.cursor-not-allowed',
+                      exact_text: I18n.t(:'viral.pagy.pagination_component.next')
 
       click_on I18n.t(:'viral.pagy.pagination_component.previous')
 

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -43,13 +43,14 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector '#workflow-executions-table table tbody tr', count: 20
 
     assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-    assert_selector "a[aria-label='#{viral.pagy.pagination_component.at_first_aria_label}']",
+    assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_first_aria_label')}']",
                     exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
     click_on I18n.t(:'viral.pagy.pagination_component.next')
     assert_selector '#workflow-executions-table table tbody tr', count: 5
 
     assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
-    assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
+    assert_selector "a[aria-label='#{I18n.t(:'viral.pagy.pagination_component.at_last_aria_label')}']",
+                    exact_text: I18n.t(:'viral.pagy.pagination_component.next')
     click_on I18n.t(:'viral.pagy.pagination_component.previous')
     assert_selector '#workflow-executions-table table tbody tr', count: 20
   end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -43,7 +43,8 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector '#workflow-executions-table table tbody tr', count: 20
 
     assert_link exact_text: I18n.t(:'viral.pagy.pagination_component.next')
-    assert_no_link exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
+    assert_selector "a[aria-label='#{viral.pagy.pagination_component.at_first_aria_label}']",
+                    exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
     click_on I18n.t(:'viral.pagy.pagination_component.next')
     assert_selector '#workflow-executions-table table tbody tr', count: 5
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Addresses [STRY0017760](https://publichealthprod.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3D70e6c613337ce21061dd45659d5c7bc7)

- Updated `limit_component.html.erb` to include ARIA labels for dropdown items, improving screen reader support.
- Enhanced `pagination_component.html.erb` with specific ARIA labels for pagination controls, ensuring better navigation for users with disabilities.
- Modified `en.yml` and `fr.yml` to add new translations for ARIA labels, providing a localized experience for users.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
