### PR TITLE
Batch Sample Import: Extend Activities

### DIFF
--- a/app/components/activities/dialogs/activity_list_dialog_component.rb
+++ b/app/components/activities/dialogs/activity_list_dialog_component.rb
@@ -54,7 +54,7 @@ module Activities
           @description = I18n.t('components.activity.dialog.import_samples.description.project',
                                 user: @activity_owner,
                                 count: @activity.parameters[:imported_samples_count])
-          @data = @extended_details.details['imported_samples_data']['project_data'][@activity.trackable.puid].to_json
+          @data = @extended_details.details['imported_samples_data'].to_json
         end
       end
 

--- a/app/components/activities/dialogs/activity_list_dialog_component.rb
+++ b/app/components/activities/dialogs/activity_list_dialog_component.rb
@@ -48,6 +48,13 @@ module Activities
                                 user: @activity_owner,
                                 count: @activity.parameters[:samples_deleted_count])
           @data = @extended_details.details['deleted_samples_data'].to_json
+
+        when 'project_import_samples'
+          @title = I18n.t(:'components.activity.dialog.import_samples.title')
+          @description = I18n.t('components.activity.dialog.import_samples.description.project',
+                                user: @activity_owner,
+                                count: @activity.parameters[:imported_samples_count])
+          @data = @extended_details.details['imported_samples_data']['project_data'][@activity.trackable.puid].to_json
         end
       end
 

--- a/app/components/activities/dialogs/activity_table_listing_dialog_component.html.erb
+++ b/app/components/activities/dialogs/activity_table_listing_dialog_component.html.erb
@@ -84,6 +84,19 @@
       </tr>
     </template>
 
+    <template
+      id="importSampleTableRow"
+      data-activities--extended_details-target="importSampleTableRow"
+    >
+      <tr>
+        <td class="px-3 py-3"><span class="mr-2" data-activities--extended_details-target="sampleName"></span>
+          <%= render PuidComponent.new(puid: "", show_clipboard: false) %>
+        </td>
+        <td class="px-3 py-3"><span class="mr-2" data-activities--extended_details-target="projectId"></span>
+        </td>
+      </tr>
+    </template>
+
     <div
       data-activities--extended_details-target="paginationContainer"
       class="flex items-center justify-end mt-4"

--- a/app/components/activities/dialogs/activity_table_listing_dialog_component.rb
+++ b/app/components/activities/dialogs/activity_table_listing_dialog_component.rb
@@ -57,6 +57,17 @@ module Activities
             I18n.t(:'components.activity.dialog.workflow_execution_destroy.name'),
             I18n.t(:'components.activity.dialog.workflow_execution_destroy.id')
           ]
+
+        when 'group_import_samples'
+          @title = I18n.t(:'components.activity.dialog.import_samples.title')
+          @description = I18n.t('components.activity.dialog.import_samples.description.group',
+                                user: @activity_owner,
+                                count: @activity.parameters[:imported_samples_count])
+          @data = @extended_details.details['imported_samples_data']['group_data'].to_json
+          @column_headers = [
+            I18n.t(:'components.activity.dialog.import_samples.sample'),
+            I18n.t(:'components.activity.dialog.import_samples.project')
+          ]
         end
       end
 

--- a/app/components/activities/dialogs/activity_table_listing_dialog_component.rb
+++ b/app/components/activities/dialogs/activity_table_listing_dialog_component.rb
@@ -63,7 +63,7 @@ module Activities
           @description = I18n.t('components.activity.dialog.import_samples.description.group',
                                 user: @activity_owner,
                                 count: @activity.parameters[:imported_samples_count])
-          @data = @extended_details.details['imported_samples_data']['group_data'].to_json
+          @data = @extended_details.details['imported_samples_data'].to_json
           @column_headers = [
             I18n.t(:'components.activity.dialog.import_samples.sample'),
             I18n.t(:'components.activity.dialog.import_samples.project')

--- a/app/components/activities/groups/sample_activity_component.html.erb
+++ b/app/components/activities/groups/sample_activity_component.html.erb
@@ -10,5 +10,16 @@
           class: "text-slate-800 dark:text-slate-300 font-medium",
         ),
     ) %>
+    <span class="block">
+      <%= link_to(
+        t(:"components.activity.more_details"),
+        activity_path(@activity[:id], dialog_type: "group_import_samples"),
+        data: {
+          turbo_stream: true,
+        },
+        class:
+          "inline-flex items-center justify-center button button--state-default button--size-small dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
+      ) %>
+    </span>
   <% end %>
 </span>

