### PR TITLE
Activities: Discernable link/button text

### DIFF
--- a/app/components/activities/groups/metadata_template_activity_component.html.erb
+++ b/app/components/activities/groups/metadata_template_activity_component.html.erb
@@ -5,6 +5,8 @@
         @activity[:template_name],
         group_metadata_templates_path(@activity[:group]),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t("components.activity.metadata_templates.group.link_descriptive_text"),
       ) %>
   <% else %>
     <% href =

--- a/app/components/activities/groups/projects/crud_activity_component.html.erb
+++ b/app/components/activities/groups/projects/crud_activity_component.html.erb
@@ -5,6 +5,11 @@
         @activity[:project_puid],
         namespace_project_path(@activity[:group], @activity[:project].project),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t(
+            "components.activity.groups.projects.link_descriptive_text",
+            project_puid: @activity[:project_puid],
+          ),
       ) %>
   <% else %>
     <% href =

--- a/app/components/activities/groups/projects/transfer_activity_component.html.erb
+++ b/app/components/activities/groups/projects/transfer_activity_component.html.erb
@@ -3,8 +3,16 @@
     <% href =
       link_to(
         @activity[:project_puid],
-        namespace_project_path(@activity[:group], @activity[:project].project),
+        namespace_project_path(
+          @activity[:project].parent,
+          @activity[:project].project,
+        ),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t(
+            "components.activity.groups.projects.link_descriptive_text",
+            project_puid: @activity[:project_puid],
+          ),
       ) %>
   <% else %>
     <% href =

--- a/app/components/activities/groups/projects/transfer_activity_component.rb
+++ b/app/components/activities/groups/projects/transfer_activity_component.rb
@@ -12,7 +12,7 @@ module Activities
         def project_exists
           return false if @activity[:project].nil?
 
-          !@activity[:project].deleted? && (@activity[:project].parent == @activity[:group])
+          !@activity[:project].deleted?
         end
       end
     end

--- a/app/components/activities/groups/sample_activity_component.html.erb
+++ b/app/components/activities/groups/sample_activity_component.html.erb
@@ -1,5 +1,8 @@
 <section>
+  <% descriptive_text = "" %>
   <% if import_samples_action %>
+    <% descriptive_text =
+      t("components.activity.samples.import.more_details.button_descriptive_text") %>
     <%= t(
       "#{@activity[:key]}",
       user: @activity[:user],
@@ -12,6 +15,8 @@
     ) %>
     <% dialog_type = "group_import_samples" %>
   <% elsif sample_destroy_action %>
+    <% descriptive_text =
+      t("components.activity.samples.destroy.more_details.button_descriptive_text") %>
     <%= t(
       "#{@activity[:key]}",
       user: @activity[:user],
@@ -34,5 +39,7 @@
     turbo_stream: true,
   },
   method: :get,
-  class: "button button-default" %>
+  class: "button button-default",
+  title: descriptive_text %>
+
 </section>

--- a/app/components/activities/groups/sample_clone_activity_component.html.erb
+++ b/app/components/activities/groups/sample_clone_activity_component.html.erb
@@ -18,5 +18,7 @@
     turbo_stream: true,
   },
   method: :get,
-  class: "button button-default" %>
+  class: "button button-default",
+  title:
+    t("components.activity.samples.clone.more_details.button_descriptive_text") %>
 </section>

--- a/app/components/activities/groups/sample_transfer_activity_component.html.erb
+++ b/app/components/activities/groups/sample_transfer_activity_component.html.erb
@@ -20,5 +20,7 @@
   },
   method: :get,
   class:
-    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
+  title:
+    t("components.activity.samples.transfer.more_details.button_descriptive_text") %>
 </section>

--- a/app/components/activities/groups/subgroup_activity_component.html.erb
+++ b/app/components/activities/groups/subgroup_activity_component.html.erb
@@ -13,6 +13,11 @@
           @activity[:created_group_puid],
           group_path(@activity[:created_group]),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.subgroups.link_descriptive_text",
