### PR TITLE
Devise: Views accessibility

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -218,6 +218,14 @@ input[type="search"] {
   & textarea {
     @apply block w-full rounded-lg border border-slate-300 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:placeholder-slate-400;
   }
+
+  &.invalid input[type="email"] {
+    @apply block w-full rounded-lg border-red-500 text-slate-900 sm:text-sm dark:border-red-400 dark:bg-red-800 dark:text-white dark:placeholder-red-300;
+  }
+
+  &.invalid input[type="password"] {
+    @apply block w-full rounded-lg border-red-500 text-slate-900 sm:text-sm dark:border-red-400 dark:bg-red-800 dark:text-white dark:placeholder-red-300;
+  }
 }
 
 @utility field_with_errors {
@@ -296,6 +304,14 @@ input[type="search"] {
   }
 
   &.form-field textarea {
+    @apply border-red-500 bg-red-50 placeholder-red-700 dark:border-red-400 dark:bg-red-800 dark:placeholder-red-300;
+  }
+
+  &.form-field input[type="email"] {
+    @apply border-red-500 bg-red-50 placeholder-red-700 dark:border-red-400 dark:bg-red-800 dark:placeholder-red-300;
+  }
+
+  &.form-field input[type="password"] {
     @apply border-red-500 bg-red-50 placeholder-red-700 dark:border-red-400 dark:bg-red-800 dark:placeholder-red-300;
   }
 }

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -4,6 +4,8 @@
 class PasswordsController < Devise::PasswordsController
   layout 'devise'
 
+  before_action :page_title
+
   # GET /resource/password/new
   # def new
   #   super
@@ -33,5 +35,15 @@ class PasswordsController < Devise::PasswordsController
   # The path used after sending reset password instructions
   def after_sending_reset_password_instructions_path_for(resource_name)
     new_session_path(resource_name, { locale: params[:locale] || I18n.locale }) if is_navigational_format?
+  end
+
+  def page_title
+    case action_name
+
+    when 'new'
+      @title = t(:'devise.passwords.new.forgot_password')
+    when 'edit'
+      @title = t(:'devise.passwords.edit.reset_password')
+    end
   end
 end

--- a/app/controllers/profiles/passwords_controller.rb
+++ b/app/controllers/profiles/passwords_controller.rb
@@ -9,6 +9,7 @@ module Profiles
     # Get password page
     def edit
       authorize! @user
+      @minimum_password_length = User.password_length.min
     end
 
     # Update the user's password

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,6 +4,7 @@
 class RegistrationsController < Devise::RegistrationsController
   layout 'devise'
 
+  before_action :page_title
   before_action :configure_sign_up_params, :configure_account_update_params
 
   # GET /resource/sign_up
@@ -64,4 +65,8 @@ class RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  def page_title
+    @title = t(:'devise.registrations.new.register')
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,7 @@
 # Devise sessions controller
 class SessionsController < Devise::SessionsController
   layout 'devise'
+  before_action :page_title
 
   # before_action :configure_sign_in_params, only: [:create]
 
@@ -38,4 +39,8 @@ class SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  def page_title
+    @title = t(:'devise.sessions.new.login')
+  end
 end

--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -1,7 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["form", "submit"];
+  static targets = [
+    "form",
+    "submit",
+    "emailError",
+    "emailFieldDiv",
+    "emailField",
+  ];
   static values = {
     emailMissing: { type: String },
     emailFormat: { type: String },
@@ -59,7 +65,7 @@ export default class extends Controller {
   }
 
   #validateEmail() {
-    let email = document.getElementById("user_email");
+    let email = this.emailFieldTarget;
     let hasErrors = false;
 
     if (email.value === "") {
@@ -83,12 +89,10 @@ export default class extends Controller {
   }
 
   #addEmailFieldErrorState() {
-    let emailError = document.getElementById(
-      "forgot_password_email_error",
-    ).lastElementChild;
+    let emailError = this.emailErrorTarget.lastElementChild;
     let emailErrorSpan = emailError.getElementsByClassName("grow")[0];
-    let email = document.getElementById("user_email");
-    let emailField = document.getElementById("forgot_password_email_field");
+    let email = this.emailFieldTarget;
+    let emailField = this.emailFieldDivTarget;
 
     email.setAttribute("autofocus", true);
     email.setAttribute("aria-invalid", true);
@@ -102,12 +106,10 @@ export default class extends Controller {
   }
 
   #removeEmailFieldErrorState() {
-    let emailError = document.getElementById(
-      "forgot_password_email_error",
-    ).lastElementChild;
+    let emailError = this.emailErrorTarget.lastElementChild;
     let emailErrorSpan = emailError.getElementsByClassName("grow")[0];
-    let email = document.getElementById("user_email");
-    let emailField = document.getElementById("forgot_password_email_field");
+    let email = this.emailFieldTarget;
+    let emailField = this.emailFieldDivTarget;
 
     email.removeAttribute("autofocus", false);
     email.removeAttribute("aria-invalid");
@@ -121,10 +123,23 @@ export default class extends Controller {
   }
 
   #validateEmailFormat(email) {
-    return String(email)
-      .toLowerCase()
-      .match(
-        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|.(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-      );
+    // Basic format check
+    const basicEmailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!basicEmailRegex.test(email)) {
+      return false;
+    }
+
+    // Additional validation
+    const [localPart, domain] = email.split("@");
+
+    // Reasonable length checks
+    if (localPart.length > 64 || domain.length > 253) {
+      return false;
+    }
+
+    // Domain format check
+    const domainRegex =
+      /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+    return domainRegex.test(domain);
   }
 }

