### PR TITLE
 Fix: Group edit forms accessibility

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -140,7 +140,7 @@ input[type="search"] {
   }
 
   & input[type="text"].prefixed {
-    @apply rounded-l-none rounded-r-lg;
+    @apply rounded-l-none rounded-r-lg p-2.5;
   }
 
   & input[type="search"].prefixed {

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -30,9 +30,8 @@
                             required: true,
                             title: t(:"groups.create.path_help"),
                             aria: {
-                              describedby: [
+                              describedby:
                                 invalid_path ? form.field_id(:path, "error") : nil,
-                              ].join(" "),
                               invalid: invalid_path,
                               required: true,
                             },
@@ -41,6 +40,7 @@
           </div>
           <% if invalid_path %>
             <%= render "shared/form/field_errors",
+            id: form.field_id(:path, "error"),
             errors: @group.errors.full_messages_for(:path) %>
           <% end %>
         </div>

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -1,14 +1,15 @@
 <%= viral_card do |card| %>
   <% card.with_header(title: t(:"groups.edit.advanced.path.title")) %>
   <% card.with_section do %>
-    <%= form_with(model: @group, url: group_path, method: :patch) do |form| %>
+    <%= form_with(model: @group, url: group_path, method: :patch, html: { novalidate: true }) do |form| %>
       <div class="grid gap-4">
         <p class="text-slate-600 dark:text-slate-400">
           <%= t(:"groups.edit.advanced.path.description") %>
         </p>
+        <%= render partial: "shared/form/required_field_legend" %>
         <% invalid_path = @group.errors.include?(:path) %>
         <div class="form-field prefixed <%= 'invalid' if invalid_path %>">
-          <%= form.label :path %>
+          <%= form.label :path, data: { required: true } %>
           <div class="flex whitespace-nowrap items-center">
             <div
               class="
@@ -28,10 +29,20 @@
                             pattern: Irida::PathRegex::PATH_REGEX_STR,
                             required: true,
                             title: t(:"groups.create.path_help"),
+                            aria: {
+                              describedby: [
+                                invalid_path ? form.field_id(:path, "error") : nil,
+                              ].join(" "),
+                              invalid: invalid_path,
+                              required: true,
+                            },
+                            autofocus: invalid_path,
                             class: "prefixed" %>
           </div>
-          <%= render "shared/form/field_errors",
-          errors: @group.errors.full_messages_for(:path) %>
+          <% if invalid_path %>
+            <%= render "shared/form/field_errors",
+            errors: @group.errors.full_messages_for(:path) %>
+          <% end %>
         </div>
         <div>
           <%= form.submit t(:"groups.edit.advanced.path.submit"),

--- a/app/views/groups/_edit_advanced_transfer_form.html.erb
+++ b/app/views/groups/_edit_advanced_transfer_form.html.erb
@@ -1,10 +1,12 @@
 <%= form_with(url: group_transfer_path, method: :put, class: "grid gap-4", id: "edit_advanced_transfer_form",
 data: { turbo_confirm: "", controller: "viral--select2" }) do |form| %>
+  <%= render partial: "shared/form/required_field_legend" %>
   <div class="form-field">
     <% form_id = "transfer_namespace_id_input" %>
     <label
       for="<%= form_id %>"
       class="mb-1 block text-sm font-medium text-slate-900 dark:text-white"
+      data-required="true"
     >
 
       <%= t("groups.edit.advanced.transfer.new_namespace_id") %>

--- a/app/views/groups/_edit_name_and_description_form.html.erb
+++ b/app/views/groups/_edit_name_and_description_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: group, url: group_path, method: :patch) do |form| %>
+<%= form_with(model: group, url: group_path, method: :patch, html: { novalidate: true }) do |form| %>
   <div class="grid gap-4">
     <%= render partial: "form_fields",
     locals: {

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,13 +1,3 @@
-<%= if group.errors.any?
-  viral_alert(
-    type: "alert",
-    message: I18n.t(:"general.form.error_notification"),
-    aria: {
-      live: "assertive",
-    },
-  )
-end %>
-
 <%= render partial: "shared/form/required_field_legend" %>
 
 <% invalid_name = group.errors.include?(:name) %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -6,6 +6,16 @@
   <%= form_with(model: @new_group, url: groups_path, method: :post, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
 
+      <%= if @new_group.errors.any?
+        viral_alert(
+          type: "alert",
+          message: I18n.t(:"general.form.error_notification"),
+          aria: {
+            live: "assertive",
+          },
+        )
+      end %>
+
       <%= render partial: "form_fields",
       locals: {
         form: form,

--- a/app/views/groups/new_subgroup.html.erb
+++ b/app/views/groups/new_subgroup.html.erb
@@ -7,6 +7,16 @@
   <%= form_with(model: @new_group, url: groups_path, method: :post, data: { controller: "viral--select2" }, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
 
+      <%= if @new_group.errors.any?
+        viral_alert(
+          type: "alert",
+          message: I18n.t(:"general.form.error_notification"),
+          aria: {
+            live: "assertive",
+          },
+        )
+      end %>
+
       <%= render partial: "form_fields",
       locals: {
         form: form,

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -195,6 +195,33 @@ class GroupsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'show errors when group name is left empty when editing' do
+    group_name = ''
+    visit group_url(groups(:group_one))
+
+    click_on I18n.t('groups.sidebar.settings')
+    click_link I18n.t('groups.sidebar.general')
+
+    fill_in I18n.t('activerecord.attributes.group.name'), with: group_name
+    click_on I18n.t('groups.edit.details.submit')
+
+    assert_text "Group name can't be blank"
+    assert_text 'Group name is too short (minimum is 3 characters)'
+  end
+
+  test 'show errors when group description is too long when editing' do
+    group_descrtiption = 'a' * 300
+    visit group_url(groups(:group_one))
+
+    click_on I18n.t('groups.sidebar.settings')
+    click_link I18n.t('groups.sidebar.general')
+
+    fill_in I18n.t('activerecord.attributes.group.description'), with: group_descrtiption
+    click_on I18n.t('groups.edit.details.submit')
+
+    assert_text 'Description is too long (maximum is 255 characters)'
+  end
+
   test 'can edit a group path' do
     group1 = groups(:group_one)
     visit group_url(group1)
@@ -207,6 +234,20 @@ class GroupsTest < ApplicationSystemTestCase
 
     assert_text I18n.t('groups.update.success', group_name: group1.name)
     assert_current_path '/-/groups/group-1-edited/-/edit'
+  end
+
+  test 'show error when editing a group path and leaving it blank' do
+    group1 = groups(:group_one)
+    visit group_url(group1)
+
+    click_on I18n.t('groups.sidebar.settings')
+    click_link I18n.t('groups.sidebar.general')
+
+    fill_in I18n.t('activerecord.attributes.group.path'), with: ''
+    click_on I18n.t('groups.edit.advanced.path.submit')
+
+    assert_text "Path can't be blank"
+    assert_text 'Path is too short (minimum is 3 characters)'
   end
 
   test 'show error when editing a group with a short name' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the forms on the group edit page to display visual cues for required fields and linked error messages to input fields. **PR is not linked to any user stories but is a part of general accessibility issues addressed on forms within the application**

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2060" height="613" alt="image" src="https://github.com/user-attachments/assets/4372f3fb-796a-4e76-b557-0b5c84c629b0" />

<img width="1948" height="525" alt="image" src="https://github.com/user-attachments/assets/ec57a697-0174-4657-adc0-82e8f7f27eb2" />

<img width="1980" height="500" alt="image" src="https://github.com/user-attachments/assets/70dd445a-133d-4eb1-b55b-e7af0d74e2f8" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

1. Create a group
2. Go into the group settings (General)
3.  Verify that visual cues are present on the forms except for the delete
4. Remove the group name and try to update. Verify errors are displayed and are linked to the input via aria-describedby
5. Enter a description for the group which is longer than 255 characters and try to update. Verify errors are displayed and are linked to the input via aria-describedby
6. Remove the path and try to change the group url. Verify errors are displayed and linked to the input via aria-describedby


- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
