### PR TITLE
Fix: Member create modal forms accessibility 

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -314,6 +314,10 @@ input[type="search"] {
   &.form-field input[type="password"] {
     @apply border-red-500 bg-red-50 placeholder-red-700 dark:border-red-400 dark:bg-red-800 dark:placeholder-red-300;
   }
+
+  &.form-field select {
+    @apply border-red-500 bg-red-50 placeholder-red-700 dark:border-red-400 dark:bg-red-800 dark:placeholder-red-300;
+  }
 }
 
 @utility field-hint {

--- a/app/components/viral/select2_component.html.erb
+++ b/app/components/viral/select2_component.html.erb
@@ -13,6 +13,14 @@
       p-2.5 dark:bg-slate-800 dark:border-slate-600 dark:placeholder-slate-400
       dark:text-slate-50
     "
+    <% if selected_value.present? %>
+    value="<%= selected_value %>"
+    <% end %>
+    <% if aria_describedby.present? %>
+    aria-describedby="<%= aria_describedby %>"
+    <% end %>
+    aria-invalid="<%= aria_invalid %>"
+    aria-required="<%= aria_required %>"
   >
   <%= form.hidden_field name, data: { "viral--select2-target": "hidden" } %>
 

--- a/app/components/viral/select2_component.rb
+++ b/app/components/viral/select2_component.rb
@@ -3,17 +3,36 @@
 module Viral
   # Search component for rendering a searchable dropdown
   class Select2Component < Viral::Component
-    attr_reader :form, :name, :id, :placeholder, :required
+    attr_reader :form, :name, :id, :placeholder, :required, :selected_value, :aria_describedby, :aria_invalid,
+                :aria_required, :field_hint
 
     renders_many :options, Viral::Select2OptionComponent
     renders_one  :empty_state
 
-    def initialize(form:, name:, id:, placeholder: '', required: true)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(form:, name:, id:, placeholder: '', required: true, selected_value: '',
+                   aria_invalid: false, field_hint: false)
       @form = form
       @name = name
       @id = id
       @placeholder = placeholder
       @required = required
+      @selected_value = selected_value.presence
+      @aria_invalid = aria_invalid
+      @aria_required = required
+      @field_hint = field_hint
+      @aria_describedby = construct_aria_describedby
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    def construct_aria_describedby
+      constructed_aria_describedby = []
+      constructed_aria_describedby << form.field_id(@name, 'error') if @aria_invalid
+      constructed_aria_describedby << form.field_id(@name, 'hint') if @field_hint
+
+      return constructed_aria_describedby.join(' ') if constructed_aria_describedby.length.positive?
+
+      nil
     end
   end
 end

--- a/app/views/groups/members/_create_modal.html.erb
+++ b/app/views/groups/members/_create_modal.html.erb
@@ -5,9 +5,21 @@
       <%= I18n.t("groups.members.new.description", name: @namespace.human_name) %>
     </p>
   </div>
-  <%= form_with(model: @new_member, url: group_members_path(tab: @tab), data: {controller: "viral--select2"}, method: :post) do |form| %>
+  <%= form_with(model: @new_member, url: group_members_path(tab: @tab), data: {controller: "viral--select2"}, method: :post, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
-      <div class="form-field">
+      <%= if @new_member.errors.any?
+        viral_alert(
+          type: "alert",
+          message: I18n.t(:"general.form.error_notification"),
+          aria: {
+            live: "assertive",
+          },
+        )
+      end %>
+
+      <%= render partial: "shared/form/required_field_legend" %>
+      <% invalid_user_id = @new_member.errors.include?(:user) %>
+      <div class="form-field <%= 'invalid' if invalid_user_id %>">
         <% form_id = "group-add-member-select2" %>
         <label
           for="<%= form_id %>"
@@ -17,11 +29,11 @@
 
           <%= t("groups.members.new.user_select") %>
         </label>
-        <%= viral_select2(form:, name: :user_id, id: form_id) do |select| %>
+        <%= viral_select2(form:, name: :user_id, id: form_id, selected_value: @new_member.user_id, aria_invalid: invalid_user_id, field_hint: true) do |select| %>
           <% @available_users.each do |user| %>
             <% select.with_option(
                       value: user.id,
-                      label: user.email
+                      label: user.email,
                     ) do %>
               <span
                 class="
@@ -39,6 +51,11 @@
             <%= t(:"groups.members.new.empty_state") %>
           <% end %>
         <% end %>
+        <% if invalid_user_id %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:user_id, "error"),
+          errors: @new_member.errors.full_messages_for(:user) %>
+        <% end %>
         <p id="<%= form.field_id(:user_id, "hint") %>" class="field-hint">
           <%= t("groups.members.new.user_hint") %>
         </p>
@@ -49,12 +66,32 @@
         <%= form.label :access_level, data: { required: true } %>
         <%= form.select :access_level,
                     @access_levels,
-                    required: true,
-                    aria: {
+                    {},
+                    {
                       required: true,
+                      aria: {
+                        describedby: [
+                          (
+                            if invalid_access_level
+                              form.field_id(:access_level, "error")
+                            else
+                              nil
+                            end
+                          ),
+                          form.field_id(:access_level, "hint"),
+                        ].join(" "),
+                        invalid: invalid_access_level,
+                        required: true,
+                      },
+                      autofocus: invalid_access_level,
+                      value: @new_member.access_level,
                     } %>
-        <%= render "shared/form/field_errors",
-        errors: @new_member.errors.full_messages_for(:access_level) %>
+
+        <% if invalid_access_level %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:access_level, "error"),
+          errors: @new_member.errors.full_messages_for(:access_level) %>
+        <% end %>
         <p id="<%= form.field_id(:access_level, "hint") %>" class="field-hint">
           <%= t("groups.members.new.access_level_hint") %>
         </p>

--- a/app/views/projects/members/_create_modal.html.erb
+++ b/app/views/projects/members/_create_modal.html.erb
@@ -5,9 +5,21 @@
       <%= I18n.t("projects.members.new.description", name: @namespace.human_name) %>
     </p>
   </div>
-  <%= form_with(model: @new_member, url: namespace_project_members_path(tab: @tab), data: {controller: "viral--select2"}, method: :post) do |form| %>
+  <%= form_with(model: @new_member, url: namespace_project_members_path(tab: @tab), data: {controller: "viral--select2"}, method: :post,  html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
-      <div class="form-field">
+      <%= if @new_member.errors.any?
+        viral_alert(
+          type: "alert",
+          message: I18n.t(:"general.form.error_notification"),
+          aria: {
+            live: "assertive",
+          },
+        )
+      end %>
+
+      <%= render partial: "shared/form/required_field_legend" %>
+      <% invalid_user_id = @new_member.errors.include?(:user) %>
+      <div class="form-field <%= 'invalid' if invalid_user_id %>">
         <% form_id = "add-user-select2" %>
         <label
           for="<%= form_id %>"
@@ -17,7 +29,7 @@
 
           <%= t("projects.members.new.user_select") %>
         </label>
-        <%= viral_select2(form:, name: :user_id, id: form_id) do |select| %>
+        <%= viral_select2(form:, name: :user_id, id: form_id, selected_value: @new_member.user_id, aria_invalid: invalid_user_id, field_hint: true) do |select| %>
           <% @available_users.each do |user| %>
             <% select.with_option(
                       value: user.id,
@@ -39,6 +51,11 @@
             <%= t(:"projects.members.new.empty_state") %>
           <% end %>
         <% end %>
+        <% if invalid_user_id %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:user_id, "error"),
+          errors: @new_member.errors.full_messages_for(:user) %>
+        <% end %>
         <p id="<%= form.field_id(:user_id, "hint") %>" class="field-hint">
           <%= t("projects.members.new.user_hint") %>
         </p>
@@ -49,9 +66,25 @@
         <%= form.label :access_level, data: { required: true } %>
         <%= form.select :access_level,
                     @access_levels,
-                    required: true,
-                    aria: {
+                    {},
+                    {
                       required: true,
+                      aria: {
+                        describedby: [
+                          (
+                            if invalid_access_level
+                              form.field_id(:access_level, "error")
+                            else
+                              nil
+                            end
+                          ),
+                          form.field_id(:access_level, "hint"),
+                        ].join(" "),
+                        invalid: invalid_access_level,
+                        required: true,
+                      },
+                      autofocus: invalid_access_level,
+                      value: @new_member.access_level,
                     } %>
         <%= render "shared/form/field_errors",
         errors: @new_member.errors.full_messages_for(:access_level) %>

--- a/app/views/projects/members/_create_modal.html.erb
+++ b/app/views/projects/members/_create_modal.html.erb
@@ -87,6 +87,7 @@
                       value: @new_member.access_level,
                     } %>
         <%= render "shared/form/field_errors",
+        id: form.field_id(:access_level, "error"),
         errors: @new_member.errors.full_messages_for(:access_level) %>
         <p id="<%= form.field_id(:access_level, "hint") %>" class="field-hint">
           <%= t("projects.members.new.access_level_hint") %>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in visual indicators for required fields and error display with informative error messages when fields are left blank.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2560" height="1473" alt="image" src="https://github.com/user-attachments/assets/c395b402-95c8-41d9-85ff-5f81b35faadf" />

<img width="2560" height="1473" alt="image" src="https://github.com/user-attachments/assets/113da549-7018-4cd4-bc44-0ca291553685" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

1. Try to add a member to a project and group but leave the access level blank
2. Verify that error messages are displayed and linked to the inputs via aria-describedby
3. The `Add Member to X` button is disabled if the user isn't selected. From the chrome inspect, remove the disabled attribute on the button
4. Try to add a member to the project and group without selecting a user
5. Verify that error messages are displayed and linked to the inputs via aria-describedby

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