--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -1,0 +1,130 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["form", "submit"];
+  static values = {
+    emailMissing: { type: String },
+    emailFormat: { type: String },
+  };
+
+  #emailError = "";
+
+  #form_error_text_css = ["text-red-500"];
+
+  #email_error_state = [
+    "bg-slate-50",
+    "border",
+    "border-red-500",
+    "text-slate-900",
+    "text-sm",
+    "rounded-lg",
+    "block",
+    "w-full",
+    "p-2.5",
+    "dark:bg-slate-700",
+    "dark:border-slate-600",
+    "dark:placeholder-slate-400",
+    "dark:text-white",
+  ];
+
+  #email_valid_state = [
+    "bg-slate-50",
+    "border",
+    "border-slate-300",
+    "text-slate-900",
+    "text-sm",
+    "rounded-lg",
+    "block",
+    "w-full",
+    "p-2.5",
+    "dark:bg-slate-700",
+    "dark:border-slate-600",
+    "dark:placeholder-slate-400",
+    "dark:text-white",
+  ];
+
+  connect() {}
+
+  idempotentConnect() {}
+
+  submit(event) {
+    event.preventDefault();
+    setTimeout(() => {
+      let emailValid = this.#validateEmail();
+
+      if (emailValid) {
+        this.formTarget.submit();
+      }
+    }, 50);
+  }
+
+  #validateEmail() {
+    let email = document.getElementById("user_email");
+    let hasErrors = false;
+
+    if (email.value === "") {
+      this.#emailError = this.emailMissingValue;
+      hasErrors = true;
+    } else {
+      if (!this.#validateEmailFormat(email.value)) {
+        this.#emailError = this.emailFormatValue;
+        hasErrors = true;
+      }
+    }
+
+    if (hasErrors) {
+      this.#addEmailFieldErrorState();
+      return false;
+    } else {
+      this.#removeEmailFieldErrorState();
+    }
+
+    return true;
+  }
+
+  #addEmailFieldErrorState() {
+    let emailError = document.getElementById(
+      "forgot_password_email_error",
+    ).lastElementChild;
+    let emailErrorSpan = emailError.getElementsByClassName("grow")[0];
+    let email = document.getElementById("user_email");
+    let emailField = document.getElementById("forgot_password_email_field");
+
+    email.setAttribute("autofocus", true);
+    email.setAttribute("aria-invalid", true);
+    email.setAttribute("aria-describedBy", "forgot_password_email_error");
+    email.classList.remove(...this.#email_valid_state);
+    email.classList.add(...this.#email_error_state);
+    emailError.classList.remove("hidden");
+    emailErrorSpan.innerHTML = this.#emailError;
+    emailErrorSpan.classList.add(...this.#form_error_text_css);
+    emailField.classList.add("invalid");
+  }
+
+  #removeEmailFieldErrorState() {
+    let emailError = document.getElementById(
+      "forgot_password_email_error",
+    ).lastElementChild;
+    let emailErrorSpan = emailError.getElementsByClassName("grow")[0];
+    let email = document.getElementById("user_email");
+    let emailField = document.getElementById("forgot_password_email_field");
+
+    email.removeAttribute("autofocus", false);
+    email.removeAttribute("aria-invalid");
+    email.removeAttribute("aria-describedBy");
+    email.classList.remove(...this.#email_error_state);
+    email.classList.add(...this.#email_valid_state);
+    emailError.classList.add("hidden");
+    emailErrorSpan.innerHTML = "";
+    emailErrorSpan.classList.remove(...this.#form_error_text_css);
+    emailField.classList.remove("invalid");
+  }
+
+  #validateEmailFormat(email) {
+    return String(email)
+      .toLowerCase()
+      .match(
+        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|.(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+      );
+  }
+}

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -10,7 +10,13 @@
 
     <div class="form-field">
       <%= f.label :password, t(".password_label"), data: { required: true } %>
-      <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+      <%= f.password_field :password,
+                       autofocus: true,
+                       required: true,
+                       aria: {
+                         required: true,
+                       },
+                       autocomplete: "new-password" %>
     </div>
 
     <div class="form-field">
@@ -19,7 +25,12 @@
               data: {
                 required: true,
               } %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      <%= f.password_field :password_confirmation,
+                       required: true,
+                       aria: {
+                         required: true,
+                       },
+                       autocomplete: "new-password" %>
     </div>
 
     <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,3 @@
-<h2><%= t(".title") %></h2>
-
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
@@ -7,21 +5,24 @@
 
   <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, t(".password_label") %><br/>
-    <% if @minimum_password_length %>
-      <em><%= t(".password_hint", minimum_password_length: @minimum_password_length) %></em><br/>
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
+  <div class="space-y-4">
+    <%= render partial: "shared/form/required_field_legend" %>
 
-  <div class="field">
-    <%= f.label :password_confirmation, t(".password_confirmation_label") %><br/>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="form-field">
+      <%= f.label :password, t(".password_label"), data: { required: true } %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit t(".submit_button") %>
+    <div class="form-field">
+      <%= f.label :password_confirmation,
+              t(".password_confirmation_label"),
+              data: {
+                required: true,
+              } %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
+
+    <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,8 +1,10 @@
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4", novalidate: true }) do |f| %>
   <%= render "devise/shared/hidden_locale_input" %>
 
+  <%= render partial: "shared/form/required_field_legend" %>
+
   <div class="form-field">
-    <%= f.label :email %>
+    <%= f.label :email, data: { required: true } %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,11 +1,19 @@
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4", novalidate: true }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
   <%= render "devise/shared/hidden_locale_input" %>
 
-  <%= render partial: "shared/form/required_field_legend" %>
+  <div class="form-field">
+    <%= render partial: "shared/form/required_field_legend" %>
+  </div>
 
   <div class="form-field">
     <%= f.label :email, data: { required: true } %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email,
+                  autofocus: true,
+                  required: true,
+                  aria: {
+                    required: true,
+                  },
+                  autocomplete: "email" %>
   </div>
 
   <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,15 +9,26 @@
 
       <%= render partial: "shared/form/required_field_legend" %>
 
-      <div id="forgot_password_email_field" class="form-field">
+      <div
+        id="forgot_password_email_field"
+        data-email-input-target="emailFieldDiv"
+        class="form-field"
+      >
         <%= f.label :email, data: { required: true } %>
         <%= f.email_field :email,
                       autofocus: true,
                       aria: {
                         required: true,
                       },
-                      autocomplete: "email" %>
-        <div id="forgot_password_email_error" class="mt-2 text-sm">
+                      autocomplete: "email",
+                      data: {
+                        email_input_target: "emailField",
+                      } %>
+        <div
+          id="forgot_password_email_error"
+          data-email-input-target="emailError"
+          class="mt-2 text-sm"
+        >
           <%= viral_help_text(state: :error, classes: "hidden") %>
         </div>
       </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,9 +1,7 @@
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
   <%= render "devise/shared/hidden_locale_input" %>
 
-  <div class="form-field">
-    <%= render partial: "shared/form/required_field_legend" %>
-  </div>
+  <%= render partial: "shared/form/required_field_legend" %>
 
   <div class="form-field">
     <%= f.label :email, data: { required: true } %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,21 +1,38 @@
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
-  <%= render "devise/shared/hidden_locale_input" %>
+<div
+  data-controller="email-input"
+  data-email-input-email-missing-value="<%= t('devise.passwords.new.email.required_error') %>"
+  data-email-input-email-format-value="<%= t('devise.passwords.new.email.format_error') %>"
+>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), data: {email_input_target: "form"}, html: { method: :post, class: "space-y-4" }) do |f| %>
+    <div class="space-y-4">
+      <%= render "devise/shared/hidden_locale_input" %>
 
-  <%= render partial: "shared/form/required_field_legend" %>
+      <%= render partial: "shared/form/required_field_legend" %>
 
-  <div class="form-field">
-    <%= f.label :email, data: { required: true } %>
-    <%= f.email_field :email,
-                  autofocus: true,
-                  required: true,
-                  aria: {
-                    required: true,
-                  },
-                  autocomplete: "email" %>
-  </div>
+      <div id="forgot_password_email_field" class="form-field">
+        <%= f.label :email, data: { required: true } %>
+        <%= f.email_field :email,
+                      autofocus: true,
+                      aria: {
+                        required: true,
+                      },
+                      autocomplete: "email" %>
+        <div id="forgot_password_email_error" class="mt-2 text-sm">
+          <%= viral_help_text(state: :error, classes: "hidden") %>
+        </div>
+      </div>
 
-  <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>
-<% end %>
+      <div>
+        <%= f.submit t(".submit_button"),
+                 class: "button button-primary w-full",
+                 data: {
+                   input_target: "submit",
+                   action: "click->email-input#submit",
+                 } %>
+      </div>
+    </div>
+  <% end %>
+</div>
 
 <div class="grid gap-2">
   <%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,11 +2,12 @@
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
+  <%= render partial: "shared/form/required_field_legend" %>
 
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
   <div class="form-field">
-    <%= f.label :email %><br/>
+    <%= f.label :email, data: { required: true } %><br/>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
@@ -15,7 +16,7 @@
   <% end %>
 
   <div class="form-field">
-    <%= f.label :password %>
+    <%= f.label :password, data: { required: true } %>
     <i><%= t(".password_blank_hint") %></i><br/>
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
@@ -25,12 +26,12 @@
   </div>
 
   <div class="form-field">
-    <%= f.label :password_confirmation %><br/>
+    <%= f.label :password_confirmation, data: { required: true } %><br/>
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="form-field">
-    <%= f.label :current_password %>
+    <%= f.label :current_password, data: { required: true } %>
     <i><%= t(".current_password_hint") %></i><br/>
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,8 +6,6 @@
 
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
-  <%= resource.errors.full_messages %>
-
   <div class="form-field">
     <%= f.label :email, data: { required: true } %><br/>
     <%= f.email_field :email,

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,14 +1,22 @@
 <h2><%= t(".title", resource_name: resource_name.to_s.humanize) %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, novalidate: true }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= render partial: "shared/form/required_field_legend" %>
 
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
+  <%= resource.errors.full_messages %>
+
   <div class="form-field">
     <%= f.label :email, data: { required: true } %><br/>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email,
