### PR TITLE
Hide clear button on search inputs

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -31,13 +31,9 @@ input[type="search"]::-webkit-search-results-decoration {
   display: none;
 }
 
-/* For Firefox */
+/* For Firefox and generic solution */
 input[type="search"] {
   -moz-appearance: none;
-}
-
-/* Generic solution using appearance property */
-input[type="search"] {
   appearance: textfield;
 }
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -20,6 +20,27 @@
   --layout-body-columns: 280px 1fr;
 }
 
+/* Hide search clear button across all browsers */
+/* For Webkit browsers (Chrome, Safari, Edge) */
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+}
+
+/* For Firefox */
+input[type="search"] {
+  -moz-appearance: none;
+}
+
+/* Generic solution using appearance property */
+input[type="search"] {
+  appearance: textfield;
+}
+
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Webkit and firefox browser search inputs have a clear input button that is not keyboard accessible.  This PR uses CSS to hide the button.

Addresses issue [STRY0018339](https://publichealthprod.service-now.com/rm_story.do?sys_id=987fa10a474e6610f24c0c21516d4363)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Go to the project samples page and try to search by name or PUID.  The clear button should not be displayed

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
