### PR TITLE
Fix: Group creation form description and error message accessibility

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -94,6 +94,11 @@
     @apply mb-1 block text-sm font-medium text-slate-900 dark:text-white;
   }
 
+  & label[required]::after {
+    content: " *" / "";
+    @apply text-red-500;
+  }
+
   & div.field_with_errors {
     @apply block w-full;
   }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -94,7 +94,10 @@
     @apply mb-1 block text-sm font-medium text-slate-900 dark:text-white;
   }
 
-  & label[required]::after {
+  /*
+    content separated by / tells the screenreader that the content is blank so that the asterisk is not read out
+  */
+  & label[data-required]::after {
     content: " *" / "";
     @apply text-red-500;
   }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -45,6 +45,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   end
 
   def create
+    @fixed = false
     @new_group = Groups::CreateService.new(current_user, group_params).execute
     if @new_group.persisted?
       flash[:success] = t('.success')

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,14 +3,14 @@
 # Controller actions for Groups
 class GroupsController < Groups::ApplicationController # rubocop:disable Metrics/ClassLength
   layout :resolve_layout
-  before_action :parent_group, only: %i[new]
+  before_action :parent_group, only: %i[new create]
   before_action :tab, :render_flat_list, only: %i[show]
   before_action :group, only: %i[activity edit show destroy update transfer]
   before_action :authorized_namespaces, except: %i[index show destroy]
   before_action :current_page
   before_action :edit_view_authorizations, only: %i[edit]
   before_action :show_view_authorizations, only: %i[show]
-  before_action :page_title, only: %i[show edit activity new]
+  before_action :page_title, only: %i[show edit activity new create]
 
   def index
     redirect_to dashboard_groups_path
@@ -194,7 +194,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     when 'show', 'edit', 'update', 'activity'
       'groups'
     when 'new', 'create'
-      if @group
+      if params.key?(:parent_id) || params[:commit] == I18n.t(:'groups.new_subgroup.submit')
         'groups'
       else
         'application'
@@ -233,8 +233,8 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
 
   def current_page
     @current_page = case action_name
-                    when 'new'
-                      if @group
+                    when 'new', 'create'
+                      if params.key?(:parent_id) || params[:commit] == I18n.t(:'groups.new_subgroup.submit')
                         t(:'groups.sidebar.details')
                       else
                         t(:'general.default_sidebar.groups')
@@ -276,7 +276,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
                [t(:'groups.sidebar.activity'), @group.full_name].join(' · ')
              when 'edit'
                [t(:'groups.sidebar.general'), t(:'groups.edit.title'), @group.full_name].join(' · ')
-             when 'new'
+             when 'new', 'create'
                if @group
                  t(:'groups.new_subgroup.title')
                else

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -148,7 +148,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   end
 
   def group_params
-    params.require(:group).permit(:name, :path, :description, :parent_id)
+    params.expect(group: %i[name path description parent_id])
   end
 
   def authorized_namespaces
@@ -194,7 +194,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
     when 'show', 'edit', 'update', 'activity'
       'groups'
     when 'new', 'create'
-      if params.key?(:parent_id) || params[:commit] == I18n.t(:'groups.new_subgroup.submit')
+      if params.key?(:parent_id) || (params[:group] && params[:group][:parent_id].present?)
         'groups'
       else
         'application'
@@ -234,7 +234,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   def current_page
     @current_page = case action_name
                     when 'new', 'create'
-                      if params.key?(:parent_id) || params[:commit] == I18n.t(:'groups.new_subgroup.submit')
+                      if params.key?(:parent_id) || (params[:group] && params[:group][:parent_id].present?)
                         t(:'groups.sidebar.details')
                       else
                         t(:'general.default_sidebar.groups')

--- a/app/models/concerns/routable.rb
+++ b/app/models/concerns/routable.rb
@@ -62,9 +62,9 @@ module Routable
   private
 
   def set_path_errors
-    route_path_errors = errors.delete(:'route.path')
-    route_path_errors&.each do |msg|
-      errors.add(:path, msg)
+    errors.delete(:'route.path')
+    route.errors.group_by_attribute[:path]&.each do |path_error|
+      errors.add(:path, path_error.message) unless errors.of_kind?(:path, path_error.type)
     end
   end
 

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -11,7 +11,7 @@ module Groups
     end
 
     def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      authorize! group.parent, to: :create_subgroup? if params[:parent_id]
+      authorize! group.parent, to: :create_subgroup? if params[:parent_id].present?
 
       group.save
 

--- a/app/validators/namespace_path_validator.rb
+++ b/app/validators/namespace_path_validator.rb
@@ -3,8 +3,10 @@
 # Validator for path attribute in Namespaces
 class NamespacePathValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    return if value.blank?
+
     unless value =~ self.class.format_regex
-      record.errors.add(attribute, self.class.format_error_message)
+      record.errors.add(attribute, :invalid_format)
       return
     end
 
@@ -13,7 +15,7 @@ class NamespacePathValidator < ActiveModel::EachValidator
 
     return if self.class.valid_path?(full_path)
 
-    record.errors.add(attribute, "#{value} is a reserved name")
+    record.errors.add(attribute, :reserved_value, value: value)
   end
 
   def self.path_regex
@@ -22,10 +24,6 @@ class NamespacePathValidator < ActiveModel::EachValidator
 
   def self.format_regex
     Irida::PathRegex.namespace_format_regex
-  end
-
-  def self.format_error_message
-    'Namespace Path is not valid'
   end
 
   def self.valid_path?(path)

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -40,7 +40,7 @@
           <%= t("activerecord.attributes.group.parent_id") %>
         </label>
         <div class="flex items-center">
-          <%= viral_prefixed_select2(form:, name: :parent_id, id: form_id, selected_value: group.parent.id, placeholder: t(:"groups.new_subgroup.select_group")) do |select| %>
+          <%= viral_prefixed_select2(form:, name: :parent_id, id: form_id, selected_value: group.parent_id, placeholder: t(:"groups.new_subgroup.select_group")) do |select| %>
             <% authorized_namespaces.each do |namespace| %>
               <% select.with_option(
                       value: namespace.id,

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <% invalid_name = group.errors.include?(:name) %>
 <div class="form-field <%= 'invalid' if invalid_name %>">
-  <%= form.label :name %>
+  <%= form.label :name, required: true %>
   <%= form.text_field :name,
                   data: {
                     "slugify-target": "name",
@@ -17,6 +17,7 @@
                       form.field_id(:name, "hint"),
                     ].join(" "),
                     invalid: invalid_name,
+                    required: true,
                   } %>
   <%= if invalid_name
     render "shared/form/field_errors",
@@ -36,6 +37,7 @@
         <label
           for="<%= form_id %>"
           class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
+          required="required"
         >
           <%= t("activerecord.attributes.group.parent_id") %>
         </label>
@@ -65,7 +67,7 @@
       </div>
       <% invalid_path = group.errors.include?(:path) %>
       <div class="form-field <%= 'invalid' if invalid_path %>">
-        <%= form.label :path %>
+        <%= form.label :path, required: true %>
         <%= form.text_field :path,
                         data: {
                           "slugify-target": "path",
@@ -80,6 +82,7 @@
                             form.field_id(:name, "hint"),
                           ].join(" "),
                           invalid: invalid_path,
+                          required: true,
                         } %>
         <%= if invalid_path
           render "shared/form/field_errors",