+                  autofocus: true,
+                  required: true,
+                  aria: {
+                    required: true,
+                  },
+                  autocomplete: "email" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -18,7 +26,12 @@
   <div class="form-field">
     <%= f.label :password, data: { required: true } %>
     <i><%= t(".password_blank_hint") %></i><br/>
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.password_field :password,
+                     required: true,
+                     aria: {
+                       required: true,
+                     },
+                     autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br/>
       <em><%= t(".password_length_hint", minimum_password_length: @minimum_password_length) %></em>
@@ -27,13 +40,23 @@
 
   <div class="form-field">
     <%= f.label :password_confirmation, data: { required: true } %><br/>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation,
+                     required: true,
+                     aria: {
+                       required: true,
+                     },
+                     autocomplete: "new-password" %>
   </div>
 
   <div class="form-field">
     <%= f.label :current_password, data: { required: true } %>
     <i><%= t(".current_password_hint") %></i><br/>
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
+    <%= f.password_field :current_password,
+                     required: true,
+                     aria: {
+                       required: true,
+                     },
+                     autocomplete: "current-password" %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,14 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4", novalidate: true }) do |f| %>
+  <%= if resource.errors.any?
+    viral_alert(
+      type: "alert",
+      message: I18n.t(:"general.form.error_notification"),
+      aria: {
+        live: "assertive",
+      },
+    )
+  end %>
+
   <%= render partial: "shared/form/required_field_legend" %>
 
   <%= render "devise/shared/hidden_locale_input", form: f %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,38 +1,112 @@
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4" }, novalidate: true) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4", novalidate: true }) do |f| %>
   <%= render partial: "shared/form/required_field_legend" %>
 
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
-  <div class="form-field">
+  <% invalid_email = resource.errors.include?(:email) %>
+  <div class="form-field <%= 'invalid' if invalid_email %>">
     <%= f.label :email, data: { required: true } %>
