### PR TITLE
Accessibility: Browser title update

### DIFF
--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -201,11 +201,11 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
                t(:'general.default_sidebar.data_exports').to_s
              when 'show'
                if @tab == 'preview'
-                 "#{t(:'data_exports.show.tabs.preview')} · " \
-                   "#{t(:'data_exports.show.page_title')} #{@data_export.id}"
+                 [t(:'data_exports.show.tabs.preview'),
+                  "#{t(:'data_exports.show.page_title')} #{@data_export.id}"].join(' · ')
                else
-                 "#{t(:'data_exports.show.tabs.summary')} · " \
-                   "#{t(:'data_exports.show.page_title')} #{@data_export.id}"
+                 [t(:'data_exports.show.tabs.summary'),
+                  "#{t(:'data_exports.show.page_title')} #{@data_export.id}"].join(' · ')
                end
              else
                t(:'general.default_sidebar.data_exports')

--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -198,16 +198,16 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
   def page_title # rubocop:disable Metrics/MethodLength
     @title = case action_name
              when 'index'
-               "#{t(:'general.default_sidebar.data_exports')} · #{current_user.namespace.full_path}"
+               "#{t(:'general.default_sidebar.data_exports')} · #{current_user.email}"
              when 'show'
                if @tab == 'preview'
                  "#{t(:'data_exports.show.tabs.preview')} · " \
                    "#{t(:'data_exports.show.page_title')} #{@data_export.id} · " \
-                   "#{current_user.namespace&.full_path}"
+                   "#{current_user.email}"
                else
                  "#{t(:'data_exports.show.tabs.summary')} · " \
                    "#{t(:'data_exports.show.page_title')} #{@data_export.id} · " \
-                   "#{current_user.namespace&.full_path}"
+                   "#{current_user.email}"
                end
              else
                t(:'general.default_sidebar.data_exports')

--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -195,19 +195,17 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
     end
   end
 
-  def page_title # rubocop:disable Metrics/MethodLength
+  def page_title
     @title = case action_name
              when 'index'
-               "#{t(:'general.default_sidebar.data_exports')} · #{current_user.email}"
+               t(:'general.default_sidebar.data_exports').to_s
              when 'show'
                if @tab == 'preview'
                  "#{t(:'data_exports.show.tabs.preview')} · " \
-                   "#{t(:'data_exports.show.page_title')} #{@data_export.id} · " \
-                   "#{current_user.email}"
+                   "#{t(:'data_exports.show.page_title')} #{@data_export.id}"
                else
                  "#{t(:'data_exports.show.tabs.summary')} · " \
-                   "#{t(:'data_exports.show.page_title')} #{@data_export.id} · " \
-                   "#{current_user.email}"
+                   "#{t(:'data_exports.show.page_title')} #{@data_export.id}"
                end
              else
                t(:'general.default_sidebar.data_exports')

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -44,7 +44,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.files')} · #{@group.full_path}"
+      @title = "#{t(:'groups.sidebar.files')} · #{@group.name}"
     end
   end
 end

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -44,7 +44,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.files')} · #{t(:'shared.group_name', name: @group.name)}"
+      @title = [t(:'groups.sidebar.files'), @group.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/groups/attachments_controller.rb
+++ b/app/controllers/groups/attachments_controller.rb
@@ -44,7 +44,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.files')} · #{@group.name}"
+      @title = "#{t(:'groups.sidebar.files')} · #{t(:'shared.group_name', name: @group.name)}"
     end
   end
 end

--- a/app/controllers/groups/bots_controller.rb
+++ b/app/controllers/groups/bots_controller.rb
@@ -47,8 +47,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.bot_accounts')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
-                                                                                        name: @group.name)}"
+      @title = [t(:'groups.sidebar.bot_accounts'), t(:'groups.edit.title'), @group.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/groups/bots_controller.rb
+++ b/app/controllers/groups/bots_controller.rb
@@ -47,7 +47,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.bot_accounts')} · #{t(:'groups.edit.title')} · #{@group.full_path}"
+      @title = "#{t(:'groups.sidebar.bot_accounts')} · #{t(:'groups.edit.title')} · #{@group.name}"
     end
   end
 end

--- a/app/controllers/groups/bots_controller.rb
+++ b/app/controllers/groups/bots_controller.rb
@@ -47,7 +47,8 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.bot_accounts')} · #{t(:'groups.edit.title')} · #{@group.name}"
+      @title = "#{t(:'groups.sidebar.bot_accounts')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
+                                                                                        name: @group.name)}"
     end
   end
 end

--- a/app/controllers/groups/history_controller.rb
+++ b/app/controllers/groups/history_controller.rb
@@ -43,8 +43,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.history')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
-                                                                                   name: @group.name)}"
+      @title = [t(:'groups.sidebar.history'), t(:'groups.edit.title'), @group.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/groups/history_controller.rb
+++ b/app/controllers/groups/history_controller.rb
@@ -43,7 +43,8 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.history')} · #{t(:'groups.edit.title')} · #{@group.name}"
+      @title = "#{t(:'groups.sidebar.history')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
+                                                                                   name: @group.name)}"
     end
   end
 end

--- a/app/controllers/groups/history_controller.rb
+++ b/app/controllers/groups/history_controller.rb
@@ -43,7 +43,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.history')} · #{t(:'groups.edit.title')} · #{@group.full_path}"
+      @title = "#{t(:'groups.sidebar.history')} · #{t(:'groups.edit.title')} · #{@group.name}"
     end
   end
 end

