### PR TITLE
Fix Attachments::TableComponent

### DIFF
--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -241,31 +241,33 @@
                   <% end %>
                 <% end %>
               <% end %>
-              <%= render_cell(
+              <% if @renders_row_actions %>
+                <%= render_cell(
                   tag: 'td',
                   classes: class_names('px-3 py-3 space-x-2')
                 ) do %>
-                <% if @row_actions[:preview] && attachment.previewable? %>
-                  <%= link_to(
-                    t(".preview"),
-                    attachment_path(attachment),
-                    data: {
-                      turbo_stream: true,
-                    },
-                    class:
-                      "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
-                  ) %>
-                <% end %>
-                <% if @row_actions[:destroy] %>
-                  <%= link_to(
-                    t(".delete"),
-                    destroy_path(attachment.id),
-                    data: {
-                      turbo_stream: true,
-                    },
-                    class:
-                      "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
-                  ) %>
+                  <% if @row_actions[:preview] && attachment.previewable? %>
+                    <%= link_to(
+                      t(".preview"),
+                      attachment_path(attachment),
+                      data: {
+                        turbo_stream: true,
+                      },
+                      class:
+                        "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
+                    ) %>
+                  <% end %>
+                  <% if @row_actions[:destroy] %>
+                    <%= link_to(
+                      t(".delete"),
+                      destroy_path(attachment.id),
+                      data: {
+                        turbo_stream: true,
+                      },
+                      class:
+                        "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline cursor-pointer",
+                    ) %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>


### PR DESCRIPTION
## What does this PR do and why?
A fix for the Attachments::TableComponent rendering an extra table cell in the table body when no row actions are permitted. This was accidentally introduced in #1109.

## Screenshots or screen recordings
BEFORE:
![image](https://github.com/user-attachments/assets/ee66a3e8-533b-4d80-a68f-b184e880ab5f)

AFTER:
![image](https://github.com/user-attachments/assets/82d5023e-42eb-47f5-aeb9-dbebab9f8939)

## How to set up and validate locally
1. Open a rails console and enable the feature flag by running the following command.
```
Flipper.disable(:attachments_preview)
```
2. Open a browser and verify the feature is enabled by navigating to http://localhost:3000/rails/flipper/features.
3. Navigate to a workflow execution files page.
4. Verify there is no extra cell in the table body.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
