### PR TITLE
Delete sample selection fix

### DIFF
--- a/app/views/projects/samples/deletions/_new_deletion_dialog.html.erb
+++ b/app/views/projects/samples/deletions/_new_deletion_dialog.html.erb
@@ -5,7 +5,6 @@
   <div
     data-controller="selection"
     data-selection-storage-key-value="<%= "#{request.base_url}#{namespace_project_samples_path(@project.namespace.parent, @project)}" %>"
-    data-selection-delete-id-param="<%= @sample.id %>"
     class="
       mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
     "

--- a/app/views/projects/samples/deletions/_new_deletion_dialog.html.erb
+++ b/app/views/projects/samples/deletions/_new_deletion_dialog.html.erb
@@ -4,6 +4,7 @@
 
   <div
     data-controller="selection"
+    data-selection-storage-key-value="<%= "#{request.base_url}#{namespace_project_samples_path(@project.namespace.parent, @project)}" %>"
     data-selection-delete-id-param="<%= @sample.id %>"
     class="
       mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -1,4 +1,5 @@
 <%= turbo_frame_tag "sample_modal" %>
+<%= turbo_frame_tag "samples_dialog" %>
 
 <%= render Viral::PageHeaderComponent.new(title: @sample.name, id: @sample.puid, subtitle: @sample.description) do |component| %>
   <%= viral_pill(text: @sample.puid, color: :blue) %>
@@ -12,15 +13,20 @@
         ) %>
       <% end %>
       <% if @allowed_to[:destroy_sample] %>
-        <%= link_to(
-          t("projects.samples.show.remove_button"),
-          namespace_project_samples_deletion_path(sample_id: @sample.id, format: :html),
-          data: {
-            turbo_method: :delete,
-            turbo_confirm: t("projects.samples.show.remove_button_confirmation"),
-          },
-          class: "button button--state-default button--size-default",
-        ) %>
+        <%= button_to t("projects.samples.show.remove_button"),
+        new_namespace_project_samples_deletion_path(
+          @project.namespace.parent,
+          @project,
+        ),
+        params: {
+          deletion_type: "single",
+          sample_id: @sample.id,
+        },
+        method: :get,
+        data: {
+          turbo_stream: true,
+        },
+        class: "button button--size-default button--state-default" %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -13,20 +13,18 @@
         ) %>
       <% end %>
       <% if @allowed_to[:destroy_sample] %>
-        <%= button_to t("projects.samples.show.remove_button"),
-        new_namespace_project_samples_deletion_path(
-          @project.namespace.parent,
-          @project,
-        ),
-        params: {
-          deletion_type: "single",
-          sample_id: @sample.id,
-        },
-        method: :get,
-        data: {
-          turbo_stream: true,
-        },
-        class: "button button--size-default button--state-default" %>
+        <%= link_to(
+          t("projects.samples.show.remove_button"),
+          new_namespace_project_samples_deletion_path(
+            @project.namespace.parent,
+            @project,
+            { params: { deletion_type: "single", sample_id: @sample.id } },
+          ),
+          data: {
+            turbo_stream: true,
+          },
+          class: "button button--size-default button--state-default",
+        ) %>
       <% end %>
     </div>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1764,7 +1764,6 @@ en:
         nav_aria_label: Sample Navigation
         new_attachment_button: Upload Files
         remove_button: Remove
-        remove_button_confirmation: Are you sure you want to remove this sample from the project?
         table_header:
           action: Action
           created_at: Uploaded

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1760,7 +1760,6 @@ fr:
         nav_aria_label: Sample Navigation
         new_attachment_button: Télécharger des fichiers
         remove_button: Retirer
-        remove_button_confirmation: Êtes-vous sûr de vouloir retirer cet échantillon du projet?
         table_header:
           action: Mesure
           created_at: Téléchargé

--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -255,10 +255,10 @@ module Dashboard
       end
 
       visit namespace_project_sample_url(@group1, @project, @sample1)
-      click_link I18n.t('projects.samples.show.remove_button')
+      click_button I18n.t('projects.samples.show.remove_button')
 
-      within('#turbo-confirm[open]') do
-        click_button I18n.t(:'components.confirmation.confirm')
+      within('dialog[open]') do
+        click_button I18n.t(:'projects.samples.deletions.new_deletion_dialog.submit_button')
       end
 
       visit dashboard_projects_url

--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -255,7 +255,7 @@ module Dashboard
       end
 
       visit namespace_project_sample_url(@group1, @project, @sample1)
-      click_button I18n.t('projects.samples.show.remove_button')
+      click_link I18n.t('projects.samples.show.remove_button')
 
       within('dialog[open]') do
         click_button I18n.t(:'projects.samples.deletions.new_deletion_dialog.submit_button')

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -297,9 +297,16 @@ module Projects
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
                                                                            locale: @user.locale))
 
-      within('#samples-table table tbody') do
+      # select all samples
+      click_button I18n.t(:'projects.samples.index.select_all_button')
+      within 'tbody' do
+        assert_selector 'input[name="sample_ids[]"]:checked', count: 3
         assert_selector "tr[id='#{dom_id(@sample1)}']"
         assert_selector 'tr', count: 3
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 3'
+        assert_selector 'strong[data-selection-target="selected"]', text: '3'
       end
 
       # nav to sample show
@@ -310,10 +317,10 @@ module Projects
 
       ### ACTIONS START ##
       # remove sample
-      click_link I18n.t(:'projects.samples.show.remove_button')
+      click_button I18n.t(:'projects.samples.show.remove_button')
 
-      within('#turbo-confirm[open]') do
-        click_button I18n.t(:'components.confirmation.confirm')
+      within('dialog[open]') do
+        click_button I18n.t(:'projects.samples.deletions.new_deletion_dialog.submit_button')
       end
       ### ACTIONS END ###
 
@@ -326,11 +333,18 @@ module Projects
       # verify samples table has loaded to prevent flakes
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 2, count: 2,
                                                                            locale: @user.locale))
-      within('#samples-table table tbody') do
+      within 'tbody' do
+        # remaining samples still appear selected
+        assert_selector 'input[name="sample_ids[]"]:checked',
+                        count: 2
         # remaining samples still appear on table
         assert_selector 'tr', count: 2
         # deleted sample row no longer exists
         assert_no_selector "tr[id='#{dom_id(@sample1)}']"
+      end
+      within 'tfoot' do
+        assert_text 'Samples: 2'
+        assert_selector 'strong[data-selection-target="selected"]', text: '2'
       end
       ### VERIFY END ###
     end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -317,7 +317,7 @@ module Projects
 
       ### ACTIONS START ##
       # remove sample
-      click_button I18n.t(:'projects.samples.show.remove_button')
+      click_link I18n.t(:'projects.samples.show.remove_button')
 
       within('dialog[open]') do
         click_button I18n.t(:'projects.samples.deletions.new_deletion_dialog.submit_button')


### PR DESCRIPTION
## What does this PR do and why?
Fixes sample selection after a sample is deleted from a show page.
Fixes #652.

## Screenshots or screen recordings
https://github.com/user-attachments/assets/ddc0f8f0-c9eb-4f9c-8e41-24f7081eb88e

## How to set up and validate locally
1. Create some samples within a project.
2. Select all samples.
3. Click a sample show page link.
4. Click the `Remove` button.
5. Verify a confirmation dialog appears.
6. Click the `Confirm` button.
7. Verify the page redirected to the samples page and the selected count within the table footer is updated.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
