### PR TITLE
WCAG AAA Button Styles

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -332,19 +332,43 @@
 }
 
 @utility button {
-  @apply inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-lg border px-5 py-2.5 text-sm disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto;
+  /* Base styles with WCAG AAA compliance */
+  @apply inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-lg border px-5 py-2.5 text-base font-medium transition-all duration-200 ease-in-out disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto;
+
+  /* Ensure focus is always visible */
+  &:focus-visible {
+    @apply outline outline-2 outline-offset-2;
+  }
 }
 
 @utility button-default {
-  @apply border-slate-300 bg-slate-50 text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:hover:bg-slate-800 dark:hover:text-white;
+  /* High contrast colors for WCAG AAA */
+  @apply border-slate-300 bg-white text-slate-900 shadow-sm hover:border-slate-400 hover:bg-slate-50 hover:text-slate-950 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:hover:border-slate-500 dark:hover:bg-slate-700;
+
+  /* Focus styles with high contrast */
+  &:focus-visible {
+    @apply outline-slate-700 dark:outline-slate-300;
+  }
 }
 
 @utility button-destructive {
-  @apply border-red-800 bg-red-700 text-white hover:bg-red-800 dark:border-red-600 dark:bg-red-600 dark:text-white dark:hover:bg-red-700;
+  /* High contrast colors for WCAG AAA */
+  @apply border-red-700 bg-red-700 text-white shadow-sm hover:border-red-800 hover:bg-red-800 dark:border-red-600 dark:bg-red-600 dark:hover:border-red-700 dark:hover:bg-red-700;
+
+  /* Focus styles with high contrast */
+  &:focus-visible {
+    @apply outline-red-800 dark:outline-red-400;
+  }
 }
 
 @utility button-primary {
-  @apply border-primary-800 bg-primary-800 hover:bg-primary-900 dark:border-primary-700 dark:bg-primary-700 dark:hover:bg-primary-600 text-white dark:text-white;
+  /* High contrast colors for WCAG AAA */
+  @apply border-primary-700 bg-primary-700 hover:bg-primary-800 hover:border-primary-800 dark:border-primary-600 dark:bg-primary-600 dark:hover:bg-primary-700 dark:hover:border-primary-700 text-white shadow-sm;
+
+  /* Focus styles with high contrast */
+  &:focus-visible {
+    @apply outline-primary-800 dark:outline-primary-400;
+  }
 }
 
 @utility dialog--size {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -336,15 +336,15 @@
 }
 
 @utility button-default {
-  @apply border-neutral-300 bg-white text-neutral-900 hover:bg-neutral-100 hover:text-neutral-950 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:hover:text-white;
+  @apply border-slate-300 bg-slate-50 text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:hover:bg-slate-800 dark:hover:text-white;
 }
 
 @utility button-destructive {
-  @apply border-red-800 bg-red-700 text-white hover:bg-red-800 dark:border-red-600 dark:bg-red-700 dark:text-white dark:hover:bg-red-800;
+  @apply border-red-800 bg-red-700 text-white hover:bg-red-800 dark:border-red-600 dark:bg-red-600 dark:text-white dark:hover:bg-red-700;
 }
 
 @utility button-primary {
-  @apply border-primary-800 bg-primary-700 hover:bg-primary-800 dark:border-primary-800 dark:bg-primary-700 dark:hover:bg-primary-800 text-white dark:text-white;
+  @apply border-primary-800 bg-primary-800 hover:bg-primary-900 dark:border-primary-700 dark:bg-primary-700 dark:hover:bg-primary-600 text-white dark:text-white;
 }
 
 @utility dialog--size {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -332,35 +332,19 @@
 }
 
 @utility button {
-  @apply inline-flex cursor-pointer items-center justify-center rounded-lg border text-sm focus:z-10 sm:w-auto;
-
-  &:disabled {
-    @apply cursor-not-allowed opacity-50;
-  }
+  @apply inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-lg border px-5 py-2.5 text-sm disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto;
 }
 
-@utility button--size-default {
-  @apply min-h-11 min-w-11 px-5 py-2.5 text-sm;
+@utility button-default {
+  @apply border-neutral-300 bg-white text-neutral-900 hover:bg-neutral-100 hover:text-neutral-950 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:hover:text-white;
 }
 
-@utility button--size-small {
-  @apply px-3 py-2 text-xs;
+@utility button-destructive {
+  @apply border-red-800 bg-red-700 text-white hover:bg-red-800 dark:border-red-600 dark:bg-red-700 dark:text-white dark:hover:bg-red-800;
 }
 
-@utility button--size-large {
-  @apply px-7 py-3 text-lg;
-}
-
-@utility button--state-default {
-  @apply border-slate-200 bg-white text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white;
-}
-
-@utility button--state-destructive {
-  @apply border-red-800 bg-red-700 text-white hover:bg-red-800 dark:border-red-600 dark:bg-red-600 dark:text-white dark:hover:bg-red-700;
-}
-
-@utility button--state-primary {
-  @apply border-primary-800 bg-primary-700 hover:bg-primary-800 dark:bg-primary-800 dark:border-primary-900 dark:hover:bg-primary-700 text-white dark:text-white;
+@utility button-primary {
+  @apply border-primary-800 bg-primary-700 hover:bg-primary-800 dark:border-primary-800 dark:bg-primary-700 dark:hover:bg-primary-800 text-white dark:text-white;
 }
 
 @utility dialog--size {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -343,7 +343,7 @@
 
 @utility button-default {
   /* High contrast colors for WCAG AAA */
-  @apply border-slate-300 bg-white text-slate-900 shadow-sm hover:border-slate-400 hover:bg-slate-50 hover:text-slate-950 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:hover:border-slate-500 dark:hover:bg-slate-700;
+  @apply border-slate-300 bg-white text-slate-900 hover:border-slate-400 hover:bg-slate-50 hover:text-slate-950 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:hover:border-slate-500 dark:hover:bg-slate-700;
 
   /* Focus styles with high contrast */
   &:focus-visible {
@@ -353,7 +353,7 @@
 
 @utility button-destructive {
   /* High contrast colors for WCAG AAA */
-  @apply border-red-700 bg-red-700 text-white shadow-sm hover:border-red-800 hover:bg-red-800 dark:border-red-600 dark:bg-red-600 dark:hover:border-red-700 dark:hover:bg-red-700;
+  @apply border-red-700 bg-red-700 text-white hover:border-red-800 hover:bg-red-800 dark:border-red-600 dark:bg-red-600 dark:hover:border-red-700 dark:hover:bg-red-700;
 
   /* Focus styles with high contrast */
   &:focus-visible {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -333,11 +333,11 @@
 
 @utility button {
   /* Base styles with WCAG AAA compliance */
-  @apply inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-lg border px-5 py-2.5 text-base font-medium transition-all duration-200 ease-in-out disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto;
+  @apply inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-lg border px-5 py-2.5 text-sm font-medium transition-all duration-200 ease-in-out disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto;
 
   /* Ensure focus is always visible */
   &:focus-visible {
-    @apply outline outline-2 outline-offset-2;
+    @apply outline-2 outline-offset-2;
   }
 }
 

--- a/app/components/activities/groups/sample_activity_component.html.erb
+++ b/app/components/activities/groups/sample_activity_component.html.erb
@@ -34,6 +34,5 @@
     turbo_stream: true,
   },
   method: :get,
-  class:
-    "inline-flex items-center justify-center button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+  class: "button button-default" %>
 </section>

--- a/app/components/activities/groups/sample_clone_activity_component.html.erb
+++ b/app/components/activities/groups/sample_clone_activity_component.html.erb
@@ -18,6 +18,5 @@
     turbo_stream: true,
   },
   method: :get,
-  class:
-    "inline-flex items-center justify-center button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+  class: "button button-default" %>
 </section>

--- a/app/components/activities/groups/sample_transfer_activity_component.html.erb
+++ b/app/components/activities/groups/sample_transfer_activity_component.html.erb
@@ -20,5 +20,5 @@
   },
   method: :get,
   class:
-    "inline-flex items-center justify-center button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
 </section>

--- a/app/components/activities/projects/sample_activity_component.html.erb
+++ b/app/components/activities/projects/sample_activity_component.html.erb
@@ -55,6 +55,6 @@
     },
     method: :get,
     class:
-      "inline-flex items-center justify-center button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+      "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
   <% end %>
 </section>

--- a/app/components/activities/projects/sample_clone_activity_component.html.erb
+++ b/app/components/activities/projects/sample_clone_activity_component.html.erb
@@ -53,5 +53,5 @@
   },
   method: :get,
   class:
-    "inline-flex items-center justify-center button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
 </section>

--- a/app/components/activities/projects/sample_transfer_activity_component.html.erb
+++ b/app/components/activities/projects/sample_transfer_activity_component.html.erb
@@ -53,5 +53,5 @@
   },
   method: :get,
   class:
-    "inline-flex items-center justify-center button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
 </section>

--- a/app/components/activities/projects/workflow_execution_activity_component.html.erb
+++ b/app/components/activities/projects/workflow_execution_activity_component.html.erb
@@ -20,6 +20,6 @@
     },
     method: :get,
     class:
-      "inline-flex items-center justify-center button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+      "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
   <% end %>
 </section>

--- a/app/components/activity_component.html.erb
+++ b/app/components/activity_component.html.erb
@@ -7,12 +7,11 @@
       <%= render Activities::ListItemComponent.new(activity: activity) %>
     <% end %>
   </ol>
-
   <div id="next_link">
     <% if @pagy.next.present? %>
       <%= button_to t(:"components.activity.load_more"),
       helpers.pagy_url_for(@pagy, @pagy.next),
-      class: "button button--state-default button--size-default" %>
+      class: "button button-default" %>
     <% end %>
   </div>
 </div>

--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -9,13 +9,7 @@
         <div class="inline-flex rounded-lg" role="group">
           <button
             type="button"
-            class="
-              inline-flex items-center justify-center w-1/2 text-sm border rounded-s-lg
-              cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white text-slate-900
-              border-slate-200 hover:bg-slate-100 hover:text-slate-950 dark:bg-slate-800
-              dark:text-slate-400 dark:border-slate-600 dark:hover:text-white
-              dark:hover:bg-slate-700
-            "
+            class="button button-default rounded-e-none border-e-0"
             data-action="advanced-search#idempotentConnect viral--dialog#open"
             aria-label="<%= t(".title") %>"
           >
@@ -23,13 +17,7 @@
           </button>
           <button
             type="button"
-            class="
-              inline-flex items-center justify-center w-1/2 text-sm border border-l-0
-              rounded-e-lg cursor-pointer sm:w-auto focus:z-10 text-sm px-5 py-2.5 bg-white
-              text-slate-900 border-slate-200 hover:bg-slate-100 hover:text-slate-950
-              dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600
-              dark:hover:text-white dark:hover:bg-slate-700
-            "
+            class="button button-default rounded-s-none"
             data-action="advanced-search#clearForm filters#submit"
             aria-label="<%= t(".clear_aria_label") %>"
           >

--- a/app/components/attachments/dialogs/new_attachment_component.html.erb
+++ b/app/components/attachments/dialogs/new_attachment_component.html.erb
@@ -43,7 +43,7 @@
       <div>
         <%= form.submit t(".upload"),
                     id: "t-upload-button",
-                    class: "button button-primary button--size-default",
+                    class: "button button-primary",
                     data: {
                       "attachment-upload-target": "submitButton",
                     } %>

--- a/app/components/attachments/dialogs/new_attachment_component.html.erb
+++ b/app/components/attachments/dialogs/new_attachment_component.html.erb
@@ -43,7 +43,7 @@
       <div>
         <%= form.submit t(".upload"),
                     id: "t-upload-button",
-                    class: "button button--state-primary button--size-default",
+                    class: "button button-primary button--size-default",
                     data: {
                       "attachment-upload-target": "submitButton",
                     } %>

--- a/app/components/confirmation_component.html.erb
+++ b/app/components/confirmation_component.html.erb
@@ -17,13 +17,10 @@
     <div class="dialog--form">
       <form method="dialog">
         <div class="flex items-center mt-6">
-          <button
-            class="button button--state-destructive button--size-default mr-2"
-            value="confirm"
-          ><%= t(:"components.confirmation.confirm") %>
+          <button class="button button-destructive mr-2" value="confirm"><%= t(:"components.confirmation.confirm") %>
           </button>
           <button
-            class="button button--state-default button--size-default"
+            class="button button-default button--size-default"
             formmethod="dialog"
             value="cancel"
           >
@@ -47,14 +44,14 @@
         />
         <div class="flex items-center mt-6">
           <button
-            class="mr-2 button button--state-destructive button--size-default"
+            class="mr-2 button button-destructive button--size-default"
             value="confirm"
             disabled="disabled"
             data-confirmation-target="confirmButton"
           ><%= t(:"components.confirmation.confirm") %>
           </button>
           <button
-            class="button button--state-default button--size-default"
+            class="button button-default button--size-default"
             formmethod="dialog"
             value="cancel"
           >

--- a/app/components/confirmation_component.html.erb
+++ b/app/components/confirmation_component.html.erb
@@ -19,11 +19,7 @@
         <div class="flex items-center mt-6">
           <button class="button button-destructive mr-2" value="confirm"><%= t(:"components.confirmation.confirm") %>
           </button>
-          <button
-            class="button button-default button--size-default"
-            formmethod="dialog"
-            value="cancel"
-          >
+          <button class="button button-default" formmethod="dialog" value="cancel">
             <%= t(:"components.confirmation.cancel") %>
           </button>
         </div>
@@ -44,17 +40,13 @@
         />
         <div class="flex items-center mt-6">
           <button
-            class="mr-2 button button-destructive button--size-default"
+            class="mr-2 button button-destructive"
             value="confirm"
             disabled="disabled"
             data-confirmation-target="confirmButton"
           ><%= t(:"components.confirmation.confirm") %>
           </button>
-          <button
-            class="button button-default button--size-default"
-            formmethod="dialog"
-            value="cancel"
-          >
+          <button class="button button-default" formmethod="dialog" value="cancel">
             <%= t(:"components.confirmation.cancel") %>
           </button>
         </div>

--- a/app/components/confirmation_component.html.erb
+++ b/app/components/confirmation_component.html.erb
@@ -19,7 +19,7 @@
         <div class="flex items-center mt-6">
           <button class="button button-destructive mr-2" value="confirm"><%= t(:"components.confirmation.confirm") %>
           </button>
-          <button class="button button-default" formmethod="dialog" value="cancel">
+          <button class="button button--state-default" formmethod="dialog" value="cancel">
             <%= t(:"components.confirmation.cancel") %>
           </button>
         </div>
@@ -46,7 +46,7 @@
             data-confirmation-target="confirmButton"
           ><%= t(:"components.confirmation.confirm") %>
           </button>
-          <button class="button button-default" formmethod="dialog" value="cancel">
+          <button class="button button--state-default" formmethod="dialog" value="cancel">
             <%= t(:"components.confirmation.cancel") %>
           </button>
         </div>

--- a/app/components/confirmation_component.html.erb
+++ b/app/components/confirmation_component.html.erb
@@ -19,7 +19,7 @@
         <div class="flex items-center mt-6">
           <button class="button button-destructive mr-2" value="confirm"><%= t(:"components.confirmation.confirm") %>
           </button>
-          <button class="button button--state-default" formmethod="dialog" value="cancel">
+          <button class="button button-default" formmethod="dialog" value="cancel">
             <%= t(:"components.confirmation.cancel") %>
           </button>
         </div>
@@ -46,7 +46,7 @@
             data-confirmation-target="confirmButton"
           ><%= t(:"components.confirmation.confirm") %>
           </button>
-          <button class="button button--state-default" formmethod="dialog" value="cancel">
+          <button class="button button-default" formmethod="dialog" value="cancel">
             <%= t(:"components.confirmation.cancel") %>
           </button>
         </div>

--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -133,7 +133,7 @@
     <% end %>
 
     <button
-      class="button button--state-primary button--size-default"
+      class="button button-primary button--size-default"
       data-nextflow--samplesheet-target="submit"
       <% if @samples.empty? %>
       type="submit"

--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -133,7 +133,7 @@
     <% end %>
 
     <button
-      class="button button-primary button--size-default"
+      class="button button-primary"
       data-nextflow--samplesheet-target="submit"
       <% if @samples.empty? %>
       type="submit"

--- a/app/components/project_dashboard_component.html.erb
+++ b/app/components/project_dashboard_component.html.erb
@@ -39,8 +39,7 @@
       </div>
       <%= link_to t(:"components.project_dashboard.view_more_activity"),
       namespace_project_activity_path(@project.namespace.parent, @project),
-      class:
-        "mt-4 button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+      class: "mt-4 button button-default" %>
     </div>
   </section>
 
@@ -67,8 +66,7 @@
       </div>
       <%= link_to t(:"components.project_dashboard.view_more_samples"),
       namespace_project_samples_path(@project.namespace.parent, @project),
-      class:
-        "mt-4 button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+      class: "mt-4 button button-default" %>
     </div>
   </section>
 </div>

--- a/app/components/project_dashboard_component.html.erb
+++ b/app/components/project_dashboard_component.html.erb
@@ -40,7 +40,7 @@
       <%= link_to t(:"components.project_dashboard.view_more_activity"),
       namespace_project_activity_path(@project.namespace.parent, @project),
       class:
-        "mt-4 button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+        "mt-4 button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
     </div>
   </section>
 
@@ -68,7 +68,7 @@
       <%= link_to t(:"components.project_dashboard.view_more_samples"),
       namespace_project_samples_path(@project.namespace.parent, @project),
       class:
-        "mt-4 button button--state-default button--size-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+        "mt-4 button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
     </div>
   </section>
 </div>

--- a/app/components/search_component.html.erb
+++ b/app/components/search_component.html.erb
@@ -6,7 +6,7 @@
                  **{ value: @value }.compact,
                  "data-action": "selection#clear",
                  class:
-                   "t-search-component block w-full p-2.5 pl-10 text-sm text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
+                   "t-search-component block w-full p-2.5 pl-10 text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
                  placeholder: @placeholder %>
     <div
       class="

--- a/app/components/search_component.html.erb
+++ b/app/components/search_component.html.erb
@@ -6,7 +6,7 @@
                  **{ value: @value }.compact,
                  "data-action": "selection#clear",
                  class:
-                   "t-search-component block w-full p-2.5 pl-10 text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
+                   "t-search-component block w-full p-2.5 pl-10 text-slate-900 border border-slate-300 text-sm rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
                  placeholder: @placeholder %>
     <div
       class="

--- a/app/components/search_component.html.erb
+++ b/app/components/search_component.html.erb
@@ -6,7 +6,7 @@
                  **{ value: @value }.compact,
                  "data-action": "selection#clear",
                  class:
-                   "t-search-component block w-full p-2.5 pl-10 text-slate-900 border border-slate-300 text-sm rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
+                   "t-search-component block w-full min-h-[44px] p-2.5 pl-10 text-slate-900 border border-slate-300 text-sm rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
                  placeholder: @placeholder %>
     <div
       class="

--- a/app/components/viral/button_component.rb
+++ b/app/components/viral/button_component.rb
@@ -12,17 +12,10 @@ module Viral
       :destructive => 'button-destructive'
     }.freeze
 
