### PR TITLE
Sorted dropdown menu state fix

### DIFF
--- a/app/components/ransack/sort_dropdown_component.html.erb
+++ b/app/components/ransack/sort_dropdown_component.html.erb
@@ -1,6 +1,6 @@
 <%= viral_dropdown(label: t(".sorting.#{@ransack_obj.sorts[0].name}_#{@ransack_obj.sorts[0].dir}"),
-                   caret: true) do |dropdown| %>
+                   caret: true, prefix: "Sort by") do |dropdown| %>
   <% @sort_options.each do |sort| %>
-    <%= helpers.sorting_item(dropdown, @ransack_obj, sort[:name], sort[:dir]) %>
+    <%= helpers.sorting_item(dropdown, @ransack_obj, sort[:name], sort[:dir], "Sort by") %>
   <% end %>
 <% end %>

--- a/app/components/ransack/sort_dropdown_component.html.erb
+++ b/app/components/ransack/sort_dropdown_component.html.erb
@@ -1,6 +1,12 @@
 <%= viral_dropdown(label: t(".sorting.#{@ransack_obj.sorts[0].name}_#{@ransack_obj.sorts[0].dir}"),
-                   caret: true, prefix: "Sort by") do |dropdown| %>
+                   caret: true, prefix: t(".prefix")) do |dropdown| %>
   <% @sort_options.each do |sort| %>
-    <%= helpers.sorting_item(dropdown, @ransack_obj, sort[:name], sort[:dir], "Sort by") %>
+    <%= helpers.sorting_item(
+      dropdown,
+      @ransack_obj,
+      sort[:name],
+      sort[:dir],
+      t(".prefix"),
+    ) %>
   <% end %>
 <% end %>

--- a/app/components/viral/dropdown/item_component.html.erb
+++ b/app/components/viral/dropdown/item_component.html.erb
@@ -5,12 +5,20 @@
       w-full px-3 py-2 text-xs font-bold tracking-wider uppercase bg-slate-200
       dark:bg-slate-500 text-slate-700 dark:text-slate-200
     "
-  ><%= label %></li>
+  >
+    <% if prefix.present? %>
+      <span class="sr-only"><%= prefix %>&nbsp;</span>
+    <% end %>
+    <%= label %>
+  </li>
 <% elsif disableable %>
   <li role="menuitem">
     <%= button_to url, method: :get, params: params, class: "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white", **system_arguments do %>
       <% if icon.present? %>
         <span class="grow-0 mr-2"><%= viral_icon(name: icon, color: :subdued, classes: "w-5 h-5") %></span>
+      <% end %>
+      <% if prefix.present? %>
+        <span class="sr-only"><%= prefix %>&nbsp;</span>
       <% end %>
       <%= label %>
     <% end %>
@@ -20,6 +28,9 @@
     <%= link_to url, class: "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white cursor-pointer", **system_arguments do %>
       <% if icon.present? %>
         <span class="grow-0 mr-2"><%= viral_icon(name: icon, color: :subdued, classes: "w-5 h-5") %></span>
+      <% end %>
+      <% if prefix.present? %>
+        <span class="sr-only"><%= prefix %>&nbsp;</span>
       <% end %>
       <%= label %>
     <% end %>

--- a/app/components/viral/dropdown/item_component.rb
+++ b/app/components/viral/dropdown/item_component.rb
@@ -4,17 +4,18 @@ module Viral
   module Dropdown
     # Item component for dropdown
     class ItemComponent < Viral::Component
-      attr_reader :label, :icon, :url, :section_header, :params, :disableable
+      attr_reader :label, :icon, :url, :section_header, :params, :disableable, :prefix
 
       # rubocop:disable Metrics/ParameterLists
       def initialize(label:, url: nil, params: nil, disableable: false, icon_name: nil, section_header: false,
-                     **system_arguments)
+                     prefix: nil, **system_arguments)
         @label = label
         @icon = icon_name
         @url = url
         @params = params || {}
         @disableable = disableable
         @section_header = section_header
+        @prefix = prefix
         @system_arguments = system_arguments
       end
       # rubocop:enable Metrics/ParameterLists

--- a/app/components/viral/dropdown_component.html.erb
+++ b/app/components/viral/dropdown_component.html.erb
@@ -34,7 +34,11 @@
     tabindex="-1"
     hidden="hidden"
   >
-    <ul class="py-2 text-sm text-slate-700 dark:text-slate-200" role="menu">
+    <ul
+      class="py-2 text-sm text-slate-700 dark:text-slate-200"
+      role="menu"
+      id="<%=@dd_id%>"
+    >
       <% items.each do |item| %>
         <%= item %>
       <% end %>

