### PR TITLE
Fix: Textarea display

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -198,6 +198,10 @@ input[type="search"] {
     border-top-left-radius: 0;
     @apply block w-full rounded-r-lg border border-slate-300 bg-white text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:placeholder-slate-400 dark:drop-shadow-sm;
   }
+
+  & textarea {
+    @apply block w-full rounded-lg border border-slate-300 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:placeholder-slate-400;
+  }
 }
 
 @utility field_with_errors {


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR re-adds css for the textarea which was accidentally removed in PR [1176](https://github.com/phac-nml/irida-next/pull/1176)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1515" height="682" alt="image" src="https://github.com/user-attachments/assets/c82940b5-39b6-4e34-aec1-166998699000" />

<img width="1563" height="702" alt="image" src="https://github.com/user-attachments/assets/deac9033-6f75-4e0b-8849-0dd7b2d2e72a" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

1. Verify anywhere we use a textarea that the field is displayed correctly (second screenshot above)

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