-    SIZE_DEFAULT = :default
-    SIZE_MAPPINGS = {
-      :small => 'button--size-default',
-      SIZE_DEFAULT => 'button--size-default',
-      :large => 'button--size-large'
-    }.freeze
-
     DISCLOSURE_DEFAULT = false
     DISCLOSURE_OPTIONS = [true, false, :down, :up, :select, :horizontal_dots].freeze
 
-    def initialize(state: STATE_DEFAULT, size: SIZE_DEFAULT, full_width: false,
+    def initialize(state: STATE_DEFAULT, full_width: false,
                    disclosure: DISCLOSURE_DEFAULT, **system_arguments)
       @disclosure = disclosure
       @disclosure = :down if @disclosure == true
@@ -34,7 +27,6 @@ module Viral
         'button',
         user_defined_classes,
         STATE_MAPPINGS[state],
-        SIZE_MAPPINGS[size],
         'w-full': full_width
       )
     end

--- a/app/components/viral/button_component.rb
+++ b/app/components/viral/button_component.rb
@@ -7,9 +7,9 @@ module Viral
 
     STATE_DEFAULT = :default
     STATE_MAPPINGS = {
-      STATE_DEFAULT => 'button--state-default',
-      :primary => 'button--state-primary',
-      :destructive => 'button--state-destructive'
+      STATE_DEFAULT => 'button-default',
+      :primary => 'button-primary',
+      :destructive => 'button-destructive'
     }.freeze
 
     SIZE_DEFAULT = :default

--- a/app/components/viral/dropdown_component.rb
+++ b/app/components/viral/dropdown_component.rb
@@ -191,12 +191,8 @@ module Viral
 
       {
         classes: class_names(
-          'text-slate-600 dark:text-slate-400',
-          'border border-slate-300 min-h-11 min-w-11',
-          'dark:border-slate-600 rounded-lg text-sm',
-          'px-3 py-1 cursor-pointer',
-          'inline-flex items-center justify-center',
-          @system_arguments[:classes]
+          'button button-default',
+          system_arguments[:classes]
         )
       }
     end

--- a/app/javascript/controllers/action_button_controller.js
+++ b/app/javascript/controllers/action_button_controller.js
@@ -7,8 +7,14 @@ export default class extends Controller {
   // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties
   #event_classes = ["pointer-events-none", "cursor-not-allowed"];
 
-  #default_colours = ["bg-slate-100", "text-slate-600", "dark:bg-slate-600", "dark:text-slate-300",
-    "border-slate-100", "dark:border-slate-600"];
+  #default_colours = [
+    "bg-slate-100",
+    "text-slate-600",
+    "dark:bg-slate-600",
+    "dark:text-slate-300",
+    "border-slate-100",
+    "dark:border-slate-600",
+  ];
 
   #primary_colours = ["bg-primary-200", "text-slate-400", "border-primary-200"];
 
