### PR TITLE
Fix: Back button behaviour

### DIFF
--- a/app/components/data_exports/table_component.rb
+++ b/app/components/data_exports/table_component.rb
@@ -37,7 +37,7 @@ module DataExports
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('table-container flex flex-col shrink min-h-0 data-turbo-temporary')
+        classes: class_names('table-container flex flex-col shrink min-h-0')
       }
     end
 

--- a/app/components/groups/table_component.rb
+++ b/app/components/groups/table_component.rb
@@ -30,8 +30,7 @@ module Groups
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('table-container relative overflow-x-auto'),
-        data: { turbo: :temporary }
+        classes: class_names('table-container relative overflow-x-auto')
       }
     end
 

--- a/app/components/members/table_component.rb
+++ b/app/components/members/table_component.rb
@@ -23,8 +23,7 @@ module Members
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('relative overflow-x-auto'),
-        data: { turbo: :temporary }
+        classes: class_names('relative overflow-x-auto')
       }
     end
 

--- a/app/components/metadata_templates/table_component.rb
+++ b/app/components/metadata_templates/table_component.rb
@@ -22,8 +22,7 @@ module MetadataTemplates
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('relative overflow-x-auto'),
-        data: { turbo: :temporary }
+        classes: class_names('relative overflow-x-auto')
       }
     end
 

--- a/app/components/viral/data_table_component.rb
+++ b/app/components/viral/data_table_component.rb
@@ -33,7 +33,7 @@ module Viral
     def wrapper_arguments
       {
         tag: 'div',
-        classes: class_names('table-container flex flex-col shrink min-h-0 data-turbo-temporary')
+        classes: class_names('table-container flex flex-col shrink min-h-0')
       }
     end
 

--- a/app/views/dashboard/projects/index.html.erb
+++ b/app/views/dashboard/projects/index.html.erb
@@ -8,7 +8,10 @@
 
 <div class="bg-white dark:bg-slate-800">
   <div
-    class="flex text-sm font-medium text-center border-b  text-slate-500 border-slate-200 dark:text-slate-400 dark:border-slate-700"
+    class="
+      flex text-sm font-medium text-center border-b text-slate-500 border-slate-200
+      dark:text-slate-400 dark:border-slate-700
+    "
   >
     <ul class="flex flex-1">
       <li class="mr-2">
@@ -45,7 +48,7 @@
     <%= turbo_frame_tag "project_sort_dropdown" %>
 
   </div>
-  <div class="flex flex-col" data-turbo-temporary>
+  <div class="flex flex-col">
     <% if @has_projects %>
       <%= turbo_frame_tag "projects_list", src: dashboard_projects_url(format: :turbo_stream, **request.query_parameters) do %>
         <%= render partial: "shared/loading/table" %>

--- a/app/views/groups/activity.html.erb
+++ b/app/views/groups/activity.html.erb
@@ -1,5 +1,5 @@
 <%= render Viral::PageHeaderComponent.new(title: t("groups.activity.title")) %>
 
-<div data-turbo-temporary>
+<div>
   <%= render ActivityComponent.new(activities: @activities, pagy: @pagy) %>
 </div>

--- a/app/views/groups/activity.html.erb
+++ b/app/views/groups/activity.html.erb
@@ -1,5 +1,3 @@
 <%= render Viral::PageHeaderComponent.new(title: t("groups.activity.title")) %>
 
-<div>
-  <%= render ActivityComponent.new(activities: @activities, pagy: @pagy) %>
-</div>
+<%= render ActivityComponent.new(activities: @activities, pagy: @pagy) %>

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -36,15 +36,13 @@
   <% end %>
 
   <% if @tab == "invited_groups" %>
-    <%= turbo_frame_tag "members", "data-turbo-temporary": true,
-                            src: group_group_links_path(format: :turbo_stream) do %>
+    <%= turbo_frame_tag "members", src: group_group_links_path(format: :turbo_stream) do %>
       <%= render partial: "shared/loading/table" %>
     <% end %>
   <% else %>
