### PR TITLE
Fix: Group Samples Index

### DIFF
--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -99,10 +99,10 @@ module Groups
       metadata_fields(@search_params['metadata_template'])
       advanced_search_fields(@group)
 
-      project_ids =
-        authorized_scope(Project, type: :relation, as: :group_projects, scope_options: { group: @group }).pluck(:id)
+      @group_project_ids = authorized_scope(Project, type: :relation, as: :group_projects,
+                                                     scope_options: { group: @group }).pluck(:id)
 
-      @query = Sample::Query.new(@search_params.except('metadata_template').merge({ project_ids: project_ids }))
+      @query = Sample::Query.new(@search_params.except('metadata_template').merge({ project_ids: @group_project_ids }))
     end
 
     def search_params

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -17,68 +17,87 @@
             <span class="ml-2"><%= t(".workflows.button_sr") %></span>
           <% end %>
         <% end %>
-        <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, classes: "font-normal button button--size-default button--state-default") do |dropdown| %>
+        <% if @group_project_ids.count.positive? %>
+          <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, classes: "font-normal button button--size-default button--state-default") do |dropdown| %>
 
-          <% if @allowed_to[:update_sample_metadata] || @allowed_to[:import_samples_and_metadata] %>
+            <% if @allowed_to[:update_sample_metadata] || @allowed_to[:import_samples_and_metadata] %>
 
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.import"),
-              section_header: true,
-            ) %>
-
-            <% if @allowed_to[:update_sample_metadata] && @has_samples %>
               <% dropdown.with_item(
-                label: t("shared.samples.actions_dropdown.import_metadata"),
-                url: new_group_samples_file_import_path,
-                disableable: true,
-                data: {
-                  turbo_stream: true,
-                },
+                label: t("shared.samples.actions_dropdown.import"),
+                section_header: true,
               ) %>
+
+              <% if @allowed_to[:update_sample_metadata] && @has_samples %>
+                <% dropdown.with_item(
+                  label: t("shared.samples.actions_dropdown.import_metadata"),
+                  url: new_group_samples_file_import_path,
+                  disableable: true,
+                  data: {
+                    turbo_stream: true,
+                  },
+                ) %>
+              <% end %>
+
+              <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && @allowed_to[:import_samples_and_metadata] %>
+                <% dropdown.with_item(
+                  label: t("shared.samples.actions_dropdown.import_samples"),
+                  url: new_group_samples_spreadsheet_import_path,
+                  disableable: true,
+                  data: {
+                    turbo_stream: true,
+                  },
+                ) %>
+              <% end %>
             <% end %>
 
-            <% if Flipper.enabled?(:batch_sample_spreadsheet_import) && @allowed_to[:import_samples_and_metadata] %>
+            <% if @allowed_to[:export_data] %>
               <% dropdown.with_item(
-                label: t("shared.samples.actions_dropdown.import_samples"),
-                url: new_group_samples_spreadsheet_import_path,
-                disableable: true,
-                data: {
-                  turbo_stream: true,
-                },
+                label: t("shared.samples.actions_dropdown.export"),
+                section_header: true,
               ) %>
-            <% end %>
-          <% end %>
 