@@ -24,7 +30,7 @@ export default class extends Controller {
     if (this.requiredValue > count) {
       this.element.disabled = true;
       this.element.classList.add(...this.#event_classes);
-      if (this.element.classList.contains("button--state-primary")) {
+      if (this.element.classList.contains("button-primary")) {
         this.element.classList.add(...this.#primary_colours);
       } else {
         this.element.classList.add(...this.#default_colours);
@@ -32,7 +38,7 @@ export default class extends Controller {
     } else {
       this.element.disabled = false;
       this.element.classList.remove(...this.#event_classes);
-      if (this.element.classList.contains("button--state-primary")) {
+      if (this.element.classList.contains("button-primary")) {
         this.element.classList.remove(...this.#primary_colours);
       } else {
         this.element.classList.remove(...this.#default_colours);

--- a/app/views/dashboard/groups/index.html.erb
+++ b/app/views/dashboard/groups/index.html.erb
@@ -2,8 +2,7 @@
   <%= component.with_buttons do %>
     <%= link_to t(:".create_group_button"),
     new_group_path,
-    class:
-      "inline-flex items-center justify-center button button-primary button--size-default" %>
+    class: "inline-flex items-center justify-center button button-primary" %>
   <% end %>
 <% end %>
 <div class="flex flex-col">

--- a/app/views/dashboard/groups/index.html.erb
+++ b/app/views/dashboard/groups/index.html.erb
@@ -3,7 +3,7 @@
     <%= link_to t(:".create_group_button"),
     new_group_path,
     class:
-      "inline-flex items-center justify-center button button--state-primary button--size-default" %>
+      "inline-flex items-center justify-center button button-primary button--size-default" %>
   <% end %>
 <% end %>
 <div class="flex flex-col">

--- a/app/views/dashboard/projects/index.html.erb
+++ b/app/views/dashboard/projects/index.html.erb
@@ -4,7 +4,7 @@
   <%= component.with_buttons do %>
     <%= link_to t(".create_project_button"),
     new_project_path,
-    class: "button button-primary button--size-default" %>
+    class: "button button-primary" %>
   <% end %>
 <% end %>
 

--- a/app/views/dashboard/projects/index.html.erb
+++ b/app/views/dashboard/projects/index.html.erb
@@ -4,7 +4,7 @@
   <%= component.with_buttons do %>
     <%= link_to t(".create_project_button"),
     new_project_path,
-    class: "button button--state-primary button--size-default" %>
+    class: "button button-primary button--size-default" %>
   <% end %>
 <% end %>
 

--- a/app/views/data_exports/_new_analysis_export_dialog.html.erb
+++ b/app/views/data_exports/_new_analysis_export_dialog.html.erb
@@ -101,7 +101,7 @@
                         data: {
                           turbo_frame: "_top",
                         },
-                        class: "button button-primary button--size-default" %>
+                        class: "button button-primary" %>
           </div>
         </div>
       <% end %>

--- a/app/views/data_exports/_new_analysis_export_dialog.html.erb
+++ b/app/views/data_exports/_new_analysis_export_dialog.html.erb
@@ -101,7 +101,7 @@
                         data: {
                           turbo_frame: "_top",
                         },
-                        class: "button button--state-primary button--size-default" %>
+                        class: "button button-primary button--size-default" %>
           </div>
         </div>
       <% end %>

--- a/app/views/data_exports/_new_linelist_export_dialog.html.erb
+++ b/app/views/data_exports/_new_linelist_export_dialog.html.erb
@@ -172,7 +172,7 @@
                               "click->viral--sortable-lists--two-lists-selection#constructParams",
                             "viral--sortable-lists--two-lists-selection-target": "submitBtn",
                           },
-                          class: "button button--state-primary button--size-default",
+                          class: "button button-primary button--size-default",
                           disabled: true %>
             </div>
           </div>

--- a/app/views/data_exports/_new_linelist_export_dialog.html.erb
+++ b/app/views/data_exports/_new_linelist_export_dialog.html.erb
@@ -172,7 +172,7 @@
                               "click->viral--sortable-lists--two-lists-selection#constructParams",
                             "viral--sortable-lists--two-lists-selection-target": "submitBtn",
                           },
-                          class: "button button-primary button--size-default",
+                          class: "button button-primary",
                           disabled: true %>
             </div>
           </div>

--- a/app/views/data_exports/_new_sample_export_dialog.html.erb
+++ b/app/views/data_exports/_new_sample_export_dialog.html.erb
@@ -123,7 +123,7 @@
                               "click->viral--sortable-lists--two-lists-selection#constructParams",
                             "viral--sortable-lists--two-lists-selection-target": "submitBtn",
                           },
-                          class: "button button-primary button--size-default" %>
+                          class: "button button-primary" %>
             </div>
           </div>
         <% end %>

--- a/app/views/data_exports/_new_sample_export_dialog.html.erb
+++ b/app/views/data_exports/_new_sample_export_dialog.html.erb
@@ -123,7 +123,7 @@
                               "click->viral--sortable-lists--two-lists-selection#constructParams",
                             "viral--sortable-lists--two-lists-selection-target": "submitBtn",
                           },
-                          class: "button button--state-primary button--size-default" %>
+                          class: "button button-primary button--size-default" %>
             </div>
           </div>
         <% end %>

--- a/app/views/data_exports/_new_single_analysis_export_dialog.html.erb
+++ b/app/views/data_exports/_new_single_analysis_export_dialog.html.erb
@@ -43,8 +43,8 @@
           </div>
           <div
             class="
-              overflow-y-auto max-h-[200px] border border-t-0 border-slate-200 rounded-b-lg block
-              w-full p-2.5 dark:bg-slate-800 dark:border-slate-700
+              overflow-y-auto max-h-[200px] border border-t-0 border-slate-200 rounded-b-lg
+              block w-full p-2.5 dark:bg-slate-800 dark:border-slate-700
             "
           >
             <div class="font-semibold text-gray-900 dark:text-white"><%= t("data_exports.list_workflow_execution.id") %>
@@ -89,7 +89,7 @@
                         data: {
                           turbo_frame: "_top",
                         },
-                        class: "button button--state-primary button--size-default" %>
+                        class: "button button-primary button--size-default" %>
           </div>
         </div>
       <% end %>

--- a/app/views/data_exports/_new_single_analysis_export_dialog.html.erb
+++ b/app/views/data_exports/_new_single_analysis_export_dialog.html.erb
@@ -89,7 +89,7 @@
                         data: {
                           turbo_frame: "_top",
                         },
-                        class: "button button-primary button--size-default" %>
+                        class: "button button-primary" %>
           </div>
         </div>
       <% end %>

--- a/app/views/data_exports/show.html.erb
+++ b/app/views/data_exports/show.html.erb
@@ -9,14 +9,14 @@
           t("data_exports.show.download"),
           rails_blob_path(@data_export.file),
           method: :get,
-          class: "button button--state-primary button--size-default",
+          class: "button button-primary button--size-default",
         ) %>
       <% else %>
         <button
           class="
-            button button--size-default button--state-default pointer-events-none
-            cursor-not-allowed bg-slate-100 text-slate-600 dark:bg-slate-600
-            dark:text-slate-300 border-slate-100 dark:border-slate-600
+            button button-default pointer-events-none cursor-not-allowed bg-slate-100
+            text-slate-600 dark:bg-slate-600 dark:text-slate-300 border-slate-100
+            dark:border-slate-600
           "
           disabled
         ><%= t("data_exports.show.download") %>
@@ -37,7 +37,7 @@
               name: @data_export.name || @data_export.id,
             ),
         },
-        class: "button button--state-default button--size-default mr-1 ml-2",
+        class: "button button-default mr-1 ml-2",
       ) %>
     </div>
   <% end %>

--- a/app/views/data_exports/show.html.erb
+++ b/app/views/data_exports/show.html.erb
@@ -9,7 +9,7 @@
           t("data_exports.show.download"),
           rails_blob_path(@data_export.file),
           method: :get,
-          class: "button button-primary button--size-default",
+          class: "button button-primary",
         ) %>
       <% else %>
         <button

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -6,8 +6,7 @@
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
-  <%= f.submit t(".submit_button"),
-           class: "button button--state-primary button--size-default w-full" %>
+  <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>
 <% end %>
 
 <div class="grid gap-2">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,8 +36,7 @@
                      autocomplete: "new-password" %>
   </div>
 
-  <%= f.submit t(".submit_button"),
-           class: "button button--state-primary button--size-default w-full" %>
+  <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>
 <% end %>
 
 <div class="flex"><span class="mr-2 dark:text-white"><%= t(".signed_up") %></span>

--- a/app/views/devise/sessions/new_with_providers.html.erb
+++ b/app/views/devise/sessions/new_with_providers.html.erb
@@ -8,7 +8,7 @@
     <%= render "devise/shared/links" %>
     <%= link_to t(".return_button"),
     new_user_session_path(**params),
-    class: "button button--state-default button--size-default w-full" %>
+    class: "button button-default w-full" %>
   <% else %>
     <%- resource_class.omniauth_providers.each do |provider| %>
       <%= button_to omniauth_authorize_path(resource_name, provider),
@@ -16,7 +16,7 @@
                       turbo: false
                     },
                     params: params,
-                    class: "button button--state-default button--size-default w-full" do %>
+                    class: "button button-default w-full" do %>
         <span class="inline-flex items-center text-center">
           <% if Rails.configuration.auth_config["#{provider}_icon"] %>
             <%= viral_icon(name: "#{provider}_icon", classes: "w-4 h-4 mr-2 -ml-1") %>
@@ -33,6 +33,6 @@
     <% end %>
     <%= link_to t(".local_button"),
     new_user_session_path(local: true, **params),
-    class: "button button--state-default button--size-default w-full" %>
+    class: "button button-default w-full" %>
   <% end %>
 </div>

--- a/app/views/devise/shared/_form.html.erb
+++ b/app/views/devise/shared/_form.html.erb
@@ -27,8 +27,6 @@
   <% end %>
 
   <div class="flow-root">
-    <%= f.submit t(".sign_in"),
-             class:
-               "button button--state-primary button--size-default w-full cursor-pointer" %>
+    <%= f.submit t(".sign_in"), class: "button button-primary w-full cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/groups/_edit_advanced_delete.html.erb
+++ b/app/views/groups/_edit_advanced_delete.html.erb
@@ -51,7 +51,7 @@
         turbo_content: ".confirm-delete",
         confirm_value: @group.path,
       },
-      class: "button button--state-destructive button--size-default" %>
+      class: "button button-destructive button--size-default" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/groups/_edit_advanced_delete.html.erb
+++ b/app/views/groups/_edit_advanced_delete.html.erb
@@ -51,7 +51,7 @@
         turbo_content: ".confirm-delete",
         confirm_value: @group.path,
       },
-      class: "button button-destructive button--size-default" %>
+      class: "button button-destructive" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -38,8 +38,7 @@
                       data: {
                         turbo_frame: "_top",
                       },
-                      class:
-                        "button button--state-destructive button--size-default inline-block" %>
+                      class: "button button-destructive inline-block" %>
         </div>
       </div>
     <% end %>

--- a/app/views/groups/_edit_advanced_transfer_form.html.erb
+++ b/app/views/groups/_edit_advanced_transfer_form.html.erb
@@ -50,8 +50,7 @@ data: { turbo_confirm: "", controller: "viral--select2" }) do |form| %>
   </div>
   <div>
     <%= form.submit t("groups.edit.advanced.transfer.submit"),
-                class:
-                  "button button--state-destructive button--size-default inline-block",
+                class: "button button-destructive inline-block",
                 disabled: true,
                 data: {
                   "viral--select2-target": "submitButton",

--- a/app/views/groups/_edit_name_and_description_form.html.erb
+++ b/app/views/groups/_edit_name_and_description_form.html.erb
@@ -7,8 +7,7 @@
       authorized_namespaces: authorized_namespaces,
     } %>
     <div>
-      <%= form.submit t(:"groups.edit.details.submit"),
-                  class: "button button-primary button--size-default" %>
+      <%= form.submit t(:"groups.edit.details.submit"), class: "button button-primary" %>
     </div>
   </div>
 <% end %>

--- a/app/views/groups/_edit_name_and_description_form.html.erb
+++ b/app/views/groups/_edit_name_and_description_form.html.erb
@@ -8,7 +8,7 @@
     } %>
     <div>
       <%= form.submit t(:"groups.edit.details.submit"),
-                  class: "button button--state-primary button--size-default" %>
+                  class: "button button-primary button--size-default" %>
     </div>
   </div>
 <% end %>

--- a/app/views/groups/activity.turbo_stream.erb
+++ b/app/views/groups/activity.turbo_stream.erb
@@ -8,6 +8,6 @@
   <% if @pagy.next.present? %>
     <%= button_to t(:"components.activity.load_more"),
     pagy_url_for(@pagy, @pagy.next),
-    class: "button button--state-default button--size-default" %>
+    class: "button button-default button--size-default" %>
   <% end %>
 <% end %>

--- a/app/views/groups/activity.turbo_stream.erb
+++ b/app/views/groups/activity.turbo_stream.erb
@@ -8,6 +8,6 @@
   <% if @pagy.next.present? %>
     <%= button_to t(:"components.activity.load_more"),
     pagy_url_for(@pagy, @pagy.next),
-    class: "button button-default button--size-default" %>
+    class: "button button-default" %>
   <% end %>
 <% end %>

--- a/app/views/groups/attachments/index.html.erb
+++ b/app/views/groups/attachments/index.html.erb
@@ -16,8 +16,7 @@
           turbo_stream: true,
         },
         method: :get,
-        class:
-          "inline-flex items-center justify-center w-1/2 text-sm border rounded-lg cursor-pointer sm:w-auto focus:z-10 px-5 py-2.5 bg-white text-slate-900 border-slate-200 hover:bg-slate-100 hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600 dark:hover:text-white dark:hover:bg-slate-700" %>
+        class: "button button-primary" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/groups/bots/_bot_modal.html.erb
+++ b/app/views/groups/bots/_bot_modal.html.erb
@@ -104,15 +104,10 @@
     </div>
     <div class="mt-4">
       <%= form.submit t("groups.bots.index.bot_listing.new_bot_modal.submit"),
-                  class:
-                    "text-sm text-white bg-primary-700 hover:bg-primary-800 rounded-lg p-2 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 cursor-pointer" %>
+                  class: "button button-primary" %>
       <button
         type="button"