@@ -91,7 +94,7 @@
   <% else %>
     <% invalid_path = group.errors.include?(:path) %>
     <div class="form-field <%= 'invalid' if invalid_path %>">
-      <%= form.label :path %>
+      <%= form.label :path, required: true %>
       <%= form.text_field :path,
                       data: {
                         "slugify-target": "path",
@@ -104,6 +107,7 @@
                           form.field_id(:path, "hint"),
                         ],
                         invalid: invalid_path,
+                        required: true,
                       } %>
       <p id="<%= form.field_id(:path, "hint") %>" class="field-hint">
         <%= t(:"groups.create.path_help") %>

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -10,9 +10,20 @@
                   maxlength: 255,
                   pattern: "[a-zA-Z0-9_\\-\\.\\s\\p{Emoji}]+",
                   placeholder: t(:"groups.create.name_placeholder"),
-                  required: true %>
-  <%= render "shared/form/field_errors", errors: group.errors.full_messages_for(:name) %>
-  <p class="field-hint">
+                  required: true,
+                  aria: {
+                    describedby: [
+                      invalid_name ? form.field_id(:name, "error") : nil,
+                      form.field_id(:name, "hint"),
+                    ].join(" "),
+                    invalid: invalid_name,
+                  } %>
+  <%= if invalid_name
+    render "shared/form/field_errors",
+    id: form.field_id(:name, "error"),
+    errors: group.errors.full_messages_for(:name)
+  end %>
+  <p id="<%= form.field_id(:name, "hint") %>" class="field-hint">
     <%== t(:"groups.create.name_help") %>
   </p>
 </div>