-    <%= f.email_field :email, autofocus: true, required: true, autocomplete: "email" %>
+    <%= f.email_field :email,
+                  autofocus: true,
+                  required: true,
+                  aria: {
+                    describedby: invalid_email ? f.field_id(:email, "error") : nil,
+                    invalid: invalid_email,
+                    required: true,
+                  },
+                  autocomplete: "email" %>
+    <%= if invalid_email
+      render "shared/form/field_errors",
+      id: f.field_id(:email, "error"),
+      errors: resource.errors.full_messages_for(:email)
+    end %>
   </div>
 
-  <div class="form-field">
+  <% invalid_first_name = resource.errors.include?(:first_name) %>
+  <div class="form-field <%= 'invalid' if invalid_first_name %>">
     <%= f.label :first_name, data: { required: true } %>
-    <%= f.text_field :first_name, required: true, autocomplete: "given-name" %>
+    <%= f.text_field :first_name,
+                 required: true,
+                 aria: {
+                   describedby:
+                     invalid_first_name ? f.field_id(:first_name, "error") : nil,
+                   invalid: invalid_first_name,
+                   required: true,
+                 },
+                 autocomplete: "given-name" %>
+    <%= if invalid_first_name
+      render "shared/form/field_errors",
+      id: f.field_id(:first_name, "error"),
+      errors: resource.errors.full_messages_for(:first_name)
+    end %>
   </div>
 
