### PR TITLE
History components accessibility fixes

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -514,7 +514,7 @@
   }
 
   .dialog--section {
-    max-height: calc(80vh - 1.25rem - 2.5rem);
+    max-height: calc(75vh - 1.25rem - 3.5rem);
     @apply overflow-y-auto p-5;
   }
 

--- a/app/components/history_component.html.erb
+++ b/app/components/history_component.html.erb
@@ -3,11 +3,11 @@
   class="relative border-s border-slate-200 dark:border-slate-700"
 >
   <% @data.each_with_index do |changes, index| %>
-    <li class="mb-10 ms-4">
+    <li class="mb-6 ms-4">
       <div
         class="
-          absolute w-3 h-3 bg-slate-200 rounded-full mt-1.5 -start-1.5 border border-white
-          dark:border-slate-700 dark:bg-slate-700
+          absolute w-3 h-3 bg-slate-500 rounded-full mt-1.5 -start-1.5 border border-white
+          dark:border-slate-500 dark:bg-slate-500
         "
       ></div>
       <span
@@ -25,7 +25,7 @@
               turbo_stream: true,
             },
             method: :get,
-            class: "text-slate-800 dark:text-white hover:underline" do %>
+            class: "text-slate-900 min-h-[44px] min-w-[44px] dark:text-white hover:underline cursor-pointer" do %>
             <span class="text-xl font-extrabold dark:text-white">
               <%= t(:"components.history.link_text", version: changes[:version]) %>
             </span>

--- a/app/components/history_version_component.html.erb
+++ b/app/components/history_version_component.html.erb
@@ -1,13 +1,13 @@
 <div>
   <div class="grid grid-cols-3 gap-2 py-4">
     <% current_version_classes =
-      "col-start-2 col-end-3 text-sm font-semibold text-slate-500 dark:text-slate-400" %>
+      "col-start-2 col-end-3 text-sm font-semibold text-slate-600 dark:text-slate-400" %>
     <% if log_data[:version] != 1 %>
       <% current_version_classes =
-        "col-start-3 col-end-4 text-sm font-semibold text-slate-500 dark:text-slate-400" %>
+        "col-start-3 col-end-4 text-sm font-semibold text-slate-600 dark:text-slate-400" %>
       <div
         class="