-    <%= turbo_frame_tag "members", "data-turbo-temporary": true,
-                        src: group_members_path(format: :turbo_stream) do %>
+    <%= turbo_frame_tag "members", src: group_members_path(format: :turbo_stream) do %>
       <%= render partial: "shared/loading/table" %>
     <% end %>
   <% end %>
-  <%= turbo_frame_tag "members_pagination", "data-turbo-temporary": true %>
+  <%= turbo_frame_tag "members_pagination" %>
 </div>

--- a/app/views/projects/activity.html.erb
+++ b/app/views/projects/activity.html.erb
@@ -1,5 +1,5 @@
 <%= render Viral::PageHeaderComponent.new(title: t("projects.activity.title")) %>
 
-<div data-turbo-temporary>
+<div>
   <%= render ActivityComponent.new(activities: @activities, pagy: @pagy) %>
 </div>

--- a/app/views/projects/activity.html.erb
+++ b/app/views/projects/activity.html.erb
@@ -1,5 +1,3 @@
 <%= render Viral::PageHeaderComponent.new(title: t("projects.activity.title")) %>
 
-<div>
-  <%= render ActivityComponent.new(activities: @activities, pagy: @pagy) %>
-</div>
+<%= render ActivityComponent.new(activities: @activities, pagy: @pagy) %>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -70,7 +70,7 @@
         </div>
       </div>
       <div class="flex flex-col">
-        <%= turbo_frame_tag "members", "data-turbo-temporary": true,
+        <%= turbo_frame_tag "members",
                             src:
                               (
                                 if @tab == "invited_groups"
@@ -104,7 +104,7 @@
             </tbody>
           </table>
         <% end %>
-        <%= turbo_frame_tag "members_pagination", "data-turbo-temporary": true %>
+        <%= turbo_frame_tag "members_pagination" %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -1,5 +1,5 @@
 <div id="sample-attachments">
-  <div class="relative overflow-x-auto table-wrapper" data-turbo-temporary>
+  <div class="relative overflow-x-auto table-wrapper">
     <% if @allowed_to[:update_sample] && @has_attachments %>
       <div class="flex items-center mb-4">
         <% if Flipper.enabled?(:sample_attachments_searching) %>

--- a/app/views/projects/samples/metadata/_table.html.erb
+++ b/app/views/projects/samples/metadata/_table.html.erb
@@ -2,7 +2,7 @@
 
 <div id="sample-metadata">
   <% if sample_metadata.present? %>
-    <div class="relative overflow-x-auto table-wrapper" data-turbo-temporary>
+    <div class="relative overflow-x-auto table-wrapper">
       <% if @allowed_to[:update_sample] %>
         <div class="flex justify-end items-center mb-4">
           <div class="flex items-center space-x-2">

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -77,7 +77,7 @@
       <% end %>
     </ul>
   </nav>
-  <section class="flex flex-col min-h-[200px]" data-turbo-temporary>
+  <section class="flex flex-col min-h-[200px]">
     <%= turbo_frame_tag "table-listing", src: namespace_project_sample_path(format: :turbo_stream, tab: @tab || 'files', **request.query_parameters) do %>
       <% if @tab == "history" %>
         <%= render partial: "shared/loading/history" %>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR removes `data-turbo-temporary` from main content of pages so that navigating forward (e.g. clicking a link in the breadcrumbs) and then navigating backward (using browser back button), doesn't result in a blank page which then has content on refresh.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch server
2. Navigate to project of choice
3. Click on `Members` sidebar menu item
4. Click on `Groups` tab
5. Hit back button (observe that Members table loads)
6. Click on `Groups` tab
7. Click on `Samples` sidebar menu item
8. Hit back button (observe that Groups table loads)
9. Repeat these same sorts of step for `Metadata Templates`, `Projects Dashboard`, `Groups Activity`, `Projects Activity`, `Group Members and Groups tab`, `Sample files tab`, `Samples metadata tab`, `Samples History Tab`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
