### PR TITLE
Members Pagination focus and sort/search fix

### DIFF
--- a/app/components/pagination_component.html.erb
+++ b/app/components/pagination_component.html.erb
@@ -7,6 +7,8 @@
 >
   <% if prev_url %>
     <%= link_to prev_url,
+          id: "prev-page-link",
+          autofocus: next_url.nil? && @autofocus_link,
           **link_arguments,
           class: [
             "flex items-center justify-center rounded-lg border border-slate-300 bg-slate-200 px-4 py-2.5 text-sm font-medium text-slate-700",
@@ -21,6 +23,8 @@
 
   <% if next_url %>
     <%= link_to next_url,
+          id: "next-page-link",
+          autofocus: prev_url.nil? && @autofocus_link,
           **link_arguments,
           class: [
             "flex items-center justify-center rounded-lg border border-slate-300 bg-slate-200 px-4 py-2.5 text-sm font-medium text-slate-700",

--- a/app/components/pagination_component.rb
+++ b/app/components/pagination_component.rb
@@ -4,10 +4,11 @@
 class PaginationComponent < Component
   attr_reader :prev_url, :next_url, :info
 
-  def initialize(info:, prev_url: nil, next_url: nil, **link_arguments)
+  def initialize(info:, prev_url: nil, next_url: nil, autofocus_link: false, **link_arguments)
     @info = info
     @prev_url = prev_url
     @next_url = next_url
+    @autofocus_link = autofocus_link
     @link_arguments = link_arguments
   end
 

--- a/app/views/groups/group_links/_pagination.html.erb
+++ b/app/views/groups/group_links/_pagination.html.erb
@@ -17,5 +17,6 @@
           nil
         end
       ),
+    autofocus_link: params.key?(:page),
   ) %>
 <% end %>

--- a/app/views/groups/members/_pagination.html.erb
+++ b/app/views/groups/members/_pagination.html.erb
@@ -16,4 +16,5 @@
         nil
       end
     ),
+  autofocus_link: params.key?(:page),
 ) %>

--- a/app/views/projects/group_links/_pagination.html.erb
+++ b/app/views/projects/group_links/_pagination.html.erb
@@ -23,5 +23,6 @@
           nil
         end
       ),
+    autofocus_link: params.key?(:page),
   ) %>
 <% end %>

--- a/app/views/projects/members/_pagination.html.erb
+++ b/app/views/projects/members/_pagination.html.erb
@@ -22,4 +22,5 @@
         nil
       end
     ),
+  autofocus_link: params.key?(:page),
 ) %>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the `_pagination.html.erb` partials for Project/Group Members/Groups tables to include the ransack params in the pagination urls. In addition the `PaginationComponent` has been updated include ids for next page and prev page buttons as well as optional autofocus when only a next or prev button is visible.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Note: I set pagy default limit to 2 to make this demo

[Peek 2025-06-18 07-42.webm](https://github.com/user-attachments/assets/d3826aa2-244c-4c03-a876-3828a89d4604)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Temporarily change `Pagy::DEFAULT[:limit]` to `2` in `config/initializers/pagy.rb`
2. Start the server and login
3. Navigate to a Group Members page of your choice with appropriate permission
4. Tab to a header column and hit enter to change sort
5. Tab to pagination buttons and hit enter and see that focus is maintained as page changes and sort is preserved
6. Tab to search box and enter a single character
7. Tab back to pagination buttons and hit enter and see that search is still applied
8. Repeat steps 4-6 on the Groups tab
9. Navigate to a Project Members page of your choice with appropriate permissions
10. Repeat steps 4-8

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.