-          col-start-2 col-end-3 text-sm font-semibold text-slate-500 dark:text-slate-400
+          col-start-2 col-end-3 text-sm font-semibold text-slate-600 dark:text-slate-400
         "
       ><%= t(
           :"components.history_version.previous_version",
@@ -42,7 +42,7 @@
                 type="button"
                 class="
                   flex items-center justify-between w-full p-5 font-medium rtl:text-right
-                  text-slate-500 border border-slate-200 dark:border-slate-700 dark:text-slate-400
+                  text-slate-600 border border-slate-200 dark:border-slate-700 dark:text-slate-400
                   hover:bg-slate-100 dark:hover:bg-slate-800 gap-3
                 "
                 data-action="collapsible#toggle"
@@ -82,7 +82,7 @@
                           <span
                             data-test-item-selector="key"
                             class="
-                              mb-1 text-slate-500 text-md dark:text-slate-400 break-all
+                              mb-1 text-slate-600 text-md dark:text-slate-400 break-all
                             "
                           ><%= k.to_s %></span>
                         </div>
@@ -92,14 +92,19 @@
                             dark:text-slate-700 p-1
                           "
                         >
-                          <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= v %></span>
+                          <span
+                            data-test-item-selector="value"
+                            class="
+                              text-md text-slate-600 dark:text-white break-all
+                            "
+                          ><%= v %></span>
                         </div>
                       <% else %>
                         <div class="col-span-1">
                           <span
                             data-test-item-selector="key"
                             class="
-                              mb-1 text-slate-500 text-md dark:text-slate-400 break-all
+                              mb-1 text-slate-600 text-md dark:text-slate-400 break-all
                             "
                           ><%= k.to_s %></span>
                         </div>
@@ -108,7 +113,10 @@
                             col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
                           "
                         >
-                          <span data-test-item-selector="value" class="text-md text-slate-500"><%= prev_changes_value_hash[k] %></span>
+                          <span
+                            data-test-item-selector="value"
+                            class="text-md text-slate-600 dark:text-white"
+                          ><%= prev_changes_value_hash[k] %></span>
                         </div>
                         <div
                           class="
@@ -116,7 +124,12 @@
                             dark:text-slate-700 p-1
                           "
                         >
-                          <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= v %></span>
+                          <span
+                            data-test-item-selector="value"
+                            class="
+                              text-md text-slate-600 dark:text-white break-all
+                            "
+                          ><%= v %></span>
                         </div>
                       <% end %>
                     <% end %>
@@ -125,7 +138,7 @@
                       prev_changes_value_hash.keys - changes_from_prev_version_hash.keys %>
                     <% if keys_no_longer_existent.length.positive? %>
                       <div class="col-span-3">
-                        <p class="text-red-500 dark:text-red-400"><%= t(:"components.history_version.keys_deleted") %></p>
+                        <p class="text-red-600 dark:text-red-400"><%= t(:"components.history_version.keys_deleted") %></p>
                       </div>
                       <% keys_no_longer_existent.each do |key_no_longer_existent| %>
                         <div
@@ -135,7 +148,7 @@
                           <span
                             data-test-item-selector="key"
                             class="
-                              mb-1 text-slate-500 text-md dark:text-slate-400 break-all
+                              mb-1 text-slate-600 text-md dark:text-slate-400 break-all
                             "
                           ><%= key_no_longer_existent %></span>
                         </div>
@@ -144,7 +157,12 @@
                             col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
                           "
                         >
-                          <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= prev_changes_value_hash[key_no_longer_existent] %></span>
+                          <span
+                            data-test-item-selector="value"
+                            class="
+                              text-md text-slate-600 dark:text-white break-all
+                            "
+                          ><%= prev_changes_value_hash[key_no_longer_existent] %></span>
                         </div>
                         <div
                           class="
@@ -153,7 +171,9 @@
                         >
                           <span
                             data-test-item-selector="value"
-                            class="text-md text-slate-500 p-2 break-all"
+                            class="
+                              text-md text-slate-600 dark:text-white p-2 break-all
+                            "
                           ></span>
                         </div>
                       <% end %>
@@ -168,7 +188,7 @@
             <div class="col-span-1" id="<%= "metadata-#{key}" %>">
               <span
                 data-test-item-selector="key"
-                class="mb-1 text-slate-500 text-md dark:text-slate-400"
+                class="mb-1 text-slate-600 text-md dark:text-slate-400"
               ><%= key.to_s %></span>
             </div>
             <% col_span = "col-span-2" %>
@@ -186,7 +206,7 @@
             >
               <span
                 data-test-item-selector="value"
-                class="text-lg text-slate-600 p-2 break-words"
+                class="text-lg text-slate-600 dark:text-white p-2 break-words"
               ><%= value %></span>
             </div>
           </div>

--- a/app/components/history_version_component.html.erb
+++ b/app/components/history_version_component.html.erb
@@ -80,7 +80,7 @@
                         <% col_span = "col-span-2" %>
                         <div class="col-span-1">
                           <span
-                            data-test-item-selector="key"
+                            <% unless Rails.env.production? %>data-test-item-selector="key"<% end %>
                             class="
                               mb-1 text-slate-600 text-md dark:text-slate-400 break-all
                             "
@@ -93,7 +93,7 @@
                           "
                         >
                           <span
-                            data-test-item-selector="value"
+                            <% unless Rails.env.production? %>data-test-item-selector="value"<% end %>
                             class="
                               text-md text-slate-600 dark:text-white break-all
                             "
@@ -102,7 +102,7 @@
                       <% else %>
                         <div class="col-span-1">
                           <span
-                            data-test-item-selector="key"
+                            <% unless Rails.env.production? %>data-test-item-selector="key"<% end %>
                             class="
                               mb-1 text-slate-600 text-md dark:text-slate-400 break-all
                             "
@@ -114,7 +114,7 @@
                           "
                         >
                           <span
-                            data-test-item-selector="value"
+                            <% unless Rails.env.production? %>data-test-item-selector="value"<% end %>
                             class="text-md text-slate-600 dark:text-white"
                           ><%= prev_changes_value_hash[k] %></span>
                         </div>
@@ -125,7 +125,7 @@
                           "
                         >
                           <span
-                            data-test-item-selector="value"
+                            <% unless Rails.env.production? %>data-test-item-selector="value"<% end %>
                             class="
                               text-md text-slate-600 dark:text-white break-all
                             "
@@ -146,7 +146,7 @@
                           id="<%= "metadata-deleted-#{key_no_longer_existent}" %>"
                         >
                           <span
-                            data-test-item-selector="key"
+                            <% unless Rails.env.production? %>data-test-item-selector="key"<% end %>
                             class="
                               mb-1 text-slate-600 text-md dark:text-slate-400 break-all
                             "
@@ -158,7 +158,7 @@
                           "
                         >
                           <span
-                            data-test-item-selector="value"
+                            <% unless Rails.env.production? %>data-test-item-selector="value"<% end %>
                             class="
                               text-md text-slate-600 dark:text-white break-all
                             "
@@ -170,7 +170,7 @@
                           "
                         >
                           <span
-                            data-test-item-selector="value"
+                            <% unless Rails.env.production? %>data-test-item-selector="value"<% end %>
                             class="
                               text-md text-slate-600 dark:text-white p-2 break-all
                             "
@@ -187,14 +187,14 @@
           <div class="grid grid-cols-3 gap-2 py-2">
             <div class="col-span-1" id="<%= "metadata-#{key}" %>">
               <span
-                data-test-item-selector="key"
+                <% unless Rails.env.production? %>data-test-item-selector="key"<% end %>
                 class="mb-1 text-slate-600 text-md dark:text-slate-400"
               ><%= key.to_s %></span>
             </div>
             <% col_span = "col-span-2" %>
             <% if log_data[:version] != 1 %>
               <div class=" col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 ">
-                <span data-test-item-selector="value" class="text-md p-1"><%= log_data[:previous_version][key.to_s] %></span>
+                <span <% unless Rails.env.production? %>data-test-item-selector="value"<% end %> class="text-md p-1"><%= log_data[:previous_version][key.to_s] %></span>
               </div>
               <% col_span = "col-span-1" %>
             <% end %>
@@ -205,7 +205,7 @@
               "
             >
               <span
-                data-test-item-selector="value"
+                <% unless Rails.env.production? %>data-test-item-selector="value"<% end %>
                 class="text-lg text-slate-600 dark:text-white p-2 break-words"
               ><%= value %></span>
             </div>

--- a/app/components/history_version_component.html.erb
+++ b/app/components/history_version_component.html.erb
@@ -78,7 +78,7 @@
 
                       <% if log_data[:version] == 1 %>
                         <% col_span = "col-span-2" %>
-                        <div class="col-span-1" id="<%= "metadata-#{k}" %>">
+                        <div class="col-span-1">
                           <span
                             data-test-item-selector="key"
                             class="
@@ -91,12 +91,11 @@
                             <%= col_span %> bg-slate-100 dark:bg-slate-700
                             dark:text-slate-700 p-1
                           "
-                          aria-labelledby="<%= "metadata-#{k}" %>"
                         >
                           <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= v %></span>
                         </div>
                       <% else %>
-                        <div class="col-span-1" id="<%= "metadata-#{k}" %>">
+                        <div class="col-span-1">
                           <span
                             data-test-item-selector="key"
                             class="
@@ -108,7 +107,6 @@
                           class="
                             col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
                           "
-                          aria-labelledby="<%= "metadata-#{k}" %>"
                         >
                           <span data-test-item-selector="value" class="text-md text-slate-500"><%= prev_changes_value_hash[k] %></span>
                         </div>
@@ -117,7 +115,6 @@
                             <%= col_span %> bg-slate-100 dark:bg-slate-700
                             dark:text-slate-700 p-1
                           "
-                          aria-labelledby="<%= "metadata-#{k}" %>"
                         >
                           <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= v %></span>
                         </div>
@@ -146,7 +143,6 @@
                           class="
                             col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
                           "
-                          aria-labelledby="<%= "metadata-deleted-#{key_no_longer_existent}" %>"
                         >
                           <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= prev_changes_value_hash[key_no_longer_existent] %></span>
                         </div>
@@ -154,7 +150,6 @@
                           class="
                             col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
                           "
-                          aria-labelledby="<%= "metadata-deleted-#{key_no_longer_existent}" %>"
                         >
                           <span
                             data-test-item-selector="value"
@@ -178,12 +173,7 @@
             </div>
             <% col_span = "col-span-2" %>
             <% if log_data[:version] != 1 %>
-              <div
-                class="
-                  col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700
-                "
-                aria-labelledby="<%= "metadata-#{key}" %>"
-              >
+              <div class=" col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 ">
                 <span data-test-item-selector="value" class="text-md p-1"><%= log_data[:previous_version][key.to_s] %></span>
               </div>
               <% col_span = "col-span-1" %>
@@ -193,7 +183,6 @@
                 <%= col_span %> bg-slate-100 dark:bg-slate-700
                 dark:text-slate-700
               "
-              aria-labelledby="<%= "metadata-#{key}" %>"
             >
               <span
                 data-test-item-selector="value"

--- a/app/components/history_version_component.html.erb
+++ b/app/components/history_version_component.html.erb
@@ -78,21 +78,48 @@
 
                       <% if log_data[:version] == 1 %>
                         <% col_span = "col-span-2" %>
-                        <div class="col-span-1">
-                          <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= k.to_s %></span>
+                        <div class="col-span-1" id="<%= "metadata-#{k}" %>">
+                          <span
+                            data-test-item-selector="key"
+                            class="
+                              mb-1 text-slate-500 text-md dark:text-slate-400 break-all
+                            "
+                          ><%= k.to_s %></span>
                         </div>
-                        <div class="<%= col_span %> bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <span class="text-md text-slate-500 p-2 break-words"><%= v %></span>
+                        <div
+                          class="
+                            <%= col_span %> bg-slate-100 dark:bg-slate-700
+                            dark:text-slate-700 p-1
+                          "
+                          aria-labelledby="<%= "metadata-#{k}" %>"
+                        >
+                          <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= v %></span>
                         </div>
                       <% else %>
-                        <div class="col-span-1">
-                          <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= k.to_s %></span>
+                        <div class="col-span-1" id="<%= "metadata-#{k}" %>">
+                          <span
+                            data-test-item-selector="key"
+                            class="
+                              mb-1 text-slate-500 text-md dark:text-slate-400 break-all
+                            "
+                          ><%= k.to_s %></span>
                         </div>
-                        <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <span class="text-md text-slate-500 p-2"><%= prev_changes_value_hash[k] %></span>
+                        <div
+                          class="
+                            col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
+                          "
+                          aria-labelledby="<%= "metadata-#{k}" %>"
+                        >
+                          <span data-test-item-selector="value" class="text-md text-slate-500"><%= prev_changes_value_hash[k] %></span>
                         </div>
-                        <div class="<%= col_span %> bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <span class="text-md text-slate-500 p-2 break-words"><%= v %></span>
+                        <div
+                          class="
+                            <%= col_span %> bg-slate-100 dark:bg-slate-700
+                            dark:text-slate-700 p-1
+                          "
+                          aria-labelledby="<%= "metadata-#{k}" %>"
+                        >
+                          <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= v %></span>
                         </div>
                       <% end %>
                     <% end %>
@@ -104,14 +131,35 @@
                         <p class="text-red-500 dark:text-red-400"><%= t(:"components.history_version.keys_deleted") %></p>
                       </div>
                       <% keys_no_longer_existent.each do |key_no_longer_existent| %>
-                        <div class="col-span-1">
-                          <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= key_no_longer_existent %></span>
+                        <div
+                          class="col-span-1"
+                          id="<%= "metadata-deleted-#{key_no_longer_existent}" %>"
+                        >
+                          <span
+                            data-test-item-selector="key"
+                            class="
+                              mb-1 text-slate-500 text-md dark:text-slate-400 break-all
+                            "
+                          ><%= key_no_longer_existent %></span>
                         </div>
-                        <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <span class="text-md text-slate-500 p-2"><%= prev_changes_value_hash[key_no_longer_existent] %></span>
+                        <div
+                          class="
+                            col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
+                          "
+                          aria-labelledby="<%= "metadata-deleted-#{key_no_longer_existent}" %>"
+                        >
+                          <span data-test-item-selector="value" class="text-md text-slate-500 break-all"><%= prev_changes_value_hash[key_no_longer_existent] %></span>
                         </div>
-                        <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <span class="text-md text-slate-500 p-2 break-words"></span>
+                        <div
+                          class="
+                            col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700 p-1
+                          "
+                          aria-labelledby="<%= "metadata-deleted-#{key_no_longer_existent}" %>"
+                        >
+                          <span
+                            data-test-item-selector="value"
+                            class="text-md text-slate-500 p-2 break-all"
+                          ></span>
                         </div>
                       <% end %>
                     <% end %>
@@ -122,18 +170,35 @@
           </div>
         <% else %>
           <div class="grid grid-cols-3 gap-2 py-2">
-            <div class="col-span-1">
-              <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= key.to_s %></span>
+            <div class="col-span-1" id="<%= "metadata-#{key}" %>">
+              <span
+                data-test-item-selector="key"
+                class="mb-1 text-slate-500 text-md dark:text-slate-400"
+              ><%= key.to_s %></span>
             </div>
             <% col_span = "col-span-2" %>
             <% if log_data[:version] != 1 %>
-              <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                <span class="text-md p-1"><%= log_data[:previous_version][key.to_s] %></span>
+              <div
+                class="
+                  col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700
+                "
+                aria-labelledby="<%= "metadata-#{key}" %>"
+              >
+                <span data-test-item-selector="value" class="text-md p-1"><%= log_data[:previous_version][key.to_s] %></span>
               </div>
               <% col_span = "col-span-1" %>
             <% end %>
-            <div class="<%= col_span %> bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-              <span class="text-lg text-slate-600 p-2 break-words"><%= value %></span>
+            <div
+              class="
+                <%= col_span %> bg-slate-100 dark:bg-slate-700
+                dark:text-slate-700
+              "
+              aria-labelledby="<%= "metadata-#{key}" %>"
+            >
+              <span
+                data-test-item-selector="value"
+                class="text-lg text-slate-600 p-2 break-words"
+              ><%= value %></span>
             </div>
           </div>
         <% end %>

--- a/app/components/history_version_component.html.erb
+++ b/app/components/history_version_component.html.erb
@@ -60,7 +60,7 @@
             <div
               data-collapsible-target="item"
               id="<%= "accordion-collapse-body-#{index + 1}" %>"
-              class="<%= index == 0 ? "" : "hispanen"%>"
+              class="<%= index == 0 ? "" : "hidden"%>"
               aria-labelledby="<%= "accordion-collapse-heading-#{index + 1}" %>"
             >
               <div

--- a/app/components/history_version_component.html.erb
+++ b/app/components/history_version_component.html.erb
@@ -17,7 +17,7 @@
     <div class="<%= current_version_classes %>"><%= t(:"components.history_version.current_version", version: log_data[:version]) %></div>
   </div>
 
-  <dl
+  <div
     class="
       text-slate-900 dark:text-white divide-y divide-slate-200 dark:divide-slate-700
     "
@@ -60,7 +60,7 @@
             <div
               data-collapsible-target="item"
               id="<%= "accordion-collapse-body-#{index + 1}" %>"
-              class="<%= index == 0 ? "" : "hidden"%>"
+              class="<%= index == 0 ? "" : "hispanen"%>"
               aria-labelledby="<%= "accordion-collapse-heading-#{index + 1}" %>"
             >
               <div
@@ -79,20 +79,20 @@
                       <% if log_data[:version] == 1 %>
                         <% col_span = "col-span-2" %>
                         <div class="col-span-1">
-                          <dt class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= k.to_s %></dt>
+                          <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= k.to_s %></span>
                         </div>
                         <div class="<%= col_span %> bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <dd class="text-md p-1 break-words"><%= v %></dd>
+                          <span class="text-md text-slate-500 p-2 break-words"><%= v %></span>
                         </div>
                       <% else %>
                         <div class="col-span-1">
-                          <dt class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= k.to_s %></dt>
+                          <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= k.to_s %></span>
                         </div>
                         <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <dd class="text-md p-1"><%= prev_changes_value_hash[k] %></dd>
+                          <span class="text-md text-slate-500 p-2"><%= prev_changes_value_hash[k] %></span>
                         </div>
                         <div class="<%= col_span %> bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <dd class="text-md p-1 break-words"><%= v %></dd>
+                          <span class="text-md text-slate-500 p-2 break-words"><%= v %></span>
                         </div>
                       <% end %>
                     <% end %>
@@ -105,13 +105,13 @@
                       </div>
                       <% keys_no_longer_existent.each do |key_no_longer_existent| %>
                         <div class="col-span-1">
-                          <dt class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= key_no_longer_existent %></dt>
+                          <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= key_no_longer_existent %></span>
                         </div>
                         <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <dd class="text-md p-1"><%= prev_changes_value_hash[key_no_longer_existent] %></dd>
+                          <span class="text-md text-slate-500 p-2"><%= prev_changes_value_hash[key_no_longer_existent] %></span>
                         </div>
                         <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                          <dd class="text-md p-1 break-words"></dd>
+                          <span class="text-md text-slate-500 p-2 break-words"></span>
                         </div>
                       <% end %>
                     <% end %>
@@ -123,21 +123,21 @@
         <% else %>
           <div class="grid grid-cols-3 gap-2 py-2">
             <div class="col-span-1">
-              <dt class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= key.to_s %></dt>
+              <span class="mb-1 text-slate-500 text-md dark:text-slate-400"><%= key.to_s %></span>
             </div>
             <% col_span = "col-span-2" %>
             <% if log_data[:version] != 1 %>
               <div class="col-span-1 bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-                <dd class="text-md p-1"><%= log_data[:previous_version][key.to_s] %></dd>
+                <span class="text-md p-1"><%= log_data[:previous_version][key.to_s] %></span>
               </div>
               <% col_span = "col-span-1" %>
             <% end %>
             <div class="<%= col_span %> bg-slate-100 dark:bg-slate-700 dark:text-slate-700">
-              <dd class="text-md p-1 break-words"><%= value %></dd>
+              <span class="text-lg text-slate-600 p-2 break-words"><%= value %></span>
             </div>
           </div>
         <% end %>
       <% end %>
     </div>
-  </dl>
+  </div>
 </div>

--- a/test/components/history_version_component_test.rb
+++ b/test/components/history_version_component_test.rb
@@ -32,12 +32,13 @@ class HistoryVersionComponentTest < ViewComponentTestCase
 
     render_inline HistoryVersionComponent.new(log_data: @log_data)
 
-    assert_selector 'span', count: 3
+    assert_selector 'span[data-test-item-selector="key"]', count: 1
+    assert_selector 'span[data-test-item-selector="value"]', count: 2
 
-    assert_selector 'span', text: 'description'
+    assert_selector 'span[data-test-item-selector="key"]', text: 'description'
 
-    assert_selector 'span', text: 'New description for Project 1'
-    assert_selector 'span', text: 'Another new description for this project'
+    assert_selector 'span[data-test-item-selector="value"]', text: 'New description for Project 1'
+    assert_selector 'span[data-test-item-selector="value"]', text: 'Another new description for this project'
   end
 
   test 'display of sample version changes' do
@@ -86,12 +87,13 @@ class HistoryVersionComponentTest < ViewComponentTestCase
 
     assert_text I18n.t(:'components.history_version.keys_deleted')
 
-    assert_selector 'span', count: 6
+    assert_selector 'span[data-test-item-selector="key"]', count: 2
+    assert_selector 'span[data-test-item-selector="value"]', count: 4
 
-    assert_selector 'span', text: 'field1'
-    assert_selector 'span', text: 'field2'
+    assert_selector 'span[data-test-item-selector="key"]', text: 'field1'
+    assert_selector 'span[data-test-item-selector="key"]', text: 'field2'
 
-    assert_selector 'span', text: 'newvalue2'
-    assert_selector 'span', text: 'newvalue3'
+    assert_selector 'span[data-test-item-selector="value"]', text: 'newvalue2'
+    assert_selector 'span[data-test-item-selector="value"]', text: 'newvalue3'
   end
 end

--- a/test/components/history_version_component_test.rb
+++ b/test/components/history_version_component_test.rb
@@ -32,13 +32,12 @@ class HistoryVersionComponentTest < ViewComponentTestCase
 
     render_inline HistoryVersionComponent.new(log_data: @log_data)
 
-    assert_selector 'dt', count: 1
-    assert_selector 'dd', count: 2
+    assert_selector 'span', count: 3
 
-    assert_selector 'dt', text: 'description'
+    assert_selector 'span', text: 'description'
 
-    assert_selector 'dd', text: 'New description for Project 1'
-    assert_selector 'dd', text: 'Another new description for this project'
+    assert_selector 'span', text: 'New description for Project 1'
+    assert_selector 'span', text: 'Another new description for this project'
   end
 
   test 'display of sample version changes' do
@@ -87,13 +86,12 @@ class HistoryVersionComponentTest < ViewComponentTestCase
 
     assert_text I18n.t(:'components.history_version.keys_deleted')
 
-    assert_selector 'dt', count: 2
-    assert_selector 'dd', count: 4
+    assert_selector 'span', count: 6
 
-    assert_selector 'dt', text: 'field1'
-    assert_selector 'dt', text: 'field2'
+    assert_selector 'span', text: 'field1'
+    assert_selector 'span', text: 'field2'
 
-    assert_selector 'dd', text: 'newvalue2'
-    assert_selector 'dd', text: 'newvalue3'
+    assert_selector 'span', text: 'newvalue2'
+    assert_selector 'span', text: 'newvalue3'
   end
 end

--- a/test/system/groups/history_test.rb
+++ b/test/system/groups/history_test.rb
@@ -40,17 +40,17 @@ module Groups
         assert_no_text I18n.t(:'components.history_version.previous_version')
         assert_text I18n.t(:'components.history_version.current_version', version: 1)
 
-        assert_selector 'span', text: 'name'
-        assert_selector 'span', text: 'path'
-        assert_selector 'span', text: 'type'
-        assert_selector 'span', text: 'owner_id'
-        assert_selector 'span', text: 'description'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'name'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'path'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'type'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'owner_id'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'description'
 
-        assert_selector 'span', text: 'Group 1'
-        assert_selector 'span', text: 'group-1'
-        assert_selector 'span', text: 'Group'
-        assert_selector 'span', text: @group.owner.id
-        assert_selector 'span', text: 'Group 1 description'
+        assert_selector 'span[data-test-item-selector="value"]', text: 'Group 1'
+        assert_selector 'span[data-test-item-selector="value"]', text: 'group-1'
+        assert_selector 'span[data-test-item-selector="value"]', text: 'Group'
+        assert_selector 'span[data-test-item-selector="value"]', text: @group.owner.id
+        assert_selector 'span[data-test-item-selector="value"]', text: 'Group 1 description'
       end
     end
   end

--- a/test/system/groups/history_test.rb
+++ b/test/system/groups/history_test.rb
@@ -40,17 +40,17 @@ module Groups
         assert_no_text I18n.t(:'components.history_version.previous_version')
         assert_text I18n.t(:'components.history_version.current_version', version: 1)
 
-        assert_selector 'dt', text: 'name'
-        assert_selector 'dt', text: 'path'
-        assert_selector 'dt', text: 'type'
-        assert_selector 'dt', text: 'owner_id'
-        assert_selector 'dt', text: 'description'
+        assert_selector 'span', text: 'name'
+        assert_selector 'span', text: 'path'
+        assert_selector 'span', text: 'type'
+        assert_selector 'span', text: 'owner_id'
+        assert_selector 'span', text: 'description'
 
-        assert_selector 'dd', text: 'Group 1'
-        assert_selector 'dd', text: 'group-1'
-        assert_selector 'dd', text: 'Group'
-        assert_selector 'dd', text: @group.owner.id
-        assert_selector 'dd', text: 'Group 1 description'
+        assert_selector 'span', text: 'Group 1'
+        assert_selector 'span', text: 'group-1'
+        assert_selector 'span', text: 'Group'
+        assert_selector 'span', text: @group.owner.id
+        assert_selector 'span', text: 'Group 1 description'
       end
     end
   end

--- a/test/system/projects/history_test.rb
+++ b/test/system/projects/history_test.rb
@@ -40,21 +40,21 @@ module Projects
         assert_no_text I18n.t(:'components.history_version.previous_version')
         assert_text I18n.t(:'components.history_version.current_version', version: 1)
 
-        assert_selector 'span', text: 'name'
-        assert_selector 'span', text: 'path'
-        assert_selector 'span', text: 'type'
-        assert_selector 'span', text: 'owner_id'
-        assert_selector 'span', text: 'parent_id'
-        assert_selector 'span', text: 'description'
-        assert_selector 'span', text: 'puid'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'name'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'path'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'type'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'owner_id'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'parent_id'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'description'
+        assert_selector 'span[data-test-item-selector="key"]', text: 'puid'
 
-        assert_selector 'span', text: 'Project 1'
-        assert_selector 'span', text: 'project-1'
-        assert_selector 'span', text: 'Project'
-        assert_selector 'span', text: @project.namespace.owner.id
-        assert_selector 'span', text: @project.namespace.parent.id
-        assert_selector 'span', text: 'Project 1 description'
-        assert_selector 'span', text: @project.puid
+        assert_selector 'span[data-test-item-selector="value"]', text: 'Project 1'
+        assert_selector 'span[data-test-item-selector="value"]', text: 'project-1'
+        assert_selector 'span[data-test-item-selector="value"]', text: 'Project'
+        assert_selector 'span[data-test-item-selector="value"]', text: @project.namespace.owner.id
+        assert_selector 'span[data-test-item-selector="value"]', text: @project.namespace.parent.id
+        assert_selector 'span[data-test-item-selector="value"]', text: 'Project 1 description'
+        assert_selector 'span[data-test-item-selector="value"]', text: @project.puid
       end
     end
   end

--- a/test/system/projects/history_test.rb
+++ b/test/system/projects/history_test.rb
@@ -40,21 +40,21 @@ module Projects
         assert_no_text I18n.t(:'components.history_version.previous_version')
         assert_text I18n.t(:'components.history_version.current_version', version: 1)
 
-        assert_selector 'dt', text: 'name'
-        assert_selector 'dt', text: 'path'
-        assert_selector 'dt', text: 'type'
-        assert_selector 'dt', text: 'owner_id'
-        assert_selector 'dt', text: 'parent_id'
-        assert_selector 'dt', text: 'description'
-        assert_selector 'dt', text: 'puid'
+        assert_selector 'span', text: 'name'
+        assert_selector 'span', text: 'path'
+        assert_selector 'span', text: 'type'
+        assert_selector 'span', text: 'owner_id'
+        assert_selector 'span', text: 'parent_id'
+        assert_selector 'span', text: 'description'
+        assert_selector 'span', text: 'puid'
 
-        assert_selector 'dd', text: 'Project 1'
-        assert_selector 'dd', text: 'project-1'
-        assert_selector 'dd', text: 'Project'
-        assert_selector 'dd', text: @project.namespace.owner.id
-        assert_selector 'dd', text: @project.namespace.parent.id
-        assert_selector 'dd', text: 'Project 1 description'
-        assert_selector 'dd', text: @project.puid
+        assert_selector 'span', text: 'Project 1'
+        assert_selector 'span', text: 'project-1'
+        assert_selector 'span', text: 'Project'
+        assert_selector 'span', text: @project.namespace.owner.id
+        assert_selector 'span', text: @project.namespace.parent.id
+        assert_selector 'span', text: 'Project 1 description'
+        assert_selector 'span', text: @project.puid
       end
     end
   end

--- a/test/system/projects/samples/history_test.rb
+++ b/test/system/projects/samples/history_test.rb
@@ -41,15 +41,15 @@ module Projects
           assert_no_text I18n.t(:'components.history_version.previous_version')
           assert_text I18n.t(:'components.history_version.current_version', version: 1)
 
-          assert_selector 'span', text: 'name'
-          assert_selector 'span', text: 'description'
-          assert_selector 'span', text: 'puid'
-          assert_selector 'span', text: 'project_id'
+          assert_selector 'span[data-test-item-selector="key"]', text: 'name'
+          assert_selector 'span[data-test-item-selector="key"]', text: 'description'
+          assert_selector 'span[data-test-item-selector="key"]', text: 'puid'
+          assert_selector 'span[data-test-item-selector="key"]', text: 'project_id'
 
-          assert_selector 'span', text: 'Project 1 Sample 1'
-          assert_selector 'span', text: 'Sample 1 description.'
-          assert_selector 'span', text: @sample1.puid
-          assert_selector 'span', text: @sample1.project.id
+          assert_selector 'span[data-test-item-selector="value"]', text: 'Project 1 Sample 1'
+          assert_selector 'span[data-test-item-selector="value"]', text: 'Sample 1 description.'
+          assert_selector 'span[data-test-item-selector="value"]', text: @sample1.puid
+          assert_selector 'span[data-test-item-selector="value"]', text: @sample1.project.id
         end
       end
     end

--- a/test/system/projects/samples/history_test.rb
+++ b/test/system/projects/samples/history_test.rb
@@ -41,15 +41,15 @@ module Projects
           assert_no_text I18n.t(:'components.history_version.previous_version')
           assert_text I18n.t(:'components.history_version.current_version', version: 1)
 
-          assert_selector 'dt', text: 'name'
-          assert_selector 'dt', text: 'description'
-          assert_selector 'dt', text: 'puid'
-          assert_selector 'dt', text: 'project_id'
+          assert_selector 'span', text: 'name'
+          assert_selector 'span', text: 'description'
+          assert_selector 'span', text: 'puid'
+          assert_selector 'span', text: 'project_id'
 
-          assert_selector 'dd', text: 'Project 1 Sample 1'
-          assert_selector 'dd', text: 'Sample 1 description.'
-          assert_selector 'dd', text: @sample1.puid
-          assert_selector 'dd', text: @sample1.project.id
+          assert_selector 'span', text: 'Project 1 Sample 1'
+          assert_selector 'span', text: 'Sample 1 description.'
+          assert_selector 'span', text: @sample1.puid
+          assert_selector 'span', text: @sample1.project.id
         end
       end
     end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the history_version_component dialog to use spans within a div instead of using `datalist` tags as dl tags cannot have elements other than `dd` and `dt` as direct children. Also updated was the timeline bullet to meet `3:1` constrast ratio with its surrounding color, and minimum width/height for the buttons which launch the history version component dialog. Addresses the following:

- [STRY0018436](https://publichealthprod.service-now.com/rm_story.do?sys_id=d8111c0947966250f24c0c21516d4338)

- [STRY0018435](https://publichealthprod.service-now.com/rm_story.do?sys_id=bae0140947966250f24c0c21516d439b)

- [STRY0018433](https://publichealthprod.service-now.com/rm_story.do?sys_id=44c0dc8547966250f24c0c21516d43d2)

- [STRY0018434 ](https://publichealthprod.service-now.com/rm_story.do?sys_id=e9d0180947966250f24c0c21516d4330
)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