--- a/app/components/activities/groups/sample_activity_component.rb
+++ b/app/components/activities/groups/sample_activity_component.rb
@@ -9,7 +9,7 @@ module Activities
       end
 
       def import_samples_action
-        @activity[:action] == 'import_samples'
+        @activity[:action] == 'group_import_samples'
       end
     end
   end

--- a/app/components/activities/list_item_component.rb
+++ b/app/components/activities/list_item_component.rb
@@ -36,7 +36,8 @@ module Activities
 
     def sample_action
       %w[sample_create sample_update attachment_create attachment_destroy
-         metadata_update sample_destroy sample_destroy_multiple import_samples].include?(@activity[:action])
+         metadata_update sample_destroy sample_destroy_multiple project_import_samples
+         group_import_samples].include?(@activity[:action])
     end
 
     def sample_transfer_action

--- a/app/components/activities/projects/sample_activity_component.html.erb
+++ b/app/components/activities/projects/sample_activity_component.html.erb
@@ -51,5 +51,17 @@
           "inline-flex items-center justify-center button button--state-default button--size-small dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
       ) %>
     </span>
+  <% elsif import_samples_action %>
+    <span class="block">
+      <%= link_to(
+        t(:"components.activity.more_details"),
+        activity_path(@activity[:id], dialog_type: "project_import_samples"),
+        data: {
+          turbo_stream: true,
+        },
+        class:
+          "inline-flex items-center justify-center button button--state-default button--size-small dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
+      ) %>
+    </span>
   <% end %>
 </span>

--- a/app/components/activities/projects/sample_activity_component.rb
+++ b/app/components/activities/projects/sample_activity_component.rb
@@ -20,7 +20,7 @@ module Activities
       end
 
       def import_samples_action
-        @activity[:action] == 'import_samples'
+        @activity[:action] == 'project_import_samples'
       end
     end
   end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -44,9 +44,9 @@ class ActivitiesController < ApplicationController
     type = params[:dialog_type]
 
     case type
-    when 'samples_clone', 'workflow_executions_destroy'
+    when 'samples_clone', 'workflow_executions_destroy', 'group_import_samples'
       Activities::Dialogs::ActivityTableListingDialogComponent
-    when 'samples_transfer', 'samples_destroy'
+    when 'samples_transfer', 'samples_destroy', 'project_import_samples'
       Activities::Dialogs::ActivityListDialogComponent
     end
   end