--- a/app/components/viral/dropdown_component.html.erb
+++ b/app/components/viral/dropdown_component.html.erb
@@ -12,6 +12,9 @@
         classes: label.present? ? "w-6 h-6 flex-none mr-3" : "w-6 h-6 flex-none",
       ) %>
     <% end %>
+    <% if prefix.present? %>
+      <span class="sr-only"><%= prefix %>&nbsp;</span>
+    <% end %>
     <% if label.present? %>
       <span class="text-left truncate grow"><%= label %></span>
     <% end %>

--- a/app/components/viral/dropdown_component.html.erb
+++ b/app/components/viral/dropdown_component.html.erb
@@ -37,11 +37,7 @@
     tabindex="-1"
     hidden="hidden"
   >
-    <ul
-      class="py-2 text-sm text-slate-700 dark:text-slate-200"
-      role="menu"
-      id="<%=@dd_id%>"
-    >
+    <ul class="py-2 text-sm text-slate-700 dark:text-slate-200" role="menu">
       <% items.each do |item| %>
         <%= item %>
       <% end %>

--- a/app/components/viral/dropdown_component.rb
+++ b/app/components/viral/dropdown_component.rb
@@ -21,7 +21,7 @@ module Viral
     renders_many :items, Dropdown::ItemComponent
 
     # Public: Expose key dropdown configuration
-    attr_reader :distance, :label, :icon_name, :caret, :skidding, :trigger, :tooltip, :styles
+    attr_reader :distance, :label, :icon_name, :caret, :skidding, :trigger, :tooltip, :styles, :prefix
 
     TRIGGER_DEFAULT = :click
     TRIGGER_MAPPINGS = {
@@ -65,6 +65,7 @@ module Viral
         TRIGGER_MAPPINGS[TRIGGER_DEFAULT]
       )
       @dd_id = "dd-#{SecureRandom.hex(10)}"
+      @prefix = @params[:prefix]
     end
 
     # 🛠️ Build and enhance system arguments for the dropdown trigger

--- a/app/helpers/sorting_helper.rb
+++ b/app/helpers/sorting_helper.rb
@@ -10,13 +10,14 @@ module SortingHelper
     true
   end
 
-  def sorting_item(dropdown, ransack_obj, field, dir)
+  def sorting_item(dropdown, ransack_obj, field, dir, prefix = nil)
     dropdown.with_item(label: t(format('.sorting.%<field>s_%<dir>s', field:, dir:)),
                        url: sorting_url(ransack_obj, field, dir:),
                        icon_name: active_sort(ransack_obj, field, dir) ? 'check' : 'blank',
                        data: {
                          turbo_stream: true
-                       })
+                       },
+                       prefix:)
   end
 
   def sorting_url(ransack_obj, field, dir: nil, with_search_params: true)

--- a/app/helpers/sorting_helper.rb
+++ b/app/helpers/sorting_helper.rb
@@ -14,10 +14,19 @@ module SortingHelper
     dropdown.with_item(label: t(format('.sorting.%<field>s_%<dir>s', field:, dir:)),
                        url: sorting_url(ransack_obj, field, dir:),
                        icon_name: active_sort(ransack_obj, field, dir) ? 'check' : 'blank',
+                       prefix:,
                        data: {
                          turbo_stream: true
                        },
-                       prefix:)
+                       **add_aria_current(ransack_obj, field, dir))
+  end
+
+  def add_aria_current(ransack_obj, field, dir)
+    if active_sort(ransack_obj, field, dir)
+      { 'aria-current': 'page' }
+    else
+      {}
+    end
   end
 
   def sorting_url(ransack_obj, field, dir: nil, with_search_params: true)

--- a/app/helpers/sorting_helper.rb
+++ b/app/helpers/sorting_helper.rb
@@ -16,7 +16,7 @@ module SortingHelper
                        icon_name: active_sort(ransack_obj, field, dir) ? 'check' : 'blank',
                        prefix:,
                        data: {
-                         turbo_stream: true,
+                         turbo: true,
                          turbo_action: 'replace'
                        },
                        **add_aria_current(ransack_obj, field, dir))

--- a/app/helpers/sorting_helper.rb
+++ b/app/helpers/sorting_helper.rb
@@ -16,7 +16,8 @@ module SortingHelper
                        icon_name: active_sort(ransack_obj, field, dir) ? 'check' : 'blank',
                        prefix:,
                        data: {
-                         turbo_stream: true
+                         turbo_stream: true,
+                         turbo_action: 'replace'
                        },
                        **add_aria_current(ransack_obj, field, dir))
   end

