### PR TITLE
Members pages accessibilty fixes

### DIFF
--- a/app/views/groups/group_links/_invite_group_modal.html.erb
+++ b/app/views/groups/group_links/_invite_group_modal.html.erb
@@ -17,10 +17,11 @@
         <label
           for="<%= form_id %>"
           class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
+          data-required="true"
         >
           <%= t("groups.group_links.new.label.group_id") %>
         </label>
-        <%= viral_select2(form:, name: :group_id, id: form_id, placeholder: t("groups.group_links.new.placeholder.search_for_group")) do |select| %>
+        <%= viral_select2(form:, name: :group_id, id: form_id) do |select| %>
           <% @namespace_linkable_groups.each do |group| %>
             <% select.with_option(
                       value: group.id,
@@ -40,25 +41,29 @@
             <%= t(:"groups.group_links.new.empty_state") %>
           <% end %>
         <% end %>
+        <p id="<%= form.field_id(:group_id, "hint") %>" class="field-hint">
+          <%= t("groups.group_links.new.group_hint") %>
+        </p>
       </div>
       <div class="form-field">
-        <%= form.label I18n.t("groups.group_links.new.label.group_access_level") %>
+        <%= form.label I18n.t("groups.group_links.new.label.group_access_level"),
+                   data: {
+                     required: true,
+                   } %>
         <%= form.select :group_access_level,
                     options_for_select(
                       @access_levels,
                       new_group_link.group_access_level,
                     ),
-                    {
-                      prompt:
-                        I18n.t(
-                          "groups.group_links.new.placeholder.select_access_level",
-                        ),
-                    },
-                    {
-                      required: true,
-                      "aria-label":
+                    required: true,
+                    aria: {
+                      label:
                         t(:"groups.group_links.index.aria_labels.group_access_level"),
+                      required: true,
                     } %>
+        <p id="<%= form.field_id(:group_access_level, "hint") %>" class="field-hint">
+          <%= t("groups.group_links.new.access_level_hint") %>
+        </p>
       </div>
       <div
         class="form-field datepicker"

--- a/app/views/groups/members/_create_modal.html.erb
+++ b/app/views/groups/members/_create_modal.html.erb
@@ -12,15 +12,16 @@
         <label
           for="<%= form_id %>"
           class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
+          data-required="true"
         >
 
-          <%= t("groups.members.new.select_user") %>
+          <%= t("groups.members.new.user_select") %>
         </label>
-        <%= viral_select2(form:, name: :user_id, id: form_id, placeholder: t("groups.members.new.select_user")) do |select| %>
+        <%= viral_select2(form:, name: :user_id, id: form_id) do |select| %>
           <% @available_users.each do |user| %>
             <% select.with_option(
                       value: user.id,
-                      label: user.email,
+                      label: user.email
                     ) do %>
               <span
                 class="
@@ -38,17 +39,25 @@
             <%= t(:"groups.members.new.empty_state") %>
           <% end %>
         <% end %>
+        <p id="<%= form.field_id(:user_id, "hint") %>" class="field-hint">
+          <%= t("groups.members.new.user_hint") %>
+        </p>
       </div>
 
       <% invalid_access_level = @new_member.errors.include?(:access_level) %>
       <div class="form-field <%= 'invalid' if invalid_access_level %>">
-        <%= form.label :access_level %>
+        <%= form.label :access_level, data: { required: true } %>
         <%= form.select :access_level,
                     @access_levels,
-                    { prompt: t(:"groups.members.new.select_access_level") },
-                    required: true %>
+                    required: true,
+                    aria: {
+                      required: true,
+                    } %>
         <%= render "shared/form/field_errors",
         errors: @new_member.errors.full_messages_for(:access_level) %>
+        <p id="<%= form.field_id(:access_level, "hint") %>" class="field-hint">
+          <%= t("groups.members.new.access_level_hint") %>
+        </p>
       </div>
 
       <div

--- a/app/views/groups/members/index.html.erb
+++ b/app/views/groups/members/index.html.erb
@@ -31,8 +31,7 @@
         :turbo_stream => true,
       },
       method: :get,
-      class: "button button-default",
-      "aria-label": t(:".actions.button_add_aria_label") %>
+      class: "button button-primary" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/projects/group_links/_invite_group_modal.html.erb
+++ b/app/views/projects/group_links/_invite_group_modal.html.erb
@@ -17,11 +17,12 @@
         <label
           for="<%= form_id %>"
           class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
+          data-required="true"
         >
 
           <%= t("projects.group_links.new.label.shared_group") %>
         </label>
-        <%= viral_select2(form:, name: :group_id, id: form_id, placeholder: t("projects.group_links.new.placeholder.select_group")) do |select| %>
+        <%= viral_select2(form:, name: :group_id, id: form_id) do |select| %>
           <% @namespace_linkable_groups.each do |group| %>
             <% select.with_option(
                       value: group.id,
@@ -44,23 +45,29 @@
             <%= t(:"projects.group_links.new.empty_state") %>
           <% end %>
         <% end %>
+        <p id="<%= form.field_id(:group_id, "hint") %>" class="field-hint">
+          <%= t("projects.group_links.new.group_hint") %>
+        </p>
       </div>
       <div class="form-field">
-        <%= form.label I18n.t("projects.group_links.new.label.group_access_level") %>
+        <%= form.label I18n.t("projects.group_links.new.label.group_access_level"),
+                   data: {
+                     required: true,
+                   } %>
         <%= form.select :group_access_level,
                     options_for_select(
                       @access_levels,
                       new_group_link.group_access_level,
                     ),
-                    {
-                      prompt:
-                        I18n.t(
-                          "projects.group_links.new.placeholder.select_access_level",
-                        ),
-                    },
                     required: true,
-                    "aria-label":
-                      t(:"projects.group_links.index.aria_labels.group_access_level") %>
+                    aria: {
+                      label:
+                        t(:"projects.group_links.index.aria_labels.group_access_level"),
+                      required: true,
+                    } %>
+        <p id="<%= form.field_id(:group_access_level, "hint") %>" class="field-hint">
+          <%= t("projects.group_links.new.access_level_hint") %>
+        </p>
       </div>
       <div
         class="form-field datepicker"

--- a/app/views/projects/members/_create_modal.html.erb
+++ b/app/views/projects/members/_create_modal.html.erb
@@ -12,11 +12,12 @@
         <label
           for="<%= form_id %>"
           class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
+          data-required="true"
         >
 
           <%= t("projects.members.new.user_select") %>
         </label>
-        <%= viral_select2(form:, name: :user_id, id: form_id, placeholder: t("projects.members.new.select_user")) do |select| %>
+        <%= viral_select2(form:, name: :user_id, id: form_id) do |select| %>
           <% @available_users.each do |user| %>
             <% select.with_option(
                       value: user.id,
@@ -38,17 +39,25 @@
             <%= t(:"projects.members.new.empty_state") %>
           <% end %>
         <% end %>
+        <p id="<%= form.field_id(:user_id, "hint") %>" class="field-hint">
+          <%= t("projects.members.new.user_hint") %>
+        </p>
       </div>
 
       <% invalid_access_level = @new_member.errors.include?(:access_level) %>
       <div class="form-field <%= 'invalid' if invalid_access_level %>">
-        <%= form.label :access_level %>
+        <%= form.label :access_level, data: { required: true } %>
         <%= form.select :access_level,
                     @access_levels,
-                    { prompt: t(:"projects.members.new.select_access_level") },
-                    required: true %>
+                    required: true,
+                    aria: {
+                      required: true,
+                    } %>
         <%= render "shared/form/field_errors",
         errors: @new_member.errors.full_messages_for(:access_level) %>
+        <p id="<%= form.field_id(:access_level, "hint") %>" class="field-hint">
+          <%= t("projects.members.new.access_level_hint") %>
+        </p>
       </div>
 
       <div

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -16,9 +16,6 @@
         "turbo-frame" => "new_member_modal",
         :turbo_stream => true,
       },
-      aria: {
-        label: t(:".actions.button_add_aria_label"),
-      },
       class: "button button-default" %>
     <% end %>
     <% if @allowed_to[:create_member] %>
@@ -32,8 +29,7 @@
         "turbo-frame" => "new_member_modal",
         :turbo_stream => true,
       },
-      class: "button button-primary",
-      "aria-label": t(:".actions.button_add_aria_label") %>
+      class: "button button-primary" %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -991,17 +991,16 @@ en:
         unlink: Unlink
         unlink_confirmation: Are you sure you want to unlink the group %{namespace_name} with group %{group_name}
       new:
+        access_level_hint: Maximum access level to assign to group
         button:
           cancel: Cancel
           submit: Share
         empty_state: No groups are associated with that name or ID
+        group_hint: Select a group to share namespace with
         label:
           access_expiration: Access expiration (optional)
-          group_access_level: Maximum group access level
-          group_id: Group to share namespace with
-        placeholder:
-          search_for_group: Search for group to share namespace with
-          select_access_level: Select access level
+          group_access_level: Access level
+          group_id: Group
         sharing_namespace_with_group: You're sharing group %{name} with a group
         title: Share namespace
     history:
@@ -1021,7 +1020,6 @@ en:
         aria_label: Access Level
       index:
         actions:
-          button_add_aria_label: Add new group member link
           link_leave_group_aria_label: Leave group button
           link_remove_aria_label: Remove group member %{member} link
         add: Add New Member
@@ -1042,14 +1040,15 @@ en:
           members: Members
         title: Members
       new:
+        access_level_hint: Select group access level to assign to user
         add_member_to_group: Add member to group
         button:
           cancel: Cancel
         description: You are adding a new member to group %{name}
         empty_state: There are no users with the provided email or name
-        select_access_level: Select Access Level
-        select_user: Select a User
         title: Add New Member
+        user_hint: Select a user to add to group
+        user_select: User
     metadata_templates:
       index:
         new_button: Add New Template
@@ -1567,18 +1566,17 @@ en:
         unlink: Unlink
         unlink_confirmation: Are you sure you want to unlink the project %{namespace_name} with group %{group_name}
       new:
+        access_level_hint: Maximum access level to assign to group
         button:
           cancel: Cancel
           submit: Share
         empty_state: No groups are associated with that name or ID
+        group_hint: Select a group to share project namespace with
         label:
           access_expiration: Access expiration (optional)
-          group_access_level: Maximum group access level
-          shared_group: Group to share namespace with
-        placeholder:
-          select_access_level: Select access level
-          select_group: Select group
-        sharing_namespace_with_group: You're sharing group %{name} with a group
+          group_access_level: Access level
+          shared_group: Group
+        sharing_namespace_with_group: You're sharing project %{name} with a group
         title: Share namespace
     history:
       index:
@@ -1605,7 +1603,6 @@ en:
           level_40: Maintainer
           level_50: Owner
         actions:
-          button_add_aria_label: Add new project member button
           link_leave_project_aria_label: Leave project link
           link_remove_aria_label: Remove project member %{member} link
         add: Add New Member
@@ -1626,14 +1623,14 @@ en:
           members: Members
         title: Members
       new:
+        access_level_hint: Select project access level to assign to user
         add_member_to_project: Add member to project
         button:
           cancel: Cancel
         description: You are adding a new member to project %{name}
         empty_state: There are no users with the provided email or name
-        select_access_level: Select Access Level
-        select_user: Select a User
         title: Add New Member
+        user_hint: Select a user to add to project
         user_select: User
     metadata_templates:
       index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -991,17 +991,16 @@ fr:
         unlink: Dissocier
         unlink_confirmation: Êtes-vous sûr de vouloir dissocier le groupe %{namespace_name} du groupe %{group_name}?
       new:
+        access_level_hint: Maximum access level to assign to group
         button:
           cancel: Annuler
           submit: Partager
         empty_state: Aucun groupe n’est associé à ce nom ou à cet identifiant
+        group_hint: Select a group to share namespace with
         label:
           access_expiration: Expiration de l’accès (facultatif)
-          group_access_level: Niveau maximal d’accès du groupe
-          group_id: Groupe avec lequel partager l’espace de noms
-        placeholder:
-          search_for_group: Search for group to share namespace with
-          select_access_level: Sélectionnez le niveau d’accès
+          group_access_level: Niveau d’accès
+          group_id: Groupe
         sharing_namespace_with_group: Vous partagez le %{name} de groupe avec un groupe
         title: Partager l’espace de noms
     history:
@@ -1021,7 +1020,6 @@ fr:
         aria_label: Niveau d’accès
       index:
         actions:
-          button_add_aria_label: Ajouter un lien vers un nouveau membre du groupe
           link_leave_group_aria_label: Bouton Quitter le groupe
           link_remove_aria_label: Supprimer le lien %{member} du membre du groupe
         add: Ajouter un nouveau membre
@@ -1042,14 +1040,15 @@ fr:
           members: Membres
         title: Membres
       new:
+        access_level_hint: Select group access level to assign to user
         add_member_to_group: Ajouter un membre au groupe
         button:
           cancel: Annuler
         description: Vous ajoutez un nouveau membre au groupe %{name}
         empty_state: Il n’y a pas d’utilisateurs avec l’adresse courriel ou le nom fourni
-        select_access_level: Sélectionnez le niveau d’accès
-        select_user: Sélectionner un utilisateur
         title: Ajouter un nouveau membre
+        user_hint: Select a user to add to group
+        user_select: Utilisateur
     metadata_templates:
       index:
         new_button: Ajouter un nouveau modèle
@@ -1567,17 +1566,16 @@ fr:
         unlink: Dissocier
         unlink_confirmation: Êtes-vous sûr de vouloir dissocier le projet %{namespace_name} du groupe %{group_name}?
       new:
+        access_level_hint: Maximum access level to assign to group
         button:
           cancel: Annuler
           submit: Partager
         empty_state: Aucun groupe n’est associé à ce nom ou à cet identifiant
+        group_hint: Select a group to share project namespace with
         label:
           access_expiration: Expiration de l’accès (facultatif)
-          group_access_level: Niveau maximal d’accès du groupe
-          shared_group: Groupe avec lequel partager l’espace de noms
-        placeholder:
-          select_access_level: Sélectionnez le niveau d’accès
-          select_group: Sélectionner un groupe
+          group_access_level: Niveau d’accès
+          shared_group: Groupe
         sharing_namespace_with_group: Vous partagez le %{name} de groupe avec un groupe
         title: Partager l’espace de noms
     history:
@@ -1605,7 +1603,6 @@ fr:
           level_40: Responsable
           level_50: Propriétaire
         actions:
-          button_add_aria_label: Bouton Ajouter un nouveau membre du projet
           link_leave_project_aria_label: Laisser le lien du projet
           link_remove_aria_label: Supprimer le lien du membre du projet %{member}
         add: Ajouter un nouveau membre
@@ -1626,14 +1623,14 @@ fr:
           members: Membres
         title: Membres
       new:
+        access_level_hint: Select project access level to assign to user
         add_member_to_project: Ajouter un membre au projet
         button:
           cancel: Annuler
         description: Vous ajoutez un nouveau membre au projet %{name}
         empty_state: Il n’y a pas d’utilisateurs avec l’adresse courriel ou le nom fourni
-        select_access_level: Sélectionnez le niveau d’accès
-        select_user: Sélectionner un utilisateur
         title: Ajouter un nouveau membre
+        user_hint: Select a user to add to project
         user_select: User
     metadata_templates:
       index:


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes the following accessibility issues on the group/project members pages:

- Updated invite group and add new member buttons so that the accessible name matches the text of the button [STRY0018282](https://publichealthprod.service-now.com/rm_story.do?sys_id=5b3087154742e210f24c0c21516d4338)
- Removed placeholders and added hints to fix reflow issue at 400% zoom for members/invite_group create modals [STRY0018292](https://publichealthprod.service-now.com/rm_story.do?sys_id=01010b554742e210f24c0c21516d4309)
- Updated required fields to be marked by an asterix and setting aria-required attribute [STRY0018287](https://publichealthprod.service-now.com/rm_story.do?sys_id=f9b08fd14742e210f24c0c21516d43e3)


## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