--- a/app/javascript/controllers/activities/extended_details_controller.js
+++ b/app/javascript/controllers/activities/extended_details_controller.js
@@ -58,7 +58,6 @@ export default class extends Controller {
       ) {
         lastIndex = (this.#currentDataIndexes.length % 5) + startingIndex;
       }
-      console.log(this.#data);
       let indexRangeData = this.#data.slice(startingIndex, lastIndex);
 
       // If activityType value is set, this else statement

--- a/app/javascript/controllers/activities/extended_details_controller.js
+++ b/app/javascript/controllers/activities/extended_details_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     "listContainer",
     "sampleCloneTableRow",
     "workflowTableRow",
+    "importSampleTableRow",
     "listRow",
     "ariaLabels",
     "itemName",
@@ -57,7 +58,7 @@ export default class extends Controller {
       ) {
         lastIndex = (this.#currentDataIndexes.length % 5) + startingIndex;
       }
-
+      console.log(this.#data);
       let indexRangeData = this.#data.slice(startingIndex, lastIndex);
 
       // If activityType value is set, this else statement
@@ -66,6 +67,8 @@ export default class extends Controller {
       if (this.hasTbodyTarget) {
         if (this.activityTypeValue === "workflow_execution_destroy") {
           this.#generateWorkflowTableRows(indexRangeData);
+        } else if (this.activityTypeValue === "group_import_samples") {
+          this.#generateImportSampleTableRows(indexRangeData);
         } else {
           this.#generateTableRows(indexRangeData);
         }
@@ -236,6 +239,41 @@ export default class extends Controller {
         };
         updateTextContent(0, data["workflow_name"], workflowNameSelector);
         updateTextContent(1, data["workflow_id"], workflowIdSelector);
+
+        fragment.appendChild(clone);
+      });
+
+      this.tbodyTarget.appendChild(fragment);
+    }
+  }
+
+  #generateImportSampleTableRows(table_data) {
+    if ("content" in document.createElement("template")) {
+      const template = this.importSampleTableRowTarget;
+      const fragment = document.createDocumentFragment();
+      const sampleNameSelector =
+        "span[data-activities--extended_details-target='sampleName']";
+      const puidSelector = "span:nth-child(2)";
+      const projectIdSelector =
+        "span[data-activities--extended_details-target='projectId']";
+
+      table_data.forEach((data) => {
+        const clone = template.content.cloneNode(true);
+        const tds = clone.querySelectorAll("td");
+
+        const updateTextContent = (tdIndex, sampleName, puid) => {
+          const td = tds[tdIndex];
+          if (tdIndex === 0) {
+            td.querySelector(sampleNameSelector).textContent = sampleName;
+            td.querySelector(puidSelector).textContent = puid;
+          } else {
+            td.querySelector(projectIdSelector).textContent =
+              data["project_puid"];
+          }
+        };
+
+        updateTextContent(0, data["sample_name"], data["sample_puid"]);
+        updateTextContent(1, data["project_puid"], projectIdSelector);
 
         fragment.appendChild(clone);
       });

--- a/app/models/concerns/track_activity.rb
+++ b/app/models/concerns/track_activity.rb
@@ -254,7 +254,7 @@ module TrackActivity # rubocop:disable Metrics/ModuleLength
   end
 
   def add_samples_import_params(params, activity)
-    return params unless activity.parameters[:action] == 'import_samples'
+    return params unless %w[group_import_samples project_import_samples].include?(activity.parameters[:action])
 
     params.merge(
       imported_samples_count: activity.parameters[:imported_samples_count]

--- a/app/services/samples/batch_file_import_service.rb
+++ b/app/services/samples/batch_file_import_service.rb
@@ -175,17 +175,18 @@ module Samples
                                                project_puid: project_puid }
     end
 
-    def create_activities # rubocop:disable Metrics/MethodLength
+    def create_activities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       total_imported_samples_count = 0
 
       @imported_samples_data[:project_data].each do |project_puid, sample_data|
+        imported_samples_count = sample_data.count
         project_ext_details = ExtendedDetail.create!(
           details: {
-            imported_samples_data: @imported_samples_data[:project_data][project_puid]
+            imported_samples_data: @imported_samples_data[:project_data][project_puid],
+            imported_samples_count:
           }
         )
 
-        imported_samples_count = sample_data.count
         project_namespace = Namespaces::ProjectNamespace.find_by(puid: project_puid)
         project_activity = project_namespace.create_activity(
           key: 'namespaces_project_namespace.import_samples.create',
@@ -206,7 +207,8 @@ module Samples
 
       group_ext_details = ExtendedDetail.create!(
         details: {
-          imported_samples_data: @imported_samples_data[:group_data]
+          imported_samples_data: @imported_samples_data[:group_data],
+          imported_samples_count: total_imported_samples_count
         }
       )
       group_activity = @namespace.create_activity key: 'group.import_samples.create',

--- a/app/services/samples/batch_file_import_service.rb
+++ b/app/services/samples/batch_file_import_service.rb
@@ -17,7 +17,7 @@ module Samples
       else
         @static_project = namespace.project
       end
-      @project_samples_count = {}
+      @imported_samples_data = {}
       @project_puid_map = {}
       super(namespace, user, blob_id, required_headers, 0, params)
     end
@@ -73,7 +73,7 @@ module Samples
       end
       cleanup_files
 
-      create_activities unless @project_samples_count.empty?
+      create_activities unless @imported_samples_data.empty?
 
       response
     end
@@ -141,7 +141,7 @@ module Samples
           sample.project, sample, current_user, { 'metadata' => metadata, include_activity: false }
         ).execute
 
-        increment_sample_count(project)
+        add_imported_sample_to_data(sample, project.puid)
 
         sample
       else
@@ -162,40 +162,48 @@ module Samples
       )
     end
 
+    def add_imported_sample_to_data(sample, project_puid)
+      if @imported_samples_data.key?(project_puid)
+        @imported_samples_data[project_puid] << { sample_name: sample.name, sample_puid: sample.puid }
+      else
+        @imported_samples_data[project_puid] = [{ sample_name: sample.name, sample_puid: sample.puid }]
+      end
+    end
+
     def create_activities # rubocop:disable Metrics/MethodLength
-      total_sample_count = 0
-      @project_samples_count.each do |project_puid, sample_count|
-        @project_puid_map[project_puid].namespace.create_activity(
+      total_imported_samples_count = 0
+      ext_details = ExtendedDetail.create!(details: {
+                                             imported_samples_data: @imported_samples_data
+                                           })
+      @imported_samples_data.each do |project_puid, sample_data|
+        imported_samples_count = sample_data.count
+        project_namespace = Namespaces::ProjectNamespace.find_by(puid: project_puid)
+        project_activity = project_namespace.create_activity(
           key: 'namespaces_project_namespace.import_samples.create',
           owner: current_user,
           parameters:
           {
-            imported_samples_count: sample_count,
-            action: 'import_samples'
+            imported_samples_count: imported_samples_count,
+            action: 'project_import_samples'
           }
         )
-        total_sample_count += sample_count
+
+        project_activity.create_activity_extended_detail(extended_detail_id: ext_details.id,
+                                                         activity_type: 'project_import_samples')
+        total_imported_samples_count += imported_samples_count
       end
 
-      return unless @namespace.group_namespace? && total_sample_count.positive?
+      return unless @namespace.group_namespace?
 
-      @namespace.create_activity key: 'group.import_samples.create',
-                                 owner: current_user,
-                                 parameters:
+      group_activity = @namespace.create_activity key: 'group.import_samples.create',
+                                                  owner: current_user,
+                                                  parameters:
                                  {
-                                   imported_samples_count: total_sample_count,
-                                   action: 'import_samples'
+                                   imported_samples_count: total_imported_samples_count,
+                                   action: 'group_import_samples'
                                  }
-    end
-
-    def increment_sample_count(project)
-      project_puid = project.puid
-      @project_samples_count[project_puid] = if @project_samples_count.key?(project_puid)
-                                               @project_samples_count[project_puid] + 1
-                                             else
-                                               @project_puid_map[project_puid] = project
-                                               1
-                                             end
+      group_activity.create_activity_extended_detail(extended_detail_id: ext_details.id,
+                                                     activity_type: 'group_import_samples')
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,7 +415,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -476,6 +476,13 @@ en:
     activity:
       dialog:
         close: Close
+        import_samples:
+          description:
+            group: "%{user} imported %{count} samples to group"
+            project: "%{user} imported %{count} samples to project"
+          project: Project
+          sample: Sample
+          title: Imported Samples
         pagination:
           aria_label: Pagination
           at_first_aria_label: You are on the first page
@@ -543,7 +550,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     layout:
       main_content_link: Skip to content
@@ -584,7 +591,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -701,14 +708,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -776,7 +783,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -811,7 +818,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -875,11 +882,11 @@ en:
         delete:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning:
               post_html: After you delete a group, you <strong>cannot</strong> restore it or its components.
-              pre_html: 'You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:'
+              pre_html: "You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:"
               projects_count: "%{count} project(s)"
               samples_count: "%{count} sample(s)"
               subgroups_count: "%{count} subgroup(s)"
@@ -894,18 +901,18 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1101,7 +1108,7 @@ en:
   layouts:
     application:
       language_selection:
-        aria_label: 'Selected language: English'
+        aria_label: "Selected language: English"
       site_title: IRIDA Next
   locales:
     en: English
@@ -1112,10 +1119,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1123,11 +1130,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1138,15 +1145,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1163,7 +1170,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -1242,7 +1249,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: 'The following samples are missing required data: '
+    data_missing_error: "The following samples are missing required data: "
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1273,8 +1280,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1335,7 +1342,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1363,7 +1370,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1430,12 +1437,12 @@ en:
         destroy:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning:
               automated_workflows_count: "%{count} automated workflow execution(s)"
               post_html: After you delete a project, you <strong>cannot</strong> restore it or its components.
-              pre_html: 'You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:'
+              pre_html: "You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:"
               samples_count: "%{count} sample(s)"
           description: Deleting a project is permanent and cannot be undone. All samples and direct members will be deleted along with the project.
           submit: Delete project
@@ -1449,20 +1456,20 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1581,11 +1588,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1593,20 +1600,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1637,8 +1644,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1666,7 +1673,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1706,7 +1713,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1758,8 +1765,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1933,8 +1940,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1957,8 +1964,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
     spreadsheet_import:
       csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
@@ -2022,7 +2029,7 @@ en:
             title: Upload Sample Metadata
             uploading: Uploading
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -2067,7 +2074,7 @@ en:
           submit_button: Import Samples
           title: Import Samples
         errors:
-          description: 'The sample import completed with the following errors:'
+          description: "The sample import completed with the following errors:"
           ok_button: OK
         success:
           description: The sample spreadsheet has been processed.
@@ -2085,16 +2092,16 @@ en:
         title: Delete Workflow Executions
         workflow_executions: Workflow Executions
       list_workflow_execution:
-        id: 'ID:'
-        name: 'Name:'
-        run_id: 'Run ID:'
-        workflow: 'Workflow:'
+        id: "ID:"
+        name: "Name:"
+        run_id: "Run ID:"
+        workflow: "Workflow:"
   spreadsheet_helper:
-    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
+    failed_parsing: "Failed to parse spreadsheet file: %{error}"
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
-    unknown_file_format: 'Unknown file type: %{extension}'
+    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
+    unknown_file_format: "Unknown file type: %{extension}"
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -2151,7 +2158,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: 'The following errors prevented the Workflow Execution from being created:'
+      error_message: "The following errors prevented the Workflow Execution from being created:"
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,7 +415,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -550,7 +550,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     layout:
       main_content_link: Skip to content
@@ -591,7 +591,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -708,14 +708,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -783,7 +783,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -818,7 +818,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -882,11 +882,11 @@ en:
         delete:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning:
               post_html: After you delete a group, you <strong>cannot</strong> restore it or its components.
-              pre_html: "You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:"
+              pre_html: 'You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:'
               projects_count: "%{count} project(s)"
               samples_count: "%{count} sample(s)"
               subgroups_count: "%{count} subgroup(s)"
@@ -901,18 +901,18 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1108,7 +1108,7 @@ en:
   layouts:
     application:
       language_selection:
-        aria_label: "Selected language: English"
+        aria_label: 'Selected language: English'
       site_title: IRIDA Next
   locales:
     en: English
@@ -1119,10 +1119,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1130,11 +1130,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1145,15 +1145,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1170,7 +1170,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -1249,7 +1249,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: "The following samples are missing required data: "
+    data_missing_error: 'The following samples are missing required data: '
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1280,8 +1280,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1342,7 +1342,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1370,7 +1370,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1437,12 +1437,12 @@ en:
         destroy:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning:
               automated_workflows_count: "%{count} automated workflow execution(s)"
               post_html: After you delete a project, you <strong>cannot</strong> restore it or its components.
-              pre_html: "You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:"
+              pre_html: 'You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:'
               samples_count: "%{count} sample(s)"
           description: Deleting a project is permanent and cannot be undone. All samples and direct members will be deleted along with the project.
           submit: Delete project
@@ -1456,20 +1456,20 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1588,11 +1588,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1600,20 +1600,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1644,8 +1644,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1673,7 +1673,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1713,7 +1713,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1765,8 +1765,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1940,8 +1940,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1964,8 +1964,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
     spreadsheet_import:
       csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
@@ -2029,7 +2029,7 @@ en:
             title: Upload Sample Metadata
             uploading: Uploading
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -2074,7 +2074,7 @@ en:
           submit_button: Import Samples
           title: Import Samples
         errors:
-          description: "The sample import completed with the following errors:"
+          description: 'The sample import completed with the following errors:'
           ok_button: OK
         success:
           description: The sample spreadsheet has been processed.
@@ -2092,16 +2092,16 @@ en:
         title: Delete Workflow Executions
         workflow_executions: Workflow Executions
       list_workflow_execution:
-        id: "ID:"
-        name: "Name:"
-        run_id: "Run ID:"
-        workflow: "Workflow:"
+        id: 'ID:'
+        name: 'Name:'
+        run_id: 'Run ID:'
+        workflow: 'Workflow:'
   spreadsheet_helper:
-    failed_parsing: "Failed to parse spreadsheet file: %{error}"
+    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
-    unknown_file_format: "Unknown file type: %{extension}"
+    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
+    unknown_file_format: 'Unknown file type: %{extension}'
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -2158,7 +2158,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: "The following errors prevented the Workflow Execution from being created:"
+      error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -476,6 +476,13 @@ fr:
     activity:
       dialog:
         close: Close
+        import_samples:
+          description:
+            group: "%{user} imported %{count} samples to group"
+            project: "%{user} imported %{count} samples to project"
+          project: Project
+          sample: Sample
+          title: Imported Samples
         pagination:
           aria_label: Pagination
           at_first_aria_label: You are on the first page

--- a/test/components/activities/dialogs/activity_list_dialog_component_test.rb
+++ b/test/components/activities/dialogs/activity_list_dialog_component_test.rb
@@ -109,6 +109,40 @@ module Activities
           assert_selector 'li > p > span:nth-child(2)', text: 'INXT_SAM_AAAAAAAAAA'
         end
       end
+
+      test 'project import samples activity dialog' do
+        project_namespace = namespaces_project_namespaces(:project1_namespace)
+
+        activities = project_namespace.human_readable_activity(project_namespace.retrieve_project_activity).reverse
+
+        assert_equal(1, activities.count do |activity|
+          activity[:key].include?('namespaces_project_namespace.import_samples.create')
+        end)
+
+        activity_to_render = activities.find do |a|
+          a[:key] == 'activity.namespaces_project_namespace.import_samples.create_html'
+        end
+
+        visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
+
+        load_more_button = find('button', text: 'Load more')
+        click_button 'Load more' if load_more_button
+
+        click_link(I18n.t('components.activity.more_details'),
+                   href: activity_path(activity_to_render[:id], dialog_type: 'project_import_samples').to_s)
+
+        assert_selector 'h1', text: I18n.t(:'components.activity.dialog.import_samples.title')
+
+        within %(div[data-controller="activities--extended_details"][data-controller-connected="true"]) do
+          assert_selector 'p',
+                          text: I18n.t(:'components.activity.dialog.import_samples.description.project',
+                                       user: 'System', count: 1)
+
+          assert_selector 'li', count: 1
+          assert_selector 'li > p > span:nth-child(1)', text: 'sample name'
+          assert_selector 'li > p > span:nth-child(2)', text: 'sample puid'
+        end
+      end
     end
   end
 end

--- a/test/components/activities/dialogs/activity_table_listing_dialog_component_test.rb
+++ b/test/components/activities/dialogs/activity_table_listing_dialog_component_test.rb
@@ -121,6 +121,42 @@ module Activities
         assert_selector 'tr > td', text: workflow_execution.name
         assert_selector 'tr > td', text: workflow_execution.id
       end
+
+      test 'group import samples activity dialog' do
+        group_namespace = groups(:group_one)
+
+        activities = group_namespace.human_readable_activity(group_namespace.retrieve_group_activity).reverse
+
+        assert_equal(1, activities.count do |activity|
+          activity[:key].include?('group.import_samples.create')
+        end)
+
+        activity_to_render = activities.find do |a|
+          a[:key] == 'activity.group.import_samples.create_html'
+        end
+
+        visit group_activity_path(group_namespace)
+
+        click_link(I18n.t('components.activity.more_details'),
+                   href: activity_path(activity_to_render[:id], dialog_type: 'group_import_samples').to_s)
+
+        assert_selector 'h1', text: I18n.t(:'components.activity.dialog.import_samples.title')
+
+        assert_selector 'p',
+                        text: I18n.t(:'components.activity.dialog.import_samples.description.group',
+                                     user: 'System', count: 2)
+        assert_selector 'table', count: 1
+        assert_selector 'th', count: 2
+        assert_selector 'tr', count: 3
+        assert_selector 'tr > th', text: I18n.t(:'components.activity.dialog.import_samples.sample').upcase
+        assert_selector 'tr > th', text: I18n.t(:'components.activity.dialog.import_samples.project').upcase
+        assert_selector 'tr > td', text: 'sample 1 name'
+        assert_selector 'tr > td', text: 'sample 1 puid'
+        assert_selector 'tr > td', text: 'sample 2 name'
+        assert_selector 'tr > td', text: 'sample 1 puid'
+        assert_selector 'tr > td', text: 'INXT_PRJ_AAAAAAAAAA'
+        assert_selector 'tr > td', text: 'INXT_PRJ_AAAAAAAAAB'
+      end
     end
   end
 end

--- a/test/components/projects/sample_activity_component_test.rb
+++ b/test/components/projects/sample_activity_component_test.rb
@@ -270,10 +270,10 @@ module Projects
       assert_text strip_tags(
         I18n.t('activity.namespaces_project_namespace.import_samples.create_html',
                user: 'System',
-               href: 2)
+               href: 1)
       )
       assert_selector 'span',
-                      text: 2
+                      text: 1
     end
   end
 end

--- a/test/fixtures/activity_extended_details.yml
+++ b/test/fixtures/activity_extended_details.yml
@@ -32,3 +32,17 @@ project1_namespace_workflow_execution_destroy_activity_extended_details:
   activity_type: workflow_execution_destroy
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>
+
+project1_namespace_import_sample_activity_extended_details:
+  activity: project1_namespace_sample_import_create
+  extended_detail: project1_namespace_import_sample_create_extended_details
+  activity_type: project_import_samples
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+
+group1_namespace_import_sample_activity_extended_details:
+  activity: group1_sample_import_create
+  extended_detail: group1_namespace_import_sample_create_extended_details
+  activity_type: project_import_samples
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>

--- a/test/fixtures/extended_details.yml
+++ b/test/fixtures/extended_details.yml
@@ -53,3 +53,34 @@ project1_namespace_workflow_execution_destroy_extended_details:
     }
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>
+
+project1_namespace_import_sample_create_extended_details:
+  details:
+    {
+      "imported_samples_data":
+        [{ sample_name: "sample name", sample_puid: "sample puid" }],
+      "imported_samples_count": 1,
+    }
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+
+group1_namespace_import_sample_create_extended_details:
+  details:
+    {
+      "imported_samples_data":
+        [
+          {
+            sample_name: "sample 1 name",
+            sample_puid: "sample 1 puid",
+            project_puid: "INXT_PRJ_AAAAAAAAAA",
+          },
+          {
+            sample_name: "sample 2 name",
+            sample_puid: "sample 2 puid",
+            project_puid: "INXT_PRJ_AAAAAAAAAB",
+          },
+        ],
+      "imported_samples_count": 2,
+    }
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>

--- a/test/fixtures/files/batch_sample_import/group/valid_with_multiple_project_puids.csv
+++ b/test/fixtures/files/batch_sample_import/group/valid_with_multiple_project_puids.csv
@@ -1,0 +1,3 @@
+sample_name,project_puid,description
+my new sample 1,INXT_PRJ_AAAAAAAAAA,my description
+my new sample 2,INXT_PRJ_AAAAAAAAAB,my description 2

--- a/test/fixtures/public_activity/activities.yml
+++ b/test/fixtures/public_activity/activities.yml
@@ -321,8 +321,8 @@ project1_namespace_sample_import_create:
   key: "namespaces_project_namespace.import_samples.create"
   parameters:
     {
-      imported_samples_count: 2,
-      action: "import_samples",
+      imported_samples_count: 1,
+      action: "project_import_samples",
     }
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>
@@ -334,7 +334,7 @@ group1_sample_import_create:
   parameters:
     {
       imported_samples_count: 2,
-      action: "import_samples",
+      action: "group_import_samples",
     }
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>

--- a/test/services/samples/group_batch_sample_import_service_test.rb
+++ b/test/services/samples/group_batch_sample_import_service_test.rb
@@ -348,9 +348,12 @@ module Samples
       assert_equal 2, activity.parameters[:imported_samples_count]
       first_sample = Sample.find_by(name: 'my new sample 1')
       second_sample = Sample.find_by(name: 'my new sample 2')
-      assert_equal [{ 'sample_name' => first_sample.name, 'sample_puid' => first_sample.puid, 'project_puid' => 'INXT_PRJ_AAAAAAAAAA' },
-                    { 'sample_name' => second_sample.name, 'sample_puid' => second_sample.puid,
-                      'project_puid' => 'INXT_PRJ_AAAAAAAAAB' }],
+      assert_equal [
+        { 'sample_name' => first_sample.name, 'sample_puid' => first_sample.puid,
+          'project_puid' => 'INXT_PRJ_AAAAAAAAAA' },
+        { 'sample_name' => second_sample.name, 'sample_puid' => second_sample.puid,
+          'project_puid' => 'INXT_PRJ_AAAAAAAAAB' }
+      ],
                    activity.extended_details.details['imported_samples_data']
       assert_equal 'group_import_samples', activity.parameters[:action]
 
@@ -362,8 +365,8 @@ module Samples
       assert_equal 'namespaces_project_namespace.import_samples.create', activity.key
       assert_equal @john_doe, activity.owner
       assert_equal 1, activity.parameters[:imported_samples_count]
-      sample_2 = Sample.find_by(name: 'my new sample 2')
-      assert_equal [{ 'sample_name' => sample_2.name, 'sample_puid' => sample_2.puid }],
+      sample2 = Sample.find_by(name: 'my new sample 2')
+      assert_equal [{ 'sample_name' => sample2.name, 'sample_puid' => sample2.puid }],
                    activity.extended_details.details['imported_samples_data']
       assert_equal 'project_import_samples', activity.parameters[:action]
 
@@ -375,8 +378,8 @@ module Samples
       assert_equal 'namespaces_project_namespace.import_samples.create', activity.key
       assert_equal @john_doe, activity.owner
       assert_equal 1, activity.parameters[:imported_samples_count]
-      sample_1 = Sample.find_by(name: 'my new sample 1')
-      assert_equal [{ 'sample_name' => sample_1.name, 'sample_puid' => sample_1.puid }],
+      sample1 = Sample.find_by(name: 'my new sample 1')
+      assert_equal [{ 'sample_name' => sample1.name, 'sample_puid' => sample1.puid }],
                    activity.extended_details.details['imported_samples_data']
       assert_equal 'project_import_samples', activity.parameters[:action]
     end

--- a/test/services/samples/group_batch_sample_import_service_test.rb
+++ b/test/services/samples/group_batch_sample_import_service_test.rb
@@ -322,5 +322,35 @@ module Samples
       assert_equal 'user', @project.samples.where(name: 'my new sample 1')[0].metadata_provenance['metadata1']['source']
       assert_equal 'user', @project.samples.where(name: 'my new sample 2')[0].metadata_provenance['metadata1']['source']
     end
+
+    test 'should create activities for sample import' do
+      file = Rack::Test::UploadedFile.new(
+        Rails.root.join('test/fixtures/files/batch_sample_import/group/valid_with_multiple_project_puids.csv')
+      )
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: file,
+        filename: file.original_filename,
+        content_type: file.content_type
+      )
+      assert_difference -> { Sample.count } => 2,
+                        -> { PublicActivity::Activity.count } => 3 do
+                          Samples::BatchFileImportService.new(@group, @john_doe, blob.id,
+                                                              @default_params).execute
+                        end
+      activity = PublicActivity::Activity.where(
+        key: 'group.import_samples.create'
+      ).order(created_at: :desc).first
+
+      assert_equal 'group.import_samples.create', activity.key
+      assert_equal @john_doe, activity.owner
+      assert_equal 2, activity.parameters[:imported_samples_count]
+      first_sample = Sample.find_by(name: 'my new sample 1')
+      second_sample = Sample.find_by(name: 'my new sample 2')
+      assert_equal [{ 'sample_name' => first_sample.name, 'sample_puid' => first_sample.puid, 'project_puid' => 'INXT_PRJ_AAAAAAAAAA' },
+                    { 'sample_name' => second_sample.name, 'sample_puid' => second_sample.puid,
+                      'project_puid' => 'INXT_PRJ_AAAAAAAAAB' }],
+                   activity.extended_details.details['imported_samples_data']
+      assert_equal 'group_import_samples', activity.parameters[:action]
+    end
   end
 end