--- a/app/javascript/controllers/viral/dropdown_controller.js
+++ b/app/javascript/controllers/viral/dropdown_controller.js
@@ -66,7 +66,9 @@ export default class extends Controller {
   #focusByKey(event, menuLinks, currentIndex) {
     switch (event.key) {
       case "Escape":
+        event.preventDefault();
         this.triggerTarget.focus();
+        break;
       case "ArrowUp":
       case "ArrowLeft":
         event.preventDefault();

--- a/app/javascript/controllers/viral/dropdown_controller.js
+++ b/app/javascript/controllers/viral/dropdown_controller.js
@@ -10,7 +10,8 @@ export default class extends Controller {
   };
 
   initialize() {
-    this.boundHandleTriggerFocusOut = this.handleTriggerFocusOut.bind(this);
+    this.boundKeydown = this.keyDown.bind(this);
+    this.boundFocusOut = this.focusOut.bind(this);
   }
 
   connect() {
@@ -19,12 +20,13 @@ export default class extends Controller {
 
   menuTargetConnected(element) {
     element.setAttribute("aria-hidden", "true");
-
-    element.addEventListener("focusout", this.boundHandleTriggerFocusOut);
+    element.addEventListener("keydown", this.boundKeydown);
+    element.addEventListener("focusout", this.boundFocusOut);
   }
 
   menuTargetDisconnected(element) {
-    element.removeEventListener("focusout", this.boundHandleTriggerFocusOut);
+    element.removeEventListener("keydown", this.boundKeydown);
+    element.removeEventListener("focusout", this.boundFocusOut);
   }
 
   triggerTargetConnected(element) {
@@ -47,9 +49,48 @@ export default class extends Controller {
     });
   }
 
-  handleTriggerFocusOut(event) {
+  focusOut(event) {
     if (!this.menuTarget.contains(event.relatedTarget)) {
       this.dropdown.hide();
+    }
+  }
+
+  keyDown(event) {
+    var menuLinks = Array.prototype.slice.call(
+      this.menuTarget.querySelectorAll("a"),
+    );
+    var currentIndex = menuLinks.indexOf(document.activeElement);
+    this.#focusByKey(event, menuLinks, currentIndex);
+  }
+
+  #focusByKey(event, menuLinks, currentIndex) {
+    switch (event.key) {
+      case "Escape":
+        this.triggerTarget.focus();
+      case "ArrowUp":
+      case "ArrowLeft":
+        event.preventDefault();
+        if (currentIndex > -1) {
+          var prevIndex = Math.max(0, currentIndex - 1);
+          menuLinks[prevIndex].focus();
+        }
+        break;
+      case "ArrowDown":
+      case "ArrowRight":
+        event.preventDefault();
+        if (currentIndex > -1) {
+          var nextIndex = Math.min(menuLinks.length - 1, currentIndex + 1);
+          menuLinks[nextIndex].focus();
+        }
+        break;
+      case "Home":
+        event.preventDefault();
+        menuLinks[0].focus();
+        break;
+      case "End":
+        event.preventDefault();
+        menuLinks[menuLinks.length - 1].focus();
+        break;
     }
   }
 }

--- a/app/javascript/controllers/viral/dropdown_controller.js
+++ b/app/javascript/controllers/viral/dropdown_controller.js
@@ -65,6 +65,14 @@ export default class extends Controller {
 
   #focusByKey(event, menuLinks, currentIndex) {
     switch (event.key) {
+      case "Enter":
+        return document.addEventListener(
+          "turbo:morph",
+          () => {
+            this.triggerTarget.focus();
+          },
+          { once: true },
+        );
       case "Escape":
         event.preventDefault();
         this.triggerTarget.focus();

--- a/app/views/dashboard/groups/index.html.erb
+++ b/app/views/dashboard/groups/index.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+
 <%= render Viral::PageHeaderComponent.new(title: t(".title")) do |component| %>
   <%= component.with_buttons do %>
     <%= link_to t(:".create_group_button"),
@@ -22,22 +24,20 @@
           "data-turbo-permanent": "true",
         },
       ) %>
-      <%= form_for @q, url: dashboard_groups_url, method: :post, html: { method: :post, "data-controller": "filters", "data-turbo": false } do %>
-        <div class="flex flex-row items-center ml-auto space-x-2 font-normal py-1.5">
-          <%= render Ransack::SortDropdownComponent.new(
-            @q,
-            "groups",
-            [
-              { name: "created_at", dir: "desc" },
-              { name: "created_at", dir: "asc" },
-              { name: "name", dir: "asc" },
-              { name: "name", dir: "desc" },
-              { name: "updated_at", dir: "desc" },
-              { name: "updated_at", dir: "asc" },
-            ],
-          ) %>
-        </div>
-      <% end %>
+      <div class="flex flex-row items-center ml-auto space-x-2 font-normal py-1.5">
+        <%= render Ransack::SortDropdownComponent.new(
+          @q,
+          "groups",
+          [
+            { name: "created_at", dir: "desc" },
+            { name: "created_at", dir: "asc" },
+            { name: "name", dir: "asc" },
+            { name: "name", dir: "desc" },
+            { name: "updated_at", dir: "desc" },
+            { name: "updated_at", dir: "asc" },
+          ],
+        ) %>
+      </div>
     </div>
   </div>
   <% if @groups.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1852,6 +1852,7 @@ en:
           title: No automated pipelines.
   ransack:
     sort_dropdown_component:
+      prefix: Sort by
       sorting:
         created_at_asc: Oldest created
         created_at_desc: Last created

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1852,6 +1852,7 @@ fr:
           title: Pas de pipeline automatisé.
   ransack:
     sort_dropdown_component:
+      prefix: Sort by
       sorting:
         created_at_asc: Plus ancien créé
         created_at_desc: Dernier créé

--- a/test/helpers/sorting_helper_test.rb
+++ b/test/helpers/sorting_helper_test.rb
@@ -62,7 +62,7 @@ class SortingHelperTest < ActionView::TestCase
     assert_equal 'Email (A-Z)', dropdown.instance_variable_get(:@item)[:label]
     assert_equal '/sort/email/asc', dropdown.instance_variable_get(:@item)[:url]
     assert_equal 'check', dropdown.instance_variable_get(:@item)[:icon_name]
-    assert_equal({ turbo_stream: true }, dropdown.instance_variable_get(:@item)[:data])
+    assert_equal({ turbo_stream: true, turbo_action: 'replace' }, dropdown.instance_variable_get(:@item)[:data])
   end
 
   test 'sorting_item uses blank icon when not actively sorted' do

--- a/test/helpers/sorting_helper_test.rb
+++ b/test/helpers/sorting_helper_test.rb
@@ -62,7 +62,7 @@ class SortingHelperTest < ActionView::TestCase
     assert_equal 'Email (A-Z)', dropdown.instance_variable_get(:@item)[:label]
     assert_equal '/sort/email/asc', dropdown.instance_variable_get(:@item)[:url]
     assert_equal 'check', dropdown.instance_variable_get(:@item)[:icon_name]
-    assert_equal({ turbo_stream: true, turbo_action: 'replace' }, dropdown.instance_variable_get(:@item)[:data])
+    assert_equal({ turbo: true, turbo_action: 'replace' }, dropdown.instance_variable_get(:@item)[:data])
   end
 
   test 'sorting_item uses blank icon when not actively sorted' do

--- a/test/system/dashboard/groups_test.rb
+++ b/test/system/dashboard/groups_test.rb
@@ -78,7 +78,7 @@ module Dashboard
       end
 
       click_on I18n.t(:'dashboard.groups.index.sorting.created_at_desc')
-      click_on I18n.t(:'dashboard.groups.index.sorting.name_asc')
+      click_on I18n.t(:'dashboard.groups.index.sorting.name_asc'), match: :first
       assert_no_text I18n.t(:'dashboard.groups.index.sorting.created_at_desc')
       assert_text I18n.t(:'dashboard.groups.index.sorting.name_asc')
 

--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -267,7 +267,7 @@ module Dashboard
       assert_selector 'h1', text: I18n.t(:'dashboard.projects.index.title')
 
       click_on I18n.t(:'dashboard.projects.index.sorting.updated_at_desc')
-      click_on I18n.t(:'dashboard.projects.index.sorting.namespace_name_asc')
+      click_on I18n.t(:'dashboard.projects.index.sorting.namespace_name_asc'), match: :first
 
       assert_text @project.namespace.name
       assert_equal 2, @project.reload.samples.size


### PR DESCRIPTION
## What does this PR do and why?
The [disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/
) is implemented on the dropdown component. 
STRY0018228 (ART-8931) & STRY0018191 (ART-8909) & STRY0018214 (ART-8932)

## Screenshots or screen recordings
![dropdown-state-fix](https://github.com/user-attachments/assets/49ff1585-fdf3-4329-ae28-2653551bd572)

## How to set up and validate locally
1. Navigate to the groups and/or projects dashboard page.
2. Try these [keyboard interactions](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid/#kbd_label) on the sorting dropdown.
3. Verify the screen reader announces `Sorted by` before each dropdown option.
4. Verify the screen reader announces which dropdown option is currently selected.

Note: When testing with NVDA, tab to the dropdown, then use `Insert`+`Space` keys to change from browse mode to form mode to use arrow keys.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