--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -50,9 +50,9 @@ module Groups
 
     def page_title
       @title = if @tab == 'invited_groups'
-                 "#{t(:'groups.members.index.invited_groups')} · #{@namespace.full_path}"
+                 "#{t(:'groups.members.index.invited_groups')} · #{@namespace.name}"
                else
-                 "#{t(:'groups.sidebar.members')} · #{@namespace.full_path}"
+                 "#{t(:'groups.sidebar.members')} · #{@namespace.name}"
                end
     end
   end

--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -50,9 +50,9 @@ module Groups
 
     def page_title
       @title = if @tab == 'invited_groups'
-                 "#{t(:'groups.members.index.invited_groups')} · #{@namespace.name}"
+                 "#{t(:'groups.members.index.invited_groups')} · #{t(:'shared.group_name', name: @namespace.name)}"
                else
-                 "#{t(:'groups.sidebar.members')} · #{@namespace.name}"
+                 "#{t(:'groups.sidebar.members')} · #{t(:'shared.group_name', name: @namespace.name)}"
                end
     end
   end

--- a/app/controllers/groups/members_controller.rb
+++ b/app/controllers/groups/members_controller.rb
@@ -50,9 +50,9 @@ module Groups
 
     def page_title
       @title = if @tab == 'invited_groups'
-                 "#{t(:'groups.members.index.invited_groups')} · #{t(:'shared.group_name', name: @namespace.name)}"
+                 [t(:'groups.members.index.invited_groups'), @namespace.full_name].join(' · ')
                else
-                 "#{t(:'groups.sidebar.members')} · #{t(:'shared.group_name', name: @namespace.name)}"
+                 [t(:'groups.sidebar.members'), @namespace.full_name].join(' · ')
                end
     end
   end

--- a/app/controllers/groups/metadata_templates_controller.rb
+++ b/app/controllers/groups/metadata_templates_controller.rb
@@ -42,7 +42,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.metadata_templates')} · #{t(:'groups.edit.title')} · #{@group.full_path}"
+      @title = "#{t(:'groups.sidebar.metadata_templates')} · #{t(:'groups.edit.title')} · #{@group.name}"
     end
   end
 end