--- a/test/services/samples/group_batch_sample_import_service_test.rb
+++ b/test/services/samples/group_batch_sample_import_service_test.rb
@@ -332,11 +332,13 @@ module Samples
         filename: file.original_filename,
         content_type: file.content_type
       )
+      # 3 activities created, 1 at the group level, and 1 for each of 2 projects
       assert_difference -> { Sample.count } => 2,
                         -> { PublicActivity::Activity.count } => 3 do
                           Samples::BatchFileImportService.new(@group, @john_doe, blob.id,
                                                               @default_params).execute
                         end
+      # verify group activity
       activity = PublicActivity::Activity.where(
         key: 'group.import_samples.create'
       ).order(created_at: :desc).first
@@ -351,6 +353,32 @@ module Samples
                       'project_puid' => 'INXT_PRJ_AAAAAAAAAB' }],
                    activity.extended_details.details['imported_samples_data']
       assert_equal 'group_import_samples', activity.parameters[:action]
+
+      # verify project activity 1
+      activity = PublicActivity::Activity.where(
+        key: 'namespaces_project_namespace.import_samples.create'
+      ).order(created_at: :desc).first
+
+      assert_equal 'namespaces_project_namespace.import_samples.create', activity.key
+      assert_equal @john_doe, activity.owner
+      assert_equal 1, activity.parameters[:imported_samples_count]
+      sample_2 = Sample.find_by(name: 'my new sample 2')
+      assert_equal [{ 'sample_name' => sample_2.name, 'sample_puid' => sample_2.puid }],
+                   activity.extended_details.details['imported_samples_data']
+      assert_equal 'project_import_samples', activity.parameters[:action]
+
+      # verify project activity 2
+      activity = PublicActivity::Activity.where(
+        key: 'namespaces_project_namespace.import_samples.create'
+      ).order(created_at: :desc).second
+
+      assert_equal 'namespaces_project_namespace.import_samples.create', activity.key
+      assert_equal @john_doe, activity.owner
+      assert_equal 1, activity.parameters[:imported_samples_count]
+      sample_1 = Sample.find_by(name: 'my new sample 1')
+      assert_equal [{ 'sample_name' => sample_1.name, 'sample_puid' => sample_1.puid }],
+                   activity.extended_details.details['imported_samples_data']
+      assert_equal 'project_import_samples', activity.parameters[:action]
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR extends the activities created from performing sample imports

## Screenshots or screen recordings
Project Import:
![image](https://github.com/user-attachments/assets/904d5fd7-d532-44fd-a436-628dd982fe65)

Group Import:
![image](https://github.com/user-attachments/assets/00b13be4-45a9-410c-944a-4aa1969fb642)

## How to set up and validate locally
1. Navigate to a project that you can import samples
2. Upload `test/fixtures/files/batch_sample_import/project/valid.csv`
3. Import the samples, and verify the activity displays as expected
4. Create a group with two projects
5. Open `test/fixtures/files/batch_sample_import/group/valid.csv` and replace the project puids with each project (so each project has 1 sample assigned)
6. On the group samples page, import the above csv
7. Verify the group activities lists the two samples with the correct associated project
8. Navigate to each of the 2 project's activity pages, and verify each activity contains only the sample corresponding to that project based on the csv

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
