### PR TITLE
Fix: Sample new/edit forms accessibility

### DIFF
--- a/app/views/projects/samples/_form_fields.html.erb
+++ b/app/views/projects/samples/_form_fields.html.erb
@@ -1,15 +1,56 @@
+<%= if @sample.errors.any?
+  viral_alert(
+    type: "alert",
+    message: I18n.t(:"general.form.error_notification"),
+    aria: {
+      live: "assertive",
+    },
+  )
+end %>
+
+<%= render partial: "shared/form/required_field_legend" %>
+
 <% invalid_name = sample.errors.include?(:name) %>
 <div class="form-field <%= 'invalid' if invalid_name %>">
-  <%= form.label :name %>
-  <%= form.text_field :name, required: true, minlength: 3, maxlength: 255 %>
-  <%= render "shared/form/field_errors",
-  errors: sample.errors.full_messages_for(:name) %>
+  <%= form.label :name, data: { required: true } %>
+  <%= form.text_field :name,
+                  required: true,
+                  minlength: 3,
+                  maxlength: 255,
+                  aria: {
+                    describedby:
+                      invalid_name ? form.field_id(:name, "error") : nil,
+                    invalid: invalid_name,
+                    required: true,
+                  } %>
+
+  <% if invalid_name %>
+    <%= render "shared/form/field_errors",
+    id: form.field_id(:name, "error"),
+    errors: sample.errors.full_messages_for(:name) %>
+  <% end %>
 </div>
 
 <% invalid_description = sample.errors.include?(:description) %>
 <div class="form-field <%= 'invalid' if invalid_description %>">
   <%= form.label :description %>
-  <%= form.text_area :description, rows: 4 %>
-  <%= render "shared/form/field_errors",
-  errors: sample.errors.full_messages_for(:description) %>
+  <%= form.text_area :description,
+                 rows: 4,
+                 aria: {
+                   describedby:
+                     (
+                       if invalid_description
+                         form.field_id(:description, "error")
+                       else
+                         nil
+                       end
+                     ),
+                   invalid: invalid_description,
+                   required: true,
+                 } %>
+  <% if invalid_description %>
+    <%= render "shared/form/field_errors",
+    id: form.field_id(:description, "error"),
+    errors: sample.errors.full_messages_for(:description) %>
+  <% end %>
 </div>

--- a/app/views/projects/samples/edit.html.erb
+++ b/app/views/projects/samples/edit.html.erb
@@ -17,7 +17,7 @@
       >
         <%= t("projects.samples.edit.form.title") %>
       </h2>
-      <%= form_with(model: @sample, url: namespace_project_sample_path(id: @sample.id), data: {turbo: false}, method: :patch) do |form| %>
+      <%= form_with(model: @sample, url: namespace_project_sample_path(id: @sample.id), data: {turbo: false}, method: :patch, html: { novalidate: true}) do |form| %>
         <div class="grid gap-4">
           <%= render partial: "form_fields", locals: { form: form, sample: @sample } %>
           <div>

--- a/app/views/projects/samples/new.html.erb
+++ b/app/views/projects/samples/new.html.erb
@@ -10,7 +10,7 @@
         dark:border-slate-700 sm:p-6 dark:bg-slate-800
       "
     >
-      <%= form_with(model: @sample, url: namespace_project_samples_path, data: {turbo: false}, method: :post) do |form| %>
+      <%= form_with(model: @sample, url: namespace_project_samples_path, data: {turbo: false}, method: :post, html: { novalidate: true}) do |form| %>
         <div class="grid gap-4">
           <%= render partial: "form_fields", locals: { form: form, sample: @sample } %>
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the forms on the sample new and edit pages to display visual cues for required fields and linked error messages to input fields. **PR is not linked to any user stories but is a part of general accessibility issues addressed on forms within the application**

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1543" height="927" alt="image" src="https://github.com/user-attachments/assets/e9b7f322-364b-4187-b10d-3135b76bb3ca" />

<img width="1622" height="956" alt="image" src="https://github.com/user-attachments/assets/f15cd1ad-db6d-4bed-b037-4dc3b4169dd0" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Create a project
2. Verify required field cues are visible
3. Try to create a sample with no name and verify error messages are displayed and are linked to the input via aria-describedby
4. Create a sample, then edit it. Repeat step 3

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