--- a/app/controllers/groups/metadata_templates_controller.rb
+++ b/app/controllers/groups/metadata_templates_controller.rb
@@ -42,8 +42,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.metadata_templates')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
-                                                                                              name: @group.name)}"
+      @title = [t(:'groups.sidebar.metadata_templates'), t(:'groups.edit.title'), @group.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/groups/metadata_templates_controller.rb
+++ b/app/controllers/groups/metadata_templates_controller.rb
@@ -42,7 +42,8 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'groups.sidebar.metadata_templates')} · #{t(:'groups.edit.title')} · #{@group.name}"
+      @title = "#{t(:'groups.sidebar.metadata_templates')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
+                                                                                              name: @group.name)}"
     end
   end
 end

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -131,7 +131,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'activerecord.models.sample.other')} · #{@group.name}"
+      @title = "#{t(:'activerecord.models.sample.other')} · #{t(:'shared.group_name', name: @group.name)}"
     end
   end
 end

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -131,7 +131,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'activerecord.models.sample.other')} · #{t(:'shared.group_name', name: @group.name)}"
+      @title = [t(:'activerecord.models.sample.other'), @group.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/groups/samples_controller.rb
+++ b/app/controllers/groups/samples_controller.rb
@@ -131,7 +131,7 @@ module Groups
     end
 
     def page_title
-      @title = "#{t(:'activerecord.models.sample.other')} · #{@group.full_path}"
+      @title = "#{t(:'activerecord.models.sample.other')} · #{@group.name}"
     end
   end
 end

--- a/app/controllers/groups/workflow_executions_controller.rb
+++ b/app/controllers/groups/workflow_executions_controller.rb
@@ -87,28 +87,28 @@ module Groups
       group_workflow_executions_path
     end
 
-    def page_title # rubocop:disable Metrics/MethodLength
+    def page_title # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       case action_name
       when 'index'
-        @title = "#{t(:'general.default_sidebar.workflows')} · #{t(:'shared.group_name', name: @group.name)}"
+        @title = [t(:'general.default_sidebar.workflows'), @group.full_name].join(' · ')
       when 'show'
         @title = case @tab
                  when 'params'
-                   "#{t(:'workflow_executions.show.tabs.params')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.group_name', name: @group.name)}"
+                   [t(:'workflow_executions.show.tabs.params'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @group.full_name].join(' · ')
                  when 'samplesheet'
-                   "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.group_name', name: @group.name)}"
+                   [t(:'workflow_executions.show.tabs.samplesheet'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @group.full_name].join(' · ')
                  when 'files'
-                   "#{t(:'workflow_executions.show.tabs.files')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.group_name', name: @group.name)}"
+                   [t(:'workflow_executions.show.tabs.files'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @group.full_name].join(' · ')
                  else
-                   "#{t(:'workflow_executions.show.tabs.summary')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.group_name', name: @group.name)}"
+                   [t(:'workflow_executions.show.tabs.summary'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @group.full_name].join(' · ')
                  end
       end
     end

--- a/app/controllers/groups/workflow_executions_controller.rb
+++ b/app/controllers/groups/workflow_executions_controller.rb
@@ -90,25 +90,25 @@ module Groups
     def page_title # rubocop:disable Metrics/MethodLength
       case action_name
       when 'index'
-        @title = "#{t(:'general.default_sidebar.workflows')} · #{@group.name}"
+        @title = "#{t(:'general.default_sidebar.workflows')} · #{t(:'shared.group_name', name: @group.name)}"
       when 'show'
         @title = case @tab
                  when 'params'
                    "#{t(:'workflow_executions.show.tabs.params')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.name}"
+                   "#{t(:'shared.group_name', name: @group.name)}"
                  when 'samplesheet'
                    "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.name}"
+                   "#{t(:'shared.group_name', name: @group.name)}"
                  when 'files'
                    "#{t(:'workflow_executions.show.tabs.files')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.name}"
+                   "#{t(:'shared.group_name', name: @group.name)}"
                  else
                    "#{t(:'workflow_executions.show.tabs.summary')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.name}"
+                   "#{t(:'shared.group_name', name: @group.name)}"
                  end
       end
     end

--- a/app/controllers/groups/workflow_executions_controller.rb
+++ b/app/controllers/groups/workflow_executions_controller.rb
@@ -90,25 +90,25 @@ module Groups
     def page_title # rubocop:disable Metrics/MethodLength
       case action_name
       when 'index'
-        @title = "#{t(:'general.default_sidebar.workflows')} · #{@group.full_path}"
+        @title = "#{t(:'general.default_sidebar.workflows')} · #{@group.name}"
       when 'show'
         @title = case @tab
                  when 'params'
                    "#{t(:'workflow_executions.show.tabs.params')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.full_path}"
+                   "#{@group.name}"
                  when 'samplesheet'
                    "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.full_path}"
+                   "#{@group.name}"
                  when 'files'
                    "#{t(:'workflow_executions.show.tabs.files')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.full_path}"
+                   "#{@group.name}"
                  else
                    "#{t(:'workflow_executions.show.tabs.summary')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@group.full_path}"
+                   "#{@group.name}"
                  end
       end
     end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -268,14 +268,15 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     @title = case action_name
              when 'show'
                if @tab == 'shared_namespaces'
-                 "#{t(:'groups.show.tabs.shared_namespaces')} · #{@group.name}"
+                 "#{t(:'groups.show.tabs.shared_namespaces')} · #{t(:'shared.group_name', name: @group.name)}"
                else
-                 "#{t(:'groups.show.tabs.subgroups_and_projects')} · #{@group.name}"
+                 "#{t(:'groups.show.tabs.subgroups_and_projects')} · #{t(:'shared.group_name', name: @group.name)}"
                end
              when 'activity'
-               "#{t(:'groups.sidebar.activity')} · #{@group.name}"
+               "#{t(:'groups.sidebar.activity')} · #{t(:'shared.group_name', name: @group.name)}"
              when 'edit'
-               "#{t(:'groups.sidebar.general')} · #{t(:'groups.edit.title')} · #{@group.name}"
+               "#{t(:'groups.sidebar.general')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
+                                                                                   name: @group.name)}"
              when 'new'
                if @group
                  t(:'groups.new_subgroup.title')

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -268,15 +268,14 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     @title = case action_name
              when 'show'
                if @tab == 'shared_namespaces'
-                 "#{t(:'groups.show.tabs.shared_namespaces')} · #{t(:'shared.group_name', name: @group.name)}"
+                 [t(:'groups.show.tabs.shared_namespaces'), @group.full_name].join(' · ')
                else
-                 "#{t(:'groups.show.tabs.subgroups_and_projects')} · #{t(:'shared.group_name', name: @group.name)}"
+                 [t(:'groups.show.tabs.subgroups_and_projects'), @group.full_name].join(' · ')
                end
              when 'activity'
-               "#{t(:'groups.sidebar.activity')} · #{t(:'shared.group_name', name: @group.name)}"
+               [t(:'groups.sidebar.activity'), @group.full_name].join(' · ')
              when 'edit'
-               "#{t(:'groups.sidebar.general')} · #{t(:'groups.edit.title')} · #{t(:'shared.group_name',
-                                                                                   name: @group.name)}"
+               [t(:'groups.sidebar.general'), t(:'groups.edit.title'), @group.full_name].join(' · ')
              when 'new'
                if @group
                  t(:'groups.new_subgroup.title')

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -268,14 +268,14 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     @title = case action_name
              when 'show'
                if @tab == 'shared_namespaces'
-                 "#{t(:'groups.show.tabs.shared_namespaces')} · #{@group.full_path}"
+                 "#{t(:'groups.show.tabs.shared_namespaces')} · #{@group.name}"
                else
-                 "#{t(:'groups.show.tabs.subgroups_and_projects')} · #{@group.full_path}"
+                 "#{t(:'groups.show.tabs.subgroups_and_projects')} · #{@group.name}"
                end
              when 'activity'
-               "#{t(:'groups.sidebar.activity')} · #{@group.full_path}"
+               "#{t(:'groups.sidebar.activity')} · #{@group.name}"
              when 'edit'
-               "#{t(:'groups.sidebar.general')} · #{t(:'groups.edit.title')} · #{@group.full_path}"
+               "#{t(:'groups.sidebar.general')} · #{t(:'groups.edit.title')} · #{@group.name}"
              when 'new'
                if @group
                  t(:'groups.new_subgroup.title')

--- a/app/controllers/profiles/accounts_controller.rb
+++ b/app/controllers/profiles/accounts_controller.rb
@@ -22,7 +22,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.account')} · #{current_user.email}"
+      @title = [t(:'profiles.sidebar.account'), current_user.email].join(' · ')
     end
   end
 end

--- a/app/controllers/profiles/accounts_controller.rb
+++ b/app/controllers/profiles/accounts_controller.rb
@@ -22,7 +22,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.account')} · #{current_user.namespace&.full_path}"
+      @title = "#{t(:'profiles.sidebar.account')} · #{current_user.email}"
     end
   end
 end

--- a/app/controllers/profiles/passwords_controller.rb
+++ b/app/controllers/profiles/passwords_controller.rb
@@ -37,7 +37,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.password')} · #{current_user.email}"
+      @title = [t(:'profiles.sidebar.password'), current_user.email].join(' · ')
     end
   end
 end

--- a/app/controllers/profiles/passwords_controller.rb
+++ b/app/controllers/profiles/passwords_controller.rb
@@ -37,7 +37,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.password')} · #{current_user.namespace&.full_path}"
+      @title = "#{t(:'profiles.sidebar.password')} · #{current_user.email}"
     end
   end
 end

--- a/app/controllers/profiles/personal_access_tokens_controller.rb
+++ b/app/controllers/profiles/personal_access_tokens_controller.rb
@@ -59,7 +59,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.access_tokens')} · #{current_user.namespace&.full_path}"
+      @title = "#{t(:'profiles.sidebar.access_tokens')} · #{current_user.email}"
     end
   end
 end

--- a/app/controllers/profiles/personal_access_tokens_controller.rb
+++ b/app/controllers/profiles/personal_access_tokens_controller.rb
@@ -59,7 +59,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.access_tokens')} · #{current_user.email}"
+      @title = [t(:'profiles.sidebar.access_tokens'), current_user.email].join(' · ')
     end
   end
 end

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -40,7 +40,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.preferences')} · #{current_user.namespace&.full_path}"
+      @title = "#{t(:'profiles.sidebar.preferences')} · #{current_user.email}"
     end
   end
 end

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -40,7 +40,7 @@ module Profiles
     end
 
     def page_title
-      @title = "#{t(:'profiles.sidebar.preferences')} · #{current_user.email}"
+      @title = [t(:'profiles.sidebar.preferences'), current_user.email].join(' · ')
     end
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -40,6 +40,6 @@ class ProfilesController < Profiles::ApplicationController
   end
 
   def page_title
-    @title = "#{t(:'profiles.sidebar.profile')} · #{current_user.namespace&.full_path}"
+    @title = "#{t(:'profiles.sidebar.profile')} · #{current_user.email}"
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -40,6 +40,6 @@ class ProfilesController < Profiles::ApplicationController
   end
 
   def page_title
-    @title = "#{t(:'profiles.sidebar.profile')} · #{current_user.email}"
+    @title = [t(:'profiles.sidebar.profile'), current_user.email].join(' · ')
   end
 end

--- a/app/controllers/projects/attachments_controller.rb
+++ b/app/controllers/projects/attachments_controller.rb
@@ -39,7 +39,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.files')} · #{t(:'shared.project_name', name: @project.name)}"
+      @title = [t(:'projects.sidebar.files'), @project.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/projects/attachments_controller.rb
+++ b/app/controllers/projects/attachments_controller.rb
@@ -39,7 +39,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.files')} · #{@project.name}"
+      @title = "#{t(:'projects.sidebar.files')} · #{t(:'shared.project_name', name: @project.name)}"
     end
   end
 end

--- a/app/controllers/projects/attachments_controller.rb
+++ b/app/controllers/projects/attachments_controller.rb
@@ -39,7 +39,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.files')} · #{@project.full_path}"
+      @title = "#{t(:'projects.sidebar.files')} · #{@project.name}"
     end
   end
 end

--- a/app/controllers/projects/automated_workflow_executions_controller.rb
+++ b/app/controllers/projects/automated_workflow_executions_controller.rb
@@ -156,8 +156,8 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.automated_workflow_executions')} · #{t(:'projects.edit.title')} · " \
-               "#{t(:'shared.project_name', name: @project.name)}"
+      @title = [t(:'projects.sidebar.automated_workflow_executions'), t(:'projects.edit.title'),
+                @project.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/projects/automated_workflow_executions_controller.rb
+++ b/app/controllers/projects/automated_workflow_executions_controller.rb
@@ -157,7 +157,7 @@ module Projects
 
     def page_title
       @title = "#{t(:'projects.sidebar.automated_workflow_executions')} · #{t(:'projects.edit.title')} · " \
-               "#{@project.name}"
+               "#{t(:'shared.project_name', name: @project.name)}"
     end
   end
 end

--- a/app/controllers/projects/automated_workflow_executions_controller.rb
+++ b/app/controllers/projects/automated_workflow_executions_controller.rb
@@ -157,7 +157,7 @@ module Projects
 
     def page_title
       @title = "#{t(:'projects.sidebar.automated_workflow_executions')} · #{t(:'projects.edit.title')} · " \
-               "#{@project.full_path}"
+               "#{@project.name}"
     end
   end
 end

--- a/app/controllers/projects/bots_controller.rb
+++ b/app/controllers/projects/bots_controller.rb
@@ -48,7 +48,8 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.bot_accounts')} · #{t(:'projects.edit.title')} · #{@project.name}"
+      @title = "#{t(:'projects.sidebar.bot_accounts')} · #{t(:'projects.edit.title')} · #{t(:'shared.project_name',
+                                                                                            name: @project.name)}"
     end
   end
 end

--- a/app/controllers/projects/bots_controller.rb
+++ b/app/controllers/projects/bots_controller.rb
@@ -48,7 +48,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.bot_accounts')} · #{t(:'projects.edit.title')} · #{@project.full_path}"
+      @title = "#{t(:'projects.sidebar.bot_accounts')} · #{t(:'projects.edit.title')} · #{@project.name}"
     end
   end
 end

--- a/app/controllers/projects/bots_controller.rb
+++ b/app/controllers/projects/bots_controller.rb
@@ -48,8 +48,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.bot_accounts')} · #{t(:'projects.edit.title')} · #{t(:'shared.project_name',
-                                                                                            name: @project.name)}"
+      @title = [t(:'projects.sidebar.bot_accounts'), t(:'projects.edit.title'), @project.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/projects/history_controller.rb
+++ b/app/controllers/projects/history_controller.rb
@@ -38,8 +38,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.history')} · #{t(:'projects.edit.title')} · #{t(:'shared.project_name',
-                                                                                       name: @project.name)}"
+      @title = [t(:'projects.sidebar.history'), t(:'projects.edit.title'), @project.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/projects/history_controller.rb
+++ b/app/controllers/projects/history_controller.rb
@@ -38,7 +38,8 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.history')} · #{t(:'projects.edit.title')} · #{@project.name}"
+      @title = "#{t(:'projects.sidebar.history')} · #{t(:'projects.edit.title')} · #{t(:'shared.project_name',
+                                                                                       name: @project.name)}"
     end
   end
 end

