### PR TITLE
Fix: Avatar colour consistency

### DIFF
--- a/app/components/viral/avatar_component.rb
+++ b/app/components/viral/avatar_component.rb
@@ -28,7 +28,7 @@ module Viral
     end
 
     def generate_hsla_colour(name)
-      h = name.hash.abs % 360
+      h = (Digest::MD5.hexdigest name).to_i(16) % 360
       { border: "hsla(#{h}, 100%, var(--tw-avatar-border-lightness), var(--tw-avatar-bg-alpha))",
         background: "hsla(#{h}, 100%, var(--tw-avatar-bg-lightness), var(--tw-avatar-bg-alpha))" }
     end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

When multiple web servers are running, the avatar colour can change as the `.hash` method on a string does not produce reproducible results. This updates it to use md5 which will generate reproducible results.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/56b46041-70da-478e-9992-bb69defa5e82)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Checkout this branch
2. Run `bin/rails db:reset`
3. Start server
4. Login as `user1@email.com`
5. Navigate to http://localhost:3000/rails/lookbook/inspect/viral_avatar/default and confirm colour matches screenshot

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