+              subgroup_puid: @activity[:created_group_puid],
+            ),
         ) %>
     <% else %>
       <% href =

--- a/app/components/activities/groups/subgroup_activity_component.rb
+++ b/app/components/activities/groups/subgroup_activity_component.rb
@@ -14,7 +14,6 @@ module Activities
 
       def subgroup_exists
         return false if @activity[:created_group].nil?
-        return false if @activity[:created_group].parent != @activity[:group]
 
         !@activity[:created_group].deleted?
       end

--- a/app/components/activities/groups/transfer_in_activity_component.html.erb
+++ b/app/components/activities/groups/transfer_in_activity_component.html.erb
@@ -5,6 +5,11 @@
         @activity[:transferred_group_puid],
         group_path(@activity[:transferred_group]),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t(
+            "components.activity.subgroups.link_descriptive_text",
+            subgroup_puid: @activity[:transferred_group_puid],
+          ),
       ) %>
   <% else %>
     <% href =

--- a/app/components/activities/groups/transfer_in_activity_component.rb
+++ b/app/components/activities/groups/transfer_in_activity_component.rb
@@ -15,7 +15,7 @@ module Activities
       def transferred_group_exists
         return false if @activity[:transferred_group].nil?
 
-        !@activity[:transferred_group].deleted? && (@activity[:transferred_group].parent_id == @activity[:group].id)
+        !@activity[:transferred_group].deleted?
       end
     end
   end

--- a/app/components/activities/member_activity_component.html.erb
+++ b/app/components/activities/member_activity_component.html.erb
@@ -5,6 +5,11 @@
         @activity[:member_email],
         members_page,
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t(
+            "components.activity.members.link_descriptive_text",
+            namespace_type: @activity[:member].namespace.type.downcase,
+          ),
       ) %>
   <% else %>
     <% href =

--- a/app/components/activities/namespace_group_link_activity_component.html.erb
+++ b/app/components/activities/namespace_group_link_activity_component.html.erb
@@ -5,6 +5,11 @@
         @activity[:namespace_puid],
         group_path(@activity[:group_link].namespace),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t(
+            "components.activity.groups.link_descriptive_text",
+            group_puid: @activity[:namespace_puid],
+          ),
       ) %>
   <% else %>
     <% href =
@@ -12,6 +17,11 @@
         @activity[:group_puid],
         group_path(@activity[:group_link].group),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t(
+            "components.activity.groups.link_descriptive_text",
+            group_puid: @activity[:group_puid],
+          ),
       ) %>
   <% end %>
 <% else %>

--- a/app/components/activities/projects/metadata_template_activity_component.html.erb
+++ b/app/components/activities/projects/metadata_template_activity_component.html.erb
@@ -8,6 +8,8 @@
           @activity[:current_project].project,
         ),
         class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+        title:
+          t("components.activity.metadata_templates.project.link_descriptive_text"),
       ) %>
   <% else %>
     <% href =

--- a/app/components/activities/projects/sample_activity_component.html.erb
+++ b/app/components/activities/projects/sample_activity_component.html.erb
@@ -1,5 +1,8 @@
 <section>
+  <% descriptive_text = "" %>
   <% if sample_destroy_multiple_action %>
+    <% descriptive_text =
+      t("components.activity.samples.destroy.more_details.button_descriptive_text") %>
     <% href =
       content_tag(
         :span,
@@ -7,6 +10,8 @@
         class: "text-slate-800 dark:text-slate-300 font-medium",
       ) %>
   <% elsif import_samples_action %>
+    <% descriptive_text =
+      t("components.activity.samples.import.more_details.button_descriptive_text") %>
     <% href =
       content_tag(
         :span,
@@ -26,6 +31,11 @@
           @activity[:sample_puid],
           path_with_params(url, { tab: samples_tab }),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.samples.link_descriptive_text",
+              sample_puid: @activity[:sample_puid],
+            ),
         ) %>
     <% else %>
       <% href =
