### PR TITLE
Fix for sorting samples table by project column

### DIFF
--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -31,7 +31,6 @@
                     selection_target: "selectPage",
                   } %>
                 <% end %>
-                <%# i18n-tasks-use t('samples.table_component.namespaces.puid') %>
                 <%= render SortComponent.new(
                   sort: @search_params[:sort],
                   label: t(".#{column}"),

--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -31,7 +31,7 @@
                     selection_target: "selectPage",
                   } %>
                 <% end %>
-
+                <%# i18n-tasks-use t('samples.table_component.namespaces.puid') %>
                 <%= render SortComponent.new(
                   sort: @search_params[:sort],
                   label: t(".#{column}"),

--- a/app/components/samples/table_component.html.erb
+++ b/app/components/samples/table_component.html.erb
@@ -106,7 +106,7 @@
                         ) %>
                       </span>
                     <% end %>
-                  <% elsif column == :project_id %>
+                  <% elsif column == "namespaces.puid" %>
                     <%= link_to sample.project.puid,
                     namespace_project_samples_path(sample.project.namespace.parent, sample.project),
                     data: {

--- a/app/components/samples/table_component.rb
+++ b/app/components/samples/table_component.rb
@@ -97,7 +97,7 @@ module Samples
 
     def columns
       columns = %i[puid name]
-      columns << :project_id if @namespace.type == 'Group'
+      columns << 'namespaces.puid' if @namespace.type == 'Group'
       columns += %i[created_at updated_at attachments_updated_at]
       columns
     end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -158,6 +158,7 @@ ignore_unused:
   - "activity.*"
   - "devise.*"
   - "viral.data_table_component.*"
+  - "samples.table_component.namespaces.puid"
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1877,7 +1877,8 @@ en:
       limit:
         item: Samples
       name: Sample Name
-      project_id: Project
+      namespaces:
+        puid: Project
       puid: Sample ID
       select_page: Select / Deselect visible samples
       updated_at: Last Updated

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1873,7 +1873,8 @@ fr:
       limit:
         item: Échantillons
       name: Nom de l’échantillon
-      project_id: Projet
+      namespaces:
+        puid: Projet
       puid: ID de l’échantillon
       select_page: Sélectionner/Désélectionner les échantillons visibles
       updated_at: Dernière mise à jour

--- a/test/components/samples/table_component_test.rb
+++ b/test/components/samples/table_component_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Samples
+  class TableComponentTest < ViewComponent::TestCase
+    test 'Should render a table of samples for a group sort by the project column' do
+      with_request_url '/-/groups/group-1/-/samples' do
+        namespace = groups(:group_one)
+        project_ids = Project.where(namespace_id: namespace.project_namespace_ids).pluck(:id)
+        query = Sample::Query.new({ sort: 'namespaces.puid asc', project_ids: project_ids })
+        pagy, samples = query.results(limit: 50, page: 1)
+        samples = samples.includes(project: { namespace: :parent })
+
+        render_inline Samples::TableComponent.new(
+          samples,
+          namespace,
+          pagy,
+          has_samples: namespace.has_samples?,
+          abilities: {
+            select_samples: true,
+            edit_sample_metadata: true
+          },
+          metadata_fields: [],
+          search_params: { metadata_template: 'none', sort: 'namespaces.puid asc' },
+          empty: {
+            title: I18n.t(:'groups.samples.table.no_samples'),
+            description: I18n.t(:'groups.samples.table.no_associated_samples')
+          }
+        )
+
+        assert_selector 'table', count: 1
+        assert_selector 'table thead th', count: 6
+        assert_selector 'table tbody tr', count: samples.count
+        previous_project_puid = ''
+        samples.each do |sample|
+          assert_selector 'table tbody tr td:nth-child(2)', text: sample.name
+          assert_selector 'table tbody tr td:nth-child(3)', text: sample.project.puid
+          # verify the samples are sorted
+          assert previous_project_puid <= sample.project.puid
+          previous_project_puid = sample.project.puid
+        end
+      end
+    end
+  end
+end

--- a/test/components/samples/table_component_test.rb
+++ b/test/components/samples/table_component_test.rb
@@ -4,10 +4,10 @@ require 'test_helper'
 
 module Samples
   class TableComponentTest < ViewComponent::TestCase
-    test 'Should render a table of samples for a group sort by the project column' do
+    test 'Should render a table of samples for a group that are sorted by the project column' do
       with_request_url '/-/groups/group-1/-/samples' do
         namespace = groups(:group_one)
-        project_ids = Project.where(namespace_id: namespace.project_namespace_ids).pluck(:id)
+        project_ids = namespace.project_namespaces.pluck(:id)
         query = Sample::Query.new({ sort: 'namespaces.puid asc', project_ids: project_ids })
         pagy, samples = query.results(limit: 50, page: 1)
         samples = samples.includes(project: { namespace: :parent })

--- a/test/components/samples/table_component_test.rb
+++ b/test/components/samples/table_component_test.rb
@@ -32,6 +32,7 @@ module Samples
         assert_selector 'table', count: 1
         assert_selector 'table thead th', count: 6
         assert_selector 'table tbody tr', count: samples.count
+        assert_selector 'table thead th:nth-child(3) svg.icon-arrow_up'
         previous_project_puid = ''
         samples.each do |sample|
           assert_selector 'table tbody tr td:nth-child(2)', text: sample.name

--- a/test/components/samples/table_component_test.rb
+++ b/test/components/samples/table_component_test.rb
@@ -7,7 +7,7 @@ module Samples
     test 'Should render a table of samples for a group that are sorted by the project column' do
       with_request_url '/-/groups/group-1/-/samples' do
         namespace = groups(:group_one)
-        project_ids = namespace.project_namespaces.pluck(:id)
+        project_ids = Project.where(namespace_id: namespace.project_namespace_ids).pluck(:id)
         query = Sample::Query.new({ sort: 'namespaces.puid asc', project_ids: project_ids })
         pagy, samples = query.results(limit: 50, page: 1)
         samples = samples.includes(project: { namespace: :parent })
@@ -31,8 +31,16 @@ module Samples
 
         assert_selector 'table', count: 1
         assert_selector 'table thead th', count: 6
-        assert_selector 'table tbody tr', count: samples.count
+        assert_selector 'table thead th:first-child', text: I18n.t('samples.table_component.puid')
+        assert_selector 'table thead th:nth-child(2)', text: I18n.t('samples.table_component.name')
+        assert_selector 'table thead th:nth-child(3)', text: I18n.t('samples.table_component.namespaces.puid')
         assert_selector 'table thead th:nth-child(3) svg.icon-arrow_up'
+        assert_selector 'table thead th:nth-child(4)', text: I18n.t('samples.table_component.created_at')
+        assert_selector 'table thead th:nth-child(5)', text: I18n.t('samples.table_component.updated_at')
+        assert_selector 'table thead th:nth-child(6)',
+                        text: I18n.t('samples.table_component.attachments_updated_at')
+        assert_selector 'table tbody tr', count: samples.count
+
         previous_project_puid = ''
         samples.each do |sample|
           assert_selector 'table tbody tr td:nth-child(2)', text: sample.name


### PR DESCRIPTION
## What does this PR do and why?
Fix for sorting the project column of the group samples table.
Fixes #833.

## Screenshots or screen recordings
https://github.com/user-attachments/assets/4e325bdd-16db-4735-a738-712182a2ff1b

## How to set up and validate locally
1. Navigate to a group samples page.
2. Verify the sort works on the `Project` column.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