--- a/app/controllers/projects/history_controller.rb
+++ b/app/controllers/projects/history_controller.rb
@@ -38,7 +38,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.history')} · #{t(:'projects.edit.title')} · #{@project.full_path}"
+      @title = "#{t(:'projects.sidebar.history')} · #{t(:'projects.edit.title')} · #{@project.name}"
     end
   end
 end

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -49,9 +49,9 @@ module Projects
 
     def page_title
       @title = if @tab == 'invited_groups'
-                 "#{t(:'projects.members.index.invited_groups')} · #{@project.full_path}"
+                 "#{t(:'projects.members.index.invited_groups')} · #{@project.name}"
                else
-                 "#{t(:'projects.sidebar.members')} · #{@project.full_path}"
+                 "#{t(:'projects.sidebar.members')} · #{@project.name}"
                end
     end
   end

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -49,9 +49,9 @@ module Projects
 
     def page_title
       @title = if @tab == 'invited_groups'
-                 "#{t(:'projects.members.index.invited_groups')} · #{@project.name}"
+                 "#{t(:'projects.members.index.invited_groups')} · #{t(:'shared.project_name', name: @project.name)}"
                else
-                 "#{t(:'projects.sidebar.members')} · #{@project.name}"
+                 "#{t(:'projects.sidebar.members')} · #{t(:'shared.project_name', name: @project.name)}"
                end
     end
   end

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -49,9 +49,9 @@ module Projects
 
     def page_title
       @title = if @tab == 'invited_groups'