@@ -55,6 +65,7 @@
     },
     method: :get,
     class:
-      "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+      "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
+    title: descriptive_text %>
   <% end %>
 </section>

--- a/app/components/activities/projects/sample_clone_activity_component.html.erb
+++ b/app/components/activities/projects/sample_clone_activity_component.html.erb
@@ -16,6 +16,11 @@
           namespace_puid(namespace),
           namespace_project_samples_path(namespace.parent, namespace.project),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.samples.clone.link_descriptive_text",
+              project_puid: namespace_puid(namespace),
+            ),
         ),
       cloned_samples_count:
         content_tag(
@@ -53,5 +58,7 @@
   },
   method: :get,
   class:
-    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
+  title:
+    t("components.activity.samples.clone.more_details.button_descriptive_text") %>
 </section>

--- a/app/components/activities/projects/sample_transfer_activity_component.html.erb
+++ b/app/components/activities/projects/sample_transfer_activity_component.html.erb
@@ -16,6 +16,11 @@
           namespace_puid(namespace),
           namespace_project_samples_path(namespace.parent, namespace.project),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.samples.transfer.link_descriptive_text",
+              project_puid: namespace_puid(namespace),
+            ),
         ),
       transferred_samples_count:
         content_tag(
@@ -53,5 +58,7 @@
   },
   method: :get,
   class:
-    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+    "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
+  title:
+    t("components.activity.samples.transfer.more_details.button_descriptive_text") %>
 </section>

--- a/app/components/activities/projects/workflow_execution_activity_component.html.erb
+++ b/app/components/activities/projects/workflow_execution_activity_component.html.erb
@@ -20,6 +20,10 @@
     },
     method: :get,
     class:
-      "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600" %>
+      "inline-flex items-center justify-center button button-default dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600",
+    title:
+      t(
+        "components.activity.workflow_executions.destroy.more_details.button_descriptive_text",
+      ) %>
   <% end %>
 </section>

--- a/app/components/activities/workflow_execution_activity_component.html.erb
+++ b/app/components/activities/workflow_execution_activity_component.html.erb
@@ -9,6 +9,8 @@
             @activity[:namespace].project,
           ),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t("components.activity.workflow_executions.index.link_descriptive_text"),
         ) %>
     <% else %>
       <% href =
@@ -31,6 +33,11 @@
             @activity[:workflow_id],
           ),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.workflow_executions.show.link_descriptive_text",
+              workflow_id: @activity[:workflow_id],
+            ),
         ) %>
 
       <% sample_href =
@@ -42,6 +49,11 @@
             @activity[:sample_id],
           ),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.samples.link_descriptive_text",
+              sample_puid: @activity[:sample_puid],
+            ),
         ) %>
     <% elsif workflow_execution_exists %>
       <% href =
@@ -53,6 +65,11 @@
             @activity[:workflow_id],
           ),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.workflow_executions.show.link_descriptive_text",
+              workflow_id: @activity[:workflow_id],
+            ),
         ) %>
 
       <% sample_href =
@@ -78,6 +95,11 @@
             @activity[:sample_id],
           ),
           class: "text-slate-800 dark:text-slate-300 font-medium hover:underline",
+          title:
+            t(
+              "components.activity.samples.link_descriptive_text",
+              sample_puid: @activity[:sample_puid],
+            ),
         ) %>
     <% else %>
       <% href =

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -553,8 +553,45 @@ en:
           id: id
           name: name
           title: Deleted Workflow Executions
+      groups:
+        link_descriptive_text: View group page for group with persistent unique identifier %{group_puid}
+        projects:
+          link_descriptive_text: View details page for project with persistent unique identifier %{project_puid}
       load_more: Load more