-  <div class="form-field">
+  <% invalid_last_name = resource.errors.include?(:last_name) %>
+  <div class="form-field <%= 'invalid' if invalid_first_name %>">
     <%= f.label :last_name, data: { required: true } %>
-    <%= f.text_field :last_name, required: true, autocomplete: "family-name" %>
+    <%= f.text_field :last_name,
+                 required: true,
+                 aria: {
+                   describedby:
+                     invalid_last_name ? f.field_id(:last_name, "error") : nil,
+                   invalid: invalid_last_name,
+                   required: true,
+                 },
+                 autocomplete: "family-name" %>
+    <%= if invalid_last_name
+      render "shared/form/field_errors",
+      id: f.field_id(:last_name, "error"),
+      errors: resource.errors.full_messages_for(:last_name)
+    end %>
   </div>
 
-  <div class="form-field">
+  <% invalid_password = resource.errors.include?(:password) %>
+  <div class="form-field <%= 'invalid' if invalid_password %>">
     <%= f.label :password, data: { required: true } %>
+    <%= f.password_field :password,
+                     required: true,
+                     aria: {
+                       describedby:
+                         invalid_password ? f.field_id(:password, "error") : nil,
+                       invalid: invalid_password,
+                       required: true,
+                     },
+                     autocomplete: "new-password" %>
+
     <% if @minimum_password_length %>
       <span class="text-sm font-light text-slate-500 dark:text-slate-400"><%= t(".password_hint", minimum_password_length: @minimum_password_length) %></span>
     <% end %>
-    <%= f.password_field :password, required: true, autocomplete: "new-password" %>
+    <%= if invalid_password
+      render "shared/form/field_errors",
+      id: f.field_id(:password, "error"),
+      errors: resource.errors.full_messages_for(:password)
+    end %>
   </div>
 
-  <div class="form-field">
+  <% invalid_password_confirmation = resource.errors.include?(:password_confirmation) %>
+  <div class="form-field <%= 'invalid' if invalid_password_confirmation %>">
     <%= f.label :password_confirmation, data: { required: true } %>
     <%= f.password_field :password_confirmation,
                      required: true,
+                     aria: {
+                       describedby:
+                         (
+                           if invalid_password_confirmation
+                             f.field_id(:password_confirmation, "error")
+                           else
+                             nil
+                           end
+                         ),
+                       invalid: invalid_password_confirmation,
+                       required: true,
+                     },
                      autocomplete: "new-password" %>
+
+    <%= if invalid_password_confirmation
+      render "shared/form/field_errors",
+      id: f.field_id(:password_confirmation, "error"),
+      errors: resource.errors.full_messages_for(:password_confirmation)
+    end %>
   </div>
 
   <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,25 +1,27 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4" }, novalidate: true) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