@@ -62,13 +73,22 @@
                         minlength: 3,
                         maxlength: 255,
                         pattern: Irida::PathRegex::PATH_REGEX_STR,
-                        required: true %>
-        <%= render "shared/form/field_errors", errors: group.errors.full_messages_for(:path) %>
+                        required: true,
+                        aria: {
+                          describedby: [
+                            invalid_path ? form.field_id(:path, "error") : nil,
+                            form.field_id(:name, "hint"),
+                          ].join(" "),
+                          invalid: invalid_path,
+                        } %>
+        <%= if invalid_path
+          render "shared/form/field_errors",
+          id: form.field_id(:path, "error"),
+          errors: group.errors.full_messages_for(:path)
+        end %>
       </div>
     </div>
-  <% end %>
-
-  <% unless group.parent_id.present? %>
+  <% else %>
     <% invalid_path = group.errors.include?(:path) %>
     <div class="form-field <%= 'invalid' if invalid_path %>">
       <%= form.label :path %>
@@ -77,11 +97,22 @@
                         "slugify-target": "path",
                       },
                       pattern: Irida::PathRegex::PATH_REGEX_STR,
-                      required: true %>
-      <p class="field-hint">
+                      required: true,
+                      aria: {
+                        describedby: [
+                          invalid_path ? form.field_id(:path, "error") : nil,
+                          form.field_id(:path, "hint"),
+                        ],
+                        invalid: invalid_path,
+                      } %>
+      <p id="<%= form.field_id(:path, "hint") %>" class="field-hint">
         <%= t(:"groups.create.path_help") %>
       </p>
-      <%= render "shared/form/field_errors", errors: group.errors.full_messages_for(:path) %>
+      <%= if invalid_path
+        render "shared/form/field_errors",
+        id: form.field_id(:path, "error"),
+        errors: group.errors.full_messages_for(:path)
+      end %>
     </div>
   <% end %>
 <% end %>
@@ -89,7 +120,21 @@
 <% invalid_description = group.errors.include?(:description) %>
 <div class="form-field <%= 'invalid' if invalid_description %>">
   <%= form.label :description %>
-  <%= form.text_area :description %>
-  <%= render "shared/form/field_errors",
-  errors: group.errors.full_messages_for(:description) %>
+  <%= form.text_area :description,
+                 aria: {
+                   describedby:
+                     (
+                       if invalid_description
+                         form.field_id(:description, "error")
+                       else
+                         nil
+                       end
+                     ),
+                   invalid: invalid_description,
+                 } %>
+  <%= if invalid_description
+    render "shared/form/field_errors",
+    id: form.field_id(:description, "error"),
+    errors: group.errors.full_messages_for(:description)
+  end %>
 </div>

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -10,7 +10,7 @@ end %>
 
 <% invalid_name = group.errors.include?(:name) %>
 <div class="form-field <%= 'invalid' if invalid_name %>">
-  <%= form.label :name, required: true %>
+  <%= form.label :name, data: { required: true } %>
   <%= form.text_field :name,
                   data: {
                     "slugify-target": "name",
@@ -28,7 +28,8 @@ end %>
                     ].join(" "),
                     invalid: invalid_name,
                     required: true,
-                  } %>
+                  },
+                  autofocus: invalid_name %>
   <%= if invalid_name
     render "shared/form/field_errors",
     id: form.field_id(:name, "error"),
@@ -47,7 +48,6 @@ end %>
         <label
           for="<%= form_id %>"
           class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
-          required="required"
         >
           <%= t("activerecord.attributes.group.parent_id") %>
         </label>
@@ -77,7 +77,7 @@ end %>
       </div>
       <% invalid_path = group.errors.include?(:path) %>
       <div class="form-field <%= 'invalid' if invalid_path %>">
-        <%= form.label :path, required: true %>
+        <%= form.label :path, data: { required: true } %>
         <%= form.text_field :path,
                         data: {
                           "slugify-target": "path",
@@ -93,7 +93,11 @@ end %>
                           ].join(" "),
                           invalid: invalid_path,
                           required: true,
-                        } %>
+                        },
+                        autofocus: invalid_path %>
+        <p id="<%= form.field_id(:path, "hint") %>" class="field-hint">
+          <%= t(:"groups.create.path_help") %>
+        </p>
         <%= if invalid_path
           render "shared/form/field_errors",
           id: form.field_id(:path, "error"),
