### PR TITLE
Fix: Project creation form description and error message accessibility

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -371,7 +371,7 @@
 
 @utility button-primary {
   /* High contrast colors for WCAG AAA */
-  @apply border-primary-700 bg-primary-700 hover:bg-primary-800 hover:border-primary-800 dark:border-primary-600 dark:bg-primary-600 dark:hover:bg-primary-700 dark:hover:border-primary-700 text-white shadow-sm;
+  @apply border-primary-700 bg-primary-700 hover:bg-primary-800 hover:border-primary-800 dark:border-primary-600 dark:bg-primary-700 dark:hover:bg-primary-700 dark:hover:border-primary-700 text-white shadow-sm;
 
   /* Focus styles with high contrast */
   &:focus-visible {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -267,7 +267,7 @@
 
 @utility invalid {
   &.form-field label {
-    @apply text-red-700 dark:text-red-500;
+    @apply text-red-700 dark:text-red-400;
   }
 
   &.form-field input[type="text"] {

--- a/app/components/viral/form/help_text_component.html.erb
+++ b/app/components/viral/form/help_text_component.html.erb
@@ -1,6 +1,9 @@
 <%= render Viral::BaseComponent.new(**system_arguments) do %>
   <%- if icon.present? %>
-    <%= render Viral::IconComponent.new(name: icon, classes: "w-4 h-4 mr-1.5") %>
+    <%= render Viral::IconComponent.new(
+      name: icon,
+      classes: "w-4 h-4 mr-1.5 dark:text-red-400",
+    ) %>
   <% end %>
-  <span class="grow"><%= content %></span>
+  <span class="grow dark:text-red-400"><%= content %></span>
 <% end %>

--- a/app/components/viral/form/help_text_component.html.erb
+++ b/app/components/viral/form/help_text_component.html.erb
@@ -1,9 +1,6 @@
 <%= render Viral::BaseComponent.new(**system_arguments) do %>
   <%- if icon.present? %>
-    <%= render Viral::IconComponent.new(
-      name: icon,
-      classes: "w-4 h-4 mr-1.5 dark:text-red-400",
-    ) %>
+    <%= render Viral::IconComponent.new(name: icon, classes: "w-4 h-4 mr-1.5") %>
   <% end %>
-  <span class="grow dark:text-red-400"><%= content %></span>
+  <span class="grow"><%= content %></span>
 <% end %>

--- a/app/components/viral/form/help_text_component.rb
+++ b/app/components/viral/form/help_text_component.rb
@@ -9,7 +9,7 @@ module Viral
       STATE_MAPPINGS = {
         default: 'mt-2 text-sm text-slate-500 dark:text-slate-400',
         success: 'mt-2 text-sm text-green-600 dark:text-green-500',
-        error: 'mt-2 text-sm text-red-600 dark:text-red-500'
+        error: 'mt-2 text-sm text-red-600 dark:text-red-400'
       }.freeze
 
       ICON_MAPPINGS = {

--- a/app/components/viral/form/help_text_component.rb
+++ b/app/components/viral/form/help_text_component.rb
@@ -26,9 +26,9 @@ module Viral
 
       def system_arguments
         @arguments.tap do |args|
-          args[:tag] = 'p'
+          args[:tag] = 'span'
           args[:classes] = class_names(
-            'flex items-start justify-start',
+            'flex items-center',
             STATE_MAPPINGS.key?(@state) ? STATE_MAPPINGS[@state] : STATE_MAPPINGS[:default],
             args[:classes]
           )

--- a/app/components/viral/page_header_component.html.erb
+++ b/app/components/viral/page_header_component.html.erb
@@ -28,14 +28,14 @@
       <!-- Subtitle -->
       <% if subtitle.present? %>
         <div class="<%= icon? ? 'pl-12' : '' %>">
-          <p
+          <span
             class="
               text-lg text-neutral-600 dark:text-neutral-300 leading-relaxed break-words
             "
             id="page-subtitle"
           >
             <%= subtitle %>
-          </p>
+          </span>
         </div>
       <% end %>
       <!-- PUID (Mobile: Last element, Desktop: After subtitle) -->

--- a/app/services/projects/create_service.rb
+++ b/app/services/projects/create_service.rb
@@ -3,6 +3,7 @@
 module Projects
   # Service used to Create Projects
   class CreateService < BaseService
+    ProjectNamespaceCreateError = Class.new(StandardError)
     ProjectCreateError = Class.new(StandardError)
     attr_accessor :namespace_params, :project, :namespace
 
@@ -14,12 +15,15 @@ module Projects
     end
 
     def execute
-      raise ProjectCreateError, I18n.t('services.projects.create.namespace_required') if namespace.nil?
+      raise ProjectNamespaceCreateError, I18n.t('services.projects.create.namespace_required') if namespace.nil?
 
       create_associations(project)
       project
     rescue Projects::CreateService::ProjectCreateError => e
-      project.errors.add(:base, e.message)
+      project.namespace.errors.add(:base, e.message)
+      project
+    rescue Projects::CreateService::ProjectNamespaceCreateError => e
+      project.namespace.errors.add(:namespace, e.message)
       project
     end
 

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -8,6 +8,8 @@
   )
 end %>
 
+<%= render partial: "shared/form/required_field_legend" %>
+
 <% invalid_name = group.errors.include?(:name) %>
 <div class="form-field <%= 'invalid' if invalid_name %>">
   <%= form.label :name, data: { required: true } %>

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -37,9 +37,9 @@ end %>
     id: form.field_id(:name, "error"),
     errors: group.errors.full_messages_for(:name)
   end %>
-  <p id="<%= form.field_id(:name, "hint") %>" class="field-hint">
+  <span id="<%= form.field_id(:name, "hint") %>" class="field-hint">
     <%== t(:"groups.create.name_help") %>
-  </p>
+  </span>
 </div>
 
 <% if group.new_record? %>
@@ -97,9 +97,9 @@ end %>
                           required: true,
                         },
                         autofocus: invalid_path %>
-        <p id="<%= form.field_id(:path, "hint") %>" class="field-hint">
+        <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
           <%= t(:"groups.create.path_help") %>
-        </p>
+        </span>
         <%= if invalid_path
           render "shared/form/field_errors",
           id: form.field_id(:path, "error"),
@@ -131,9 +131,9 @@ end %>
         id: form.field_id(:path, "error"),
         errors: group.errors.full_messages_for(:path)
       end %>
-      <p id="<%= form.field_id(:path, "hint") %>" class="field-hint">
+      <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
         <%= t(:"groups.create.path_help") %>
-      </p>
+      </span>
     </div>
   <% end %>
 <% end %>

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -1,24 +1,54 @@
+<%= if @project.namespace.errors.any?
+  viral_alert(
+    type: "alert",
+    message: I18n.t(:"general.form.error_notification"),
+    aria: {
+      live: "assertive",
+    },
+  )
+end %>
+
+<%= render partial: "shared/form/required_field_legend" %>
+
 <% invalid_name = @project.namespace.errors.include?(:name) %>
 <div class="form-field <%= 'invalid' if invalid_name %>">
-  <%= builder.label :name %>
+  <%= builder.label :name, data: { required: true } %>
   <%= builder.text_field :name,
                      data: {
                        "slugify-target": "name",
                        action: "input->slugify#nameChanged",
                      },
                      required: true,
-                     placeholder: t(:"projects.new.placeholder") %>
-  <%= render "shared/form/field_errors",
-  errors: @project.namespace.errors.full_messages_for(:name) %>
+                     placeholder: t(:"projects.new.placeholder"),
+                     aria: {
+                       describedby: [
+                         invalid_name ? builder.field_id(:name, "error") : nil,
+                         builder.field_id(:name, "hint"),
+                       ].join(" "),
+                       invalid: invalid_name,
+                       required: true,
+                     },
+                     autofocus: invalid_name %>
+
+  <% if invalid_name %>
+    <%= render "shared/form/field_errors",
+    id: builder.field_id(:name, "error"),
+    errors: @project.namespace.errors.full_messages_for(:name) %>
+  <% end %>
+  <p id="<%= builder.field_id(:name, "hint") %>" class="field-hint">
+    <%== t(:"projects.create.name_help") %>
+  </p>
 </div>
 <div class="grid @xs:grid-cols-1 @5xl:grid-cols-2 gap-4">
-  <div>
+  <% invalid_namespace = @project.namespace.errors.include?(:namespace) %>
+  <div class="form-field <%= 'invalid' if invalid_namespace %>">
     <% form_id = "namespace-select" %>
     <label
       for="<%= form_id %>"
       class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
     >
       <%= t("activerecord.attributes.namespaces/project_namespace.parent_id") %>
+      <span class="text-red-500">*</span>
     </label>
     <div class="flex items-center">
       <% selected_value =
@@ -48,19 +78,40 @@
       <% end %>
       <div class="ml-4 dark:text-slate-200">/</div>
     </div>
+    <% if invalid_namespace %>
+      <%= render "shared/form/field_errors",
+      id: builder.field_id(:namespace, "error"),
+      errors: @project.namespace.errors.messages.values.flatten %>
+    <% end %>
   </div>
   <% invalid_path = @project.namespace.errors.include?(:path) %>
   <div class="form-field <%= 'invalid' if invalid_path %>">
-    <%= builder.label :path %>
+    <%= builder.label :path, data: { required: true } %>
     <%= builder.text_field :path,
                        data: {
                          "slugify-target": "path",
                        },
                        pattern: Irida::PathRegex::PATH_REGEX_STR,
                        required: true,
-                       title: t(:"projects.new.help") %>
-    <%= render "shared/form/field_errors",
-    errors: @project.namespace.errors.full_messages_for(:path) %>
+                       title: t(:"projects.new.help"),
+                       aria: {
+                         describedby: [
+                           invalid_path ? builder.field_id(:path, "error") : nil,
+                           builder.field_id(:path, "hint"),
+                         ].join(" "),
+                         invalid: invalid_path,
+                         required: true,
+                       },
+                       autofocus: invalid_path %>
+
+    <% if invalid_path %>
+      <%= render "shared/form/field_errors",
+      errors: @project.namespace.errors.full_messages_for(:path) %>
+    <% end %>
+    <p id="<%= builder.field_id(:path, "hint") %>" class="field-hint">
+      <%= t(:"projects.create.path_help") %>
+    </p>
+
   </div>
 </div>
 <% invalid_description = @project.namespace.errors.include?(:description) %>
@@ -70,7 +121,22 @@
                     {
                       :class => "form-control",
                       "aria-label" => "Project description, not required",
+                      "aria-described-by" =>
+                        (
+                          if invalid_description
+                            builder.field_id(:description, "error")
+                          else
+                            nil
+                          end
+                        ),
+                      "aria-invalid" => invalid_description,
+                      :autofocus => invalid_description,
                     } %>
-  <%= render "shared/form/field_errors",
-  errors: @project.namespace.errors.full_messages_for(:description) %>
+  <% if invalid_description %>
+    <%= render "shared/form/field_errors",
+    errors: @project.namespace.errors.full_messages_for(:description) %>
+  <% end %>
+  <p id="<%= builder.field_id(:description, "hint") %>" class="field-hint">
+    <%= t(:"projects.create.description_help") %>
+  </p>
 </div>

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -120,7 +120,8 @@ end %>
   <%= builder.text_area :description,
                     {
                       :class => "form-control",
-                      "aria-label" => "Project description, not required",
+                      "aria-label" =>
+                        t(:"projects.create.description.aria_label"),
                       "aria-described-by" =>
                         (
                           if invalid_description

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -83,7 +83,12 @@ end %>
       id: builder.field_id(:namespace, "error"),
       errors: @project.namespace.errors.messages.values.flatten %>
     <% end %>
+
+    <p id="<%= builder.field_id(:namespace, "hint") %>" class="field-hint">
+      <%= t(:"projects.create.namespace_help") %>
+    </p>
   </div>
+
   <% invalid_path = @project.namespace.errors.include?(:path) %>
   <div class="form-field <%= 'invalid' if invalid_path %>">
     <%= builder.label :path, data: { required: true } %>

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -35,9 +35,9 @@ end %>
     id: builder.field_id(:name, "error"),
     errors: @project.namespace.errors.full_messages_for(:name) %>
   <% end %>
-  <p id="<%= builder.field_id(:name, "hint") %>" class="field-hint">
+  <span id="<%= builder.field_id(:name, "hint") %>" class="field-hint">
     <%== t(:"projects.create.name_help") %>
-  </p>
+  </span>
 </div>
 <div class="grid @xs:grid-cols-1 @5xl:grid-cols-2 gap-4">
   <% invalid_namespace = @project.namespace.errors.include?(:namespace) %>
@@ -84,9 +84,9 @@ end %>
       errors: @project.namespace.errors.messages.values.flatten %>
     <% end %>
 
-    <p id="<%= builder.field_id(:namespace, "hint") %>" class="field-hint">
+    <span id="<%= builder.field_id(:namespace, "hint") %>" class="field-hint">
       <%= t(:"projects.create.namespace_help") %>
-    </p>
+    </span>
   </div>
 
   <% invalid_path = @project.namespace.errors.include?(:path) %>
@@ -113,9 +113,9 @@ end %>
       <%= render "shared/form/field_errors",
       errors: @project.namespace.errors.full_messages_for(:path) %>
     <% end %>
-    <p id="<%= builder.field_id(:path, "hint") %>" class="field-hint">
+    <span id="<%= builder.field_id(:path, "hint") %>" class="field-hint">
       <%= t(:"projects.create.path_help") %>
-    </p>
+    </span>
 
   </div>
 </div>
@@ -142,7 +142,7 @@ end %>
     <%= render "shared/form/field_errors",
     errors: @project.namespace.errors.full_messages_for(:description) %>
   <% end %>
-  <p id="<%= builder.field_id(:description, "hint") %>" class="field-hint">
+  <span id="<%= builder.field_id(:description, "hint") %>" class="field-hint">
     <%= t(:"projects.create.description_help") %>
-  </p>
+  </span>
 </div>

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -39,7 +39,8 @@ end %>
     <%== t(:"projects.create.name_help") %>
   </span>
 </div>
-<div class="grid @xs:grid-cols-1 @5xl:grid-cols-2 gap-4">
+<fieldset class="grid @xs:grid-cols-1 @5xl:grid-cols-2 gap-4 border-0 p-0 m-0">
+  <legend class="sr-only"><%= t(:"projects.create.namespace_and_path") %></legend>
   <% invalid_namespace = @project.namespace.errors.include?(:namespace) %>
   <div class="form-field <%= 'invalid' if invalid_namespace %>">
     <% form_id = "namespace-select" %>
@@ -118,7 +119,7 @@ end %>
     </span>
 
   </div>
-</div>
+</fieldset>
 <% invalid_description = @project.namespace.errors.include?(:description) %>
 <div class="form-field <%= 'invalid' if invalid_description %>">
   <%= builder.label :description %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -5,7 +5,7 @@
 
 <div class="@xl:container" data-controller="slugify">
   <%= form_with(model: @project, url: projects_path(namespace_id: params[:group_id]), method: :post,
-  data: { controller: "viral--select2" }) do |form| %>
+  data: { controller: "viral--select2" }, html: { novalidate: true }) do |form| %>
     <%= turbo_frame_tag "project_form" do %>
       <div class="grid gap-4">
         <%= form.fields_for :namespace do |builder| %>

--- a/app/views/shared/form/_required_field_legend.html.erb
+++ b/app/views/shared/form/_required_field_legend.html.erb
@@ -1,0 +1,3 @@
+<p class="text-sm text-slate-500"><span class="text-red-500">*
+  </span><%= t("shared.form.required_field") %>
+</p>

--- a/app/views/shared/form/_required_field_legend.html.erb
+++ b/app/views/shared/form/_required_field_legend.html.erb
@@ -1,3 +1,3 @@
-<span class="text-sm text-slate-500 dark:text-slate-300"><span class="text-red-500 dark:text-red-500">*
-  </span><%= t("shared.form.required_field") %>
+<span class="text-sm text-slate-500 dark:text-slate-300">
+  <span class="text-red-500 dark:text-red-500" aria-hidden="true">*</span><%= t("shared.form.required_field") %>
 </span>

--- a/app/views/shared/form/_required_field_legend.html.erb
+++ b/app/views/shared/form/_required_field_legend.html.erb
@@ -1,3 +1,3 @@
-<p class="text-sm text-slate-500 dark:text-slate-300"><span class="text-red-500 dark:text-red-500">*
+<span class="text-sm text-slate-500 dark:text-slate-300"><span class="text-red-500 dark:text-red-500">*
   </span><%= t("shared.form.required_field") %>
-</p>
+</span>

--- a/app/views/shared/form/_required_field_legend.html.erb
+++ b/app/views/shared/form/_required_field_legend.html.erb
@@ -1,3 +1,3 @@
-<p class="text-sm text-slate-500"><span class="text-red-500">*
+<p class="text-sm text-slate-500 dark:text-slate-300"><span class="text-red-500 dark:text-red-500">*
   </span><%= t("shared.form.required_field") %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1557,6 +1557,7 @@ en:
         aria_label: Project description, optional
       description_help: Description can have a maximum 255 characters
       name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
+      namespace_and_path: Namespace in which to create project and the path to the project which is used in the URL
       namespace_help: The namespace in which the project will be created
       path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores
       success: Project %{project_name} was successfully created

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1557,6 +1557,7 @@ en:
         aria_label: Project description, optional
       description_help: Description can have a maximum 255 characters
       name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
+      namespace_help: The namespace in which the project will be created
       path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores
       success: Project %{project_name} was successfully created
     destroy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1553,6 +1553,9 @@ en:
         subtitle: Setup bot accounts to be able to perform actions through the API that cannot be attributed to an individual user.
         title: Bot Accounts
     create:
+      description_help: Description can have a maximum 255 characters
+      name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
+      path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores
       success: Project %{project_name} was successfully created
     destroy:
       success: Project %{project_name} was successfully deleted
@@ -2100,6 +2103,8 @@ en:
     alert:
       list:
         danger: Danger
+    form:
+      required_field: indicates required field
     loading:
       samples_list_skeleton:
         loading: Loading...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1553,6 +1553,8 @@ en:
         subtitle: Setup bot accounts to be able to perform actions through the API that cannot be attributed to an individual user.
         title: Bot Accounts
     create:
+      description:
+        aria_label: Project description, optional
       description_help: Description can have a maximum 255 characters
       name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
       path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1553,6 +1553,8 @@ fr:
         subtitle: Configurez des comptes de bot pour pouvoir effectuer des actions en utilisant l’API qui ne peuvent pas être attribuées à un utilisateur individuel.
         title: Comptes de bot
     create:
+      description:
+        aria_label: Project description, optional
       description_help: Description can have a maximum 255 characters
       name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
       path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1553,6 +1553,9 @@ fr:
         subtitle: Configurez des comptes de bot pour pouvoir effectuer des actions en utilisant l’API qui ne peuvent pas être attribuées à un utilisateur individuel.
         title: Comptes de bot
     create:
+      description_help: Description can have a maximum 255 characters
+      name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
+      path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores
       success: Le projet %{project_name} a été créé avec succès
     destroy:
       success: Le projet %{project_name} a été supprimé avec succès
@@ -2100,6 +2103,8 @@ fr:
     alert:
       list:
         danger: Danger
+    form:
+      required_field: indicates required field
     loading:
       samples_list_skeleton:
         loading: Chargement...

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1557,6 +1557,7 @@ fr:
         aria_label: Project description, optional
       description_help: Description can have a maximum 255 characters
       name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
+      namespace_help: The namespace in which the project will be created
       path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores
       success: Le projet %{project_name} a été créé avec succès
     destroy:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1557,6 +1557,7 @@ fr:
         aria_label: Project description, optional
       description_help: Description can have a maximum 255 characters
       name_help: Project name must be at least 3 letters long and start with a letter, digit, or emoji. For more information see <a class="font-medium hover:underline" href="https://phac-nml.github.io/irida-next/docs/user/project/projects/reserved-names/">Reserved project names</a>
+      namespace_and_path: Namespace in which to create project and the path to the project which is used in the URL
       namespace_help: The namespace in which the project will be created
       path_help: The path is used in URLs and can only contain letters, numbers, dashes and underscores
       success: Le projet %{project_name} a été créé avec succès

--- a/test/components/viral/form/datepicker_component_test.rb
+++ b/test/components/viral/form/datepicker_component_test.rb
@@ -23,7 +23,7 @@ module Viral
         render_preview(:with_help_text)
         assert_no_selector 'label'
         assert_selector 'input[type="text"]', count: 1
-        assert_selector 'p.text-sm', text: 'Select a date in the future'
+        assert_selector 'span.text-sm', text: 'Select a date in the future'
       end
 
       test 'with placeholder' do

--- a/test/components/viral/form/file_input_component_test.rb
+++ b/test/components/viral/form/file_input_component_test.rb
@@ -20,7 +20,7 @@ module Viral
         render_preview(:with_help_text)
         assert_selector 'label', text: 'File Input', count: 1
         assert_selector "input[type='file']", count: 1
-        assert_selector 'p.text-sm', text: 'This is a help text', count: 1
+        assert_selector 'span.text-sm', text: 'This is a help text', count: 1
       end
     end
   end

--- a/test/components/viral/form/help_text_component_test.rb
+++ b/test/components/viral/form/help_text_component_test.rb
@@ -8,19 +8,19 @@ module Viral
       def test_default
         render_preview(:default)
 
-        assert_selector 'p.text-slate-500', text: 'Default help text!'
+        assert_selector 'span.text-slate-500', text: 'Default help text!'
       end
 
       def test_success
         render_preview(:success)
 
-        assert_selector 'p.text-green-600', text: 'Success help text!'
+        assert_selector 'span.text-green-600', text: 'Success help text!'
       end
 
       def test_error
         render_preview(:error)
 
-        assert_selector 'p.text-red-600', text: 'Error help text!'
+        assert_selector 'span.text-red-600', text: 'Error help text!'
       end
     end
   end

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -20,7 +20,7 @@ module Groups
 
       # header and description
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
 
       # table
       assert_selector 'tr', count: 20 + header_row_count
@@ -46,7 +46,7 @@ module Groups
       visit group_bots_path(groups(:group_two))
 
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
 
       assert_selector 'tr', count: 0
 
@@ -65,7 +65,7 @@ module Groups
       visit group_bots_path(namespace)
 
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
 
       assert_selector 'a', text: I18n.t(:'groups.bots.index.add_new_bot'), count: 1
 
@@ -116,7 +116,7 @@ module Groups
       visit group_bots_path(groups(:group_two))
 
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
 
       assert_selector 'a', text: I18n.t(:'groups.bots.index.add_new_bot'), count: 1
 
@@ -158,7 +158,7 @@ module Groups
       ### SETUP START ###
       visit group_bots_path(@namespace)
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###
@@ -191,7 +191,7 @@ module Groups
       token = @group_bot_active_tokens.first
       visit group_bots_path(@namespace)
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###
@@ -243,7 +243,7 @@ module Groups
       visit group_bots_path(@namespace)
       # verify page and table loaded
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###
@@ -287,7 +287,7 @@ module Groups
       visit group_bots_path(@namespace)
       # verify page rendered
       assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###

--- a/test/system/groups/metadata_templates_test.rb
+++ b/test/system/groups/metadata_templates_test.rb
@@ -17,7 +17,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       within('table thead tr') do
         assert_selector 'th', count: 6
@@ -58,7 +58,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       assert_no_selector 'table'
 
@@ -147,7 +147,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('groups.metadata_templates.index.new_button'), count: 1
 
@@ -202,7 +202,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('groups.metadata_templates.index.new_button'), count: 1
 
@@ -245,7 +245,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('groups.metadata_templates.index.new_button'), count: 1
 
@@ -288,7 +288,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('groups.metadata_templates.index.new_button'), count: 1
 
@@ -376,7 +376,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('groups.metadata_templates.index.new_button'), count: 1
 
@@ -442,7 +442,7 @@ module Groups
       visit group_metadata_templates_url(group)
 
       assert_selector 'h1', text: I18n.t('groups.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('groups.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('groups.metadata_templates.index.subtitle')
 
       assert_no_selector 'a', text: I18n.t('groups.metadata_templates.index.new_button')
     end

--- a/test/system/groups/workflow_executions_test.rb
+++ b/test/system/groups/workflow_executions_test.rb
@@ -28,7 +28,7 @@ module Groups
       visit group_workflow_executions_path(@group)
 
       assert_selector 'h1', text: I18n.t(:'groups.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.workflow_executions.index.subtitle')
 
       assert_selector '#workflow-executions-table table tbody tr', count: 11
     end
@@ -40,7 +40,7 @@ module Groups
       visit group_workflow_executions_path(@group)
 
       assert_selector 'h1', text: I18n.t(:'groups.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.workflow_executions.index.subtitle')
 
       click_on I18n.t(:'workflow_executions.table_component.run_id')
       assert_selector "#workflow-executions-table table thead th[aria-sort='ascending']",
@@ -321,7 +321,8 @@ module Groups
       assert_selector 'h1', text: @workflow_execution_group_shared1.name
       assert_selector 'dt', text: dt_value
 
-      assert_selector 'button', text: I18n.t(:'groups.workflow_executions.show.edit_button', locale: user.locale), count: 1
+      assert_selector 'button', text: I18n.t(:'groups.workflow_executions.show.edit_button', locale: user.locale),
+                                count: 1
       click_button I18n.t(:'groups.workflow_executions.show.edit_button', locale: user.locale)
 
       within('dialog') do
@@ -345,7 +346,7 @@ module Groups
       visit group_workflow_executions_path(@group)
 
       assert_selector 'h1', text: I18n.t(:'groups.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'groups.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'groups.workflow_executions.index.subtitle')
 
       within('#workflow-executions-table table tbody') do
         assert_selector 'tr', count: 11

--- a/test/system/projects/automated_workflow_executions_test.rb
+++ b/test/system/projects/automated_workflow_executions_test.rb
@@ -17,7 +17,7 @@ module Projects
       visit namespace_project_automated_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.automated_workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
 
       assert_selector 'tr', count: 3 + header_row_count
     end
@@ -27,7 +27,7 @@ module Projects
       visit namespace_project_automated_workflow_executions_path(@namespace, project)
 
       assert_selector 'h1', text: I18n.t(:'projects.automated_workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
 
       assert_selector 'tr', count: 0
 
@@ -42,7 +42,7 @@ module Projects
       visit namespace_project_automated_workflow_executions_path(@namespace, project)
 
       assert_selector 'h1', text: I18n.t(:'projects.automated_workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
 
       assert_selector(
         'button',
@@ -79,7 +79,7 @@ module Projects
     test 'can delete an automated workflow execution for a project' do
       visit namespace_project_automated_workflow_executions_path(@namespace, @project)
       assert_selector 'h1', text: I18n.t(:'projects.automated_workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
 
       within('table tbody tr:first-child') do
         click_button I18n.t(:'projects.automated_workflow_executions.actions.delete_button')
@@ -96,7 +96,7 @@ module Projects
     test 'can edit an automated workflow execution for a project' do
       visit namespace_project_automated_workflow_executions_path(@namespace, @project)
       assert_selector 'h1', text: I18n.t(:'projects.automated_workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
 
       within('table tbody tr:first-child') do
         click_button I18n.t(:'projects.automated_workflow_executions.actions.edit_button')

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -22,7 +22,7 @@ module Projects
 
       # header and description
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
 
       # table
       assert_selector 'tr', count: 20 + header_row_count
@@ -48,7 +48,7 @@ module Projects
       visit namespace_project_bots_path(@namespace, @project2)
 
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
 
       assert_selector 'tr', count: 0
 
@@ -66,7 +66,7 @@ module Projects
       visit namespace_project_bots_path(@namespace, @project2)
 
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
 
       assert_selector 'button', text: I18n.t(:'projects.bots.index.add_new_bot'), count: 1
 
@@ -116,7 +116,7 @@ module Projects
       visit namespace_project_bots_path(@namespace, @project2)
 
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
 
       assert_selector 'button', text: I18n.t(:'projects.bots.index.add_new_bot'), count: 1
 
@@ -158,7 +158,7 @@ module Projects
       ### SETUP START ###
       visit namespace_project_bots_path(@namespace, @project)
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###
@@ -192,7 +192,7 @@ module Projects
       visit namespace_project_bots_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###
@@ -243,7 +243,7 @@ module Projects
       visit namespace_project_bots_path(@namespace, @project)
       # verify page and table loaded
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###
@@ -289,7 +289,7 @@ module Projects
       visit namespace_project_bots_path(@namespace, @project)
       # verify page rendered
       assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.bots.index.subtitle')
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 21,
                                                                            locale: @user.locale))
       ### SETUP END ###

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -17,7 +17,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       within('table thead tr') do
         assert_selector 'th', count: 6
@@ -57,7 +57,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       assert_no_selector 'table'
 
@@ -154,7 +154,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('projects.metadata_templates.index.new_button'), count: 1
 
@@ -205,7 +205,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('projects.metadata_templates.index.new_button'), count: 1
 
@@ -245,7 +245,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('projects.metadata_templates.index.new_button'), count: 1
 
@@ -287,7 +287,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('projects.metadata_templates.index.new_button'), count: 1
 
@@ -371,7 +371,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       assert_selector 'button', text: I18n.t('projects.metadata_templates.index.new_button'), count: 1
 
@@ -431,7 +431,7 @@ module Projects
       visit namespace_project_metadata_templates_url(project.namespace.parent, project)
 
       assert_selector 'h1', text: I18n.t('projects.metadata_templates.index.title')
-      assert_selector 'p', text: I18n.t('projects.metadata_templates.index.subtitle')
+      assert_selector 'span', text: I18n.t('projects.metadata_templates.index.subtitle')
 
       assert_no_selector 'a', text: I18n.t('projects.metadata_templates.index.new_button')
     end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -263,7 +263,7 @@ module Projects
       assert_text I18n.t('projects.samples.create.success')
       # verify redirect to sample show page after successful sample creation
       assert_selector 'h1', text: 'New Name'
-      assert_selector 'p', text: 'A sample description'
+      assert_selector 'span', text: 'A sample description'
       # verify sample exists in samples table
       visit namespace_project_samples_url(@namespace, @project)
       # verify samples table has loaded to prevent flakes

--- a/test/system/projects/workflow_executions_test.rb
+++ b/test/system/projects/workflow_executions_test.rb
@@ -30,7 +30,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       assert_selector '#workflow-executions-table table tbody tr', count: WORKFLOW_EXECUTION_COUNT
     end
@@ -45,7 +45,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       click_on I18n.t(:'workflow_executions.table_component.run_id')
       assert_selector "#workflow-executions-table table thead th[aria-sort='ascending']",
@@ -134,7 +134,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -165,7 +165,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -182,7 +182,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -197,7 +197,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       # Select all workflow executions within the table
       click_button I18n.t(:'projects.workflow_executions.index.select_all_button')
@@ -244,7 +244,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -267,7 +267,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -284,7 +284,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -307,7 +307,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -324,7 +324,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       tr = find('a', text: workflow_execution.id).ancestor('tr')
 
@@ -368,7 +368,7 @@ module Projects
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_selector 'h1', text: I18n.t(:'projects.workflow_executions.index.title')
-      assert_selector 'p', text: I18n.t(:'projects.workflow_executions.index.subtitle')
+      assert_selector 'span', text: I18n.t(:'projects.workflow_executions.index.subtitle')
 
       # Select all workflow executions within the table
       click_button I18n.t(:'projects.workflow_executions.index.select_all_button')
@@ -465,7 +465,8 @@ module Projects
       ### VERIFY END ###
 
       ### ACTIONS START ###
-      assert_selector 'button', text: I18n.t(:'projects.workflow_executions.show.edit_button', locale: user.locale), count: 1
+      assert_selector 'button', text: I18n.t(:'projects.workflow_executions.show.edit_button', locale: user.locale),
+                                count: 1
       click_button I18n.t(:'projects.workflow_executions.show.edit_button', locale: user.locale)
 
       within('dialog') do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Hints and error messages on Create project form have been updated to use aria-describedby to link to ids of elements containing hints and error messages. Addresses the following:

- [STRY0018225](https://publichealthprod.service-now.com/rm_story.do?sys_id=a38c33db4739aa50f24c0c21516d43dc)
- [STRY0018229](https://publichealthprod.service-now.com/rm_story.do?sys_id=894d33db4739aa50f24c0c21516d435a)
- [STRY0018234](https://publichealthprod.service-now.com/rm_story.do?sys_id=a9dd7f1f4739aa50f24c0c21516d4350)
- [STRY0018252](https://publichealthprod.service-now.com/rm_story.do?sys_id=841fd1bb47f12e50f24c0c21516d43b6)
- [STRY0018251](https://publichealthprod.service-now.com/rm_story.do?sys_id=f7ce11bb47f12e50f24c0c21516d4310)
- [STRY0018235](https://publichealthprod.service-now.com/rm_story.do?sys_id=343fb39f4739aa50f24c0c21516d43be)

Form inputs now set aria-invalid when errors have been encountered.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/83b18254-c829-442a-af6a-fbb544df13eb)

![image](https://github.com/user-attachments/assets/d31b7823-0f0f-44c0-940f-fcd7bad6c5a7)

![image](https://github.com/user-attachments/assets/ba3c37e1-7d14-4c9f-9be3-8d633bb8a4e3)

![image](https://github.com/user-attachments/assets/202a1b31-968f-4fdc-b0a3-07d8879bb247)

![image](https://github.com/user-attachments/assets/3c015788-f6f5-46ba-84c0-6199f53d3f97)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