-        class="
-          text-sm text-slate-900 border border-slate-200 bg-white hover:bg-slate-100
-          hover:text-slate-950 rounded-lg p-2 dark:text-white dark:bg-slate-600
-          dark:hover:bg-slate-700
-        "
+        class="button button-default"
         data-action="click->viral--dialog#close"
       >
         <%= t("groups.bots.index.bot_listing.new_bot_modal.cancel") %>

--- a/app/views/groups/bots/_destroy_confirmation_modal.html.erb
+++ b/app/views/groups/bots/_destroy_confirmation_modal.html.erb
@@ -19,8 +19,7 @@
             }
           ) do |form| %>
       <%= form.submit t("bots.destroy_confirmation.submit_button"),
-                  class:
-                    "button text-sm px-5 py-2.5 text-white bg-red-700 border-red-800 hover:bg-red-800 dark:bg-red-600 dark:text-white dark:border-red-600 dark:hover:bg-red-700",
+                  class: "button button-destructive",
                   data: {
                     action: "click->token#removeTokenPanel",
                   } %>

--- a/app/views/groups/bots/index.html.erb
+++ b/app/views/groups/bots/index.html.erb
@@ -9,8 +9,7 @@
         turbo_frame: "bot_modal",
         turbo_stream: true,
       },
-      class:
-        "inline-flex items-center justify-center text-sm border rounded-lg cursor-pointer sm:w-auto focus:z-10 text-white bg-primary-700 hover:bg-primary-800 px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700" %>
+      class: "button button-primary" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -88,15 +88,10 @@
       <%= form.submit t(
                     "groups.bots.index.bot_listing.generate_personal_access_token_modal.submit",
                   ),
-                  class:
-                    "text-sm text-white bg-primary-700 hover:bg-primary-800 rounded-lg p-2 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 cursor-pointer" %>
+                  class: "button button-primary" %>
       <button
         type="button"
-        class="
-          p-2 text-sm bg-white border rounded-lg text-slate-900 border-slate-200
-          hover:bg-slate-100 hover:text-slate-950 dark:text-white dark:bg-slate-600
-          dark:hover:bg-slate-700
-        "
+        class="button button-default"
         data-action="click->viral--dialog#close"
       >
         <%= t("groups.bots.index.bot_listing.generate_personal_access_token_modal.cancel") %>

--- a/app/views/groups/group_links/_invite_group_modal.html.erb
+++ b/app/views/groups/group_links/_invite_group_modal.html.erb
@@ -88,14 +88,14 @@
       </div>
       <div class="my-4">
         <%= form.submit I18n.t("groups.group_links.new.button.submit"),
-                    class: "button button--size-default button--state-primary",
+                    class: "button button-primary",
                     disabled: true,
                     data: {
                       "viral--select2-target": "submitButton",
                     } %>
         <button
           type="button"
-          class="button button--size-default button--state-default"
+          class="button button-default"
           data-action="click->viral--dialog#close"
         >
           <%= I18n.t("groups.group_links.new.button.cancel") %>

--- a/app/views/groups/members/_create_modal.html.erb
+++ b/app/views/groups/members/_create_modal.html.erb
@@ -86,7 +86,7 @@
 
         <button
           type="button"
-          class="button button--size-default button--state-default"
+          class="button button-default"
           data-action="click->viral--dialog#close"
         >
           <%= I18n.t(:"groups.members.new.button.cancel") %>

--- a/app/views/groups/members/_create_modal.html.erb
+++ b/app/views/groups/members/_create_modal.html.erb
@@ -78,7 +78,7 @@
 
       <div class="my-4">
         <%= form.submit t(:"groups.members.new.add_member_to_group"),
-                    class: "button button--state-primary button--size-default",
+                    class: "button button-primary mr-1",
                     disabled: true,
                     data: {
                       "viral--select2-target": "submitButton",

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -30,7 +30,8 @@
         "turbo-frame" => "new_member_modal",
         :turbo_stream => true,
       },
-      class: "button button-primary",
+      method: :get,
+      class: "button button-default",
       "aria-label": t(:".actions.button_add_aria_label") %>
     <% end %>
   <% end %>

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -17,7 +17,7 @@
         :turbo_stream => true,
       },
       method: :get,
-      class: "button button--state-default button--size-default" %>
+      class: "button button-default" %>
     <% end %>
     <% if @allowed_to[:create_member] %>
       <%= button_to t(:".add"),
@@ -30,8 +30,7 @@
         "turbo-frame" => "new_member_modal",
         :turbo_stream => true,
       },
-      method: :get,
-      class: "button button--state-default button--size-default",
+      class: "button button-primary",
       "aria-label": t(:".actions.button_add_aria_label") %>
     <% end %>
   <% end %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -15,9 +15,7 @@
 
       <div class="flex">
         <%= form.submit t(:"groups.create.submit"), class: " button button-primary mr-2" %>
-        <%= link_to t(:"groups.create.cancel"),
-        groups_path,
-        class: "button button-default button--size-default" %>
+        <%= link_to t(:"groups.create.cancel"), groups_path, class: "button button-default" %>
       </div>
     </div>
 

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -14,11 +14,10 @@
       } %>
 
       <div class="flex">
-        <%= form.submit t(:"groups.create.submit"),
-                    class: " button button--state-primary button--size-default mr-2" %>
+        <%= form.submit t(:"groups.create.submit"), class: " button button-primary mr-2" %>
         <%= link_to t(:"groups.create.cancel"),
         groups_path,
-        class: "button button--state-default button--size-default" %>
+        class: "button button-default button--size-default" %>
       </div>
     </div>
 

--- a/app/views/groups/new_subgroup.html.erb
+++ b/app/views/groups/new_subgroup.html.erb
@@ -16,10 +16,10 @@
 
       <div class="flex">
         <%= form.submit t(:"groups.new_subgroup.submit"),
-                    class: "button button--state-primary button--size-default mr-2" %>
+                    class: "button button-primary mr-2" %>
         <%= link_to t(:"groups.new_subgroup.cancel"),
         group_path(@group),
-        class: "button button--state-default button--size-default" %>
+        class: "button button-default button--size-default" %>
       </div>
     </div>
   <% end %>

--- a/app/views/groups/new_subgroup.html.erb
+++ b/app/views/groups/new_subgroup.html.erb
@@ -19,7 +19,7 @@
                     class: "button button-primary mr-2" %>
         <%= link_to t(:"groups.new_subgroup.cancel"),
         group_path(@group),
-        class: "button button-default button--size-default" %>
+        class: "button button-default" %>
       </div>
     </div>
   <% end %>

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -188,8 +188,7 @@
             <input type="hidden" name="format" value="turbo_stream"/>
             <input type="hidden" name="select" value="on"/>
             <%= render "shared/samples/timestamp_input" %>
-            <%= f.submit t(".select_all_button"),
-                     class: "button button-default button--size-default" %>
+            <%= f.submit t(".select_all_button"), class: "button button-default" %>
           <% end %>
           <%= form_with(
                   url: select_group_samples_url,
@@ -198,8 +197,7 @@
                   class: "filters align-middle"
                 ) do |f| %>
             <input type="hidden" name="format" value="turbo_stream"/>
-            <%= f.submit t(".deselect_all_button"),
-                     class: "button button-default button--size-default" %>
+            <%= f.submit t(".deselect_all_button"), class: "button button-default" %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -12,13 +12,13 @@
         <% if @allowed_to[:submit_workflow] && @pipelines_enabled %>
           <%= button_to pipeline_selection_workflow_executions_submissions_path, params: { namespace_id: @group.id }, method: :get,
         data: { turbo_stream: true, controller: "action-button", action_button_required_value: 1, action: "turbo:morph-element->action-button#idempotentConnect " },
-                  class: "button button--size-default button--state-default action-button" do %>
+                  class: "button button-default action-button" do %>
             <%= viral_icon(name: :rocket_launch, classes: "w-5 h-5 inline-block") %>
             <span class="ml-2"><%= t(".workflows.button_sr") %></span>
           <% end %>
         <% end %>
         <% if @group_project_ids.count.positive? && @render_sample_actions %>
-          <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, styles: { button: "font-normal button button--size-default button--state-default" }) do |dropdown| %>
+          <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, styles: { button: "button button-default" }) do |dropdown| %>
             <% if @allowed_to[:clone_sample] && Flipper.enabled?(:group_samples_clone) %>
               <% dropdown.with_item(
                 label: t("shared.samples.actions_dropdown.clone"),
@@ -189,7 +189,7 @@
             <input type="hidden" name="select" value="on"/>
             <%= render "shared/samples/timestamp_input" %>
             <%= f.submit t(".select_all_button"),
-                     class: "button button--state-default button--size-default" %>
+                     class: "button button-default button--size-default" %>
           <% end %>
           <%= form_with(
                   url: select_group_samples_url,
@@ -199,7 +199,7 @@
                 ) do |f| %>
             <input type="hidden" name="format" value="turbo_stream"/>
             <%= f.submit t(".deselect_all_button"),
-                     class: "button button--state-default button--size-default" %>
+                     class: "button button-default button--size-default" %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -12,10 +12,10 @@
     <% if @allowed_to[:create_subgroup_or_project] %>
       <%= link_to t(:"groups.show.create_subgroup_button"),
       new_group_path(parent_id: @group.id),
-      class: "button button--size-default button--state-default" %>
+      class: "button button-default" %>
       <%= link_to t(:"groups.show.create_project_button"),
       new_project_path(group_id: @group.id),
-      class: "button button--size-default button--state-primary ml-2" %>
+      class: "button button-primary ml-2" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/groups/workflow_executions/index.html.erb
+++ b/app/views/groups/workflow_executions/index.html.erb
@@ -36,8 +36,7 @@
                 ) do |f| %>
           <input type="hidden" name="format" value="turbo_stream"/>
           <input type="hidden" name="select" value="on"/>
-          <%= f.submit t(".select_all_button"),
-                   class: "button button-default button--size-default" %>
+          <%= f.submit t(".select_all_button"), class: "button button-default" %>
         <% end %>
         <%= form_with(
                   url: select_group_workflow_executions_url,
@@ -45,8 +44,7 @@
                   id: "deselect-all-form" ,
                 ) do |f| %>
           <input type="hidden" name="format" value="turbo_stream"/>
-          <%= f.submit t(".deselect_all_button"),
-                   class: "button button-default button--size-default" %>
+          <%= f.submit t(".deselect_all_button"), class: "button button-default" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/groups/workflow_executions/index.html.erb
+++ b/app/views/groups/workflow_executions/index.html.erb
@@ -22,7 +22,7 @@
       controller: "action-button",
       action_button_required_value: 1,
     },
-    class: "button button--size-default button--state-default action-button" %>
+    class: "button button-default action-button" %>
   <% end %>
 <% end %>
 <div class="flow-root">
@@ -37,7 +37,7 @@
           <input type="hidden" name="format" value="turbo_stream"/>
           <input type="hidden" name="select" value="on"/>
           <%= f.submit t(".select_all_button"),
-                   class: "button button--state-default button--size-default" %>
+                   class: "button button-default button--size-default" %>
         <% end %>
         <%= form_with(
                   url: select_group_workflow_executions_url,
@@ -46,7 +46,7 @@
                 ) do |f| %>
           <input type="hidden" name="format" value="turbo_stream"/>
           <%= f.submit t(".deselect_all_button"),
-                   class: "button button--state-default button--size-default" %>
+                   class: "button button-default button--size-default" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/groups/workflow_executions/show.html.erb
+++ b/app/views/groups/workflow_executions/show.html.erb
@@ -25,7 +25,7 @@
           data: {
             turbo_stream: true,
           },
-          class: "button button--size-default button--state-default mr-2" %>
+          class: "button button-default mr-2" %>
         <% else %>
           <%= button_to t("groups.workflow_executions.show.create_export_button"),
           new_data_export_path,
@@ -41,7 +41,7 @@
             turbo_stream: true,
           },
           class:
-            "button button--size-default button--state-default pointer-events-none cursor-not-allowed bg-slate-100 text-slate-600 mr-2 dark:bg-slate-600 dark:text-slate-300" %>
+            "button button-default pointer-events-none cursor-not-allowed bg-slate-100 text-slate-600 mr-2 dark:bg-slate-600 dark:text-slate-300" %>
         <% end %>
       <% end %>
       <% if @workflow_execution.cancellable? && @allowed_to[:cancel] %>
