### PR TITLE
Workflow Executions: Display namespace on summary page

### DIFF
--- a/app/components/namespace_tree/row/row_contents_component.html.erb
+++ b/app/components/namespace_tree/row/row_contents_component.html.erb
@@ -12,7 +12,7 @@
 <div class="flex items-center ml-2 namespace-text-container grow">
   <div class="flex flex-col namespace-text">
     <div class="flex flex-wrap items-center space-x-2 font-semibold title">
-      <%= link_to namespace_path, data: { turbo: false }, class: "hover:underline" do %>
+      <%= link_to namespace_path(@namespace), data: { turbo: false }, class: "hover:underline" do %>
         <%= highlight(
           @namespace.name,
           defined?(@search_params[:name_or_puid_cont]) &&

--- a/app/components/namespace_tree/row/row_contents_component.rb
+++ b/app/components/namespace_tree/row/row_contents_component.rb
@@ -4,7 +4,7 @@ module NamespaceTree
   module Row
     # Component for the contents of NamespaceTree row
     class RowContentsComponent < Viral::Component
-      include NamespaceHelper
+      include NamespacePathHelper
 
       # rubocop:disable Metrics/ParameterLists
       def initialize(namespace:, path: nil, path_args: {}, collapsed: false, icon_size: :small, search_params: nil)

--- a/app/components/namespace_tree/row/row_contents_component.rb
+++ b/app/components/namespace_tree/row/row_contents_component.rb
@@ -4,6 +4,8 @@ module NamespaceTree
   module Row
     # Component for the contents of NamespaceTree row
     class RowContentsComponent < Viral::Component
+      include NamespaceHelper
+
       # rubocop:disable Metrics/ParameterLists
       def initialize(namespace:, path: nil, path_args: {}, collapsed: false, icon_size: :small, search_params: nil)
         @namespace = namespace
@@ -20,14 +22,6 @@ module NamespaceTree
           :squares_2x2
         elsif @namespace.type == 'Project'
           :rectangle_stack
-        end
-      end
-
-      def namespace_path
-        if @namespace.type == 'Group'
-          group_path(@namespace)
-        elsif @namespace.type == 'Project'
-          namespace_project_path(@namespace.parent, @namespace.project)
         end
       end
     end

--- a/app/controllers/concerns/workflow_execution_actions.rb
+++ b/app/controllers/concerns/workflow_execution_actions.rb
@@ -4,7 +4,7 @@
 module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
   include ListActions
-  include NamespaceHelper
+  include NamespacePathHelper
 
   included do
     before_action :set_default_tab, only: :show

--- a/app/controllers/concerns/workflow_execution_actions.rb
+++ b/app/controllers/concerns/workflow_execution_actions.rb
@@ -4,6 +4,7 @@
 module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
   include ListActions
+  include NamespaceHelper
 
   included do
     before_action :set_default_tab, only: :show
@@ -72,7 +73,7 @@ module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
     when 'samplesheet'
       format_samplesheet_params
     when 'summary'
-      @namespace_path = namespace_path
+      @namespace_path = namespace_path(@workflow_execution.namespace)
     end
   end
 
@@ -263,13 +264,5 @@ module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
     search_params = {}
     search_params[:name_or_id_cont] = params.dig(:q, :name_or_id_cont)
     search_params
-  end
-
-  def namespace_path
-    if @workflow_execution.namespace.group_namespace?
-      group_path(@workflow_execution.namespace)
-    elsif @workflow_execution.namespace.project_namespace?
-      namespace_project_path(@workflow_execution.namespace.parent, @workflow_execution.namespace.project)
-    end
   end
 end

--- a/app/helpers/namespace_helper.rb
+++ b/app/helpers/namespace_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Helper for namespace paths
+module NamespaceHelper
+  def namespace_path(namespace)
+    if namespace.type == 'Group'
+      group_path(namespace)
+    elsif namespace.type == 'Project'
+      namespace_project_path(namespace.parent, namespace.project)
+    end
+  end
+end

--- a/app/helpers/namespace_helper.rb
+++ b/app/helpers/namespace_helper.rb
@@ -3,9 +3,9 @@
 # Helper for namespace paths
 module NamespaceHelper
   def namespace_path(namespace)
-    if namespace.type == 'Group'
+    if namespace.group_namespace?
       group_path(namespace)
-    elsif namespace.type == 'Project'
+    elsif namespace.project_namespace?
       namespace_project_path(namespace.parent, namespace.project)
     end
   end

--- a/app/helpers/namespace_path_helper.rb
+++ b/app/helpers/namespace_path_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Helper for namespace paths
-module NamespaceHelper
+module NamespacePathHelper
   def namespace_path(namespace)
     if namespace.group_namespace?
       group_path(namespace)

--- a/app/views/workflow_executions/_summary.html.erb
+++ b/app/views/workflow_executions/_summary.html.erb
@@ -34,7 +34,13 @@
       <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= @workflow_execution.metadata["workflow_version"] %></dd>
     </div>
     <div class="flex flex-col py-3">
-      <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400">Namespace</dt>
+      <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400">
+        <% if @workflow_execution.shared_with_namespace %>
+          <%= t(:".shared_with_namespace.#{@workflow_execution.namespace.type.downcase}") %>
+        <% else %>
+          <%= t(:".run_from_namespace.#{@workflow_execution.namespace.type.downcase}") %>
+        <% end %>
+      </dt>
       <dd class="text-lg font-semibold text-slate-900 dark:text-white ">
         <div class="flex items-center space-x-2">
           <%= link_to @workflow_execution.namespace.name,
@@ -50,19 +56,6 @@
         </div>
       </dd>
     </div>
-    <% if @workflow_execution.shared_with_namespace %>
-      <div class="flex flex-col py-3">
-        <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".shared_with_namespace.#{@workflow_execution.namespace.type.downcase}") %></dt>
-        <dd class="text-lg font-semibold text-slate-900 dark:text-white">
-          <%= link_to @workflow_execution.namespace.name,
-          @namespace_path,
-          data: {
-            turbo: false,
-          },
-          class: "hover:underline" %>
-        </dd>
-      </div>
-    <% end %>
     <div class="flex flex-col py-3">
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".created_at") %></dt>
       <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= local_time(@workflow_execution.created_at, :full_date) %></dd>

