### PR TITLE
Consistent reference for Sample ID

### DIFF
--- a/app/jobs/data_exports/create_job.rb
+++ b/app/jobs/data_exports/create_job.rb
@@ -321,7 +321,7 @@ module DataExports
     end
 
     def write_spreadsheet_header(metadata_fields)
-      header = ['SAMPLE ID', 'SAMPLE NAME', 'PROJECT ID']
+      header = ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID']
       header += metadata_fields.map(&:upcase)
       header
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -417,7 +417,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -555,7 +555,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: 'Keys deleted:'
+      keys_deleted: "Keys deleted:"
       previous_version: Previous (Version %{version})
     layout:
       language_selection:
@@ -598,7 +598,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: 'File %{filename} was not removed due to the following errors: %{errors}'
+        error: "File %{filename} was not removed due to the following errors: %{errors}"
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -715,14 +715,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Name:'
-      run_id: 'Run ID:'
-      workflow: 'Workflow:'
+      id: "ID:"
+      name: "Name:"
+      run_id: "Run ID:"
+      workflow: "Workflow:"
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: 'Export Name (Optional):'
+      name_label: "Export Name (Optional):"
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -790,7 +790,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: '1 error prohibited this %{resource} from being saved:'
+        one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -825,7 +825,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -889,11 +889,11 @@ en:
         delete:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning:
               post_html: After you delete a group, you <strong>cannot</strong> restore it or its components.
-              pre_html: 'You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:'
+              pre_html: "You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:"
               projects_count: "%{count} project(s)"
               samples_count: "%{count} sample(s)"
               subgroups_count: "%{count} subgroup(s)"
@@ -908,18 +908,18 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer group to another parent group.
+            - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-          - Be careful. Changing a group's parent can have unintended side effects.
-          - You can only transfer groups where you have sufficient permissions.
-          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+            - Be careful. Changing a group's parent can have unintended side effects.
+            - You can only transfer groups where you have sufficient permissions.
+            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1115,7 +1115,7 @@ en:
   layouts:
     application:
       language_selection:
-        aria_label: 'Selected language: English'
+        aria_label: "Selected language: English"
       site_title: IRIDA Next
   locales:
     en: English
@@ -1126,10 +1126,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: 'To view and download the export, click the button below:'
+        view_exports: "To view and download the export, click the button below:"
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: 'Or copy and paste this link into your browser:'
+      copy_paste: "Or copy and paste this link into your browser:"
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1137,11 +1137,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
+        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1152,15 +1152,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: 'To view %{type} ''%{name}'', click the button below:'
+        view_details: "To view %{type} '%{name}', click the button below:"
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
+        view_details: "To view all the members of %{type} '%{name}', click the button below:"
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1177,7 +1177,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: 'To view the pipeline summary, click the button below:'
+      view_details: "To view the pipeline summary, click the button below:"
   members:
     access_levels:
       level_0: No Access
@@ -1256,7 +1256,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: 'The following samples are missing required data: '
+    data_missing_error: "The following samples are missing required data: "
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1287,8 +1287,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-        - All projects and groups you own will be deleted
-        - All projects and groups you are a member of will be left intact
+          - All projects and groups you own will be deleted
+          - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1352,7 +1352,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1380,7 +1380,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: 'Editing Automated Pipeline: %{workflow_name}'
+        title: "Editing Automated Pipeline: %{workflow_name}"
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1447,12 +1447,12 @@ en:
         destroy:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning:
               automated_workflows_count: "%{count} automated workflow execution(s)"
               post_html: After you delete a project, you <strong>cannot</strong> restore it or its components.
-              pre_html: 'You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:'
+              pre_html: "You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:"
               samples_count: "%{count} sample(s)"
           description: Deleting a project is permanent and cannot be undone. All samples and direct members will be deleted along with the project.
           submit: Delete project
@@ -1466,20 +1466,20 @@ en:
         transfer:
           confirm:
             points_html:
-            - To prevent accidental actions we ask you to confirm your intention.
-            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+              - To prevent accidental actions we ask you to confirm your intention.
+              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-          - Transfer your project into another namespace.
-          - When you transfer your project to a group, you can easily manage multiple projects and users.
-          - 'Things to be aware of before transferring your project:'
+            - Transfer your project into another namespace.
+            - When you transfer your project to a group, you can easily manage multiple projects and users.
+            - "Things to be aware of before transferring your project:"
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-          - Be careful! Changing a project's namespace can have unintended side effects.
-          - You can only transfer projects to groups where you have sufficient permissions.
-          - Project visibility level will change to match namespace rules when transferring to a group.
+            - Be careful! Changing a project's namespace can have unintended side effects.
+            - You can only transfer projects to groups where you have sufficient permissions.
+            - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1598,11 +1598,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: 'The following files were selected to be concatenated:'
+            description: "The following files were selected to be concatenated:"
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
+          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1610,20 +1610,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: 'File %{filename} was not removed due to the following errors: %{errors}'
+            error: "File %{filename} was not removed due to the following errors: %{errors}"
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: 'The following files were selected for deletion:'
+            description: "The following files were selected for deletion:"
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: 'File %{filename} was not removed due to the following errors: %{errors}'
+          error: "File %{filename} was not removed due to the following errors: %{errors}"
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: 'The following list of samples failed to copy:'
-          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
+          error: "The following list of samples failed to copy:"
+          no_samples_cloned_error: "Samples were not copied for the following reasons:"
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1654,8 +1654,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
-            singular: 'The following sample has been selected for deletion:'
+            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
+            singular: "The following sample has been selected for deletion:"
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1683,7 +1683,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: 'Metadata fields selected for deletion:'
+            description: "Metadata fields selected for deletion:"
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1723,7 +1723,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
+        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1775,8 +1775,8 @@ en:
           placeholder: Filter by ID or name
       transfers:
         create:
-          error: 'The following list of samples failed to transfer:'
-          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
+          error: "The following list of samples failed to transfer:"
+          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1881,7 +1881,7 @@ en:
       name: Sample Name
       namespaces:
         puid: Project
-      puid: Sample ID
+      puid: Sample PUID
       select_page: Select / Deselect visible samples
       updated_at: Last Updated
   services:
@@ -1951,8 +1951,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1975,8 +1975,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
-        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
+        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
+        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
     spreadsheet_import:
       csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
@@ -2029,19 +2029,19 @@ en:
             namespace:
               description: The spreadsheet is required to have a column that contains a sample identifier.
               group:
-                description_html: The identifier is case-sensitive and must contain the <b>sample ID</b>.
+                description_html: The identifier is case-sensitive and must contain the <b>sample PUID</b>.
               project:
-                description_html: The identifier is case-sensitive and can contain either the <b>sample name or ID</b>.
+                description_html: The identifier is case-sensitive and can contain either the <b>sample name or PUID</b>.
             no_valid_metadata: The uploaded spreadsheet contains no viable metadata
-            sample_id_column: Sample ID Column
-            select_sample_id_column: Select a Sample ID Column
+            sample_id_column: Sample Identifier Column
+            select_sample_id_column: Select a Sample Identifier Column
             selected: Selected
             spinner_message: Importing sample metadata, this might take a while...
             submit_button: Import Metadata
             title: Upload Sample Metadata
             uploading: Uploading
           errors:
-            description: 'The sample metadata import completed with the following errors:'
+            description: "The sample metadata import completed with the following errors:"
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -2088,7 +2088,7 @@ en:
           title: Import Samples
           uploading: Uploading
         errors:
-          description: 'The sample import completed with the following errors:'
+          description: "The sample import completed with the following errors:"
           ok_button: OK
         success:
           description: The sample spreadsheet has been processed.
@@ -2106,16 +2106,16 @@ en:
         title: Delete Workflow Executions
         workflow_executions: Workflow Executions
       list_workflow_execution:
-        id: 'ID:'
-        name: 'Name:'
-        run_id: 'Run ID:'
-        workflow: 'Workflow:'
+        id: "ID:"
+        name: "Name:"
+        run_id: "Run ID:"
+        workflow: "Workflow:"
   spreadsheet_helper:
-    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
+    failed_parsing: "Failed to parse spreadsheet file: %{error}"
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
-    unknown_file_format: 'Unknown file type: %{extension}'
+    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
+    unknown_file_format: "Unknown file type: %{extension}"
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -2170,7 +2170,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: 'The following errors prevented the Workflow Execution from being created:'
+      error_message: "The following errors prevented the Workflow Execution from being created:"
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -417,7 +417,7 @@ en:
         title: Delete File
       new_attachment_component:
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         upload: Upload
         upload_files: Upload Files
         uploading: Uploading
@@ -555,7 +555,7 @@ en:
       transferred_by: "%{type} transferred by %{user}"
     history_version:
       current_version: Current (Version %{version})
-      keys_deleted: "Keys deleted:"
+      keys_deleted: 'Keys deleted:'
       previous_version: Previous (Version %{version})
     layout:
       language_selection:
@@ -598,7 +598,7 @@ en:
   concerns:
     attachment_actions:
       destroy:
-        error: "File %{filename} was not removed due to the following errors: %{errors}"
+        error: 'File %{filename} was not removed due to the following errors: %{errors}'
     bot_actions:
       create:
         success: Bot account was successfully added
@@ -715,14 +715,14 @@ en:
         status: Status
       title: Data Exports
     list_workflow_execution:
-      id: "ID:"
-      name: "Name:"
-      run_id: "Run ID:"
-      workflow: "Workflow:"
+      id: 'ID:'
+      name: 'Name:'
+      run_id: 'Run ID:'
+      workflow: 'Workflow:'
     new:
       after_submission_description_html: After submission, you will be redirected to the export page. While the export status is <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">processing</span>, the contents of the export are being created. Once the export status is <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">ready</span>, it will be available for download. You will have 3 business days to download the export before it's deleted.
       email_label: Receive an email notification when your export is ready to download?
-      name_label: "Export Name (Optional):"
+      name_label: 'Export Name (Optional):'
       sample_description:
         plural: This export will contain COUNT_PLACEHOLDER samples.
         singular: This export will contain 1 sample.
@@ -790,7 +790,7 @@ en:
   errors:
     messages:
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
   general:
     default_sidebar:
@@ -825,7 +825,7 @@ en:
       title: Group activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -889,11 +889,11 @@ en:
         delete:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning:
               post_html: After you delete a group, you <strong>cannot</strong> restore it or its components.
-              pre_html: "You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:"
+              pre_html: 'You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:'
               projects_count: "%{count} project(s)"
               samples_count: "%{count} sample(s)"
               subgroups_count: "%{count} subgroup(s)"
