### PR TITLE
Automated Workflow Execution: Update name to include sample name

### DIFF
--- a/app/services/automated_workflow_executions/launch_service.rb
+++ b/app/services/automated_workflow_executions/launch_service.rb
@@ -50,9 +50,9 @@ module AutomatedWorkflowExecutions
 
     def name
       if @automated_workflow_execution.name.blank?
-        @sample.puid
+        "#{@sample.name} (#{@sample.puid})"
       else
-        [@automated_workflow_execution.name, @sample.puid].join(' ')
+        [@automated_workflow_execution.name, @sample.name, "(#{@sample.puid})"].join(' ')
       end
     end
   end

--- a/test/services/automated_workflow_executions/launch_service_test.rb
+++ b/test/services/automated_workflow_executions/launch_service_test.rb
@@ -48,7 +48,7 @@ module AutomatedWorkflowExecutions
       workflow_execution = AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample,
                                                                           @pe_attachment_pair,
                                                                           @automation_bot).execute
-      assert_equal @sample.puid, workflow_execution.name
+      assert_equal "#{@sample.name} (#{@sample.puid})", workflow_execution.name
     end
 
     test 'sets the name in the created workflow execution to automated workflow execution name plus samples puid if automated workflow execution has a name' do # rubocop:disable Layout/LineLength
@@ -56,7 +56,7 @@ module AutomatedWorkflowExecutions
       workflow_execution = AutomatedWorkflowExecutions::LaunchService.new(@automated_workflow_execution, @sample,
                                                                           @pe_attachment_pair,
                                                                           @automation_bot).execute
-      assert_equal "Prefix #{@sample.puid}", workflow_execution.name
+      assert_equal "Prefix #{@sample.name} (#{@sample.puid})", workflow_execution.name
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updated automated workflow executions launch service to set workflow execution name to `USER_SUPPLIED NAME SAMPLE_NAME (SAMPLE_PUID)`. This addresses [STRY0017741](https://publichealthprod.service-now.com/rm_story.do?sys_id=1b2a86923b34aa105c163064c3e45a9d)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/1583dded-2911-4dfc-9bae-fa1fc940bb1e)

![image](https://github.com/user-attachments/assets/35948f9f-5dd9-4e40-8c12-2a9ba89522af)

![image](https://github.com/user-attachments/assets/a5a00932-1f8d-4951-98a1-416599033dc6)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Setup 2 automated workflow executions for a project, one with a name set and another without
2. Create a new sample in the project and upload a paired-end dataset to the sample
3. Go to the project `Workflow Executions`
4. Verify the name for one of the workflow executions is `USER_SUPPLIED_AUTOMATED_WE_NAME SAMPLE_NAME (SAMPLE_PUID)` and the other is `SAMPLE_NAME (SAMPLE_PUID)`
5. Click into both of these workflow executions, and verify that the title of the page matches the `Name` in the details list

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