@@ -53,7 +53,7 @@
             t("groups.workflow_executions.show.cancel_button_confirmation"),
         },
         method: :put,
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
       <% if @allowed_to[:update] %>
         <%= button_to t("groups.workflow_executions.show.edit_button"),
@@ -62,7 +62,7 @@
         data: {
           turbo_stream: true,
         },
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
       <% if @workflow_execution.deletable? && @allowed_to[:destroy] %>
         <%= button_to t("groups.workflow_executions.show.remove_button"),
@@ -73,7 +73,7 @@
             t("groups.workflow_executions.show.remove_button_confirmation"),
         },
         method: :delete,
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -18,7 +18,6 @@
   </div>
   <br/>
   <div class="my-2">
-    <%= f.submit t(:"profiles.show.email.submit"),
-             class: "button button-primary button--size-default" %>
+    <%= f.submit t(:"profiles.show.email.submit"), class: "button button-primary" %>
   </div>
 <% end %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -19,6 +19,6 @@
   <br/>
   <div class="my-2">
     <%= f.submit t(:"profiles.show.email.submit"),
-             class: "button button--state-primary button--size-default" %>
+             class: "button button-primary button--size-default" %>
   </div>
 <% end %>

--- a/app/views/profiles/accounts/_form.html.erb
+++ b/app/views/profiles/accounts/_form.html.erb
@@ -21,6 +21,6 @@
       turbo_confirm: t(:"profiles.accounts.delete.confirm"),
     },
     method: :delete,
-    class: "button button--state-destructive button--size-default" %>
+    class: "button button-destructive" %>
   </div>
 </div>

--- a/app/views/profiles/passwords/_form.html.erb
+++ b/app/views/profiles/passwords/_form.html.erb
@@ -38,7 +38,7 @@
     </div>
     <div class="flex items-center justify-between my-2">
       <%= form.submit t(:"profiles.passwords.update.submit"),
-                  class: "button button-primary button--size-default" %>
+                  class: "button button-primary" %>
       <p class="field-hint"><%= link_to t("profiles.passwords.update.forgot"),
         profile_password_path(@user),
         class: "link" %></p>

--- a/app/views/profiles/passwords/_form.html.erb
+++ b/app/views/profiles/passwords/_form.html.erb
@@ -38,7 +38,7 @@
     </div>
     <div class="flex items-center justify-between my-2">
       <%= form.submit t(:"profiles.passwords.update.submit"),
-                  class: "button button--state-primary button--size-default" %>
+                  class: "button button-primary button--size-default" %>
       <p class="field-hint"><%= link_to t("profiles.passwords.update.forgot"),
         profile_password_path(@user),
         class: "link" %></p>

--- a/app/views/profiles/personal_access_tokens/_form.html.erb
+++ b/app/views/profiles/personal_access_tokens/_form.html.erb
@@ -65,7 +65,7 @@
       </div>
       <div class="my-2">
         <%= f.submit t("profiles.personal_access_tokens.create.submit"),
-                 class: "button button-primary button--size-default" %>
+                 class: "button button-primary" %>
       </div>
     </div>
   <% end %>

--- a/app/views/profiles/personal_access_tokens/_form.html.erb
+++ b/app/views/profiles/personal_access_tokens/_form.html.erb
@@ -65,7 +65,7 @@
       </div>
       <div class="my-2">
         <%= f.submit t("profiles.personal_access_tokens.create.submit"),
-                 class: "button button--state-primary button--size-default" %>
+                 class: "button button-primary button--size-default" %>
       </div>
     </div>
   <% end %>

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -39,8 +39,7 @@
                         data: {
                           turbo_frame: "_top",
                         },
-                        class:
-                          "button button--state-destructive button--size-default inline-block" %>
+                        class: "button button-destructive inline-block" %>
           </div>
         </div>
       <% end %>

--- a/app/views/projects/_destroy.html.erb
+++ b/app/views/projects/_destroy.html.erb
@@ -47,7 +47,7 @@
         turbo_content: ".confirm-destroy",
         confirm_value: @project.name,
       },
-      class: "button button--state-destructive button--size-default" %>
+      class: "button button-destructive button--size-default" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/projects/_destroy.html.erb
+++ b/app/views/projects/_destroy.html.erb
@@ -47,7 +47,7 @@
         turbo_content: ".confirm-destroy",
         confirm_value: @project.name,
       },
-      class: "button button-destructive button--size-default" %>
+      class: "button button-destructive" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/projects/_edit_name_and_description_form.html.erb
+++ b/app/views/projects/_edit_name_and_description_form.html.erb
@@ -22,7 +22,7 @@
     </div>
     <div>
       <%= form.submit t("projects.edit.general.submit"),
-                  class: "button button--state-default button--size-default" %>
+                  class: "button button-default button--size-default" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/projects/_edit_name_and_description_form.html.erb
+++ b/app/views/projects/_edit_name_and_description_form.html.erb
@@ -21,8 +21,7 @@
       errors: project.namespace.errors.full_messages_for(:description) %>
     </div>
     <div>
-      <%= form.submit t("projects.edit.general.submit"),
-                  class: "button button-default button--size-default" %>
+      <%= form.submit t("projects.edit.general.submit"), class: "button button-default" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/projects/_transfer_form.html.erb
+++ b/app/views/projects/_transfer_form.html.erb
@@ -51,7 +51,7 @@
 
   <div>
     <%= form.submit t(:"projects.edit.advanced.transfer.submit"),
-                class: "button button--state-destructive button--size-default",
+                class: "button button-destructive button--size-default",
                 data: {
                   turbo_content: ".confirm-transfer",
                   confirm_value: @project.name,

--- a/app/views/projects/_transfer_form.html.erb
+++ b/app/views/projects/_transfer_form.html.erb
@@ -51,7 +51,7 @@
 
   <div>
     <%= form.submit t(:"projects.edit.advanced.transfer.submit"),
-                class: "button button-destructive button--size-default",
+                class: "button button-destructive",
                 data: {
                   turbo_content: ".confirm-transfer",
                   confirm_value: @project.name,

--- a/app/views/projects/activity.turbo_stream.erb
+++ b/app/views/projects/activity.turbo_stream.erb
@@ -8,6 +8,6 @@
   <% if @pagy.next.present? %>
     <%= button_to t(:"components.activity.load_more"),
     pagy_url_for(@pagy, @pagy.next),
-    class: "button button--state-default button--size-default" %>
+    class: "button button-default button--size-default" %>
   <% end %>
 <% end %>

--- a/app/views/projects/activity.turbo_stream.erb
+++ b/app/views/projects/activity.turbo_stream.erb
@@ -8,6 +8,6 @@
   <% if @pagy.next.present? %>
     <%= button_to t(:"components.activity.load_more"),
     pagy_url_for(@pagy, @pagy.next),
-    class: "button button-default button--size-default" %>
+    class: "button button-default" %>
   <% end %>
 <% end %>

--- a/app/views/projects/attachments/index.html.erb
+++ b/app/views/projects/attachments/index.html.erb
@@ -16,8 +16,7 @@
           turbo_stream: true,
         },
         method: :get,
-        class:
-          "inline-flex items-center justify-center w-1/2 text-sm border rounded-lg cursor-pointer sm:w-auto focus:z-10 px-5 py-2.5 bg-white text-slate-900 border-slate-200 hover:bg-slate-100 hover:text-slate-950 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600 dark:hover:text-white dark:hover:bg-slate-700" %>
+        class: "button button-default" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/projects/automated_workflow_executions/index.html.erb
+++ b/app/views/projects/automated_workflow_executions/index.html.erb
@@ -11,8 +11,7 @@
       turbo_stream: true,
     },
     method: :get,
-    class:
-      "inline-flex items-center justify-center text-sm border cursor-pointer sm:w-auto focus:z-10 text-white bg-primary-700 hover:bg-primary-800 rounded-lg px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700" %>
+    class: "button button-primary" %>
   <% end %>
 <% end %>
 

--- a/app/views/projects/bots/_bot_modal.html.erb
+++ b/app/views/projects/bots/_bot_modal.html.erb
@@ -105,15 +105,10 @@
     </div>
     <div class="mt-4">
       <%= form.submit t("projects.bots.index.bot_listing.new_bot_modal.submit"),
-                  class:
-                    "text-sm text-white bg-primary-700 hover:bg-primary-800 rounded-lg p-2 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 cursor-pointer" %>
+                  class: "button button-primary" %>
       <button
         type="button"
-        class="
-          p-2 text-sm bg-white border rounded-lg text-slate-900 border-slate-200
-          hover:bg-slate-100 hover:text-slate-950 dark:text-white dark:bg-slate-600
-          dark:hover:bg-slate-700
-        "
+        class="button button-default"
         data-action="click->viral--dialog#close"
       >
         <%= t("projects.bots.index.bot_listing.new_bot_modal.cancel") %>

--- a/app/views/projects/bots/_destroy_confirmation_modal.html.erb
+++ b/app/views/projects/bots/_destroy_confirmation_modal.html.erb
@@ -18,8 +18,7 @@
             }
           ) do |form| %>
       <%= form.submit t("bots.destroy_confirmation.submit_button"),
-                  class:
-                    "button text-sm px-5 py-2.5 text-white bg-red-700 border-red-800 hover:bg-red-800 dark:bg-red-600 dark:text-white dark:border-red-600 dark:hover:bg-red-700",
+                  class: "button button-destructive",
                   data: {
                     action: "click->token#removeTokenPanel",
                   } %>

--- a/app/views/projects/bots/index.html.erb
+++ b/app/views/projects/bots/index.html.erb
@@ -10,8 +10,7 @@
         turbo_stream: true,
       },
       method: :get,
-      class:
-        "inline-flex items-center justify-center text-sm border cursor-pointer sm:w-auto focus:z-10 text-white bg-primary-700 hover:bg-primary-800 rounded-lg px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700" %>
+      class: "button button-primary" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -87,15 +87,10 @@
       <%= form.submit t(
                     "projects.bots.index.bot_listing.generate_personal_access_token_modal.submit",
                   ),
-                  class:
-                    "text-sm text-white bg-primary-700 hover:bg-primary-800 rounded-lg p-2 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 cursor-pointer" %>
+                  class: "button button-primary" %>
       <button
         type="button"
-        class="
-          p-2 text-sm bg-white border rounded-lg text-slate-900 border-slate-200
-          hover:bg-slate-100 hover:text-slate-950 dark:text-white dark:bg-slate-600
-          dark:hover:bg-slate-700
-        "
+        class="button button-default"
         data-action="click->viral--dialog#close"
       >
         <%= t("projects.bots.index.bot_listing.generate_personal_access_token_modal.cancel") %>

--- a/app/views/projects/group_links/_invite_group_modal.html.erb
+++ b/app/views/projects/group_links/_invite_group_modal.html.erb
@@ -90,14 +90,14 @@
       </div>
       <div class="my-4">
         <%= form.submit I18n.t("projects.group_links.new.button.submit"),
-                    class: "button button--size-default button--state-primary",
+                    class: "button button-primary",
                     disabled: true,
                     data: {
                       "viral--select2-target": "submitButton",
                     } %>
         <button
           type="button"
-          class="button button--size-default button--state-default"
+          class="button button-default"
           data-action="click->viral--dialog#close"
         >
           <%= I18n.t("projects.group_links.new.button.cancel") %>

--- a/app/views/projects/members/_create_modal.html.erb
+++ b/app/views/projects/members/_create_modal.html.erb
@@ -78,7 +78,7 @@
 
       <div class="my-4">
         <%= form.submit t(:"projects.members.new.add_member_to_project"),
-                    class: "button button--state-primary button--size-default",
+                    class: "button button-primary mr-1",
                     disabled: true,
                     data: {
                       "viral--select2-target": "submitButton",

--- a/app/views/projects/members/_create_modal.html.erb
+++ b/app/views/projects/members/_create_modal.html.erb
@@ -86,7 +86,7 @@
 
         <button
           type="button"
-          class="button button--size-default button--state-default"
+          class="button button-default"
           data-action="click->viral--dialog#close"
         >
           <%= I18n.t(:"projects.members.new.button.cancel") %>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -32,10 +32,8 @@
         "turbo-frame" => "new_member_modal",
         :turbo_stream => true,
       },
