### PR TITLE
Fix: Broken Breadcrumb links

### DIFF
--- a/app/components/layout/breadcrumb_component.html.erb
+++ b/app/components/layout/breadcrumb_component.html.erb
@@ -18,7 +18,7 @@
           <% next if index == @links.length - 1 %>
           <%= dropdown.with_item(
             label: link[:name],
-            url: root_path + link[:path],
+            url: URI.join(root_url, link[:path]).to_s,
             data: {
               turbo_frame: "_top",
             },
@@ -41,7 +41,7 @@
         <% else %>
           <!-- Navigable link -->
           <%= link_to link[:name],
-          root_path + link[:path],
+          URI.join(root_url, link[:path]).to_s,
           class:
             "text-sm text-slate-600 dark:text-slate-400 hover:underline py-3 font-normal",
           data: {

--- a/app/javascript/controllers/breadcrumb_controller.js
+++ b/app/javascript/controllers/breadcrumb_controller.js
@@ -1,4 +1,4 @@
-// app/javascript/controllers/breadcrumb_controller.js
+// app/javascript/controllers/controller.js
 import { Controller } from "@hotwired/stimulus";
 
 /**

--- a/app/javascript/controllers/breadcrumb_controller.js
+++ b/app/javascript/controllers/breadcrumb_controller.js
@@ -1,4 +1,4 @@
-// app/javascript/controllers/controller.js
+// app/javascript/controllers/breacrumb_controller.js
 import { Controller } from "@hotwired/stimulus";
 
 /**

--- a/test/components/layout/breadcrumb_component_test.rb
+++ b/test/components/layout/breadcrumb_component_test.rb
@@ -37,12 +37,12 @@ module Layout
     test 'renders links correctly with the last item as the current page' do
       render_inline(Layout::BreadcrumbComponent.new(links: @links))
 
-      # Check for linked items - note the double slashes due to root_path + path concatenation
-      assert_selector "a[href='//']", text: 'Home'
-      assert_selector "a[href='//projects']", text: 'Projects'
+      # Check for linked items - note the http://test.host which is the default base url for tests
+      assert_selector "a[href='http://test.host/']", text: 'Home'
+      assert_selector "a[href='http://test.host/projects']", text: 'Projects'
 
       # The last item should be a span, not a link
-      assert_no_selector "a[href='//projects/my-project']"
+      assert_no_selector "a[href='http://test.host/projects/my-project']"
       assert_selector 'span[aria-current="page"]', text: 'My Project'
     end
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes broken breadcrumb links that was introduced in #1128. This reverts URL generation to use `URI.join` with `root_url` so that links actually point to the correct endpoint.

This was broken in alot of places but an easy place to verify is to navigate directly to a sample and then click the `Samples` link in the breadcrumb.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