-          <% if @allowed_to[:export_data] %>
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.export"),
-              section_header: true,
-            ) %>
-
-            <% if @group.metadata_fields.empty? %>
+              <% if @group.metadata_fields.empty? %>
+                <% dropdown.with_item(
+                  label: t("shared.samples.actions_dropdown.linelist_export"),
+                  url: new_data_export_path,
+                  params: {
+                    export_type: "linelist",
+                    namespace_id: @group.id,
+                  },
+                  disableable: true,
+                  data: {
+                    action: "turbo:morph-element->action-button#idempotentConnect ",
+                    turbo_stream: true,
+                    controller: "action-button",
+                    action_button_required_value: 1,
+                  },
+                  class:
+                    "flex w-full items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300 border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
+                ) %>
+              <% else %>
+                <% dropdown.with_item(
+                  label: t("shared.samples.actions_dropdown.linelist_export"),
+                  url: new_data_export_path,
+                  params: {
+                    export_type: "linelist",
+                    namespace_id: @group.id,
+                  },
+                  disableable: true,
+                  data: {
+                    action: "turbo:morph-element->action-button#idempotentConnect ",
+                    turbo_stream: true,
+                    controller: "action-button",
+                    action_button_required_value: 1,
+                  },
+                  class:
+                    "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white action-button",
+                ) %>
+              <% end %>
               <% dropdown.with_item(
-                label: t("shared.samples.actions_dropdown.linelist_export"),
+                label: t("shared.samples.actions_dropdown.sample_export"),
                 url: new_data_export_path,
                 params: {
-                  export_type: "linelist",
-                  namespace_id: @group.id,
-                },
-                disableable: true,
-                data: {
-                  action: "turbo:morph-element->action-button#idempotentConnect ",
-                  turbo_stream: true,
-                  controller: "action-button",
-                  action_button_required_value: 1,
-                },
-                class:
-                  "flex w-full items-center px-4 py-2 bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300 border-slate-100 dark:border-slate-600 pointer-events-none cursor-not-allowed",
-              ) %>
-            <% else %>
-              <% dropdown.with_item(
-                label: t("shared.samples.actions_dropdown.linelist_export"),
-                url: new_data_export_path,
-                params: {
-                  export_type: "linelist",
+                  export_type: "sample",
                   namespace_id: @group.id,
                 },
                 disableable: true,
@@ -92,23 +111,6 @@
                   "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white action-button",
               ) %>
             <% end %>
-            <% dropdown.with_item(
-              label: t("shared.samples.actions_dropdown.sample_export"),
-              url: new_data_export_path,
-              params: {
-                export_type: "sample",
-                namespace_id: @group.id,
-              },
-              disableable: true,
-              data: {
-                action: "turbo:morph-element->action-button#idempotentConnect ",
-                turbo_stream: true,
-                controller: "action-button",
-                action_button_required_value: 1,
-              },
-              class:
-                "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white action-button",
-            ) %>
           <% end %>
         <% end %>
       </div>
@@ -154,16 +156,16 @@
         pagy: @pagy,
       } %>
     </div>
-
-    <%= render partial: "table",
-    locals: {
-      allowed_to: @allowed_to,
-      fields: @fields,
-      group: @group,
-      has_samples: @has_samples,
-      pagy: @pagy,
-      samples: @samples,
-      search_params: @search_params,
-    } %>
   <% end %>
+
+  <%= render partial: "table",
+  locals: {
+    allowed_to: @allowed_to,
+    fields: @fields,
+    group: @group,
+    has_samples: @has_samples,
+    pagy: @pagy,
+    samples: @samples,
+    search_params: @search_params,
+  } %>
 </div>

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -117,7 +117,7 @@
     <% end %>
   <% end %>
 
-  <% if @has_samples %>
+  <% if @group_project_ids.count.positive? %>
     <div class="flex @max-2xl:flex-col @max-2xl:space-y-2 mb-2">
       <div class="inline-flex grow space-x-2">
         <% if @allowed_to[:submit_workflow] || @allowed_to[:export_data] %>

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -1643,5 +1643,17 @@ module Groups
         assert_selector 'tr:nth-child(2) td:nth-child(7)', text: 'a'
       end
     end
+
+    test 'group without projects should not render sample actions dropdown' do
+      group = groups(:group_seven)
+      ### SETUP START ###
+      visit group_samples_url(group)
+
+      assert_selector 'div.empty_state_message'
+      assert_text I18n.t('groups.samples.table.no_associated_samples')
+      assert_text I18n.t('groups.samples.table.no_samples')
+
+      assert_no_selector 'button', text: 'Sample Actions'
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR changes a couple items on the group samples page:
- Hides `Sample Actions` dropdown if the group has no projects associated with it (because the user can't import samples or use any other action)
- Renders the sample table (ie: empty state message).
- Renders the select/de-select samples and filter/search actions based on if projects are present. This is due to `Advanced Search` requiring at least 1 project present to pass validation

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Create a new group, a subgroup (subgroup 1) within the group, and then another subgroup (subgroup 2) within subgroup 1.
2. Create a project in the top level Group
3. Navigate to a group with at least a project that you have maintainer/owner access, and share it to subgroup 1
4. Navigate back to Group, verify `Sample Actions` renders (because it owns a project)
5. Navigate to Subgroup 1, verify `Sample Actions` renders (because it has shared group/projects)
6. Navigate to Subgroup 2, verify `Sample Actions` is hidden because it has no projects associated. Verify the `No samples` empty state message also displays.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