@@ -104,7 +108,7 @@ end %>
   <% else %>
     <% invalid_path = group.errors.include?(:path) %>
     <div class="form-field <%= 'invalid' if invalid_path %>">
-      <%= form.label :path, required: true %>
+      <%= form.label :path, data: { required: true } %>
       <%= form.text_field :path,
                       data: {
                         "slugify-target": "path",
@@ -118,15 +122,16 @@ end %>
                         ],
                         invalid: invalid_path,
                         required: true,
-                      } %>
-      <p id="<%= form.field_id(:path, "hint") %>" class="field-hint">
-        <%= t(:"groups.create.path_help") %>
-      </p>
+                      },
+                      autofocus: invalid_path %>
       <%= if invalid_path
         render "shared/form/field_errors",
         id: form.field_id(:path, "error"),
         errors: group.errors.full_messages_for(:path)
       end %>
+      <p id="<%= form.field_id(:path, "hint") %>" class="field-hint">
+        <%= t(:"groups.create.path_help") %>
+      </p>
     </div>
   <% end %>
 <% end %>
@@ -145,7 +150,8 @@ end %>
                        end
                      ),
                    invalid: invalid_description,
-                 } %>
+                 },
+                 autofocus: invalid_description %>
   <%= if invalid_description
     render "shared/form/field_errors",
     id: form.field_id(:description, "error"),

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,3 +1,13 @@
+<%= if group.errors.any?
+  viral_alert(
+    type: "alert",
+    message: I18n.t(:"general.form.error_notification"),
+    aria: {
+      live: "assertive",
+    },
+  )
+end %>
+
 <% invalid_name = group.errors.include?(:name) %>
 <div class="form-field <%= 'invalid' if invalid_name %>">
   <%= form.label :name, required: true %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -3,7 +3,7 @@
   subtitle: t(:"groups.create.subtitle"),
 ) %>
 <div data-controller="slugify" class="@xl:container">
-  <%= form_with(model: @new_group, url: groups_path, method: :post) do |form| %>
+  <%= form_with(model: @new_group, url: groups_path, method: :post, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
 
       <%= render partial: "form_fields",

--- a/app/views/groups/new_subgroup.html.erb
+++ b/app/views/groups/new_subgroup.html.erb
@@ -4,7 +4,7 @@
 ) %>
 
 <div data-controller="slugify" class="@xl:container">