-                 "#{t(:'projects.members.index.invited_groups')} · #{t(:'shared.project_name', name: @project.name)}"
+                 [t(:'projects.members.index.invited_groups'), @project.full_name].join(' · ')
                else
-                 "#{t(:'projects.sidebar.members')} · #{t(:'shared.project_name', name: @project.name)}"
+                 [t(:'projects.sidebar.members'), @project.full_name].join(' · ')
                end
     end
   end

--- a/app/controllers/projects/metadata_templates_controller.rb
+++ b/app/controllers/projects/metadata_templates_controller.rb
@@ -43,7 +43,9 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.metadata_templates')} · #{t(:'projects.edit.title')} · #{@project.name}"
+      @title = "#{t(:'projects.sidebar.metadata_templates')} · #{t(:'projects.edit.title')} · #{t(
+        :'shared.project_name', name: @project.name
+      )}"
     end
   end
 end

--- a/app/controllers/projects/metadata_templates_controller.rb
+++ b/app/controllers/projects/metadata_templates_controller.rb
@@ -43,9 +43,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.metadata_templates')} · #{t(:'projects.edit.title')} · #{t(
-        :'shared.project_name', name: @project.name
-      )}"
+      @title = [t(:'projects.sidebar.metadata_templates'), t(:'projects.edit.title'), @project.full_name].join(' · ')
     end
   end
 end

--- a/app/controllers/projects/metadata_templates_controller.rb
+++ b/app/controllers/projects/metadata_templates_controller.rb
@@ -43,7 +43,7 @@ module Projects
     end
 
     def page_title
-      @title = "#{t(:'projects.sidebar.metadata_templates')} · #{t(:'projects.edit.title')} · #{@project.full_path}"
+      @title = "#{t(:'projects.sidebar.metadata_templates')} · #{t(:'projects.edit.title')} · #{@project.name}"
     end
   end
 end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -213,27 +213,28 @@ module Projects
     def page_title # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       case action_name
       when 'new'
