### PR TITLE
Devcontainer: Update sapporo config to fix permission issues

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -81,6 +81,7 @@ services:
       SAPPORO_PORT: 1122
       SAPPORO_RUN_SH: /app/sapporo/run_irida_next.sh
       SAPPORO_RUN_DIR: /opt/sapporo-runs
+      IRIDA_NEXT_PATH: /workspaces/irida-next
 
     ports:
       - "1122:1122"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -63,7 +63,7 @@ jobs:
           bin/rails assets:precompile
       - name: Run tests
         run: |
-          bin/rails test:all
+          bin/rails test:all --exclude test/integration/integration_sapporo_test.rb
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/sapporo.yml
+++ b/.github/workflows/sapporo.yml
@@ -69,4 +69,4 @@ jobs:
         run: sudo chmod -R 777 ${GITHUB_WORKSPACE}
       - name: Run tests
         run: |
-          bin/rails test test/integration/sapporo.rb
+          bin/rails test test/integration/integration_sapporo_test.rb

--- a/test/integration/integration_sapporo_test.rb
+++ b/test/integration/integration_sapporo_test.rb
@@ -6,7 +6,7 @@ require 'active_job_test_case'
 class IntegrationSapporoTest < ActiveJobTestCase
   def setup
     @workflow_execution = workflow_executions(:irida_next_example_end_to_end)
-    Rails.configuration.ga4gh_wes_server_endpoint = 'http://localhost:1122/'
+    Rails.configuration.ga4gh_wes_server_endpoint = ENV.fetch('GA4GH_WES_URL', 'http://localhost:1122/')
   end
 
   def teardown


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the sapporo config to pass `IRIDA_NEXT_PATH` env variable which due to a commit in phac-nml/sapporo-service (https://github.com/phac-nml/sapporo-service/commit/0fc5d97751ee073cc1cb69a52f7a69293254c720) it will chown the outputs to match the UID and GID of the IRIDA_NEXT_PATH folder.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Checkout this branch
2. Execute `Ctrl-Shift-P` in vscode
3. Type in `Rebuild Container` and hit enter
4. After rebuild run the following test `bin/rails test test/integration/integration_sapporo_test.rb`
5. Verify that both tests pass

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