-      aria: {
-        label: t(:".actions.button_add_aria_label"),
-      },
-      class: "button button-default" %>
+      class: "button button-primary",
+      "aria-label": t(:".actions.button_add_aria_label") %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -19,7 +19,7 @@
       aria: {
         label: t(:".actions.button_add_aria_label"),
       },
-      class: "button button--state-default button--size-default" %>
+      class: "button button-default" %>
     <% end %>
     <% if @allowed_to[:create_member] %>
       <%= button_to t(:".add"),
@@ -35,7 +35,7 @@
       aria: {
         label: t(:".actions.button_add_aria_label"),
       },
-      class: "button button--state-default button--size-default" %>
+      class: "button button-default" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -17,8 +17,7 @@
 
         <% end %>
         <div>
-          <%= form.submit t("projects.new.submit"),
-                      class: "button button-primary button--size-default" %>
+          <%= form.submit t("projects.new.submit"), class: "button button-primary" %>
         </div>
       </div>
     <% end %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -18,7 +18,7 @@
         <% end %>
         <div>
           <%= form.submit t("projects.new.submit"),
-                      class: "button button--state-primary button--size-default" %>
+                      class: "button button-primary button--size-default" %>
         </div>
       </div>
     <% end %>

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -4,7 +4,7 @@
     <%= f.search_field :name_or_puid_cont,
                    "data-action": "selection#clear",
                    class:
-                     "t-search-component block w-full p-2.5 pl-10 text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
+                     "t-search-component block w-full p-2.5 pl-10 text-sm text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
                    placeholder: t(".search.placeholder") %>
     <div
       class="

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -4,7 +4,7 @@
     <%= f.search_field :name_or_puid_cont,
                    "data-action": "selection#clear",
                    class:
-                     "t-search-component block w-full p-2.5 pl-10 text-sm text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
+                     "t-search-component block w-full p-2.5 pl-10 text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white",
                    placeholder: t(".search.placeholder") %>
     <div
       class="

--- a/app/views/projects/samples/attachments/_form.html.erb
+++ b/app/views/projects/samples/attachments/_form.html.erb
@@ -40,7 +40,7 @@
 
     <div>
       <%= form.submit t("projects.samples.show.upload"),
-                  class: "button button-primary button--size-default",
+                  class: "button button-primary",
                   data: {
                     "attachment-upload-target": "submitButton",
                   } %>

--- a/app/views/projects/samples/attachments/_form.html.erb
+++ b/app/views/projects/samples/attachments/_form.html.erb
@@ -40,7 +40,7 @@
 
     <div>
       <%= form.submit t("projects.samples.show.upload"),
-                  class: "button button--state-primary button--size-default",
+                  class: "button button-primary button--size-default",
                   data: {
                     "attachment-upload-target": "submitButton",
                   } %>

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -17,7 +17,7 @@
                 value="<%=params.dig(:q, :puid_or_file_blob_filename_cont)%>"
               >
               <%= f.submit t(".select_all_button"),
-                       class: "button button--state-default button--size-default" %>
+                       class: "button button-default button--size-default" %>
             <% end %>
             <%= form_with(
                   url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
@@ -26,7 +26,7 @@
                 ) do |f| %>
               <input type="hidden" name="format" value="turbo_stream"/>
               <%= f.submit t(".deselect_all_button"),
-                       class: "button button--state-default button--size-default" %>
+                       class: "button button-default button--size-default" %>
             <% end %>
           </div>
         <% end %>
@@ -52,7 +52,7 @@
             turbo_frame: "sample_modal",
             turbo_stream: true,
           },
-          class: "button button--size-default button--state-default" %>
+          class: "button button-default" %>
           <%= button_to t("projects.samples.show.concatenate_button"),
           new_namespace_project_sample_attachments_concatenation_path(
             sample_id: @sample.id,
@@ -64,7 +64,7 @@
             controller: "action-button",
             action_button_required_value: 2,
           },
-          class: "button button--size-default button--state-default action-button" %>
+          class: "button button-default action-button" %>
           <%= button_to t("projects.samples.show.delete_files_button"),
           new_namespace_project_sample_attachments_deletion_path(sample_id: @sample.id),
           method: :get,
@@ -74,7 +74,7 @@
             controller: "action-button",
             action_button_required_value: 1,
           },
-          class: "button button--size-default button--state-default action-button" %>
+          class: "button button-default action-button" %>
         </div>
       </div>
     <% end %>

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -16,8 +16,7 @@
                 name="q[puid_or_file_blob_filename_cont]"
                 value="<%=params.dig(:q, :puid_or_file_blob_filename_cont)%>"
               >
-              <%= f.submit t(".select_all_button"),
-                       class: "button button-default button--size-default" %>
+              <%= f.submit t(".select_all_button"), class: "button button-default" %>
             <% end %>
             <%= form_with(
                   url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
@@ -25,8 +24,7 @@
                   id: "deselect-all-form" ,
                 ) do |f| %>
               <input type="hidden" name="format" value="turbo_stream"/>
-              <%= f.submit t(".deselect_all_button"),
-                       class: "button button-default button--size-default" %>
+              <%= f.submit t(".deselect_all_button"), class: "button button-default" %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -46,8 +46,7 @@
       </div>
 
       <div>
-        <%= form.submit t(".submit_button"),
-                    class: "button button--size-default button--state-primary" %>
+        <%= form.submit t(".submit_button"), class: "button button-primary" %>
       </div>
     </div>
   <% end %>

--- a/app/views/projects/samples/attachments/deletions/_modal.html.erb
+++ b/app/views/projects/samples/attachments/deletions/_modal.html.erb
@@ -25,8 +25,7 @@
     <div data-projects--samples--attachments--selected-attachments-target="field"></div>
 
     <div>
-      <%= form.submit t(".submit_button"),
-                  class: "button button--size-default button--state-destructive" %>
+      <%= form.submit t(".submit_button"), class: "button button-destructive" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/projects/samples/edit.html.erb
+++ b/app/views/projects/samples/edit.html.erb
@@ -22,10 +22,10 @@
           <%= render partial: "form_fields", locals: { form: form, sample: @sample } %>
           <div>
             <%= form.submit t("projects.samples.edit.submit_button"),
-                        class: "button button--state-primary button--size-default mr-1" %>
+                        class: "button button-primary mr-1" %>
             <%= link_to t("projects.samples.edit.cancel_button"),
             namespace_project_sample_path(id: @sample.id),
-            class: "button button--state-default button--size-default" %>
+            class: "button button-default button--size-default" %>
           </div>
         </div>
       <% end %>

--- a/app/views/projects/samples/edit.html.erb
+++ b/app/views/projects/samples/edit.html.erb
@@ -25,7 +25,7 @@
                         class: "button button-primary mr-1" %>
             <%= link_to t("projects.samples.edit.cancel_button"),
             namespace_project_sample_path(id: @sample.id),
-            class: "button button-default button--size-default" %>
+            class: "button button-default" %>
           </div>
         </div>
       <% end %>

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -14,13 +14,13 @@
         <% if @allowed_to[:submit_workflow] && @pipelines_enabled %>
           <%= button_to pipeline_selection_workflow_executions_submissions_path, params: { namespace_id: @project.namespace.id }, method: :get,
         data: { action: "turbo:morph-element->action-button#idempotentConnect ", turbo_stream: true, controller: "action-button", action_button_required_value: 1 },
-                  class: "button button--size-default button--state-default action-button cursor-pointer" do %>
+                  class: "button button-default action-button cursor-pointer" do %>
             <%= viral_icon(name: :rocket_launch, classes: "w-5 h-5 inline-block") %>
             <span class="ml-2"><%= t(:".workflows.button_sr") %></span>
           <% end %>
         <% end %>
         <% if @render_sample_actions %>
-          <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, styles: { button: "font-normal button button--size-default button--state-default" }) do |dropdown| %>
+          <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
             <% if @allowed_to[:create_sample] %>
               <% dropdown.with_item(
                 label: t("shared.samples.actions_dropdown.new_sample"),
@@ -203,7 +203,7 @@
           <input type="hidden" name="select" value="on"/>
           <%= render "shared/samples/timestamp_input" %>
           <%= f.submit t(".select_all_button"),
-                   class: "button button--state-default button--size-default" %>
+                   class: "button button-default button--size-default" %>
         <% end %>
         <%= form_with(
                   url: select_namespace_project_samples_url,
@@ -212,7 +212,7 @@
                 ) do |f| %>
           <input type="hidden" name="format" value="turbo_stream"/>
           <%= f.submit t(".deselect_all_button"),
-                   class: "button button--state-default button--size-default" %>
+                   class: "button button-default button--size-default" %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -202,8 +202,7 @@
           <input type="hidden" name="format" value="turbo_stream"/>
           <input type="hidden" name="select" value="on"/>
           <%= render "shared/samples/timestamp_input" %>
-          <%= f.submit t(".select_all_button"),
-                   class: "button button-default button--size-default" %>
+          <%= f.submit t(".select_all_button"), class: "button button-default" %>
         <% end %>
         <%= form_with(
                   url: select_namespace_project_samples_url,
@@ -211,8 +210,7 @@
                   id: "deselect-all-form" ,
                 ) do |f| %>
           <input type="hidden" name="format" value="turbo_stream"/>
-          <%= f.submit t(".deselect_all_button"),
-                   class: "button button-default button--size-default" %>
+          <%= f.submit t(".deselect_all_button"), class: "button button-default" %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/projects/samples/metadata/_table.html.erb
+++ b/app/views/projects/samples/metadata/_table.html.erb
@@ -17,7 +17,7 @@
               turbo_frame: "sample_modal",
               turbo_stream: true,
             },
-            class: "button button--size-default button--state-default" %>
+            class: "button button-default" %>
             <%= button_to t(".delete_metadata_button"),
             new_namespace_project_sample_metadata_deletion_path(
               @project.namespace.parent,
@@ -31,7 +31,7 @@
               controller: "action-button",
               action_button_required_value: 1,
             },
-            class: "button button--size-default button--state-default action-button" %>
+            class: "button button-default action-button" %>
           </div>
         </div>
       <% end %>

--- a/app/views/projects/samples/metadata/_update_form.html.erb
+++ b/app/views/projects/samples/metadata/_update_form.html.erb
@@ -30,7 +30,7 @@
 
       <div>
         <%= field.submit t("projects.samples.show.metadata.update.update"),
-                     class: "button button-primary button--size-default" %>
+                     class: "button button-primary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/samples/metadata/_update_form.html.erb
+++ b/app/views/projects/samples/metadata/_update_form.html.erb
@@ -30,7 +30,7 @@
 
       <div>
         <%= field.submit t("projects.samples.show.metadata.update.update"),
-                     class: "button button--state-primary button--size-default" %>
+                     class: "button button-primary button--size-default" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/samples/metadata/deletions/_modal.html.erb
+++ b/app/views/projects/samples/metadata/deletions/_modal.html.erb
@@ -25,8 +25,7 @@
     }, method: :delete) do |form| %>
     <div data-projects--samples--metadata--destroy-target="field"></div>
     <div>
-      <%= form.submit t(".submit_button"),
-                  class: "button button--size-default button--state-destructive" %>
+      <%= form.submit t(".submit_button"), class: "button button-destructive" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/projects/samples/new.html.erb
+++ b/app/views/projects/samples/new.html.erb
@@ -16,10 +16,10 @@
 
           <div class="flex">
             <%= form.submit t("projects.samples.new.submit_button"),
-                        class: "button button--state-primary button--size-default mr-2" %>
+                        class: "button button-primary mr-2" %>
             <%= link_to t("projects.samples.new.cancel_button"),
             namespace_project_samples_path,
-            class: "button button--state-default button--size-default" %>
+            class: "button button-default button--size-default" %>
           </div>
         </div>
       <% end %>

--- a/app/views/projects/samples/new.html.erb
+++ b/app/views/projects/samples/new.html.erb
@@ -19,7 +19,7 @@
                         class: "button button-primary mr-2" %>
             <%= link_to t("projects.samples.new.cancel_button"),
             namespace_project_samples_path,