@@ -908,18 +908,18 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{group_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer group to another parent group.
+          - Transfer group to another parent group.
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a parent group
           no_available_namespaces: You do not have access to any destination namespaces to transfer this group
           points:
-            - Be careful. Changing a group's parent can have unintended side effects.
-            - You can only transfer groups where you have sufficient permissions.
-            - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - Be careful. Changing a group's parent can have unintended side effects.
+          - You can only transfer groups where you have sufficient permissions.
+          - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
           select_group: Select Group
           submit: Transfer group
           title: Transfer group
@@ -1115,7 +1115,7 @@ en:
   layouts:
     application:
       language_selection:
-        aria_label: "Selected language: English"
+        aria_label: 'Selected language: English'
       site_title: IRIDA Next
   locales:
     en: English
@@ -1126,10 +1126,10 @@ en:
       export_ready:
         download_before_html: Please download the export before <strong>%{date}</strong> as it will be deleted after this time.
         ready_for_download_html: Your export <strong>%{name}</strong> is ready for download.
-        view_exports: "To view and download the export, click the button below:"
+        view_exports: 'To view and download the export, click the button below:'
     email_template:
       automated_message: This email was sent from an automated system. Please do not reply to this email.
-      copy_paste: "Or copy and paste this link into your browser:"
+      copy_paste: 'Or copy and paste this link into your browser:'
       greeting: Hello,
       greeting_with_name: Hello %{name},
       thanks: Thanks,
@@ -1137,11 +1137,11 @@ en:
       access_granted_manager_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view all the members of %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view all the members of %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "To view %{namespace_type} '%{namespace_name}', click the button below:"
+        view_details: 'To view %{namespace_type} ''%{namespace_name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{namespace_type} '%{namespace_name}' access has been <strong>revoked</strong> for Group '%{group_name}'"
         subject: "%{namespace_type} '%{namespace_name}' access has been revoked for Group '%{group_name}'"
@@ -1152,15 +1152,15 @@ en:
       access_granted_manager_email:
         body_html: User '%{first_name} %{last_name}' (%{email}) has been <strong>granted</strong> access to %{type} '%{name}'
         subject: User '%{first_name} %{last_name}' (%{email}) has been granted access to %{type} '%{name}'
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_granted_user_email:
         body_html: You have been <strong>granted</strong> access to %{type} '%{name}'
         subject: You have been granted access to %{type} '%{name}'
-        view_details: "To view %{type} '%{name}', click the button below:"
+        view_details: 'To view %{type} ''%{name}'', click the button below:'
       access_revoked_manager_email:
         body_html: "%{type} '%{name}' access has been <strong>revoked</strong> for User '%{first_name} %{last_name}' (%{email})"
         subject: "%{type} '%{name}' access has been revoked for User '%{first_name} %{last_name}' (%{email})"
-        view_details: "To view all the members of %{type} '%{name}', click the button below:"
+        view_details: 'To view all the members of %{type} ''%{name}'', click the button below:'
       access_revoked_user_email:
         body_html: Your access to %{type} '%{name}' has been <strong>revoked</strong>
         subject: Your access to %{type} '%{name}' has been revoked
@@ -1177,7 +1177,7 @@ en:
       error_user_email:
         body_html: Your pipeline <strong>%{id}</strong> did not complete successfully due to errors.
         subject: Pipeline Errored - %{id}
-      view_details: "To view the pipeline summary, click the button below:"
+      view_details: 'To view the pipeline summary, click the button below:'
   members:
     access_levels:
       level_0: No Access
@@ -1256,7 +1256,7 @@ en:
         aria_label: Pagination page selector
       previous: Previous
   nextflow_component:
-    data_missing_error: "The following samples are missing required data: "
+    data_missing_error: 'The following samples are missing required data: '
     filtering_samples: Filtering samples, this may take some time.
     name:
       helper: A custom name will make it easier to search for this in the future.
@@ -1287,8 +1287,8 @@ en:
         confirm: Are you sure you want to delete your account?
         description: Deleting your account has the following effects
         effects:
-          - All projects and groups you own will be deleted
-          - All projects and groups you are a member of will be left intact
+        - All projects and groups you own will be deleted
+        - All projects and groups you are a member of will be left intact
     passwords:
       update:
         forgot: Forgot your password?
@@ -1352,7 +1352,7 @@ en:
       title: Project Activity
     attachments:
       create:
-        failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+        failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
         success: File %{filename} was successfully uploaded.
       destroy:
         success: File %{filename} was successfully removed.
@@ -1380,7 +1380,7 @@ en:
       edit:
         error: Cannot edit automated pipeline %{workflow_name}
       edit_dialog:
-        title: "Editing Automated Pipeline: %{workflow_name}"
+        title: 'Editing Automated Pipeline: %{workflow_name}'
       index:
         add_new_automated_workflow_execution: New automated pipeline
         subtitle: Setup automated pipelines to launch when paired-end data is uploaded to the project
@@ -1447,12 +1447,12 @@ en:
         destroy:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning:
               automated_workflows_count: "%{count} automated workflow execution(s)"
               post_html: After you delete a project, you <strong>cannot</strong> restore it or its components.
-              pre_html: "You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:"
+              pre_html: 'You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:'
               samples_count: "%{count} sample(s)"
           description: Deleting a project is permanent and cannot be undone. All samples and direct members will be deleted along with the project.
           submit: Delete project
@@ -1466,20 +1466,20 @@ en:
         transfer:
           confirm:
             points_html:
-              - To prevent accidental actions we ask you to confirm your intention.
-              - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{project}</kbd> to proceed or close this dialog to cancel.
             warning_html: You are going to transfer <strong>%{project_name}</strong> to another namespace. Once you confirm, this action cannot be undone.
           descriptions:
-            - Transfer your project into another namespace.
-            - When you transfer your project to a group, you can easily manage multiple projects and users.
-            - "Things to be aware of before transferring your project:"
+          - Transfer your project into another namespace.
+          - When you transfer your project to a group, you can easily manage multiple projects and users.
+          - 'Things to be aware of before transferring your project:'
           empty_state: No namespaces are associated with that name or ID
           new_namespace_id: Select a new namespace
           no_available_namespaces: You do not have access to any destination namespaces to transfer this project
           points:
-            - Be careful! Changing a project's namespace can have unintended side effects.
-            - You can only transfer projects to groups where you have sufficient permissions.
-            - Project visibility level will change to match namespace rules when transferring to a group.
+          - Be careful! Changing a project's namespace can have unintended side effects.
+          - You can only transfer projects to groups where you have sufficient permissions.
+          - Project visibility level will change to match namespace rules when transferring to a group.
           select_namespace: Select Namespace
           submit: Transfer project
           title: Transfer project
@@ -1598,11 +1598,11 @@ en:
             success: Files were successfully concatenated.
           modal:
             basename: Filename
-            description: "The following files were selected to be concatenated:"
+            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:
-          failure: "File %{filename} was not uploaded due to the following errors: %{errors}"
+          failure: 'File %{filename} was not uploaded due to the following errors: %{errors}'
           success: File %{filename} was successfully uploaded.
         delete_attachment_modal:
           description: Are you sure that you want to delete this file from the sample?
@@ -1610,20 +1610,20 @@ en:
           title: Delete File
         deletions:
           destroy:
-            error: "File %{filename} was not removed due to the following errors: %{errors}"
+            error: 'File %{filename} was not removed due to the following errors: %{errors}'
             partial_success: Some files were successfully deleted.
             success: Files were successfully deleted.
           modal:
-            description: "The following files were selected for deletion:"
+            description: 'The following files were selected for deletion:'
             submit_button: Delete
             title: Delete Files
         destroy:
-          error: "File %{filename} was not removed due to the following errors: %{errors}"
+          error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
       clones:
         create:
-          error: "The following list of samples failed to copy:"
-          no_samples_cloned_error: "Samples were not copied for the following reasons:"
+          error: 'The following list of samples failed to copy:'
+          no_samples_cloned_error: 'Samples were not copied for the following reasons:'
           success: Samples were successfully copied.
         dialog:
           description:
@@ -1654,8 +1654,8 @@ en:
           title: Delete Sample
         new_multiple_deletions_dialog:
           description:
-            plural: "The following COUNT_PLACEHOLDER samples have been selected for deletion:"
-            singular: "The following sample has been selected for deletion:"
+            plural: 'The following COUNT_PLACEHOLDER samples have been selected for deletion:'
+            singular: 'The following sample has been selected for deletion:'
             zero: No samples have been selected for deletion
           loading: Loading...
           samples: Samples
@@ -1683,7 +1683,7 @@ en:
             multi_success: Metadata keys '%{deleted_keys}' were successfully deleted.
             single_success: Metadata key '%{deleted_key}' was successfully deleted.
           modal:
-            description: "Metadata fields selected for deletion:"
+            description: 'Metadata fields selected for deletion:'
             key_header: Key
             submit_button: Delete
             title: Delete Metadata
@@ -1723,7 +1723,7 @@ en:
         delete_metadata_button: Delete Metadata
         edit_button: Edit this sample
         files: Files
-        files_ignored: "fasta and fastq files must be compressed. The following file(s) cannot be uploaded:"
+        files_ignored: 'fasta and fastq files must be compressed. The following file(s) cannot be uploaded:'
         history:
           modal:
             created_by: Sample created by %{user}
@@ -1775,8 +1775,8 @@ en:
           placeholder: Filter by PUID or name
       transfers:
         create:
-          error: "The following list of samples failed to transfer:"
-          no_samples_transferred_error: "Samples were not transferred for the following reasons:"
+          error: 'The following list of samples failed to transfer:'
+          no_samples_transferred_error: 'Samples were not transferred for the following reasons:'
           success: Samples were successfully transferred.
         dialog:
           description:
@@ -1951,8 +1951,8 @@ en:
         empty_new_project_id: Destination project was not selected.
         empty_sample_ids: The sample ids are empty.
         same_project: The source and destination projects are the same. Please select a different destination project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be copied as they were not found in the source project: %{sample_ids}'
       metadata:
         empty_metadata: No metadata was received to update sample '%{sample_name}'
         fields:
@@ -1975,8 +1975,8 @@ en:
         empty_sample_ids: The sample ids are empty.
         maintainer_transfer_not_allowed: A maintainer can only transfer samples to other projects within the same hierarchy with a common ancestor
         same_project: The samples already exist in the project. Please select a different project.
-        sample_exists: "Sample %{sample_puid}: Conflicts with sample named '%{sample_name}' in the target project"
-        samples_not_found: "Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}"
+        sample_exists: 'Sample %{sample_puid}: Conflicts with sample named ''%{sample_name}'' in the target project'
+        samples_not_found: 'Samples with the following sample ids could not be transferred as they were not found in the source project: %{sample_ids}'
     spreadsheet_import:
       csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: The file has duplicate column header names. Please remove the columns with duplicate header names and retry uploading.
@@ -2041,7 +2041,7 @@ en:
             title: Upload Sample Metadata
             uploading: Uploading
           errors:
-            description: "The sample metadata import completed with the following errors:"
+            description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           success:
             description: The metadata was imported successfully!
@@ -2088,7 +2088,7 @@ en:
           title: Import Samples
           uploading: Uploading
         errors:
-          description: "The sample import completed with the following errors:"
+          description: 'The sample import completed with the following errors:'
           ok_button: OK
         success:
           description: The sample spreadsheet has been processed.
@@ -2106,16 +2106,16 @@ en:
         title: Delete Workflow Executions
         workflow_executions: Workflow Executions
       list_workflow_execution:
-        id: "ID:"
-        name: "Name:"
-        run_id: "Run ID:"
-        workflow: "Workflow:"
+        id: 'ID:'
+        name: 'Name:'
+        run_id: 'Run ID:'
+        workflow: 'Workflow:'
   spreadsheet_helper:
-    failed_parsing: "Failed to parse spreadsheet file: %{error}"
+    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
-    unknown_file_format: "Unknown file type: %{extension}"
+    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
+    unknown_file_format: 'Unknown file type: %{extension}'
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -2170,7 +2170,7 @@ en:
       download: Download
       preview: Preview
     create:
-      error_message: "The following errors prevented the Workflow Execution from being created:"
+      error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
       cancel_button: Cancel
       description: You are editing workflow execution '%{workflow_execution_id}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -433,7 +433,7 @@ en:
       delete_confirm: Are you sure you would like to delete attachment '%{name}'?
       filename: Filename
       format: Format
-      id: ID
+      id: PUID
       limit:
         item: Attachments
       select_page: Select / Deselect visible attachments
@@ -831,7 +831,7 @@ en:
         success: File %{filename} was successfully removed.
       index:
         search:
-          placeholder: Filter by ID or Filename
+          placeholder: Filter by PUID or Filename
         subtitle: These are the files that belong to Group %{group_name}
         title: Files
         upload_files: Upload Files
@@ -1358,7 +1358,7 @@ en:
         success: File %{filename} was successfully removed.
       index:
         search:
-          placeholder: Filter by ID or Filename
+          placeholder: Filter by PUID or Filename
         subtitle: These are the files that belong to Project %{project_name}
         title: Files
         upload_files: Upload Files
@@ -1757,7 +1757,7 @@ en:
           format: Format
           key: Key
           last_updated: Last Updated
-          puid: ID
+          puid: PUID
           size: Size
           source: Source
           type: Type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2069,13 +2069,13 @@ en:
               description_html: The spreadsheet is required to have columns for <b>Sample Name</b> and <b>Project PUID</b>, and optionally <b>Sample Description</b>.
             project:
               description_html: The spreadsheet is required to have a column for <b>Sample Name</b>, and optionally <b>Sample Description</b>.
-          project_puid_column: Project ID Column
+          project_puid_column: Project PUID Column
           project_puid_column_description: Assigns each sample to the associated project within the imported spreadsheet
           project_selection: Project Selection
           project_selection_description: You can specify which project(s) samples are assigned to by selecting a Project ID column and/or a static project
           sample_description_column: Sample Description Column (Optional)
           sample_name_column: Sample Name Column
-          select_project_puid_column: Select a Project ID Column
+          select_project_puid_column: Select a Project PUID Column
           select_sample_description_column: Select a Sample Description Column
           select_sample_name_column: Select a Sample Name Column
           select_static_project: Select Static Project

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -660,7 +660,7 @@ en:
         no_groups_title: No groups found
         row_aria_label: See %{name} subgroups
         search:
-          placeholder: Filter by ID or name
+          placeholder: Filter by PUID or name
         sorting:
           created_at_asc: Oldest created
           created_at_desc: Last created
@@ -677,7 +677,7 @@ en:
         row:
           samples: Samples
         search:
-          placeholder: Filter by ID or name
+          placeholder: Filter by PUID or name
         sorting:
           created_at_asc: Oldest created
           created_at_desc: Last created
@@ -1019,7 +1019,7 @@ en:
       table_filter:
         loading: Loading search results...
         search:
-          placeholder: Filter by ID or name
+          placeholder: Filter by PUID or name
     shared_namespaces:
       index:
         pagy:
@@ -1028,7 +1028,7 @@ en:
       create_project_button: New project
       create_subgroup_button: New subgroup
       search:
-        placeholder: Filter by ID or name
+        placeholder: Filter by PUID or name
       shared_namespaces:
         no_shared:
           description: Groups and projects can be shared with other groups through their members page.
@@ -1249,7 +1249,7 @@ en:
         default: "%{label} (default)"
         required: Required
     samplesheet_component:
-      filter_placeholder: Filter by ID or name
+      filter_placeholder: Filter by PUID or name
       label: Samples
       next: Next
       page_selection:
@@ -1772,7 +1772,7 @@ en:
       table_filter:
         loading: Loading search results...
         search:
-          placeholder: Filter by ID or name
+          placeholder: Filter by PUID or name
       transfers:
         create:
           error: "The following list of samples failed to transfer:"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -417,7 +417,7 @@ fr:
         title: Supprimer un fichier
       new_attachment_component:
         files: Fichiers
-        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
+        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
         upload: Télécharger
         upload_files: Télécharger des fichiers
         uploading: Téléchargement
@@ -555,7 +555,7 @@ fr:
       transferred_by: "%{type} transféré par %{user}"
     history_version:
       current_version: Actuel (Version %{version})
-      keys_deleted: "Clés supprimées :"
+      keys_deleted: 'Clés supprimées :'
       previous_version: Précédent (Version %{version})
     layout:
       language_selection:
@@ -598,7 +598,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+        error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
     bot_actions:
       create:
         success: Le compte de bot a été ajouté avec succès
@@ -715,14 +715,14 @@ fr:
         status: Statut
       title: Exportations de données
     list_workflow_execution:
-      id: "ID:"
-      name: "Nom:"
-      run_id: "Exécuter l’identifiant:"
-      workflow: "Flux de travail :"
+      id: 'ID:'
+      name: 'Nom:'
+      run_id: 'Exécuter l’identifiant:'
+      workflow: 'Flux de travail :'
     new:
       after_submission_description_html: Après la soumission, vous serez redirigé vers la page d’exportation. Pendant que le statut de l’exportation est <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">en cours de traitement</span>, le contenu de l’exportation est créé. Une fois que le statut de l’exportation sera <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">prêt</span>, il sera disponible pour téléchargement. Vous aurez 3 jours ouvrables pour télécharger l’exportation avant qu’elle ne soit supprimée.
       email_label: Vous recevez une notification par courriel lorsque votre exportation est prête à être téléchargée?
-      name_label: "Nom d’exportation (facultatif) :"
+      name_label: 'Nom d’exportation (facultatif) :'
       sample_description:
         plural: Cette exportation contiendra les échantillons COUNT_PLACEHOLDER.
         singular: Cette exportation contiendra 1 échantillon.
@@ -790,8 +790,8 @@ fr:
   errors:
     messages:
       not_saved:
-        one: "1 erreur a empêché cette %{resource} d’être sauvegardée :"
-        other: "Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :"
+        one: '1 erreur a empêché cette %{resource} d’être sauvegardée :'
+        other: 'Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :'
   general:
     default_sidebar:
       data_exports: Exportations de données
@@ -825,7 +825,7 @@ fr:
       title: Activité en groupe
     attachments:
       create:
-        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -891,7 +891,7 @@ fr:
             points_html: '["To prevent accidental actions we ask you to confirm your intention.", "Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel."]'
             warning:
               post_html: After you delete a group, you <strong>cannot</strong> restore it or its components.
-              pre_html: "You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:"
+              pre_html: 'You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:'
               projects_count: "%{count} project(s)"
               samples_count: "%{count} sample(s)"
               subgroups_count: "%{count} subgroup(s)"
@@ -906,18 +906,18 @@ fr:
         transfer:
           confirm:
             points_html:
-              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-              - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+            - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{group_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-            - Transférer le groupe à un autre groupe parent
+          - Transférer le groupe à un autre groupe parent
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Choisissez un groupe parent
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce groupe
           points:
-            - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
-            - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
-            - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
+          - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
+          - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
+          - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
           select_group: Sélectionner un groupe
           submit: Groupe de transfert
           title: Groupe de transfert
@@ -1113,7 +1113,7 @@ fr:
   layouts:
     application:
       language_selection:
-        aria_label: "Langue sélectionnée : Français"
+        aria_label: 'Langue sélectionnée : Français'
       site_title: IRIDA Next
   locales:
     en: Anglais
@@ -1124,10 +1124,10 @@ fr:
       export_ready:
         download_before_html: Veuillez télécharger l’exportation avant <strong>%{date}</strong>, car elle sera supprimée après cette période.
         ready_for_download_html: Votre exportation <strong>%{name}</strong> est prête à être téléchargée.
-        view_exports: "Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :"
+        view_exports: 'Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :'
     email_template:
       automated_message: Ce courriel a été envoyé à partir d’un système automatisé. Veuillez ne pas répondre à ce courriel.
-      copy_paste: "Ou copiez-collez ce lien dans votre navigateur :"
+      copy_paste: 'Ou copiez-collez ce lien dans votre navigateur :'
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -1135,11 +1135,11 @@ fr:
       access_granted_manager_email:
         body_html: Le groupe '%{group_name}' a <strong>obtenu</strong> l’accès à %{namespace_type} '%{namespace_name}'
         subject: Le groupe '%{group_name}' a obtenu l’accès à %{namespace_type} '%{namespace_name}'
-        view_details: "Pour voir tous les membres de %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: "Pour voir %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_manager_email:
         body_html: L’accès à %{namespace_type} '%{namespace_name}' a été <strong>révoqué</strong> pour le groupe '%{group_name}'
         subject: L’accès à %{namespace_type} '%{namespace_name}' a été révoqué pour le groupe '%{group_name}'
@@ -1150,15 +1150,15 @@ fr:
       access_granted_manager_email:
         body_html: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu <strong></strong> l’accès à %{type} '%{name}'
         subject: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu l’accès à %{type} '%{name}'
-        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_granted_user_email:
         body_html: Vous avez <strong>obtenu</strong> l’accès à %{type} '%{name}'
         subject: Vous avez obtenu l’accès à %{type} '%{name}'
-        view_details: "Pour voir %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_manager_email:
         body_html: L’accès à %{type} '%{name}' a été <strong>révoqué</strong> pour l’utilisateur '%{first_name} %{last_name}' (%{email})
         subject: L’accès à %{type} '%{name}' a été révoqué pour l’utilisateur '%{first_name} %{last_name}' (%{email})
-        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
+        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
       access_revoked_user_email:
         body_html: Votre accès à %{type} '%{name}' a été <strong>révoqué</strong>
         subject: Votre accès à %{type} '%{name}' a été révoqué
@@ -1175,7 +1175,7 @@ fr:
       error_user_email:
         body_html: Votre pipeline <strong>%{id}</strong> n’a pas été complété avec succès en raison d’erreurs.
         subject: Pipeline erroné – %{id}
-      view_details: "Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :"
+      view_details: 'Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :'
   members:
     access_levels:
       level_0: Pas d’accès
@@ -1254,7 +1254,7 @@ fr:
         aria_label: Sélecteur de page de pagination
       previous: Précédent
   nextflow_component:
-    data_missing_error: "Les échantillons suivants manquent de données requises : "
+    data_missing_error: 'Les échantillons suivants manquent de données requises : '
     filtering_samples: Le filtrage des échantillons peut prendre un certain temps.
     name:
       helper: Un nom personnalisé facilitera la recherche à l’avenir.
@@ -1285,8 +1285,8 @@ fr:
         confirm: Êtes-vous sûr de vouloir supprimer votre compte?
         description: La suppression de votre compte a les effets suivants
         effects:
-          - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
-          - Tous les projets et groupes dont vous êtes membre seront laissés intacts
+        - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
+        - Tous les projets et groupes dont vous êtes membre seront laissés intacts
     passwords:
       update:
         forgot: Vous avez oublié votre mot de passe?
@@ -1350,7 +1350,7 @@ fr:
       title: Activité du projet
     attachments:
       create:
-        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -1378,7 +1378,7 @@ fr:
       edit:
         error: Impossible de modifier le pipeline automatisé %{workflow_name}
       edit_dialog:
-        title: "Modification du pipeline automatisé : %{workflow_name}"
+        title: 'Modification du pipeline automatisé : %{workflow_name}'
       index:
         add_new_automated_workflow_execution: Nouveau pipeline automatisé
         subtitle: Configurer des pipelines automatisés à lancer lorsque les données jumelées sont téléchargées dans le projet
@@ -1448,7 +1448,7 @@ fr:
             warning:
               automated_workflows_count: "%{count} automated workflow execution(s)"
               post_html: After you delete a project, you <strong>cannot</strong> restore it or its components.
-              pre_html: "You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:"
+              pre_html: 'You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:'
               samples_count: "%{count} sample(s)"
           description: La suppression d’un projet est permanente et ne peut pas être annulée. Tous les échantillons et les membres directs seront supprimés en même temps que le projet.
           submit: Supprimer le projet
@@ -1462,20 +1462,20 @@ fr:
         transfer:
           confirm:
             points_html:
-              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-              - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+            - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{project_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-            - Transférer votre projet dans un autre espace de noms.
-            - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
-            - "Ce qu’il faut savoir avant de transférer votre projet:"
+          - Transférer votre projet dans un autre espace de noms.
+          - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
+          - 'Ce qu’il faut savoir avant de transférer votre projet:'
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Sélectionnez un nouvel espace de noms
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce projet
           points:
-            - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
-            - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
-            - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
+          - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
+          - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
+          - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
           select_namespace: Sélectionnez l’espace de noms
           submit: Projet de transfert
           title: Projet de transfert
@@ -1594,11 +1594,11 @@ fr:
             success: Les dossiers ont été concaténés avec succès.
           modal:
             basename: Nom du fichier
-            description: "Les fichiers suivants ont été sélectionnés pour être concaténés :"
+            description: 'Les fichiers suivants ont été sélectionnés pour être concaténés :'
             submit_button: Concaténer
             title: Concaténer les fichiers
         create:
-          failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
+          failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
           success: Le fichier %{filename} a été téléchargé avec succès.
         delete_attachment_modal:
           description: Êtes-vous sûr de vouloir supprimer ce fichier de l’échantillon?
@@ -1606,20 +1606,20 @@ fr:
           title: Supprimer un fichier
         deletions:
           destroy:
-            error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+            error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
             partial_success: Certains fichiers ont été supprimés avec succès.
             success: Les fichiers ont été supprimés avec succès.
           modal:
-            description: "Les fichiers suivants ont été sélectionnés pour suppression :"
+            description: 'Les fichiers suivants ont été sélectionnés pour suppression :'
             submit_button: Supprimer
             title: Supprimer des fichiers
         destroy:
-          error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
+          error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
           success: Le fichier %{filename} a été supprimé avec succès.
       clones:
         create:
-          error: "La liste suivante des échantillons n’a pas été copiée :"
-          no_samples_cloned_error: "Les échantillons n’ont pas été copiés pour les raisons suivantes :"
+          error: 'La liste suivante des échantillons n’a pas été copiée :'
+          no_samples_cloned_error: 'Les échantillons n’ont pas été copiés pour les raisons suivantes :'
           success: Les échantillons ont été copiés avec succès.
         dialog:
           description:
@@ -1650,8 +1650,8 @@ fr:
           title: Supprimer l’échantillon
         new_multiple_deletions_dialog:
           description:
-            plural: "Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :"
-            singular: "L’échantillon suivant a été sélectionné aux fins de suppression :"
+            plural: 'Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :'
+            singular: 'L’échantillon suivant a été sélectionné aux fins de suppression :'
             zero: Aucun échantillon n’a été sélectionné pour être supprimer
           loading: Chargement...
           samples: Échantillons
@@ -1679,7 +1679,7 @@ fr:
             multi_success: Les clés de métadonnées '%{deleted_keys}' ont été supprimées avec succès.
             single_success: La clé de métadonnées '%{deleted_key}' a été supprimée avec succès.
           modal:
-            description: "Champs de métadonnées sélectionnés pour suppression :"
+            description: 'Champs de métadonnées sélectionnés pour suppression :'
             key_header: Clé
             submit_button: Supprimer
             title: Supprimer les métadonnées
@@ -1719,7 +1719,7 @@ fr:
         delete_metadata_button: Supprimer les métadonnéesDelete Metadata
         edit_button: Modifier cet échantillon
         files: Fichiers
-        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
+        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
         history:
           modal:
             created_by: Échantillon créé par %{user}
@@ -1771,8 +1771,8 @@ fr:
           placeholder: Filtrer par PUID ou nom
       transfers:
         create:
-          error: "La liste suivante des échantillons n’a pas été transférée :"
-          no_samples_transferred_error: "Les échantillons n’ont pas été transférés pour les raisons suivantes :"
+          error: 'La liste suivante des échantillons n’a pas été transférée :'
+          no_samples_transferred_error: 'Les échantillons n’ont pas été transférés pour les raisons suivantes :'
           success: Les échantillons ont été transférés avec succès.
         dialog:
           description:
@@ -1947,8 +1947,8 @@ fr:
         empty_new_project_id: Le projet de destination n’a pas été sélectionné.
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         same_project: Les projets sources et de destination sont les mêmes. Veuillez sélectionner un autre projet de destination.
-        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
-        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
+        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
+        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
       metadata:
         empty_metadata: Aucune métadonnée n’a été reçue pour mettre à jour l’échantillon '%{sample_name}'
         fields:
@@ -1971,8 +1971,8 @@ fr:
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         maintainer_transfer_not_allowed: Un responsable ne peut transférer des échantillons qu’à d’autres projets dans la même hiérarchie avec un ancêtre commun
         same_project: Les échantillons existent déjà dans le projet. Veuillez sélectionner un autre projet.
-        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
-        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
+        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
+        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
     spreadsheet_import:
       csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
@@ -2023,7 +2023,7 @@ fr:
               description: Si cette option est sélectionnée, les champs de métadonnées sans valeur associée seront ignorés et ces clés de métadonnées ne seront pas supprimées de l’échantillon si elles sont présentes. Cependant, si cette option n’est pas sélectionnée, tous les échantillons avec la clé de métadonnées et la valeur vide seront supprimés.
             metadata_columns: Metadata Columns
             namespace:
-              description: "La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. "
+              description: 'La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. '
               group:
                 description_html: L’identificateur est sensible à la casse et doit contenir l’<b>PUID de l’échantillon</b>.
               project:
@@ -2037,7 +2037,7 @@ fr:
             title: Télécharger des échantillons de métadonnées
             uploading: Uploading
           errors:
-            description: "L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :"
+            description: 'L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :'
             ok_button: OK
           success:
             description: Les métadonnées ont été importées avec succès!
@@ -2084,7 +2084,7 @@ fr:
           title: Import Samples
           uploading: Uploading
         errors:
-          description: "The sample import completed with the following errors:"
+          description: 'The sample import completed with the following errors:'
           ok_button: OK
         success:
           description: The sample spreadsheet has been processed.
@@ -2102,16 +2102,16 @@ fr:
         title: Delete Workflow Executions
         workflow_executions: Workflow Executions
       list_workflow_execution:
-        id: "ID:"
-        name: "Name:"
-        run_id: "Run ID:"
-        workflow: "Workflow:"
+        id: 'ID:'
+        name: 'Name:'
+        run_id: 'Run ID:'
+        workflow: 'Workflow:'
   spreadsheet_helper:
-    failed_parsing: "Failed to parse spreadsheet file: %{error}"
+    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
-    unknown_file_format: "Unknown file type: %{extension}"
+    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
+    unknown_file_format: 'Unknown file type: %{extension}'
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -2166,7 +2166,7 @@ fr:
       download: Télécharger
       preview: Aperçu
     create:
-      error_message: "Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :"
+      error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
     edit_dialog:
       cancel_button: Annuler
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -660,7 +660,7 @@ fr:
         no_groups_title: Aucun groupe trouvé
         row_aria_label: Voir les sous-groupes %{name}
         search:
-          placeholder: Filtrer par ID ou nom
+          placeholder: Filtrer par PUID ou nom
         sorting:
           created_at_asc: Plus ancien créé
           created_at_desc: Dernier créé
@@ -677,7 +677,7 @@ fr:
         row:
           samples: Échantillons
         search:
-          placeholder: Filtrer par ID ou nom
+          placeholder: Filtrer par PUID ou nom
         sorting:
           created_at_asc: Plus ancien créé
           created_at_desc: Dernier créé
@@ -831,7 +831,7 @@ fr:
         success: Le fichier %{filename} a été supprimé avec succès.
       index:
         search:
-          placeholder: Filtrer par ID ou nom de fichier
+          placeholder: Filtrer par PUID ou nom de fichier
         subtitle: Ce sont les fichiers qui appartiennent au groupe %{group_name}
         title: Fichiers
         upload_files: Télécharger des fichiers
@@ -1017,7 +1017,7 @@ fr:
       table_filter:
         loading: Chargement des résultats de recherche...
         search:
-          placeholder: Filtrer par ID ou nom
+          placeholder: Filtrer par PUID ou nom
     shared_namespaces:
       index:
         pagy:
@@ -1026,7 +1026,7 @@ fr:
       create_project_button: Nouveau projet
       create_subgroup_button: Nouveau sous-groupe
       search:
-        placeholder: Filtrer par ID ou nom
+        placeholder: Filtrer par PUID ou nom
       shared_namespaces:
         no_shared:
           description: Les groupes et les projets peuvent être partagés avec d’autres groupes par l’intermédiaire de leur page de membres.
@@ -1247,7 +1247,7 @@ fr:
         default: "%{label} (par défaut)"
         required: Obligatoire
     samplesheet_component:
-      filter_placeholder: Filtrer par ID ou nom
+      filter_placeholder: Filtrer par PUID ou nom
       label: Échantillons
       next: Suivant
       page_selection:
@@ -1356,7 +1356,7 @@ fr:
         success: Le fichier %{filename} a été supprimé avec succès.
       index:
         search:
-          placeholder: Filtrer par ID ou nom de fichier
+          placeholder: Filtrer par PUID ou nom de fichier
         subtitle: Ce sont les fichiers qui appartiennent au projet %{project_name}
         title: Fichiers
         upload_files: Télécharger des fichiers
@@ -1768,7 +1768,7 @@ fr:
       table_filter:
         loading: Recherche en cours...
         search:
-          placeholder: Filtrer par ID ou nom
+          placeholder: Filtrer par PUID ou nom
       transfers:
         create:
           error: "La liste suivante des échantillons n’a pas été transférée :"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -417,7 +417,7 @@ fr:
         title: Supprimer un fichier
       new_attachment_component:
         files: Fichiers
-        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
+        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
         upload: Télécharger
         upload_files: Télécharger des fichiers
         uploading: Téléchargement
@@ -555,7 +555,7 @@ fr:
       transferred_by: "%{type} transféré par %{user}"
     history_version:
       current_version: Actuel (Version %{version})
-      keys_deleted: 'Clés supprimées :'
+      keys_deleted: "Clés supprimées :"
       previous_version: Précédent (Version %{version})
     layout:
       language_selection:
@@ -598,7 +598,7 @@ fr:
   concerns:
     attachment_actions:
       destroy:
-        error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+        error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
     bot_actions:
       create:
         success: Le compte de bot a été ajouté avec succès
@@ -715,14 +715,14 @@ fr:
         status: Statut
       title: Exportations de données
     list_workflow_execution:
-      id: 'ID:'
-      name: 'Nom:'
-      run_id: 'Exécuter l’identifiant:'
-      workflow: 'Flux de travail :'
+      id: "ID:"
+      name: "Nom:"
+      run_id: "Exécuter l’identifiant:"
+      workflow: "Flux de travail :"
     new:
       after_submission_description_html: Après la soumission, vous serez redirigé vers la page d’exportation. Pendant que le statut de l’exportation est <span class="px-2.5 py-0.5 mr-1 ml-1 text-xs font-medium rounded-full bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-300">en cours de traitement</span>, le contenu de l’exportation est créé. Une fois que le statut de l’exportation sera <span class="px-2.5 py-0.5 ml-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">prêt</span>, il sera disponible pour téléchargement. Vous aurez 3 jours ouvrables pour télécharger l’exportation avant qu’elle ne soit supprimée.
       email_label: Vous recevez une notification par courriel lorsque votre exportation est prête à être téléchargée?
-      name_label: 'Nom d’exportation (facultatif) :'
+      name_label: "Nom d’exportation (facultatif) :"
       sample_description:
         plural: Cette exportation contiendra les échantillons COUNT_PLACEHOLDER.
         singular: Cette exportation contiendra 1 échantillon.
@@ -790,8 +790,8 @@ fr:
   errors:
     messages:
       not_saved:
-        one: '1 erreur a empêché cette %{resource} d’être sauvegardée :'
-        other: 'Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :'
+        one: "1 erreur a empêché cette %{resource} d’être sauvegardée :"
+        other: "Les erreurs %{count} ont empêché cette %{resource} d’être sauvegardée :"
   general:
     default_sidebar:
       data_exports: Exportations de données
@@ -825,7 +825,7 @@ fr:
       title: Activité en groupe
     attachments:
       create:
-        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -891,7 +891,7 @@ fr:
             points_html: '["To prevent accidental actions we ask you to confirm your intention.", "Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel."]'
             warning:
               post_html: After you delete a group, you <strong>cannot</strong> restore it or its components.
-              pre_html: 'You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:'
+              pre_html: "You are about to delete the group <strong>%{group_name}</strong>. This action will also delete:"
               projects_count: "%{count} project(s)"
               samples_count: "%{count} sample(s)"
               subgroups_count: "%{count} subgroup(s)"
@@ -906,18 +906,18 @@ fr:
         transfer:
           confirm:
             points_html:
-            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-            - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+              - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{group_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-          - Transférer le groupe à un autre groupe parent
+            - Transférer le groupe à un autre groupe parent
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Choisissez un groupe parent
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce groupe
           points:
-          - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
-          - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
-          - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
+            - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
+            - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
+            - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
           select_group: Sélectionner un groupe
           submit: Groupe de transfert
           title: Groupe de transfert
@@ -1113,7 +1113,7 @@ fr:
   layouts:
     application:
       language_selection:
-        aria_label: 'Langue sélectionnée : Français'
+        aria_label: "Langue sélectionnée : Français"
       site_title: IRIDA Next
   locales:
     en: Anglais
@@ -1124,10 +1124,10 @@ fr:
       export_ready:
         download_before_html: Veuillez télécharger l’exportation avant <strong>%{date}</strong>, car elle sera supprimée après cette période.
         ready_for_download_html: Votre exportation <strong>%{name}</strong> est prête à être téléchargée.
-        view_exports: 'Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :'
+        view_exports: "Pour voir et télécharger l’exportation, cliquez sur le bouton ci-dessous :"
     email_template:
       automated_message: Ce courriel a été envoyé à partir d’un système automatisé. Veuillez ne pas répondre à ce courriel.
-      copy_paste: 'Ou copiez-collez ce lien dans votre navigateur :'
+      copy_paste: "Ou copiez-collez ce lien dans votre navigateur :"
       greeting: Bonjour,
       greeting_with_name: Bonjour %{name},
       thanks: Merci,
@@ -1135,11 +1135,11 @@ fr:
       access_granted_manager_email:
         body_html: Le groupe '%{group_name}' a <strong>obtenu</strong> l’accès à %{namespace_type} '%{namespace_name}'
         subject: Le groupe '%{group_name}' a obtenu l’accès à %{namespace_type} '%{namespace_name}'
-        view_details: 'Pour voir tous les membres de %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
       access_granted_user_email:
         body_html: Group '%{group_name}' has been <strong>granted</strong> access to %{namespace_type} '%{namespace_name}'
         subject: Group '%{group_name}' has been granted access to %{namespace_type} '%{namespace_name}'
-        view_details: 'Pour voir %{namespace_type} ''%{namespace_name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir %{namespace_type} '%{namespace_name}', cliquez sur le bouton ci-dessous :"
       access_revoked_manager_email:
         body_html: L’accès à %{namespace_type} '%{namespace_name}' a été <strong>révoqué</strong> pour le groupe '%{group_name}'
         subject: L’accès à %{namespace_type} '%{namespace_name}' a été révoqué pour le groupe '%{group_name}'
@@ -1150,15 +1150,15 @@ fr:
       access_granted_manager_email:
         body_html: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu <strong></strong> l’accès à %{type} '%{name}'
         subject: L’utilisateur '%{first_name} %{last_name}' (%{email}) a obtenu l’accès à %{type} '%{name}'
-        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_granted_user_email:
         body_html: Vous avez <strong>obtenu</strong> l’accès à %{type} '%{name}'
         subject: Vous avez obtenu l’accès à %{type} '%{name}'
-        view_details: 'Pour voir %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_revoked_manager_email:
         body_html: L’accès à %{type} '%{name}' a été <strong>révoqué</strong> pour l’utilisateur '%{first_name} %{last_name}' (%{email})
         subject: L’accès à %{type} '%{name}' a été révoqué pour l’utilisateur '%{first_name} %{last_name}' (%{email})
-        view_details: 'Pour voir tous les membres de %{type} ''%{name}'', cliquez sur le bouton ci-dessous :'
+        view_details: "Pour voir tous les membres de %{type} '%{name}', cliquez sur le bouton ci-dessous :"
       access_revoked_user_email:
         body_html: Votre accès à %{type} '%{name}' a été <strong>révoqué</strong>
         subject: Votre accès à %{type} '%{name}' a été révoqué
@@ -1175,7 +1175,7 @@ fr:
       error_user_email:
         body_html: Votre pipeline <strong>%{id}</strong> n’a pas été complété avec succès en raison d’erreurs.
         subject: Pipeline erroné – %{id}
-      view_details: 'Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :'
+      view_details: "Pour consulter le résumé du pipeline, cliquez sur le bouton ci-dessous :"
   members:
     access_levels:
       level_0: Pas d’accès
@@ -1254,7 +1254,7 @@ fr:
         aria_label: Sélecteur de page de pagination
       previous: Précédent
   nextflow_component:
-    data_missing_error: 'Les échantillons suivants manquent de données requises : '
+    data_missing_error: "Les échantillons suivants manquent de données requises : "
     filtering_samples: Le filtrage des échantillons peut prendre un certain temps.
     name:
       helper: Un nom personnalisé facilitera la recherche à l’avenir.
@@ -1285,8 +1285,8 @@ fr:
         confirm: Êtes-vous sûr de vouloir supprimer votre compte?
         description: La suppression de votre compte a les effets suivants
         effects:
-        - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
-        - Tous les projets et groupes dont vous êtes membre seront laissés intacts
+          - Tous les projets et groupes dont vous êtes propriétaire seront supprimés
+          - Tous les projets et groupes dont vous êtes membre seront laissés intacts
     passwords:
       update:
         forgot: Vous avez oublié votre mot de passe?
@@ -1350,7 +1350,7 @@ fr:
       title: Activité du projet
     attachments:
       create:
-        failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+        failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
         success: Le fichier %{filename} a été téléchargé avec succès.
       destroy:
         success: Le fichier %{filename} a été supprimé avec succès.
@@ -1378,7 +1378,7 @@ fr:
       edit:
         error: Impossible de modifier le pipeline automatisé %{workflow_name}
       edit_dialog:
-        title: 'Modification du pipeline automatisé : %{workflow_name}'
+        title: "Modification du pipeline automatisé : %{workflow_name}"
       index:
         add_new_automated_workflow_execution: Nouveau pipeline automatisé
         subtitle: Configurer des pipelines automatisés à lancer lorsque les données jumelées sont téléchargées dans le projet
@@ -1448,7 +1448,7 @@ fr:
             warning:
               automated_workflows_count: "%{count} automated workflow execution(s)"
               post_html: After you delete a project, you <strong>cannot</strong> restore it or its components.
-              pre_html: 'You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:'
+              pre_html: "You are about to delete the project <strong>%{project_name}</strong>. This action will also delete:"
               samples_count: "%{count} sample(s)"
           description: La suppression d’un projet est permanente et ne peut pas être annulée. Tous les échantillons et les membres directs seront supprimés en même temps que le projet.
           submit: Supprimer le projet
@@ -1462,20 +1462,20 @@ fr:
         transfer:
           confirm:
             points_html:
-            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
-            - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+              - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+              - Veuillez taper <kbd>%{project}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
             warning_html: Vous allez transférer <strong>%{project_name}</strong> vers un autre espace de noms. Une fois que vous avez confirmé, cette action ne peut pas être annulée.
           descriptions:
-          - Transférer votre projet dans un autre espace de noms.
-          - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
-          - 'Ce qu’il faut savoir avant de transférer votre projet:'
+            - Transférer votre projet dans un autre espace de noms.
+            - Lorsque vous transférez votre projet à un groupe, vous pouvez facilement gérer plusieurs projets et utilisateurs.
+            - "Ce qu’il faut savoir avant de transférer votre projet:"
           empty_state: Aucun espace de noms n’est associé à ce nom ou à cet identifiant
           new_namespace_id: Sélectionnez un nouvel espace de noms
           no_available_namespaces: Vous n’avez accès à aucun espace de noms de destination pour transférer ce projet
           points:
-          - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
-          - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
-          - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
+            - Soyez prudent! La modification de l’espace de noms d’un projet peut avoir des effets secondaires involontaires.
+            - Vous ne pouvez transférer des projets que vers des groupes où vous avez suffisamment d’autorisations.
+            - Le niveau de visibilité du projet changera pour correspondre aux règles de l’espace de noms lors du transfert vers un groupe.
           select_namespace: Sélectionnez l’espace de noms
           submit: Projet de transfert
           title: Projet de transfert
@@ -1594,11 +1594,11 @@ fr:
             success: Les dossiers ont été concaténés avec succès.
           modal:
             basename: Nom du fichier
-            description: 'Les fichiers suivants ont été sélectionnés pour être concaténés :'
+            description: "Les fichiers suivants ont été sélectionnés pour être concaténés :"
             submit_button: Concaténer
             title: Concaténer les fichiers
         create:
-          failure: 'Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}'
+          failure: "Le fichier %{filename} n’a pas été téléchargé en raison des erreurs suivantes : %{errors}"
           success: Le fichier %{filename} a été téléchargé avec succès.
         delete_attachment_modal:
           description: Êtes-vous sûr de vouloir supprimer ce fichier de l’échantillon?
@@ -1606,20 +1606,20 @@ fr:
           title: Supprimer un fichier
         deletions:
           destroy:
-            error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+            error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
             partial_success: Certains fichiers ont été supprimés avec succès.
             success: Les fichiers ont été supprimés avec succès.
           modal:
-            description: 'Les fichiers suivants ont été sélectionnés pour suppression :'
+            description: "Les fichiers suivants ont été sélectionnés pour suppression :"
             submit_button: Supprimer
             title: Supprimer des fichiers
         destroy:
-          error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
+          error: "Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}"
           success: Le fichier %{filename} a été supprimé avec succès.
       clones:
         create:
-          error: 'La liste suivante des échantillons n’a pas été copiée :'
-          no_samples_cloned_error: 'Les échantillons n’ont pas été copiés pour les raisons suivantes :'
+          error: "La liste suivante des échantillons n’a pas été copiée :"
+          no_samples_cloned_error: "Les échantillons n’ont pas été copiés pour les raisons suivantes :"
           success: Les échantillons ont été copiés avec succès.
         dialog:
           description:
@@ -1650,8 +1650,8 @@ fr:
           title: Supprimer l’échantillon
         new_multiple_deletions_dialog:
           description:
-            plural: 'Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :'
-            singular: 'L’échantillon suivant a été sélectionné aux fins de suppression :'
+            plural: "Les échantillons COUNT_PLACEHOLDER suivants ont été sélectionnés aux fins de suppression :"
+            singular: "L’échantillon suivant a été sélectionné aux fins de suppression :"
             zero: Aucun échantillon n’a été sélectionné pour être supprimer
           loading: Chargement...
           samples: Échantillons
@@ -1679,7 +1679,7 @@ fr:
             multi_success: Les clés de métadonnées '%{deleted_keys}' ont été supprimées avec succès.
             single_success: La clé de métadonnées '%{deleted_key}' a été supprimée avec succès.
           modal:
-            description: 'Champs de métadonnées sélectionnés pour suppression :'
+            description: "Champs de métadonnées sélectionnés pour suppression :"
             key_header: Clé
             submit_button: Supprimer
             title: Supprimer les métadonnées
@@ -1719,7 +1719,7 @@ fr:
         delete_metadata_button: Supprimer les métadonnéesDelete Metadata
         edit_button: Modifier cet échantillon
         files: Fichiers
-        files_ignored: 'Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :'
+        files_ignored: "Les fichiers fasta et fastq doivent être compressés. Les fichiers suivants ne peuvent pas être téléchargés :"
         history:
           modal:
             created_by: Échantillon créé par %{user}
@@ -1771,8 +1771,8 @@ fr:
           placeholder: Filtrer par ID ou nom
       transfers:
         create:
-          error: 'La liste suivante des échantillons n’a pas été transférée :'
-          no_samples_transferred_error: 'Les échantillons n’ont pas été transférés pour les raisons suivantes :'
+          error: "La liste suivante des échantillons n’a pas été transférée :"
+          no_samples_transferred_error: "Les échantillons n’ont pas été transférés pour les raisons suivantes :"
           success: Les échantillons ont été transférés avec succès.
         dialog:
           description:
@@ -1877,7 +1877,7 @@ fr:
       name: Nom de l’échantillon
       namespaces:
         puid: Projet
-      puid: ID de l’échantillon
+      puid: PUID de l’échantillon
       select_page: Sélectionner/Désélectionner les échantillons visibles
       updated_at: Dernière mise à jour
   services:
@@ -1947,8 +1947,8 @@ fr:
         empty_new_project_id: Le projet de destination n’a pas été sélectionné.
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         same_project: Les projets sources et de destination sont les mêmes. Veuillez sélectionner un autre projet de destination.
-        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
-        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
+        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
+        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être copiés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
       metadata:
         empty_metadata: Aucune métadonnée n’a été reçue pour mettre à jour l’échantillon '%{sample_name}'
         fields:
@@ -1971,8 +1971,8 @@ fr:
         empty_sample_ids: Les identifiants de l’échantillon sont vides.
         maintainer_transfer_not_allowed: Un responsable ne peut transférer des échantillons qu’à d’autres projets dans la même hiérarchie avec un ancêtre commun
         same_project: Les échantillons existent déjà dans le projet. Veuillez sélectionner un autre projet.
-        sample_exists: 'Échantillon %{sample_puid} : Conflit avec l’échantillon nommé ''%{sample_name}'' dans le projet cible'
-        samples_not_found: 'Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}'
+        sample_exists: "Échantillon %{sample_puid} : Conflit avec l’échantillon nommé '%{sample_name}' dans le projet cible"
+        samples_not_found: "Les échantillons avec les identifiants d’échantillon suivants n’ont pas pu être transférés puisqu’ils n’ont pas été trouvés dans le projet source : %{sample_ids}"
     spreadsheet_import:
       csv_file_malformed: The CSV file is malformed.
       duplicate_column_names: Le fichier comporte des noms d’en-tête de colonne en double. Veuillez supprimer les colonnes avec des noms d’en-tête en double et réessayer de les télécharger.
@@ -2023,21 +2023,21 @@ fr:
               description: Si cette option est sélectionnée, les champs de métadonnées sans valeur associée seront ignorés et ces clés de métadonnées ne seront pas supprimées de l’échantillon si elles sont présentes. Cependant, si cette option n’est pas sélectionnée, tous les échantillons avec la clé de métadonnées et la valeur vide seront supprimés.
             metadata_columns: Metadata Columns
             namespace:
-              description: 'La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. '
+              description: "La feuille de calcul doit comporter une colonne contenant un exemple d’identificateur. "
               group:
-                description_html: L’identificateur est sensible à la casse et doit contenir l’<b>identifiant de l’échantillon</b>.
+                description_html: L’identificateur est sensible à la casse et doit contenir l’<b>PUID de l’échantillon</b>.
               project:
-                description_html: L’identificateur est sensible à la casse et peut contenir le <b>nom ou l’identifiant de l’échantillon</b>.
+                description_html: L’identificateur est sensible à la casse et peut contenir le <b>nom ou l’PUID de l’échantillon</b>.
             no_valid_metadata: The uploaded spreadsheet contains no viable metadata
-            sample_id_column: Colonne ID de l’échantillon
-            select_sample_id_column: Sélectionner une colonne ID de l’échantillon
+            sample_id_column: Colonne identificateur de l’échantillon
+            select_sample_id_column: Sélectionner une colonne identificateur de l’échantillon
             selected: Sélectionné
             spinner_message: L’importation d’échantillons de métadonnées, cela peut prendre un certain temps...
             submit_button: Import Metadata
             title: Télécharger des échantillons de métadonnées
             uploading: Uploading
           errors:
-            description: 'L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :'
+            description: "L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes :"
             ok_button: OK
           success:
             description: Les métadonnées ont été importées avec succès!
@@ -2084,7 +2084,7 @@ fr:
           title: Import Samples
           uploading: Uploading
         errors:
-          description: 'The sample import completed with the following errors:'
+          description: "The sample import completed with the following errors:"
           ok_button: OK
         success:
           description: The sample spreadsheet has been processed.
@@ -2102,16 +2102,16 @@ fr:
         title: Delete Workflow Executions
         workflow_executions: Workflow Executions
       list_workflow_execution:
-        id: 'ID:'
-        name: 'Name:'
-        run_id: 'Run ID:'
-        workflow: 'Workflow:'
+        id: "ID:"
+        name: "Name:"
+        run_id: "Run ID:"
+        workflow: "Workflow:"
   spreadsheet_helper:
-    failed_parsing: 'Failed to parse spreadsheet file: %{error}'
+    failed_parsing: "Failed to parse spreadsheet file: %{error}"
     no_file: No file provided
     no_headers: No headers found in file
-    unexpected_error: 'An unexpected error occurred while parsing the file: %{error}'
-    unknown_file_format: 'Unknown file type: %{extension}'
+    unexpected_error: "An unexpected error occurred while parsing the file: %{error}"
+    unknown_file_format: "Unknown file type: %{extension}"
   time:
     formats:
       abbreviated: "%a %b%e %Y %H:%M"
@@ -2166,7 +2166,7 @@ fr:
       download: Télécharger
       preview: Aperçu
     create:
-      error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
+      error_message: "Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :"
     edit_dialog:
       cancel_button: Annuler
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2065,13 +2065,13 @@ fr:
               description_html: The spreadsheet is required to have a column for <b>Sample Name</b>, and optionally for <b>Sample Description</b> and <b>Project PUID</b>.
             project:
               description_html: The spreadsheet is required to have a column for <b>Sample Name</b>, and optionally for <b>Sample Description</b>.
-          project_puid_column: Project ID Column
+          project_puid_column: Project PUID Column
           project_puid_column_description: Assigns each sample to the associated project within the imported spreadsheet
           project_selection: Project Selection
           project_selection_description: You can specify which project(s) samples are assigned to by selecting a Project ID column and/or a static project
           sample_description_column: Sample Description Column (Optional)
           sample_name_column: Sample Name Column
-          select_project_puid_column: Select a Project ID Column
+          select_project_puid_column: Select a Project PUID Column
           select_sample_description_column: Select a Sample Description Column
           select_sample_name_column: Select a Sample Name Column
           select_static_project: Select Static Project

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -433,7 +433,7 @@ fr:
       delete_confirm: Êtes-vous sûr de vouloir supprimer la pièce jointe '%{name}'?
       filename: Nom du fichier
       format: Format
-      id: ID
+      id: PUID
       limit:
         item: Attachments
       select_page: Sélectionner/Désélectionner les pièces jointes visibles
@@ -1753,7 +1753,7 @@ fr:
           format: Format
           key: Key
           last_updated: Dernière mise à jour
-          puid: ID
+          puid: PUID
           size: Taille
           source: Source
           type: Type

--- a/docs-site/docs/user/project/samples/sample-metadata.md
+++ b/docs-site/docs/user/project/samples/sample-metadata.md
@@ -60,41 +60,42 @@ Importing metadata allows you to add multiple metadata fields to multiple sample
 
 This is an example of the expected spreadsheet format:
 
-  | Sample Name | MetadataField1 | MetadataField2 | MetadataField3 |
-  | :---------- | :------------- | :------------- | :------------- |
-  | Sample 1    | value1         | value2         | value3         |
-  | Sample 2    | value4         | value5         | value6         |
+| Sample Name | MetadataField1 | MetadataField2 | MetadataField3 |
+| :---------- | :------------- | :------------- | :------------- |
+| Sample 1    | value1         | value2         | value3         |
+| Sample 2    | value4         | value5         | value6         |
 
 The following metadata will be added:
 
-  - Sample 1:
+- Sample 1:
 
-    | Key            | Value  |
-    | :------------- | :----- |
-    | MetadataField1 | value1 |
-    | MetadataField2 | value2 |
-    | MetadataField3 | value3 |
+  | Key            | Value  |
+  | :------------- | :----- |
+  | MetadataField1 | value1 |
+  | MetadataField2 | value2 |
+  | MetadataField3 | value3 |
 
-  - Sample 2:
+- Sample 2:
 
-    | Key            | Value  |
-    | :------------- | :----- |
-    | MetadataField1 | value4 |
-    | MetadataField2 | value5 |
-    | MetadataField3 | value6 |
+  | Key            | Value  |
+  | :------------- | :----- |
+  | MetadataField1 | value4 |
+  | MetadataField2 | value5 |
+  | MetadataField3 | value6 |
 
-When creating the spreadsheet, you are required to have a column that contains a sample identifier. The identifier is case-sensitive and can contain either the sample names or IDs. When importing metadata from a **project**, the sample identifier can be either the **sample name or ID**. If importing metadata from a **group**, the sample identifier must be the **sample ID**.
+When creating the spreadsheet, you are required to have a column that contains a sample identifier. The identifier is case-sensitive and can contain either the sample names or PUIDs. When importing metadata from a **project**, the sample identifier can be either the **sample name or PUID**. If importing metadata from a **group**, the sample identifier must be the **sample PUID**.
 
 **An important note:** When importing a metadata spreadsheet, you will be asked if you'd like to **Ignore empty values**. If this is **selected**, any metadata fields without an associated value will be ignored and those metadata keys will not be removed from the sample if present. However, if this **not selected**, any samples with the metadata key and empty value will be **deleted**.
 
 For example, if the metadata above was imported and added to Sample 1 and Sample 2, and the following spreadsheet was then imported:
 
-  | Sample Name | MetadataField1 | MetadataField2 | MetadataField3 | MetadataField4 |
-  | :---------- | :------------- | :------------- | :------------- | :------------- |
-  | Sample 1    |                | newValue2      | newValue3      | anotherValue1  |
-  | Sample 2    | newValue4      |                | newValue6      | anotherValue2  |
+| Sample Name | MetadataField1 | MetadataField2 | MetadataField3 | MetadataField4 |
+| :---------- | :------------- | :------------- | :------------- | :------------- |
+| Sample 1    |                | newValue2      | newValue3      | anotherValue1  |
+| Sample 2    | newValue4      |                | newValue6      | anotherValue2  |
 
 This would result in the following sample metadata:
+
 - If **Ignore empty values** was **checked**:
 
   - Sample 1:

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -453,7 +453,8 @@ module DataExports
       export_file = Roo::Spreadsheet.open(ActiveStorage::Blob.service.path_for(data_export9.file.key),
                                           extension: 'xlsx')
 
-      assert_equal ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID', 'METADATAFIELD1', 'NON_EXISTANT_FIELD', 'METADATAFIELD2'],
+      assert_equal ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID', 'METADATAFIELD1', 'NON_EXISTANT_FIELD',
+                    'METADATAFIELD2'],
                    export_file.row(1)
       assert_equal [
         sample32.puid,

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -435,9 +435,9 @@ module DataExports
       csv_text = File.read(export_file)
       csv = CSV.parse(csv_text, headers: true)
       csv.each do |row|
-        assert_equal sample32.puid, row['SAMPLE ID']
+        assert_equal sample32.puid, row['SAMPLE PUID']
         assert_equal sample32.name, row['SAMPLE NAME']
-        assert_equal sample32.project.puid, row['PROJECT ID']
+        assert_equal sample32.project.puid, row['PROJECT PUID']
         assert_equal sample32.metadata['metadatafield1'], row['METADATAFIELD1']
         assert_equal sample32.metadata['metadatafield2'], row['METADATAFIELD2']
       end
@@ -453,7 +453,7 @@ module DataExports
       export_file = Roo::Spreadsheet.open(ActiveStorage::Blob.service.path_for(data_export9.file.key),
                                           extension: 'xlsx')
 
-      assert_equal ['SAMPLE ID', 'SAMPLE NAME', 'PROJECT ID', 'METADATAFIELD1', 'NON_EXISTANT_FIELD', 'METADATAFIELD2'],
+      assert_equal ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID', 'METADATAFIELD1', 'NON_EXISTANT_FIELD', 'METADATAFIELD2'],
                    export_file.row(1)
       assert_equal [
         sample32.puid,

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -154,21 +154,21 @@ module Groups
         assert_selector 'tr', count: 20
       end
 
-      click_on 'Sample ID'
+      click_on I18n.t(:'samples.table_component.puid')
       assert_selector 'table thead th:first-child svg.icon-arrow_up'
       puids = retrieve_puids
       (puids.length - 1).times do |n|
         assert puids[n] < puids[n + 1]
       end
 
-      click_on 'Sample ID'
+      click_on I18n.t(:'samples.table_component.puid')
       assert_selector 'table thead th:first-child svg.icon-arrow_down'
       puids = retrieve_puids
       (puids.length - 1).times do |n|
         assert puids[n] > puids[n + 1]
       end
 
-      click_on 'Sample Name'
+      click_on I18n.t(:'samples.table_component.name')
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
       within('table tbody') do
         assert_selector 'tr:first-child th', text: @sample1.puid
@@ -223,13 +223,13 @@ module Groups
       end
 
       assert_no_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
-      click_on 'Sample Name'
+      click_on I18n.t(:'samples.table_component.name')
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
 
       assert_selector 'tbody tr:first-child th', text: @sample1.puid
       assert_selector 'tbody tr:first-child td:nth-child(2)', text: @sample1.name
 
-      click_on 'Sample Name'
+      click_on I18n.t(:'samples.table_component.name')
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_down'
 
       assert_selector 'tbody tr:last-child th', text: @sample1.puid
@@ -259,7 +259,7 @@ module Groups
         assert_text @sample1.name
         assert_no_text @sample2.name
       end
-      click_on 'Sample Name'
+      click_on I18n.t(:'samples.table_component.name')
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
 
       within('table tbody') do
@@ -352,7 +352,7 @@ module Groups
         assert_text @sample1.puid
       end
 
-      click_on 'Sample Name'
+      click_on I18n.t(:'samples.table_component.name')
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
       within('table tbody') do
         assert_selector 'tr:first-child th', text: @sample1.puid
@@ -399,7 +399,7 @@ module Groups
         assert_text @sample1.puid
       end
 
-      click_on 'Sample Name'
+      click_on I18n.t(:'samples.table_component.name')
       assert_selector 'table thead th:nth-child(2) svg.icon-arrow_up'
       within('table tbody') do
         assert_selector 'tr:first-child th', text: @sample1.puid
@@ -1698,7 +1698,7 @@ module Groups
       assert_text I18n.t('groups.samples.table.no_associated_samples')
       assert_text I18n.t('groups.samples.table.no_samples')
 
-      assert_no_selector 'button', text: 'Sample Actions'
+      assert_no_selector 'button', text: I18n.t(:'shared.samples.actions_dropdown.label')
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the samples table listing `Sample ID` column to `Sample PUID` and updates the metadata import and advanced search dialogs to use `Sample PUID` so that there is consistent referencing. This address [STRY0017530](https://publichealthprod.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3D19ef87af3b1c62105c163064c3e45ad3)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/c7dc0dbf-1c2f-4e37-9b5c-2ad2c089840c)

![image](https://github.com/user-attachments/assets/3c36c5e1-4fe0-4fed-b27f-10ac27fe56f5)

![image](https://github.com/user-attachments/assets/fb297828-0579-4a7f-a110-0d30df5034ce)

![image](https://github.com/user-attachments/assets/20bd5aa6-f28d-42d8-98f0-af77a15dd4ae)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Verify the samples advanced search lists the sample puid
2. Verify the sample attachments table header displays PUID
3. Verify data exports -> spreadsheet export headers include `Sample PUID` and `Project PUID` and no reference to `Sample ID`
4. Verify sample metadata import dialogs for group and project reference the `Sample PUID` and not `Sample ID`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