-        @title = "#{t(:'projects.samples.new.title')} · #{@project.name}"
+        @title = [t(:'projects.samples.new.title'), @project.full_name].join(' · ')
       when 'edit'
-        @title = "#{t(:'projects.samples.edit.title')} · #{t(:'activerecord.models.sample.one')} #{@sample.name} · " \
-                 "#{t(:'shared.project_name', name: @project.name)}"
+        @title = [t(:'projects.samples.edit.title'),
+                  "#{t(:'activerecord.models.sample.one')} #{@sample.name}",
+                  @project.full_name].join(' · ')
       when 'show'
         @tab = params[:tab]
         @title = if @tab == 'metadata'
-                   "#{t(:'projects.samples.show.tabs.metadata')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{t(:'shared.project_name',
-                                                                                    name: @project.name)}"
+                   [t(:'projects.samples.show.tabs.metadata'),
+                    "#{t(:'activerecord.models.sample.one')} #{@sample.name}",
+                    @project.full_name].join(' · ')
                  elsif @tab == 'history'
-                   "#{t(:'projects.samples.show.tabs.history')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{t(:'shared.project_name',
-                                                                                    name: @project.name)}"
+                   [t(:'projects.samples.show.tabs.history'),
+                    "#{t(:'activerecord.models.sample.one')} #{@sample.name}",
+                    @project.full_name].join(' · ')
                  else
-                   "#{t(:'projects.samples.show.tabs.files')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{t(:'shared.project_name',
-                                                                                    name: @project.name)}"
+                   [t(:'projects.samples.show.tabs.files'),
+                    "#{t(:'activerecord.models.sample.one')} #{@sample.name}",
+                    @project.full_name].join(' · ')
                  end
       else
-        @title = "#{t(:'activerecord.models.sample.other')} · #{t(:'shared.project_name', name: @project.name)}"
+        @title = [t(:'activerecord.models.sample.other'), @project.full_name].join(' · ')
       end
     end
   end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -216,21 +216,24 @@ module Projects
         @title = "#{t(:'projects.samples.new.title')} · #{@project.name}"
       when 'edit'
         @title = "#{t(:'projects.samples.edit.title')} · #{t(:'activerecord.models.sample.one')} #{@sample.name} · " \
-                 "#{@project.name}"
+                 "#{t(:'shared.project_name', name: @project.name)}"
       when 'show'
         @tab = params[:tab]
         @title = if @tab == 'metadata'
                    "#{t(:'projects.samples.show.tabs.metadata')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.name}"
+                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{t(:'shared.project_name',
+                                                                                    name: @project.name)}"
                  elsif @tab == 'history'
                    "#{t(:'projects.samples.show.tabs.history')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.name}"
+                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{t(:'shared.project_name',
+                                                                                    name: @project.name)}"
                  else
                    "#{t(:'projects.samples.show.tabs.files')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.name}"
+                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{t(:'shared.project_name',
+                                                                                    name: @project.name)}"
                  end
       else
-        @title = "#{t(:'activerecord.models.sample.other')} · #{@project.name}"
+        @title = "#{t(:'activerecord.models.sample.other')} · #{t(:'shared.project_name', name: @project.name)}"
       end
     end
   end

--- a/app/controllers/projects/samples_controller.rb
+++ b/app/controllers/projects/samples_controller.rb
@@ -213,24 +213,24 @@ module Projects
     def page_title # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       case action_name
       when 'new'
-        @title = "#{t(:'projects.samples.new.title')} · #{@project.full_path}"
+        @title = "#{t(:'projects.samples.new.title')} · #{@project.name}"
       when 'edit'
         @title = "#{t(:'projects.samples.edit.title')} · #{t(:'activerecord.models.sample.one')} #{@sample.name} · " \
-                 "#{@project.full_path}"
+                 "#{@project.name}"
       when 'show'
         @tab = params[:tab]
         @title = if @tab == 'metadata'
                    "#{t(:'projects.samples.show.tabs.metadata')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.full_path}"
+                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.name}"
                  elsif @tab == 'history'
                    "#{t(:'projects.samples.show.tabs.history')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.full_path}"
+                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.name}"
                  else
                    "#{t(:'projects.samples.show.tabs.files')} · " \
-                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.full_path}"
+                     "#{t(:'activerecord.models.sample.one')} #{@sample.name} · #{@project.name}"
                  end
       else
-        @title = "#{t(:'activerecord.models.sample.other')} · #{@project.full_path}"
+        @title = "#{t(:'activerecord.models.sample.other')} · #{@project.name}"
       end
     end
   end

--- a/app/controllers/projects/workflow_executions_controller.rb
+++ b/app/controllers/projects/workflow_executions_controller.rb
@@ -101,25 +101,25 @@ module Projects
     def page_title # rubocop:disable Metrics/MethodLength
       case action_name
       when 'index'
-        @title = "#{t(:'general.default_sidebar.workflows')} · #{@project.full_path}"
+        @title = "#{t(:'general.default_sidebar.workflows')} · #{@project.name}"
       when 'show'
         @title = case @tab
                  when 'params'
                    "#{t(:'workflow_executions.show.tabs.params')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.full_path}"
+                   "#{@project.name}"
                  when 'samplesheet'
                    "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.full_path}"