--- a/app/views/workflow_executions/_summary.html.erb
+++ b/app/views/workflow_executions/_summary.html.erb
@@ -33,6 +33,23 @@
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".workflow_version") %></dt>
       <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= @workflow_execution.metadata["workflow_version"] %></dd>
     </div>
+    <div class="flex flex-col py-3">
+      <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400">Namespace</dt>
+      <dd class="text-lg font-semibold text-slate-900 dark:text-white ">
+        <div class="flex items-center space-x-2">
+          <%= link_to @workflow_execution.namespace.name,
+          @namespace_path,
+          data: {
+            turbo: false,
+          },
+          class: "hover:underline" %>
+          <%= render PuidComponent.new(
+            puid: @workflow_execution.namespace.puid,
+            show_clipboard: false,
+          ) %>
+        </div>
+      </dd>
+    </div>
     <% if @workflow_execution.shared_with_namespace %>
       <div class="flex flex-col py-3">
         <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".shared_with_namespace.#{@workflow_execution.namespace.type.downcase}") %></dt>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2244,6 +2244,9 @@ en:
     summary:
       created_at: Created
       name: Name
+      run_from_namespace:
+        group: Run from Group
+        project: Run from Project
       run_id: Run ID
       shared_with_namespace:
         group: Shared with Group

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2240,6 +2240,9 @@ fr:
     summary:
       created_at: Créé
       name: Nom
+      run_from_namespace:
+        group: Run from Group
+        project: Run from Project
       run_id: Exécuter l’identifiant
       shared_with_namespace:
         group: Shared with Group

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -463,6 +463,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_no_selector 'dt', text: I18n.t(:"workflow_executions.summary.shared_with_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
     assert_selector 'dt', text: I18n.t(:"workflow_executions.summary.run_from_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
     assert_selector 'dd', text: workflow_execution.namespace.name
+    assert_selector 'dd', text: workflow_execution.namespace.puid
     ### VERIFY END ###
 
     ### ACTIONS START ###
@@ -491,6 +492,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_no_selector 'dt', text: I18n.t(:"workflow_executions.summary.run_from_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
     assert_selector 'dt', text: I18n.t(:"workflow_executions.summary.shared_with_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
     assert_selector 'dd', text: workflow_execution.namespace.name
+    assert_selector 'dd', text: workflow_execution.namespace.puid
 
     ### VERIFY END ###
   end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -460,6 +460,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     ### VERIFY START ###
     assert_selector 'h1', text: workflow_execution.metadata['workflow_name']
     assert_no_selector 'dt', exact_text: dt_value
+    assert_no_selector 'dt', text: I18n.t(:"workflow_executions.summary.shared_with_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
+    assert_selector 'dt', text: I18n.t(:"workflow_executions.summary.run_from_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
+    assert_selector 'dd', text: workflow_execution.namespace.name
     ### VERIFY END ###
 
     ### ACTIONS START ###
@@ -485,6 +488,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector 'h1', text: new_we_name
     assert_selector 'dt', text: dt_value
     assert_selector 'dd', text: new_we_name
+    assert_no_selector 'dt', text: I18n.t(:"workflow_executions.summary.run_from_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
     assert_selector 'dt', text: I18n.t(:"workflow_executions.summary.shared_with_namespace.#{workflow_execution.namespace.type.downcase}") # rubocop:disable Layout/LineLength
     assert_selector 'dd', text: workflow_execution.namespace.name
 


### PR DESCRIPTION
## What does this PR do and why?
After #1036, it was requested that we display the name of the group/project that the workflow was run from.
STRY0017999

## Screenshots or screen recordings
![image](https://github.com/user-attachments/assets/64a6feeb-2a5d-4483-9bc5-d33c45081273)

## How to set up and validate locally
1. Run a workflow execution. 
1. Click on the ID of the workflow execution which was just launched.
1. Verify the Group/Project is displayed on the summary page.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
