### PR TITLE
Fix: has_puid retry logic

### DIFF
--- a/test/models/concerns/has_puid_test.rb
+++ b/test/models/concerns/has_puid_test.rb
@@ -37,4 +37,18 @@ class HasPuidTest < ActionDispatch::IntegrationTest
     assert @sample.puid
     assert_nil clone.puid
   end
+
+  test 'puid conflict retry' do
+    puid = @sample.puid
+
+    @sample.generate_puid
+    assert_equal puid, @sample.puid
+
+    sample = Sample.new(name: "#{@sample.name} copy", puid: puid, project_id: @sample.project_id)
+
+    assert_equal puid, sample.puid
+    sample.save
+
+    assert_not_equal puid, sample.puid
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

PUID retry logic was failing due to postgres invalidating the transaction upon encountering the uniqueness violation. Now we specifically use a new 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

```
$ bin/rails c
Loading development environment (Rails 8.0.2)
irida(dev)> sample = Sample.create(name: "balh", puid: Sample.last.puid, project_id: Sample.last.project_id)
  Sample Load (1.5ms)  SELECT "samples"."id", "samples"."name", "samples"."description", "samples"."created_at", "samples"."updated_at", "samples"."deleted_at", "samples"."metadata", "samples"."metadata_provenance", "samples"."puid", "samples"."project_id", "samples"."attachments_updated_at" FROM "samples" WHERE "samples"."deleted_at" IS NULL ORDER BY "samples"."created_at" DESC, "samples"."id" DESC LIMIT 1 /*application='Irida'*/
  Sample Load (1.2ms)  SELECT "samples"."id", "samples"."name", "samples"."description", "samples"."created_at", "samples"."updated_at", "samples"."deleted_at", "samples"."metadata", "samples"."metadata_provenance", "samples"."puid", "samples"."project_id", "samples"."attachments_updated_at" FROM "samples" WHERE "samples"."deleted_at" IS NULL ORDER BY "samples"."created_at" DESC, "samples"."id" DESC LIMIT 1 /*application='Irida'*/
  TRANSACTION (0.3ms)  BEGIN /*application='Irida'*/
  Project Load (0.5ms)  SELECT "projects".* FROM "projects" WHERE "projects"."deleted_at" IS NULL AND "projects"."id" = '5c3bd4c2-37b1-4a6b-93ea-21b2c956d043' LIMIT 1 /*application='Irida'*/
  Sample Exists? (4.7ms)  SELECT 1 AS one FROM "samples" WHERE "samples"."name" = 'balh' AND "samples"."deleted_at" IS NULL AND "samples"."project_id" = '5c3bd4c2-37b1-4a6b-93ea-21b2c956d043' LIMIT 1 /*application='Irida'*/
  TRANSACTION (0.2ms)  SAVEPOINT active_record_1 /*application='Irida'*/
  Sample Create (2.5ms)  INSERT INTO "samples" ("name", "description", "created_at", "updated_at", "deleted_at", "metadata", "metadata_provenance", "puid", "project_id", "attachments_updated_at") VALUES ('balh', NULL, '2025-08-05 16:21:32.769579', '2025-08-05 16:21:32.769579', NULL, '{}', '{}', 'INXT_SAM_AZIFRXA6GG', '5c3bd4c2-37b1-4a6b-93ea-21b2c956d043', NULL) RETURNING "id" /*application='Irida'*/
PUID conflict encountered for Sample, regenerating PUID and attempting to save again.
  TRANSACTION (0.2ms)  ROLLBACK TO SAVEPOINT active_record_1 /*application='Irida'*/
  TRANSACTION (0.1ms)  ROLLBACK /*application='Irida'*/
app/models/concerns/has_puid.rb:25:in 'block in Sample#create_or_update': PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_samples_on_puid" (ActiveRecord::RecordNotUnique)
DETAIL:  Key (puid)=(INXT_SAM_AZIFRXA6GG) already exists.

        from app/models/concerns/has_puid.rb:24:in 'Sample#create_or_update'
        from (irida):1:in '<main>'
/home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in 'PG::Connection#exec': ERROR:  duplicate key value violates unique constraint "index_samples_on_puid" (PG::UniqueViolation)
DETAIL:  Key (puid)=(INXT_SAM_AZIFRXA6GG) already exists.

        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:556:in 'block (2 levels) in ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:1015:in 'block in ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:984:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:555:in 'block in ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:1135:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#log'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:554:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:591:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:547:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_exec_query'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:159:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_insert'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:47:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#exec_insert'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:197:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#insert'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:27:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#insert'
        from /home/vscode/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/persistence.rb:257:in 'ActiveRecord::Persistence::ClassMethods#_insert_record'
        ... 81 levels...
```

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Open the rails console with `bin/rails c`
2. Attempt to create a new Sample with the same PUID as an existing sample
```
sample = Sample.create(name: "balh", puid: Sample.last.puid, project_id: Sample.last.project_id)
```
3. Observe that the sample saves

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