+      members:
+        link_descriptive_text: View members page for %{namespace_type}
+      metadata_templates:
+        group:
+          link_descriptive_text: View metadata templates for group
+        project:
+          link_descriptive_text: View metadata templates for project
       more_details: More details
+      samples:
+        clone:
+          link_descriptive_text: View samples page for project with persistent unique identifier %{project_puid}
+          more_details:
+            button_descriptive_text: View more details for copied samples
+        destroy:
+          more_details:
+            button_descriptive_text: View more details about deleted samples
+        import:
+          more_details:
+            button_descriptive_text: View more details about imported samples
+        link_descriptive_text: View sample details for sample with persistent unique identifier %{sample_puid}
+        transfer:
+          link_descriptive_text: View samples page for project with persistent unique identifier %{project_puid}
+          more_details:
+            button_descriptive_text: View more details for transferred samples
+      subgroups:
+        link_descriptive_text: View subgroup page for subgroup with persistent unique identifier %{subgroup_puid}
+      workflow_executions:
+        destroy:
+          more_details:
+            button_descriptive_text: View more details about deleted workflow executions
+        index:
+          link_descriptive_text: View workflow executions listing for project
+        show:
+          link_descriptive_text: View workflow execution details for workflow execution with id %{workflow_id}
     breadcrumb:
       dropdown:
         aria_label: Breadcrumb dropdown

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -553,8 +553,45 @@ fr:
           id: id
           name: name
           title: Deleted Workflow Executions
+      groups:
+        link_descriptive_text: View group page for group with persistent unique identifier %{group_puid}
+        projects:
+          link_descriptive_text: View details page for project with persistent unique identifier %{project_puid}
       load_more: Charger plus
+      members:
+        link_descriptive_text: View members page for %{namespace_type}
+      metadata_templates:
+        group:
+          link_descriptive_text: View metadata templates for group
+        project:
+          link_descriptive_text: View metadata templates for project
       more_details: More details
+      samples:
+        clone:
+          link_descriptive_text: View samples page for project with persistent unique identifier %{project_puid}
+          more_details:
+            button_descriptive_text: View more details for copied samples
+        destroy:
+          more_details:
+            button_descriptive_text: View more details about deleted samples
+        import:
+          more_details:
+            button_descriptive_text: View more details about imported samples
+        link_descriptive_text: View sample details for sample with persistent unique identifier %{sample_puid}
+        transfer:
+          link_descriptive_text: View samples page for project with persistent unique identifier %{project_puid}
+          more_details:
+            button_descriptive_text: View more details for transferred samples
+      subgroups:
+        link_descriptive_text: View subgroup page for subgroup with persistent unique identifier %{subgroup_puid}
+      workflow_executions:
+        destroy:
+          more_details:
+            button_descriptive_text: View more details about deleted workflow executions
+        index:
+          link_descriptive_text: View workflow executions listing for project
+        show:
+          link_descriptive_text: View workflow execution details for workflow execution with id %{workflow_id}
     breadcrumb:
       dropdown:
         aria_label: Breadcrumb dropdown

--- a/test/components/groups/subgroup_activity_component_test.rb
+++ b/test/components/groups/subgroup_activity_component_test.rb
@@ -105,7 +105,7 @@ module Groups
                                                        href: @subgroup.puid)
       )
 
-      assert_selector 'span',
+      assert_selector 'a',
                       text: @subgroup.puid
     end
   end

--- a/test/components/groups/transfer_out_activity_component_test.rb
+++ b/test/components/groups/transfer_out_activity_component_test.rb
@@ -53,7 +53,7 @@ module Groups
                                                        href: @subgroup.puid)
       )
 
-      assert_selector 'span',
+      assert_selector 'a',
                       text: @subgroup.puid
     end
   end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the links and buttons within activity components to include a `title` attribute which displays discernable text to help the user with clarity of what the links/buttons point to. Addresses [STRY0018275](https://publichealthprod.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3D5dbf3ed14742e210f24c0c21516d43e1)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
