### PR TITLE
Scroll handling to hide toolbar when scrolling

### DIFF
--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -19,13 +19,14 @@
   data-turbo-prefetch="false"
 >
   <%= sidebar %>
-  <div class="relative content" data-layout-target="content">
+  <div class="relative content overflow-hidden" data-layout-target="content">
     <div
       data-layout-target="header"
       class="
         flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0 z-20 h-16
         -outline-offset-1 border-b border-slate-200 dark:border-slate-950
-        transition-transform duration-300 bg-white dark:bg-slate-800
+        transition-transform duration-300 ease-in-out bg-white dark:bg-slate-800
+        max-xl:transform will-change-transform
       "
     >
       <div
@@ -54,13 +55,14 @@
       id="main-content"
       tabindex="0"
       class="
-        @container max-xl:fixed xl:absolute bottom-0 left-0 right-0 p-4 overflow-y-auto
-        top-0 transition-all duration-300
+        @container max-xl:fixed xl:absolute bottom-0 left-0 right-0 p-4 top-16
+        transition-all duration-300 ease-in-out
       "
       data-action="scroll->layout#handleScroll"
       data-layout-target="mainContent"
+      style="overflow-y: auto; overflow-x: hidden; scrollbar-width: thin; padding-right: 10px;"
     >
-      <div class="mt-16 <%= @layout %>"><%= body %></div>
+      <div class="transition-all duration-300 <%= @layout %>"><%= body %></div>
     </main>
     <%= render ConfirmationComponent.new %>
     <div id="flashes" class="fixed flex flex-col top-5 right-6 z-50">

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -21,9 +21,11 @@
   <%= sidebar %>
   <div class="relative content" data-layout-target="content">
     <div
+      data-layout-target="header"
       class="
         flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0 z-20 h-16
         -outline-offset-1 border-b border-slate-200 dark:border-slate-950
+        transition-transform duration-300
       "
     >
       <div
@@ -53,8 +55,10 @@
       tabindex="0"
       class="
         @container max-xl:fixed xl:absolute bottom-0 left-0 right-0 p-4 overflow-y-auto
-        top-16
+        top-16 transition-all duration-300
       "
+      data-action="scroll->layout#handleScroll"
+      data-layout-target="mainContent"
     >
       <div class="<%= @layout %>"><%= body %></div>
     </main>

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -25,7 +25,7 @@
       class="
         flex px-4 max-xl:fixed xl:absolute top-0 left-0 right-0 z-20 h-16
         -outline-offset-1 border-b border-slate-200 dark:border-slate-950
-        transition-transform duration-300
+        transition-transform duration-300 bg-white dark:bg-slate-800
       "
     >
       <div
@@ -55,12 +55,12 @@
       tabindex="0"
       class="
         @container max-xl:fixed xl:absolute bottom-0 left-0 right-0 p-4 overflow-y-auto
-        top-16 transition-all duration-300
+        top-0 transition-all duration-300
       "
       data-action="scroll->layout#handleScroll"
       data-layout-target="mainContent"
     >
-      <div class="<%= @layout %>"><%= body %></div>
+      <div class="mt-16 <%= @layout %>"><%= body %></div>
     </main>
     <%= render ConfirmationComponent.new %>
     <div id="flashes" class="fixed flex flex-col top-5 right-6 z-50">