+  <%= render partial: "shared/form/required_field_legend" %>
+
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
   <div class="form-field">
-    <%= f.label :email %>
+    <%= f.label :email, data: { required: true } %>
     <%= f.email_field :email, autofocus: true, required: true, autocomplete: "email" %>
   </div>
 
   <div class="form-field">
-    <%= f.label :first_name %>
+    <%= f.label :first_name, data: { required: true } %>
     <%= f.text_field :first_name, required: true, autocomplete: "given-name" %>
   </div>
 
   <div class="form-field">
-    <%= f.label :last_name %>
+    <%= f.label :last_name, data: { required: true } %>
     <%= f.text_field :last_name, required: true, autocomplete: "family-name" %>
   </div>
 
   <div class="form-field">
-    <%= f.label :password %>
+    <%= f.label :password, data: { required: true } %>
     <% if @minimum_password_length %>
       <span class="text-sm font-light text-slate-500 dark:text-slate-400"><%= t(".password_hint", minimum_password_length: @minimum_password_length) %></span>
     <% end %>
@@ -27,7 +29,7 @@
   </div>
 
   <div class="form-field">
-    <%= f.label :password_confirmation %>
+    <%= f.label :password_confirmation, data: { required: true } %>
     <%= f.password_field :password_confirmation,
                      required: true,
                      autocomplete: "new-password" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -52,7 +52,7 @@
   </div>
 
   <% invalid_last_name = resource.errors.include?(:last_name) %>
-  <div class="form-field <%= 'invalid' if invalid_first_name %>">
+  <div class="form-field <%= 'invalid' if invalid_last_name %>">
     <%= f.label :last_name, data: { required: true } %>
     <%= f.text_field :last_name,
                  required: true,

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,27 +1,27 @@
 <% if resource.errors.any? %>
   <div
-    id="error_explanation"
     class="
-      p-4 mb-4 border-l-4 text-red-800 border-red-300 bg-red-50 dark:text-red-400
-      dark:bg-slate-800 dark:border-red-800
+      bg-red-50 border-l-4 border-red-300 dark:bg-slate-800 dark:border-red-800
+      dark:text-red-400 flex items-center p-4 text-red-800
     "
-    data-turbo-cache="false"
+    role="alert"
   >
-    <h2 class="mb-2 font-semibold text-red-600">
-      <%= I18n.t(
-        "errors.messages.not_saved",
-        count: resource.errors.count,
-        resource: resource.class.model_name.human.downcase,
-      ) %>
-    </h2>
-    <ul
-      class="
-        max-w-md space-y-1 text-red-500 list-disc list-inside dark:text-slate-400
-      "
-    >
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+    <div>
+      <span class="font-semibold">
+        <%= I18n.t(
+          "errors.messages.not_saved",
+          count: resource.errors.count,
+          resource: resource.class.model_name.human.downcase,
+        ) %></span>
+      <ul
+        class="
+          mt-1.5 list-disc list-inside space-y-3 max-h-60 md:max-h-80 overflow-y-auto p-1
+        "
+      >
+        <% resource.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 <% end %>

--- a/app/views/devise/shared/_form.html.erb
+++ b/app/views/devise/shared/_form.html.erb
@@ -8,12 +8,23 @@
 
   <div class="form-field">
     <%= f.label :email, data: { required: true } %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email,
+                  autofocus: true,
+                  required: true,
+                  aria: {
+                    required: true,
+                  },
+                  autocomplete: "email" %>
   </div>
 
   <div class="form-field">
     <%= f.label :password, data: { required: true } %>
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.password_field :password,
+                     required: true,
+                     aria: {
+                       required: true,
+                     },
+                     autocomplete: "current-password" %>
   </div>
 
   <% if devise_mapping.rememberable? %>

--- a/app/views/devise/shared/_form.html.erb
+++ b/app/views/devise/shared/_form.html.erb
@@ -2,15 +2,17 @@
 
   <%= render "devise/shared/hidden_locale_input" %>
 
+  <%= render partial: "shared/form/required_field_legend" %>
+
   <input type="hidden" name="local" value="<%=params[:local]%>"/>
 
   <div class="form-field">
-    <%= f.label :email %>
+    <%= f.label :email, data: { required: true } %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="form-field">
-    <%= f.label :password %>
+    <%= f.label :password, data: { required: true } %>
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 