-            class: "button button-default button--size-default" %>
+            class: "button button-default" %>
           </div>
         </div>
       <% end %>

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -10,7 +10,7 @@
         <%= link_to(
           t("projects.samples.show.edit_button"),
           edit_namespace_project_sample_path(id: @sample.id),
-          class: "button button--state-default button--size-default",
+          class: "button button-default button--size-default",
         ) %>
       <% end %>
       <% if @allowed_to[:destroy_sample] %>
@@ -26,7 +26,7 @@
           data: {
             turbo_stream: true,
           },
-          class: "button button--size-default button--state-default",
+          class: "button button-default",
         ) %>
       <% end %>
     </div>

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -10,7 +10,7 @@
         <%= link_to(
           t("projects.samples.show.edit_button"),
           edit_namespace_project_sample_path(id: @sample.id),
-          class: "button button-default button--size-default",
+          class: "button button-default",
         ) %>
       <% end %>
       <% if @allowed_to[:destroy_sample] %>

--- a/app/views/projects/workflow_executions/index.html.erb
+++ b/app/views/projects/workflow_executions/index.html.erb
@@ -54,8 +54,7 @@
                 ) do |f| %>
         <input type="hidden" name="format" value="turbo_stream"/>
         <input type="hidden" name="select" value="on"/>
-        <%= f.submit t(".select_all_button"),
-                 class: "button button-default button--size-default" %>
+        <%= f.submit t(".select_all_button"), class: "button button-default" %>
       <% end %>
       <%= form_with(
                   url: select_namespace_project_workflow_executions_url,
@@ -63,8 +62,7 @@
                   id: "deselect-all-form" ,
                 ) do |f| %>
         <input type="hidden" name="format" value="turbo_stream"/>
-        <%= f.submit t(".deselect_all_button"),
-                 class: "button button-default button--size-default" %>
+        <%= f.submit t(".deselect_all_button"), class: "button button-default" %>
       <% end %>
     </div>
     <div class="grow-0">

--- a/app/views/projects/workflow_executions/index.html.erb
+++ b/app/views/projects/workflow_executions/index.html.erb
@@ -27,7 +27,7 @@
           controller: "action-button",
           action_button_required_value: 1,
         },
-        class: "button button--size-default button--state-default action-button" %>
+        class: "button button-default action-button" %>
       <% end %>
       <% if allowed_to?(:destroy_workflow_executions?, @project.namespace) && Flipper.enabled?(:delete_multiple_workflows) %>
         <%= button_to t(".delete_workflows_button"),
@@ -39,7 +39,7 @@
           controller: "action-button",
           action_button_required_value: 1,
         },
-        class: "button button--size-default button--state-destructive action-button" %>
+        class: "button button-destructive action-button" %>
       <% end %>
     </div>
   <% end %>
@@ -55,7 +55,7 @@
         <input type="hidden" name="format" value="turbo_stream"/>
         <input type="hidden" name="select" value="on"/>
         <%= f.submit t(".select_all_button"),
-                 class: "button button--state-default button--size-default" %>
+                 class: "button button-default button--size-default" %>
       <% end %>
       <%= form_with(
                   url: select_namespace_project_workflow_executions_url,
@@ -64,7 +64,7 @@
                 ) do |f| %>
         <input type="hidden" name="format" value="turbo_stream"/>
         <%= f.submit t(".deselect_all_button"),
-                 class: "button button--state-default button--size-default" %>
+                 class: "button button-default button--size-default" %>
       <% end %>
     </div>
     <div class="grow-0">

--- a/app/views/projects/workflow_executions/show.html.erb
+++ b/app/views/projects/workflow_executions/show.html.erb
@@ -26,7 +26,7 @@
           data: {
             turbo_stream: true,
           },
-          class: "button button--size-default button--state-default mr-2" %>
+          class: "button button-default mr-2" %>
         <% else %>
           <%= button_to t("projects.workflow_executions.show.create_export_button"),
           new_data_export_path,
@@ -42,7 +42,7 @@
             turbo_stream: true,
           },
           class:
-            "button button--size-default button--state-default pointer-events-none cursor-not-allowed bg-slate-100 text-slate-600 mr-2 dark:bg-slate-600 dark:text-slate-300",
+            "button button-default pointer-events-none cursor-not-allowed bg-slate-100 text-slate-600 mr-2 dark:bg-slate-600 dark:text-slate-300",
           disabled: true %>
         <% end %>
       <% end %>
@@ -59,7 +59,7 @@
             t("projects.workflow_executions.show.cancel_button_confirmation"),
         },
         method: :put,
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
       <% if @allowed_to[:update] %>
         <%= button_to t("projects.workflow_executions.show.edit_button"),
@@ -72,7 +72,7 @@
           turbo_stream: true,
         },
         method: :get,
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
       <% if @workflow_execution.deletable? && @allowed_to[:destroy] %>
         <%= button_to t("projects.workflow_executions.show.remove_button"),
@@ -85,7 +85,7 @@
           turbo_stream: true,
         },
         method: :get,
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/samples/clones/_dialog.html.erb
+++ b/app/views/samples/clones/_dialog.html.erb
@@ -99,11 +99,7 @@
               <% end %>
             </div>
             <div>
-              <%= form.submit t(".submit_button"),
-                          class: "button button--size-default button--state-primary",
-                          data: {
-                            action: "click->form--hidden-inputs#clearSelection",
-                          } %>
+              <%= form.submit t(".submit_button"), class: "button button-primary" %>
             </div>
           </div>
         <% end %>

--- a/app/views/samples/transfers/_dialog.html.erb
+++ b/app/views/samples/transfers/_dialog.html.erb
@@ -101,7 +101,7 @@
             </div>
             <div>
               <%= form.submit t(".submit_button"),
-                          class: "button button--size-default button--state-primary",
+                          class: "button button-primary",
                           disabled: true,
                           data: {
                             "viral--select2-target": "submitButton",

--- a/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
@@ -58,8 +58,7 @@
                             "click->viral--sortable-lists--two-lists-selection#constructParams",
                           "viral--sortable-lists--two-lists-selection-target": "submitBtn",
                         },
-                        class:
-                          "text-sm text-white bg-primary-700 hover:bg-primary-800 rounded-lg p-2 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed",
+                        class: "button button-primary",
                         disabled: true %>
           </div>
         </div>

--- a/app/views/shared/metadata_templates/_header.html.erb
+++ b/app/views/shared/metadata_templates/_header.html.erb
@@ -8,7 +8,7 @@
         :turbo_stream => true,
       },
       method: :get,
-      class: "button button--state-primary button--size-default" %>
+      class: "button button-primary" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/metadata_templates/_new_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_new_template_dialog.html.erb
@@ -59,8 +59,7 @@
                               "click->viral--sortable-lists--two-lists-selection#constructParams",
                             "viral--sortable-lists--two-lists-selection-target": "submitBtn",
                           },
-                          class:
-                            "text-sm text-white bg-primary-700 hover:bg-primary-800 rounded-lg p-2 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed",
+                          class: "button button-primary",
                           disabled: true %>
             </div>
           </div>

--- a/app/views/shared/samples/_metadata_template_dropdown.html.erb
+++ b/app/views/shared/samples/_metadata_template_dropdown.html.erb
@@ -9,18 +9,13 @@
     data-metadata-template-dd-target="trigger"
     title="<%= t("shared.samples.metadata_templates.tooltip") %>"
     id="metadata-template-dd-trigger"
-    class="
-      text-slate-900 bg-white border border-slate-300 hover:bg-slate-100 rounded-lg
-      text-sm px-5 py-2.5 dark:bg-slate-800 dark:text-white dark:border-slate-600
-      dark:hover:bg-slate-700 dark:hover:border-slate-600 cursor-pointer inline-flex
-      items-center justify-center
-    "
+    class="button button-default"
     type="button"
     aria-haspopup="listbox"
     aria-expanded="false"
     aria-controls="metadata-template-dd-menu"
   >
-    <span class="text-sm" id="metadata-template-dd-label">
+    <span id="metadata-template-dd-label">
       <%= t("shared.samples.metadata_templates.label") %>
     </span>
     <%= viral_icon(name: "adjustment_horizontal", classes: "w-4 h-4 ml-2 flex-none") %>

--- a/app/views/shared/samples/metadata/file_imports/_dialog.html.erb
+++ b/app/views/shared/samples/metadata/file_imports/_dialog.html.erb
@@ -138,7 +138,7 @@
           </div>
           <div>
             <%= form.submit t(".submit_button"),
-                        class: "button button--size-default button--state-primary",
+                        class: "button button-primary",
                         data: {
                           turbo_frame: "_top",
                           action:

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -179,7 +179,7 @@
           ></div>
           <div>
             <%= form.submit t(".submit_button"),
-                        class: "button button--size-default button--state-primary",
+                        class: "button button-primary",
                         data: {
                           turbo_frame: "_top",
                           action:

--- a/app/views/shared/workflow_executions/_destroy_confirmation_dialog.html.erb
+++ b/app/views/shared/workflow_executions/_destroy_confirmation_dialog.html.erb
@@ -17,7 +17,7 @@
           action: "click->selection#remove click->viral--dialog#close",
           "selection-id-param": @workflow_execution.id,
         },
-        class: "button button-destructive button--size-default" %>
+        class: "button button-destructive" %>
       </div>
     </div>
   </div>

--- a/app/views/shared/workflow_executions/_destroy_confirmation_dialog.html.erb
+++ b/app/views/shared/workflow_executions/_destroy_confirmation_dialog.html.erb
@@ -17,7 +17,7 @@
           action: "click->selection#remove click->viral--dialog#close",
           "selection-id-param": @workflow_execution.id,
         },
-        class: "button button--state-destructive button--size-default" %>
+        class: "button button-destructive button--size-default" %>
       </div>
     </div>
   </div>

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -23,7 +23,7 @@
         controller: "action-button",
         action_button_required_value: 1,
       },
-      class: "button button--size-default button--state-default action-button" %>
+      class: "button button-default action-button" %>
       <% if Flipper.enabled?(:delete_multiple_workflows) %>
         <%= button_to t(".delete_workflows_button"),
         destroy_multiple_confirmation_workflow_executions_path,
@@ -34,7 +34,7 @@
           controller: "action-button",
           action_button_required_value: 1,
         },
-        class: "button button--size-default button--state-destructive action-button" %>
+        class: "button button-destructive action-button" %>
       <% end %>
     </div>
   <% end %>
@@ -50,7 +50,7 @@
         <input type="hidden" name="format" value="turbo_stream"/>
         <input type="hidden" name="select" value="on"/>
         <%= f.submit t(".select_all_button"),
-                 class: "button button--state-default button--size-default" %>
+                 class: "button button-default button--size-default" %>
       <% end %>
       <%= form_with(
                   url: select_workflow_executions_url,
@@ -59,7 +59,7 @@
                 ) do |f| %>
         <input type="hidden" name="format" value="turbo_stream"/>
         <%= f.submit t(".deselect_all_button"),
-                 class: "button button--state-default button--size-default" %>
+                 class: "button button-default button--size-default" %>
       <% end %>
     </div>
     <div class="grow-0">

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -9,34 +9,32 @@
 <%= render Viral::PageHeaderComponent.new(title: t(".title")) do |component| %>
 
   <%= component.with_buttons do %>
-    <div class="flex items-center space-x-2">
-      <%= button_to t(".create_export_button"),
-      new_data_export_path,
-      params: {
-        export_type: "analysis",
-        analysis_type: "user",
-      },
+    <%= button_to t(".create_export_button"),
+    new_data_export_path,
+    params: {
+      export_type: "analysis",
+      analysis_type: "user",
+    },
+    method: :get,
+    data: {
+      action: "turbo:morph-element->action-button#idempotentConnect ",
+      turbo_stream: true,
+      controller: "action-button",
+      action_button_required_value: 1,
+    },
+    class: "button button-default action-button" %>
+    <% if Flipper.enabled?(:delete_multiple_workflows) %>
+      <%= button_to t(".delete_workflows_button"),
+      destroy_multiple_confirmation_workflow_executions_path,
       method: :get,
       data: {
-        action: "turbo:morph-element->action-button#idempotentConnect ",
+        action: "turbo:morph-element->action-button#idempotentConnect",
         turbo_stream: true,
         controller: "action-button",
         action_button_required_value: 1,
       },