+                   "#{@project.name}"
                  when 'files'
                    "#{t(:'workflow_executions.show.tabs.files')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.full_path}"
+                   "#{@project.name}"
                  else
                    "#{t(:'workflow_executions.show.tabs.summary')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.full_path}"
+                   "#{@project.name}"
                  end
       end
     end

--- a/app/controllers/projects/workflow_executions_controller.rb
+++ b/app/controllers/projects/workflow_executions_controller.rb
@@ -98,28 +98,28 @@ module Projects
       namespace_project_workflow_executions_path
     end
 
-    def page_title # rubocop:disable Metrics/MethodLength
+    def page_title # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       case action_name
       when 'index'
-        @title = "#{t(:'general.default_sidebar.workflows')} · #{t(:'shared.project_name', name: @project.name)}"
+        @title = "#{t(:'general.default_sidebar.workflows')} · #{@project.full_name}"
       when 'show'
         @title = case @tab
                  when 'params'
-                   "#{t(:'workflow_executions.show.tabs.params')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.project_name', name: @project.name)}"
+                   [t(:'workflow_executions.show.tabs.params'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @project.full_name].join(' · ')
                  when 'samplesheet'
-                   "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.project_name', name: @project.name)}"
+                   [t(:'workflow_executions.show.tabs.samplesheet'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @project.full_name].join(' · ')
                  when 'files'
-                   "#{t(:'workflow_executions.show.tabs.files')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.project_name', name: @project.name)}"
+                   [t(:'workflow_executions.show.tabs.files'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @project.full_name].join(' · ')
                  else
-                   "#{t(:'workflow_executions.show.tabs.summary')} · " \
-                   "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{t(:'shared.project_name', name: @project.name)}"
+                   [t(:'workflow_executions.show.tabs.summary'),
+                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}",
+                    @project.full_name].join(' · ')
                  end
       end
     end

--- a/app/controllers/projects/workflow_executions_controller.rb
+++ b/app/controllers/projects/workflow_executions_controller.rb
@@ -101,25 +101,25 @@ module Projects
     def page_title # rubocop:disable Metrics/MethodLength
       case action_name
       when 'index'
-        @title = "#{t(:'general.default_sidebar.workflows')} · #{@project.name}"
+        @title = "#{t(:'general.default_sidebar.workflows')} · #{t(:'shared.project_name', name: @project.name)}"
       when 'show'
         @title = case @tab
                  when 'params'
                    "#{t(:'workflow_executions.show.tabs.params')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.name}"
+                   "#{t(:'shared.project_name', name: @project.name)}"
                  when 'samplesheet'
                    "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.name}"
+                   "#{t(:'shared.project_name', name: @project.name)}"
                  when 'files'
                    "#{t(:'workflow_executions.show.tabs.files')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.name}"
+                   "#{t(:'shared.project_name', name: @project.name)}"
                  else
                    "#{t(:'workflow_executions.show.tabs.summary')} · " \
                    "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                   "#{@project.name}"
+                   "#{t(:'shared.project_name', name: @project.name)}"
                  end
       end
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -212,12 +212,11 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   def page_title
     @title = case action_name
              when 'show'
-               "#{t(:'projects.sidebar.details')} · #{t(:'shared.project_name', name: @project.name)}"
+               [t(:'projects.sidebar.details'), @project.full_name].join(' · ')
              when 'activity'
-               "#{t(:'projects.sidebar.activity')} · #{t(:'shared.project_name', name: @project.name)}"
+               [t(:'projects.sidebar.activity'), @project.full_name].join(' · ')
              when 'edit'
-               "#{t(:'projects.sidebar.general')} · #{t(:'projects.edit.title')} · #{t(:'shared.project_name',
-                                                                                       name: @project.name)}"
+               [t(:'projects.sidebar.general'), t(:'projects.edit.title'), @project.full_name].join(' · ')
              when 'new'
                t(:'projects.new.title')
              else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -212,11 +212,12 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   def page_title
     @title = case action_name
              when 'show'
-               "#{t(:'projects.sidebar.details')} · #{@project.name}"
+               "#{t(:'projects.sidebar.details')} · #{t(:'shared.project_name', name: @project.name)}"
              when 'activity'
-               "#{t(:'projects.sidebar.activity')} · #{@project.name}"
+               "#{t(:'projects.sidebar.activity')} · #{t(:'shared.project_name', name: @project.name)}"
              when 'edit'
-               "#{t(:'projects.sidebar.general')} · #{t(:'projects.edit.title')} · #{@project.name}"
+               "#{t(:'projects.sidebar.general')} · #{t(:'projects.edit.title')} · #{t(:'shared.project_name',
+                                                                                       name: @project.name)}"
              when 'new'
                t(:'projects.new.title')
              else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -212,11 +212,11 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
   def page_title
     @title = case action_name
              when 'show'
-               "#{t(:'projects.sidebar.details')} · #{@project.full_path}"
+               "#{t(:'projects.sidebar.details')} · #{@project.name}"
              when 'activity'
-               "#{t(:'projects.sidebar.activity')} · #{@project.full_path}"
+               "#{t(:'projects.sidebar.activity')} · #{@project.name}"
              when 'edit'