--- a/app/javascript/controllers/layout_controller.js
+++ b/app/javascript/controllers/layout_controller.js
@@ -129,16 +129,10 @@ export default class extends Controller {
     if (scrollTop > this.lastScrollTop) {
       // 🙈 Hide the header
       this.headerTarget.classList.add("-translate-y-full");
-      // ⬆️ Move the main content up
-      this.mainContentTarget.classList.remove("top-16");
-      this.mainContentTarget.classList.add("top-0");
     } else {
       // 👆 Scrolling up
       // 🙉 Show the header
       this.headerTarget.classList.remove("-translate-y-full");
-      // ⬇️ Move the main content down
-      this.mainContentTarget.classList.remove("top-0");
-      this.mainContentTarget.classList.add("top-16");
     }
 
     // 💾 Update the last scroll position

--- a/app/javascript/controllers/layout_controller.js
+++ b/app/javascript/controllers/layout_controller.js
@@ -1,52 +1,108 @@
 import { Controller } from "@hotwired/stimulus";
 
+/**
+ * @class LayoutController
+ * @classdesc Stimulus controller for managing the main layout, sidebar, and header behavior.
+ * @property {HTMLElement} layoutContainerTarget - The main container for the layout.
+ * @property {HTMLElement} expandButtonContainerTarget - The container for the expand button.
+ * @property {HTMLElement} linkTarget - A link element.
+ * @property {HTMLElement} contentTarget - The main content area.
+ * @property {HTMLElement} logoTarget - The logo element.
+ * @property {HTMLElement} sidebarOverlayTarget - The overlay for the sidebar.
+ * @property {HTMLElement} headerTarget - The header element.
+ * @property {HTMLElement} mainContentTarget - The main content container.
+ */
 export default class extends Controller {
   static targets = [
+    // The main layout container
     "layoutContainer",
+    // The button to expand the sidebar
     "expandButtonContainer",
+    // Links within the sidebar
     "link",
+    // The main content area of the page
     "content",
+    // The logo in the sidebar
     "logo",
+    // The overlay for the sidebar on mobile
     "sidebarOverlay",
+    // The header of the page
     "header",
+    // The main content area
     "mainContent",
   ];
 
+  /**
+   * Stimulus connect lifecycle method.
+   * Initializes the controller, sets the initial layout state from localStorage,
+   * and sets up the scroll listener.
+   * @returns {void}
+   */
   connect() {
-    // Need to determine the previous state
+    // 📦 Check for saved layout state in local storage
     if (localStorage.getItem("layout") === "collapsed") {
       this.collapse();
     }
+    // 📜 Initialize last scroll position
     this.lastScrollTop = 0;
   }
 
+  /**
+   * Stimulus disconnect lifecycle method.
+   * Cleans up event listeners when the controller is removed from the DOM.
+   * @returns {void}
+   */
   disconnect() {
+    // 🗑️ Remove event listener to prevent memory leaks
     this.contentTarget.removeEventListener(
       "click",
       this.boundHandleSidebarOverlayClick,
     );
   }
 
+  /**
+   * Collapses the sidebar.
+   * Adds CSS classes to collapse the sidebar and updates the layout state in localStorage.
+   * @returns {void}
+   */
   collapse() {
+    // 🤏 Collapse the sidebar
     this.layoutContainerTarget.classList.add("max-xl:collapsed", "collapsed");
+    // ▶️ Show the expand button
     this.expandButtonContainerTarget.classList.remove("xl:hidden");
+    // 💾 Save the collapsed state
     localStorage.setItem("layout", "collapsed");
   }
 
+  /**
+   * Expands the sidebar.
+   * Removes CSS classes to expand the sidebar and updates the layout state in localStorage.
+   * @returns {void}
+   */
   expand() {
+    // ▶️ Hide the expand button
     this.expandButtonContainerTarget.classList.add("xl:hidden");
+    // ↔️ Expand the sidebar
     this.layoutContainerTarget.classList.remove("collapsed");
     if (window.innerWidth < this.#convertRemToPixels(80)) {
       this.layoutContainerTarget.classList.remove("max-xl:collapsed");
     }
+    // 💾 Save the expanded state
     localStorage.setItem("layout", "expanded");
 
+    // 🔍 Focus on the logo after expanding
     setTimeout(() => {
       this.logoTarget.focus();
     }, 25);
   }
 
+  /**
+   * Handles focus events on the content area.
+   * Collapses the sidebar on smaller screens when the content area is focused.
+   * @returns {void}
+   */
   handleContentFocus() {
+    // 📱 Check if on a small screen
     if (window.innerWidth < this.#convertRemToPixels(80)) {
       if (
         !this.layoutContainerTarget.classList.contains(
@@ -54,30 +110,49 @@ export default class extends Controller {
           "collapsed",
         )
       ) {
+        // 🤏 Collapse the sidebar if it's expanded
         this.collapse();
       }
     }
   }
 
+  /**
+   * Handles scroll events on the main content area.
+   * Hides the header when scrolling down and shows it when scrolling up.
+   * @param {Event} event - The scroll event.
+   * @returns {void}
+   */
   handleScroll(event) {
     const { scrollTop } = event.target;
 
+    // 👇 Scrolling down
     if (scrollTop > this.lastScrollTop) {
-      // Scrolling down
+      // 🙈 Hide the header
       this.headerTarget.classList.add("-translate-y-full");
+      // ⬆️ Move the main content up
       this.mainContentTarget.classList.remove("top-16");
       this.mainContentTarget.classList.add("top-0");
     } else {
-      // Scrolling up
+      // 👆 Scrolling up
+      // 🙉 Show the header
       this.headerTarget.classList.remove("-translate-y-full");
+      // ⬇️ Move the main content down
       this.mainContentTarget.classList.remove("top-0");
       this.mainContentTarget.classList.add("top-16");
     }
 
+    // 💾 Update the last scroll position
     this.lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
   }
 
+  /**
+   * Converts rem units to pixels.
+   * @param {number} rem - The value in rem units.
+   * @returns {number} The equivalent value in pixels.
+   * @private
+   */
   #convertRemToPixels(rem) {
+    // 📏 Convert rem to pixels based on the root font size
     return (
       rem * parseFloat(getComputedStyle(document.documentElement).fontSize)
     );

--- a/app/javascript/controllers/layout_controller.js
+++ b/app/javascript/controllers/layout_controller.js
@@ -8,6 +8,8 @@ export default class extends Controller {
     "content",
     "logo",
     "sidebarOverlay",
+    "header",
+    "mainContent",
   ];
 
   connect() {
@@ -15,6 +17,7 @@ export default class extends Controller {
     if (localStorage.getItem("layout") === "collapsed") {
       this.collapse();
     }
+    this.lastScrollTop = 0;
   }
 
   disconnect() {
@@ -54,6 +57,24 @@ export default class extends Controller {
         this.collapse();
       }
     }
+  }
+
+  handleScroll(event) {
+    const { scrollTop } = event.target;
+
+    if (scrollTop > this.lastScrollTop) {
+      // Scrolling down
+      this.headerTarget.classList.add("-translate-y-full");
+      this.mainContentTarget.classList.remove("top-16");
+      this.mainContentTarget.classList.add("top-0");
+    } else {
+      // Scrolling up
+      this.headerTarget.classList.remove("-translate-y-full");
+      this.mainContentTarget.classList.remove("top-0");
+      this.mainContentTarget.classList.add("top-16");
+    }
+
+    this.lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
   }
 
   #convertRemToPixels(rem) {

--- a/app/javascript/controllers/layout_controller.js
+++ b/app/javascript/controllers/layout_controller.js
@@ -128,11 +128,11 @@ export default class extends Controller {
     // 👇 Scrolling down
     if (scrollTop > this.lastScrollTop) {
       // 🙈 Hide the header
-      this.headerTarget.classList.add("-translate-y-full");
+      this.headerTarget.classList.add("max-sm:-translate-y-full");
     } else {
       // 👆 Scrolling up
       // 🙉 Show the header
-      this.headerTarget.classList.remove("-translate-y-full");
+      this.headerTarget.classList.remove("max-sm:-translate-y-full");
     }
 
     // 💾 Update the last scroll position

--- a/app/javascript/controllers/layout_controller.js
+++ b/app/javascript/controllers/layout_controller.js
@@ -45,6 +45,9 @@ export default class extends Controller {
     }
     // 📜 Initialize last scroll position
     this.lastScrollTop = 0;
+    
+    // Ensure main content position is correctly set on initial load
+    this.mainContentTarget.style.top = "4rem"; // 16px/4rem is the header height
   }
 
   /**
@@ -128,11 +131,15 @@ export default class extends Controller {
     // 👇 Scrolling down
     if (scrollTop > this.lastScrollTop) {
       // 🙈 Hide the header
-      this.headerTarget.classList.add("max-sm:-translate-y-full");
+      this.headerTarget.classList.add("-translate-y-full");
+      // Adjust main content to fill the header space
+      this.mainContentTarget.style.top = "0";
     } else {
       // 👆 Scrolling up
       // 🙉 Show the header
-      this.headerTarget.classList.remove("max-sm:-translate-y-full");
+      this.headerTarget.classList.remove("-translate-y-full");
+      // Reset main content position
+      this.mainContentTarget.style.top = "4rem"; // 16px/4rem is the header height
     }
 
     // 💾 Update the last scroll position


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Currently, when zoomed into 400% the toolbar takes up a large portion of the screen.  With this PR, when the user scrolls to see more content, the toolbar smoothly moves off the screen, and when they scroll back up it comes back.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before scroll:
<img width="1745" height="1291" alt="image" src="https://github.com/user-attachments/assets/7a0d826a-39c1-4c20-b812-adbf33796c88" />

With scroll:
<img width="1745" height="1291" alt="image" src="https://github.com/user-attachments/assets/6ee29308-33c4-443a-be46-ca2e1a58e79b" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Go to pretty much any page with content
2. Set the width to 1280
3. Zoom in to 400%
4. Scrolling

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
