### PR TITLE
Fix: Sidebar overlay focus transfer on expand via keyboard

### DIFF
--- a/app/components/layout/sidebar_component.html.erb
+++ b/app/components/layout/sidebar_component.html.erb
@@ -177,5 +177,7 @@
     bg-slate-200/40 dark:bg-slate-600/40 z-25
   "
   data-layout-target="sidebarOverlay"
+  tabindex="0"
+  data-action="focus->layout#handleContentFocus"
 >
 </div>

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -34,7 +34,7 @@
         data-layout-target="expandButtonContainer"
       >
         <button
-          data-action="click->layout#expand"
+          data-action="click->layout#expand:capture"
           class="text-slate-500 navbar-button cursor-pointer"
           aria-label="<%= t(:'general.navbar.expand.aria_label') %>"
         >
@@ -59,10 +59,11 @@
       <div class="<%= @layout %>"><%= body %></div>
     </main>
     <%= render ConfirmationComponent.new %>
+    <div id="flashes" class="fixed flex flex-col top-5 right-6 z-50">
+      <% flash.each do |key, value| %>
+        <%= viral_flash(type: key, data: value) %>
+      <% end %>
+    </div>
   </div>
-</div>
-<div id="flashes" class="fixed flex flex-col top-5 right-6 z-50">
-  <% flash.each do |key, value| %>
-    <%= viral_flash(type: key, data: value) %>
-  <% end %>
+  <div tabindex="0" data-action="focus->layout#handleContentFocus"></div>
 </div>

--- a/app/javascript/controllers/layout_controller.js
+++ b/app/javascript/controllers/layout_controller.js
@@ -15,14 +15,6 @@ export default class extends Controller {
     if (localStorage.getItem("layout") === "collapsed") {
       this.collapse();
     }
-
-    this.boundHandleSidebarOverlayClick =
-      this.handleSidebarOverlayClick.bind(this);
-
-    this.sidebarOverlayTarget.addEventListener(
-      "click",
-      this.boundHandleSidebarOverlayClick,
-    );
   }
 
   disconnect() {
@@ -38,19 +30,20 @@ export default class extends Controller {
     localStorage.setItem("layout", "collapsed");
   }
 
-  expand(event) {
+  expand() {
+    this.expandButtonContainerTarget.classList.add("xl:hidden");
     this.layoutContainerTarget.classList.remove("collapsed");
     if (window.innerWidth < this.#convertRemToPixels(80)) {
       this.layoutContainerTarget.classList.remove("max-xl:collapsed");
     }
-    this.expandButtonContainerTarget.classList.add("xl:hidden");
-    if (typeof event !== "undefined") {
-      this.logoTarget.focus();
-    }
     localStorage.setItem("layout", "expanded");
+
+    setTimeout(() => {
+      this.logoTarget.focus();
+    }, 25);
   }
 
-  handleSidebarOverlayClick() {
+  handleContentFocus() {
     if (window.innerWidth < this.#convertRemToPixels(80)) {
       if (
         !this.layoutContainerTarget.classList.contains(


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the expand logic for the sidebar to also focus to the IRIDA Next logo after expanding the sidebar (via keyboard). In addition now when tabbing outside of the sidebar it is automatically collapses (if the user expanded the sidebar while viewing the application at high enough zoom to cause sidebar to collapse automatically). In addition, I added a tab target at the bottom of the html, so that if a user reverse tabs from the IRIDA Next logo, through their web browser tabbable areas back into the website it will also collapse the sidebar.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

[Peek 2025-05-30 08-07.webm](https://github.com/user-attachments/assets/2b70a5c1-3522-477b-b766-fd1e450e197f)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Zoom in until the sidebar automatically collapses
3. Tab to the expand sidebar button and hit enter
4. Observer that the sidebar appears and that keyboard focus has been moved to the IRIDA Next logo
5. Hit tab untill you are are the help button, then tab once more
6. Observe that the sidebar collapses
7. Hit enter on the expand sidebar button again
8. Shift - Tab untill you get back into the website and observe that the sidebar collapses

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