-               "#{t(:'projects.sidebar.general')} · #{t(:'projects.edit.title')} · #{@project.full_path}"
+               "#{t(:'projects.sidebar.general')} · #{t(:'projects.edit.title')} · #{@project.name}"
              when 'new'
                t(:'projects.new.title')
              else

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -108,28 +108,28 @@ class WorkflowExecutionsController < ApplicationController # rubocop:disable Met
     @destroy_path = destroy_multiple_workflow_executions_path
   end
 
-  def page_title # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def page_title # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     case action_name
     when 'index'
-      @title = "#{t(:'general.default_sidebar.workflows')} · #{current_user.namespace&.full_path}"
+      @title = "#{t(:'general.default_sidebar.workflows')} · #{current_user.email}"
     when 'show'
       @title = case @tab
                when 'params'
                  "#{t(:'workflow_executions.show.tabs.params')} · " \
                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.namespace&.full_path}"
+                 "#{current_user.email}"
                when 'samplesheet'
                  "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.namespace&.full_path}"
+                 "#{current_user.email}"
                when 'files'
                  "#{t(:'workflow_executions.show.tabs.files')} · " \
                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.namespace&.full_path}"
+                 "#{current_user.email}"
                else
                  "#{t(:'workflow_executions.show.tabs.summary')} · " \
                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.namespace&.full_path}"
+                 "#{current_user.email}"
                end
     end
   end

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -115,17 +115,17 @@ class WorkflowExecutionsController < ApplicationController # rubocop:disable Met
     when 'show'
       @title = case @tab
                when 'params'
-                 "#{t(:'workflow_executions.show.tabs.params')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
+                 [t(:'workflow_executions.show.tabs.params'),
+                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"].join(' · ')
                when 'samplesheet'
-                 "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
+                 [t(:'workflow_executions.show.tabs.samplesheet'),
+                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"].join(' · ')
                when 'files'
-                 "#{t(:'workflow_executions.show.tabs.files')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
+                 [t(:'workflow_executions.show.tabs.files'),
+                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"].join(' · ')
                else
-                 "#{t(:'workflow_executions.show.tabs.summary')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
+                 [t(:'workflow_executions.show.tabs.summary'),
+                  "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"].join(' · ')
                end
     end
   end

--- a/app/controllers/workflow_executions_controller.rb
+++ b/app/controllers/workflow_executions_controller.rb
@@ -108,28 +108,24 @@ class WorkflowExecutionsController < ApplicationController # rubocop:disable Met
     @destroy_path = destroy_multiple_workflow_executions_path
   end
 
-  def page_title # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def page_title # rubocop:disable Metrics/MethodLength
     case action_name
     when 'index'
-      @title = "#{t(:'general.default_sidebar.workflows')} · #{current_user.email}"
+      @title = t(:'general.default_sidebar.workflows').to_s
     when 'show'
       @title = case @tab
                when 'params'
                  "#{t(:'workflow_executions.show.tabs.params')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.email}"
+                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
                when 'samplesheet'
                  "#{t(:'workflow_executions.show.tabs.samplesheet')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.email}"
+                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
                when 'files'
                  "#{t(:'workflow_executions.show.tabs.files')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.email}"
+                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
                else
                  "#{t(:'workflow_executions.show.tabs.summary')} · " \
-                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id} · " \
-                 "#{current_user.email}"
+                 "#{t(:'shared.workflow_executions.workflow_execution')} #{@workflow_execution.id}"
                end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2010,11 +2010,13 @@ en:
     alert:
       list:
         danger: Danger
+    group_name: Group %{name}
     loading:
       samples_list_skeleton:
         loading: Loading...
     progress_bar:
       in_progress: Action in progress. Please do not refresh the page.
+    project_name: Project %{name}
     samples:
       actions_dropdown:
         clone: Copy samples

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2010,13 +2010,11 @@ en:
     alert:
       list:
         danger: Danger
-    group_name: Group %{name}
     loading:
       samples_list_skeleton:
         loading: Loading...
     progress_bar:
       in_progress: Action in progress. Please do not refresh the page.
-    project_name: Project %{name}
     samples:
       actions_dropdown:
         clone: Copy samples

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2006,13 +2006,11 @@ fr:
     alert:
       list:
         danger: Danger
-    group_name: Groupe %{name}
     loading:
       samples_list_skeleton:
         loading: Chargement...
     progress_bar:
       in_progress: Action in progress. Please do not refresh the page.
-    project_name: Projet %{name}
     samples:
       actions_dropdown:
         clone: Copier des échantillons

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2006,11 +2006,13 @@ fr:
     alert:
       list:
         danger: Danger
+    group_name: Groupe %{name}
     loading:
       samples_list_skeleton:
         loading: Chargement...
     progress_bar:
       in_progress: Action in progress. Please do not refresh the page.
+    project_name: Projet %{name}
     samples:
       actions_dropdown:
         clone: Copier des échantillons


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR addresses browser page titles to be more descriptive (removing path/url and replacing with name). [STRY0018198](https://publichealthprod.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3Dcc8be6f947f1e250f24c0c21516d43ed)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![Screenshot from 2025-05-30 15-56-17](https://github.com/user-attachments/assets/66f72d61-3c2b-475d-b9be-93c80a511a3d)

![Screenshot from 2025-05-30 15-56-02](https://github.com/user-attachments/assets/7769cd18-84de-4875-b2f3-88d099e1ed09)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Visit every page, and ensure the browser titles in the tab make sense

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