-      class: "button button-default action-button" %>
-      <% if Flipper.enabled?(:delete_multiple_workflows) %>
-        <%= button_to t(".delete_workflows_button"),
-        destroy_multiple_confirmation_workflow_executions_path,
-        method: :get,
-        data: {
-          action: "turbo:morph-element->action-button#idempotentConnect",
-          turbo_stream: true,
-          controller: "action-button",
-          action_button_required_value: 1,
-        },
-        class: "button button-destructive action-button" %>
-      <% end %>
-    </div>
+      class: "button button-destructive action-button" %>
+    <% end %>
   <% end %>
 <% end %>
 <div class="flow-root">

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -49,8 +49,7 @@
                 ) do |f| %>
         <input type="hidden" name="format" value="turbo_stream"/>
         <input type="hidden" name="select" value="on"/>
-        <%= f.submit t(".select_all_button"),
-                 class: "button button-default button--size-default" %>
+        <%= f.submit t(".select_all_button"), class: "button button-default" %>
       <% end %>
       <%= form_with(
                   url: select_workflow_executions_url,
@@ -58,8 +57,7 @@
                   id: "deselect-all-form" ,
                 ) do |f| %>
         <input type="hidden" name="format" value="turbo_stream"/>
-        <%= f.submit t(".deselect_all_button"),
-                 class: "button button-default button--size-default" %>
+        <%= f.submit t(".deselect_all_button"), class: "button button-default" %>
       <% end %>
     </div>
     <div class="grow-0">

--- a/app/views/workflow_executions/show.html.erb
+++ b/app/views/workflow_executions/show.html.erb
@@ -23,7 +23,7 @@
         data: {
           turbo_stream: true,
         },
-        class: "button button--size-default button--state-default mr-2" %>
+        class: "button button-default mr-2" %>
       <% else %>
         <%= button_to t(".create_export_button"),
         new_data_export_path,
@@ -38,7 +38,7 @@
           turbo_stream: true,
         },
         class:
-          "button button--size-default button--state-default pointer-events-none cursor-not-allowed bg-slate-100 text-slate-600 mr-2 dark:bg-slate-600 dark:text-slate-300",
+          "button button-default pointer-events-none cursor-not-allowed bg-slate-100 text-slate-600 mr-2 dark:bg-slate-600 dark:text-slate-300",
         disabled: true %>
       <% end %>
       <% if @workflow_execution.cancellable? %>
@@ -49,7 +49,7 @@
           turbo_confirm: t("workflow_executions.show.cancel_button_confirmation"),
         },
         method: :put,
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
       <% if @allowed_to[:update] %>
         <%= button_to t("workflow_executions.show.edit_button"),
@@ -58,7 +58,7 @@
           turbo_stream: true,
         },
         method: :get,
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
 
       <% end %>
       <% if @workflow_execution.deletable? %>
@@ -68,7 +68,7 @@
         data: {
           turbo_stream: true,
         },
-        class: "button button--state-default button--size-default mr-1" %>
+        class: "button button-default mr-1" %>
       <% end %>
     </div>
   <% end %>

--- a/test/components/previews/confirmation_component_preview/custom_content.html.erb
+++ b/test/components/previews/confirmation_component_preview/custom_content.html.erb
@@ -12,4 +12,4 @@ data: {
   turbo_confirm: "",
   turbo_content: "#confirmation-content",
 },
-class: "button button-destructive button--size-default" %>
+class: "button button-destructive" %>

--- a/test/components/previews/confirmation_component_preview/custom_content.html.erb
+++ b/test/components/previews/confirmation_component_preview/custom_content.html.erb
@@ -10,6 +10,6 @@
 "#",
 data: {
   turbo_confirm: "",
-  turbo_content: "#confirmation-content"
+  turbo_content: "#confirmation-content",
 },
-class: "button button--state-destructive button--size-default" %>
+class: "button button-destructive button--size-default" %>

--- a/test/components/previews/confirmation_component_preview/default.html.erb
+++ b/test/components/previews/confirmation_component_preview/default.html.erb
@@ -5,6 +5,6 @@
 <%= button_to "Confirmation",
 "#",
 data: {
-  turbo_confirm: "Custom modal text here!"
+  turbo_confirm: "Custom modal text here!",
 },
-class: "button button--state-destructive button--size-default" %>
+class: "button button-destructive button--size-default" %>

--- a/test/components/previews/confirmation_component_preview/default.html.erb
+++ b/test/components/previews/confirmation_component_preview/default.html.erb
@@ -7,4 +7,4 @@
 data: {
   turbo_confirm: "Custom modal text here!",
 },
-class: "button button-destructive button--size-default" %>
+class: "button button-destructive" %>

--- a/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
+++ b/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
@@ -28,4 +28,4 @@ data: {
   turbo_content: ".custom-content",
   confirm_value: "Project X",
 },
-class: "button button-destructive button--size-default" %>
+class: "button button-destructive" %>

--- a/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
+++ b/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
@@ -5,23 +5,14 @@
 <div class="hidden custom-content">
   <%= viral_alert(
     message: "You are about to delete this project.  This cannot be undone.",
-    type: :alert
+    type: :alert,
   ) %>
   <p class="text-base text-slate-900 dark:text-white">Enter the following to confirm:</p>
   <p class="text-slate-500 dark:text-slate-400">
     <kbd
       class="
-        px-2
-        py-1.5
-        text-xs
-        font-semibold
-        text-slate-800
-        bg-slate-100
-        border
-        border-slate-200
-        rounded-lg
-        dark:bg-slate-600
-        dark:text-slate-100
+        px-2 py-1.5 text-xs font-semibold text-slate-800 bg-slate-100 border
+        border-slate-200 rounded-lg dark:bg-slate-600 dark:text-slate-100
         dark:border-slate-500
       "
     >
@@ -35,6 +26,6 @@
 data: {
   turbo_confirm: "",
   turbo_content: ".custom-content",
-  confirm_value: "Project X"
+  confirm_value: "Project X",
 },
-class: "button button--state-destructive button--size-default" %>
+class: "button button-destructive button--size-default" %>

--- a/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
+++ b/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
@@ -1,9 +1,7 @@
 <%= viral_card do |card| %>
   <% card.with_header(title: 'Card Header') do |header| %>
     <% header.with_action do %>
-      <%= link_to "Delete",
-      "#",
-      class: "button button--state-default button--size-default" %>
+      <%= link_to "Delete", "#", class: "button button-default button--size-default" %>
     <% end %>
   <% end %>
   Content body here

--- a/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
+++ b/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
@@ -1,7 +1,7 @@
 <%= viral_card do |card| %>
   <% card.with_header(title: 'Card Header') do |header| %>
     <% header.with_action do %>
-      <%= link_to "Delete", "#", class: "button button-default button--size-default" %>
+      <%= link_to "Delete", "#", class: "button button-default" %>
     <% end %>
   <% end %>
   Content body here

--- a/test/components/previews/viral_select2_component_preview/default.html.erb
+++ b/test/components/previews/viral_select2_component_preview/default.html.erb
@@ -20,7 +20,7 @@
     <% end %>
   <% end %>
   <%= form.submit "Submit",
-              class: "button button--size-default button--state-primary",
+              class: "button button-primary",
               disabled: true,
               data: {
                 "viral--select2-target": "submitButton",

--- a/test/components/previews/viral_tooltip_component_preview/default.html.erb
+++ b/test/components/previews/viral_tooltip_component_preview/default.html.erb
@@ -1,5 +1,5 @@
 <%= viral_tooltip(title: "Tooltip body!") do %>
   <%= link_to "Hover over me!",
   "#",
-  class: "button button--state-default button--size-default" %>
+  class: "button button-default button--size-default" %>
 <% end %>

--- a/test/components/previews/viral_tooltip_component_preview/default.html.erb
+++ b/test/components/previews/viral_tooltip_component_preview/default.html.erb
@@ -1,5 +1,3 @@
 <%= viral_tooltip(title: "Tooltip body!") do %>
-  <%= link_to "Hover over me!",
-  "#",
-  class: "button button-default button--size-default" %>
+  <%= link_to "Hover over me!", "#", class: "button button-default" %>
 <% end %>

--- a/test/components/viral/button_component_test.rb
+++ b/test/components/viral/button_component_test.rb
@@ -77,25 +77,5 @@ module Viral
         assert_text 'Full Width Button'
       end
     end
-
-    test 'button large' do
-      render_inline(Viral::ButtonComponent.new(size: :large)) do
-        'Large Button'
-      end
-
-      assert_selector 'button.button--size-large' do
-        assert_text 'Large Button'
-      end
-    end
-
-    test 'button small' do
-      render_inline(Viral::ButtonComponent.new(size: :small)) do
-        'Small Button'
-      end
-
-      assert_selector 'button.button--size-default' do
-        assert_text 'Small Button'
-      end
-    end
   end
 end

--- a/test/components/viral/button_component_test.rb
+++ b/test/components/viral/button_component_test.rb
@@ -9,7 +9,7 @@ module Viral
         'Basic Button'
       end
 
-      assert_selector 'button.button--state-default' do
+      assert_selector 'button.button-default' do
         assert_text 'Basic Button'
       end
     end
@@ -19,7 +19,7 @@ module Viral
         'Destructive Button'
       end
 
-      assert_selector 'button.button--state-destructive' do
+      assert_selector 'button.button-destructive' do
         assert_text 'Destructive Button'
       end
     end

--- a/test/components/viral/system/confirmation_component_test.rb
+++ b/test/components/viral/system/confirmation_component_test.rb
@@ -28,11 +28,11 @@ class ConfirmationComponentTest < ApplicationSystemTestCase
   test 'confirmation component with custom value' do
     visit('/rails/view_components/confirmation_component/with_confirm_value')
     click_button 'Delete project'
-    assert_selector 'button.button--state-destructive:disabled'
+    assert_selector 'button.button-destructive:disabled'
     assert_text 'Confirmation required'
     assert_accessible
     find('input').set 'Project X' # TODO: update this to use fill_in
-    assert_selector 'button.button--state-destructive'
+    assert_selector 'button.button-destructive'
     assert_accessible
   end
 end

--- a/test/components/viral/system/dialog_component_test.rb
+++ b/test/components/viral/system/dialog_component_test.rb
@@ -9,8 +9,8 @@ module System
       within('div[data-controller-connected="true"] dialog') do
         assert_accessible
         assert_text 'Confirmation required'
-        assert_selector 'button.button--state-primary', count: 1
-        assert_selector 'button.button--state-default', count: 1
+        assert_selector 'button.button-primary', count: 1
+        assert_selector 'button.button-default', count: 1
       end
     end
 
@@ -50,8 +50,8 @@ module System
       visit('rails/view_components/viral_dialog_component/with_action_buttons')
       within('div[data-controller-connected="true"] dialog') do
         assert_accessible
-        assert_selector 'button.button--state-primary', count: 1
-        assert_selector 'button.button--state-default', count: 1
+        assert_selector 'button.button-primary', count: 1
+        assert_selector 'button.button-default', count: 1
       end
     end
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Working towards consistent buttons across IRIDA-Next.  Descided keeping the button styling inside application.css was the best way to keep it consistent.

The following things were considered with this update:

### Target Size:
WCAG 2.5.5: Target size (Enhanced) at Level AAA requires interactive elements, including buttons, to be at least 44x44 CSS pixels. This allows for more accurate clicking or tapping, especially for users with motor impairments. 

### Contrast:
WCAG Level AAA requires a contrast ratio of at least 7:1 for normal text and 4.5:1 for large text. This ensures that the button text is easily readable, even by people with low vision. 

### Accessibility Label:
Buttons should have accessible labels, either through their text content or with aria-label or aria-labelledby attributes. This helps screen readers and other assistive technologies identify and convey the button's purpose. 

### Focus Appearance:
When a button is focused, a clear and visible focus indicator should be present, with a sufficient size and contrast to ensure it's easily noticeable. 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/06d73b86-d2ae-4c0b-bd45-336910d645f9)

![image](https://github.com/user-attachments/assets/07bf329f-2402-424a-8fcc-039cf339147f)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