-  <%= form_with(model: @new_group, url: groups_path, method: :post, data: { controller: "viral--select2" }) do |form| %>
+  <%= form_with(model: @new_group, url: groups_path, method: :post, data: { controller: "viral--select2" }, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
 
       <%= render partial: "form_fields",

--- a/app/views/shared/form/_field_errors.html.erb
+++ b/app/views/shared/form/_field_errors.html.erb
@@ -1,5 +1,6 @@
+<%# locals: (id: nil, errors:) -%>
 <% if defined? errors %>
-  <ul class=" max-w-md text-sm text-slate-500 list-inside dark:text-slate-400 ">
+  <%= tag.ul id: id, class: "max-w-md text-sm text-slate-500 list-inside dark:text-slate-400" do %>
     <% errors.each do |error_message| %>
       <li>
         <%= viral_help_text(state: :error) do %>
@@ -7,5 +8,5 @@
         <% end %>
       </li>
     <% end %>
-  </ul>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,6 +222,9 @@ en:
             name:
               blank: can't be blank
               taken: has already been taken
+            path:
+              invalid_format: can contain only letters, digits, '_', '-', and '.'. Cannot start with '-' or end in '.'.
+              reserved_value: "%{value} is a reserved value."
         namespace_group_link:
           attributes:
             group_access_level:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -843,6 +843,8 @@ en:
       projects: Projects
       title: Your work
       workflows: Workflow Executions
+    form:
+      error_notification: 'Please review the problems below:'
     help: Help
     name: IRIDA Next
     navbar:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -222,6 +222,9 @@ fr:
             name:
               blank: Ne peut pas être vide
               taken: A déjà été pris
+            path:
+              invalid_format: can contain only letters, digits, '_', '-', and '.'. Cannot start with '-' or end in '.'.
+              reserved_value: "%{value} is a reserved value."
         namespace_group_link:
           attributes:
             group_access_level:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -843,6 +843,8 @@ fr:
       projects: Projets
       title: Votre travail
       workflows: Exécutions de flux de travail
+    form:
+      error_notification: 'Please review the problems below:'
     help: Aide
     name: IRIDA Next
     navbar:

--- a/lib/irida/path_regex.rb
+++ b/lib/irida/path_regex.rb
@@ -6,7 +6,7 @@ module Irida
     module_function
 
     # All routes that appear on the top level must be listed here.
-    # This will make sure that namespaces cannot be greated with these names
+    # This will make sure that namespaces cannot be created with these names
     # as these routes would be masked by the paths already in place.
     TOP_LEVEL_ROUTES = %w[
       -
@@ -15,9 +15,13 @@ module Irida
       500.html
       apple-touch-icon-precomposed.png
       apple-touch-icon.png
+      activities
+      api
       assets
+      console
       dashboard
       favicon.ico
+      graphiql
       groups
       rails
       recede_historical_location
@@ -28,7 +32,7 @@ module Irida
     ].freeze
 
     # All routes for groups and projects will be under `-` this allows
-    # makes namespace validation simplier and more robust. I.E. if we
+    # makes namespace validation simpler and more robust. I.E. if we
     # add a new route under the `/-/` scope instead of directly we do
     # not need to worry about existing namespaces that could conflict
     WILDCARD_ROUTES = %w[

--- a/test/graphql/create_group_mutation_test.rb
+++ b/test/graphql/create_group_mutation_test.rb
@@ -192,7 +192,8 @@ class CreateProjectMutationTest < ActiveSupport::TestCase
     assert_nil data['group']
 
     assert_equal 1, data['errors'].count
-    expected_error = { 'path' => %w[group path], 'message' => 'Namespace Path is not valid' }
+    expected_error = { 'path' => %w[group path],
+                       'message' => I18n.t('activerecord.errors.models.namespace.attributes.path.invalid_format') }
 
     assert_equal expected_error, data['errors'][0]
   end

--- a/test/graphql/create_project_mutation_test.rb
+++ b/test/graphql/create_project_mutation_test.rb
@@ -186,7 +186,8 @@ class CreateProjectMutationTest < ActiveSupport::TestCase
     assert_nil data['project']
 
     assert_equal 1, data['errors'].count
-    expected_error = { 'path' => ['project', 'namespace.path'], 'message' => 'Namespace Path is not valid' }
+    expected_error = { 'path' => ['project', 'namespace.path'],
+                       'message' => I18n.t('activerecord.errors.models.namespace.attributes.path.invalid_format') }
 
     assert_equal expected_error, data['errors'][0]
   end

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -43,6 +43,10 @@ class GroupsTest < ApplicationSystemTestCase
       click_on I18n.t('groups.create.submit')
     end
 
+    assert_text I18n.t(:'general.form.error_notification')
+
+    assert_selector '#group_name', focused: true
+
     assert_text 'Group name is too short'
     assert_current_path '/-/groups/new'
   end
@@ -55,6 +59,10 @@ class GroupsTest < ApplicationSystemTestCase
       fill_in I18n.t('activerecord.attributes.group.name'), with: group2.name
       click_on I18n.t('groups.create.submit')
     end
+
+    assert_text I18n.t(:'general.form.error_notification')
+
+    assert_selector '#group_name', focused: true
 
     assert_text 'Group name has already been taken'
     assert_current_path '/-/groups/new'
@@ -69,6 +77,10 @@ class GroupsTest < ApplicationSystemTestCase
       click_on I18n.t('groups.create.submit')
     end
 
+    assert_text I18n.t(:'general.form.error_notification')
+
+    assert_selector '#group_description', focused: true
+
     assert_text 'Description is too long'
     assert_current_path '/-/groups/new'
   end
@@ -82,6 +94,10 @@ class GroupsTest < ApplicationSystemTestCase
       fill_in I18n.t('activerecord.attributes.group.path'), with: group2.path
       click_on I18n.t('groups.create.submit')
     end
+
+    assert_text I18n.t(:'general.form.error_notification')
+
+    assert_selector '#group_path', focused: true
 
     assert_text 'Path has already been taken'
     assert_current_path '/-/groups/new'


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Hints and error messages on Group/Subgroup form have been updated to use `aria-describedby` to link to ids of elements containing hints and error messages.

Form inputs now set `aria-invalid` when errors have been encountered.

Updated `routable` to not add error from `route.path` to `namespace` when error of type already exists on the `namespace.path`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

[Peek 2025-06-19 10-05.webm](https://github.com/user-attachments/assets/8def2493-d713-4688-87cf-a8e77e1c9333)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server, and login as your preferred user
2. Open the create menu at the top of the sidebar and click `Create new group`
3. Submit the form without filling it out
4. Observe error display and name input should be autofocused.
5. Repeat tests on Create subgroup

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