--- a/app/views/profiles/passwords/_form.html.erb
+++ b/app/views/profiles/passwords/_form.html.erb
@@ -7,14 +7,28 @@
       <%= t :"profiles.passwords.update.subtitle" %>
     </p>
   </div>
-  <%= form_with(model: user, url: profile_password_path, method: :patch) do |form| %>
+  <%= form_with(model: user, url: profile_password_path, method: :patch, html: {class: "space-y-4", novalidate: true}) do |form| %>
     <% invalid_current = user.errors.include?(:current_password) %>
     <div class="form-field <%= 'invalid' if invalid_current %>">
       <%= form.label :current_password %>
       <%= form.password_field :current_password,
                           required: true,
+                          aria: {
+                            describedby: [
+                              (
+                                if invalid_current
+                                  form.field_id(:current_password, "error")
+                                else
+                                  nil
+                                end
+                              ),
+                              form.field_id(:current_password, "hint"),
+                            ].join(" "),
+                            invalid: invalid_current,
+                            required: true,
+                          },
                           autocomplete: "current-password" %>
-      <p class="field-hint"><%= t :"profiles.passwords.update.hint" %></p>
+      <p id="<%= form.field_id(:current_password, "hint") %>" class="field-hint"><%= t :"profiles.passwords.update.hint" %></p>
       <%= render "shared/form/field_errors",
       errors: user.errors.full_messages_for(:current_password) %>
     </div>
@@ -22,7 +36,31 @@
     <% invalid_password = user.errors.include?(:password) %>
     <div class="form-field <%= 'invalid' if invalid_password %>">
       <%= form.label :password %>
-      <%= form.password_field :password, required: true, autocomplete: "new-password" %>
+      <%= form.password_field :password,
+                          required: true,
+                          aria: {
+                            describedby: [
+                              (
+                                if invalid_password
+                                  form.field_id(:password, "error")
+                                else
+                                  nil
+                                end
+                              ),
+                              form.field_id(:password, "hint"),
+                            ].join(" "),
+                            invalid: invalid_password,
+                            required: true,
+                          },
+                          autocomplete: "new-password" %>
+      <% if @minimum_password_length %>
+        <p id="<%= form.field_id(:password, "hint") %>" class="field-hint">
+          <%== t(
+            "devise.passwords.edit.password_hint",
+            minimum_password_length: @minimum_password_length,
+          ) %>
+        </p>
+      <% end %>
       <%= render "shared/form/field_errors",
       errors: user.errors.full_messages_for(:password) %>
     </div>
@@ -32,6 +70,18 @@
       <%= form.label :password_confirmation %>
       <%= form.password_field :password_confirmation,
                           required: true,
+                          aria: {
+                            describedby:
+                              (
+                                if invalid_password_confirmation
+                                  form.field_id(:password_confirmation, "error")
+                                else
+                                  nil
+                                end
+                              ),
+                            invalid: invalid_password_confirmation,
+                            required: true,
+                          },
                           autocomplete: "new-password" %>
       <%= render "shared/form/field_errors",
       errors: user.errors.full_messages_for(:password_confirmation) %>

--- a/app/views/profiles/passwords/_form.html.erb
+++ b/app/views/profiles/passwords/_form.html.erb
@@ -8,6 +8,17 @@
     </p>
   </div>
   <%= form_with(model: user, url: profile_password_path, method: :patch, html: {class: "space-y-4", novalidate: true}) do |form| %>
+
+    <%= if user.errors.any?
+      viral_alert(
+        type: "alert",
+        message: I18n.t(:"general.form.error_notification"),
+        aria: {
+          live: "assertive",
+        },
+      )
+    end %>
+
     <% invalid_current = user.errors.include?(:current_password) %>
     <div class="form-field <%= 'invalid' if invalid_current %>">
       <%= form.label :current_password %>

--- a/app/views/shared/form/_required_field_legend.html.erb
+++ b/app/views/shared/form/_required_field_legend.html.erb
@@ -1,3 +1,3 @@
 <span class="text-sm text-slate-500 dark:text-slate-300">
-  <span class="text-red-500 dark:text-red-500" aria-hidden="true">*</span><%= t("shared.form.required_field") %>
+  <span class="text-red-500 dark:text-red-500 mr-1" aria-hidden="true">*</span><%= t("shared.form.required_field") %>
 </span>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -44,6 +44,9 @@ en:
         submit_button: Change my password
         title: Change your password
       new:
+        email:
+          format_error: Invalid email format. Pleae enter an email address with the format xxx@yyy.zz
+          required_error: Email is required. Please enter a an email address.
         submit_button: Send me reset password instructions
       no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
       send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -45,8 +45,8 @@ en:
         title: Change your password
       new:
         email:
-          format_error: Invalid email format. Pleae enter an email address with the format xxx@yyy.zz
-          required_error: Email is required. Please enter a an email address.
+          format_error: Invalid email format. Please enter an email address with the format xxx@yyy.zzz
+          required_error: Email is required. Please enter a valid email address.
         submit_button: Send me reset password instructions
       no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
       send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -45,8 +45,8 @@ fr:
         title: Changer votre mot de passe
       new:
         email:
-          format_error: Invalid email format. Pleae enter an email address with the format xxx@yyy.zz
-          required_error: Email is required. Please enter a an email address.
+          format_error: Invalid email format. Please enter an email address with the format xxx@yyy.zzz
+          required_error: Email is required. Please enter a valid email address.
         submit_button: Envoyez-moi des instructions pour réinitialiser mon mot de passe
       no_token: Vous ne pouvez pas accéder à cette page si vous n’avez pas été dirigé vers celle-ci à partir d’un courriel de réinitialisation de mot de passe. Si vous tentez d’accéder à cette page à partir d’un courriel de réinitialisation de mot de passe, assurez-vous d’utiliser l’URL fournie au complet.
       send_instructions: Vous recevrez un courriel d’instructions sur la façon de réinitialiser votre mot de passe dans quelques minutes.

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -44,6 +44,9 @@ fr:
         submit_button: Changer mon mot de passe
         title: Changer votre mot de passe
       new:
+        email:
+          format_error: Invalid email format. Pleae enter an email address with the format xxx@yyy.zz
+          required_error: Email is required. Please enter a an email address.
         submit_button: Envoyez-moi des instructions pour réinitialiser mon mot de passe
       no_token: Vous ne pouvez pas accéder à cette page si vous n’avez pas été dirigé vers celle-ci à partir d’un courriel de réinitialisation de mot de passe. Si vous tentez d’accéder à cette page à partir d’un courriel de réinitialisation de mot de passe, assurez-vous d’utiliser l’URL fournie au complet.
       send_instructions: Vous recevrez un courriel d’instructions sur la façon de réinitialiser votre mot de passe dans quelques minutes.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -880,6 +880,18 @@ en:
   date:
     formats:
       iso: YYYY-MM-DD
+  devise:
+    passwords:
+      edit:
+        reset_password: Change Password
+      new:
+        forgot_password: Reset Password
+    registrations:
+      new:
+        register: Register
+    sessions:
+      new:
+        login: Login
   errors:
     messages:
       not_saved:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -880,6 +880,18 @@ fr:
   date:
     formats:
       iso: AAAA/MM/JJ
+  devise:
+    passwords:
+      edit:
+        reset_password: Change Password
+      new:
+        forgot_password: Reset Password
+    registrations:
+      new:
+        register: Register
+    sessions:
+      new:
+        login: Login
   errors:
     messages:
       not_saved:


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes contrast issues on devise pages, adds unique browser page titles, and adds visual cues for required fields for forms. The styling of the change password page was also updated to match the other devise views. Addresses the following:

- [STRY0018479](https://publichealthprod.service-now.com/rm_story.do?sys_id=eaaa8da6335e621061dd45659d5c7b3f)
- [STRY0018480](https://publichealthprod.service-now.com/rm_story.do?sys_id=59ea01e6335e621061dd45659d5c7bf9)
- [STRY0018482](https://publichealthprod.service-now.com/rm_story.do?sys_id=245bc5e6335e621061dd45659d5c7b23
)
- [STRY0018483](https://publichealthprod.service-now.com/rm_story.do?sys_id=aa6bc5a6335e621061dd45659d5c7b47)
- [STRY0018486](https://publichealthprod.service-now.com/rm_story.do?sys_id=9fabc12a335e621061dd45659d5c7b04)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

![image](https://github.com/user-attachments/assets/b7f4b73e-9770-4937-87d6-abcbc68be217)

![image](https://github.com/user-attachments/assets/25bd66f0-3156-432a-a605-ece4d539ee12)

![image](https://github.com/user-attachments/assets/c449281d-e882-412b-8d31-b4106d6aa22a)

![image](https://github.com/user-attachments/assets/08873f05-29ff-41ee-aa66-30abc926e004)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
