### PR TITLE
Fix: Invite Group create modal forms accessibility

### DIFF
--- a/app/controllers/concerns/share_actions.rb
+++ b/app/controllers/concerns/share_actions.rb
@@ -145,7 +145,7 @@ module ShareActions # rubocop:disable Metrics/ModuleLength
 
   def namespace_linkable_groups
     @namespace_linkable_groups = Group.where.not(
-      id: NamespaceGroupLink.where(namespace:).select(:group_id) + Group.where(id: namespace.id).select(:id)
+      id: NamespaceGroupLink.where(namespace:).pluck(:group_id) + Group.where(id: namespace.id).pluck(:id)
     ).order(:name)
   end
 

--- a/app/services/group_links/group_link_service.rb
+++ b/app/services/group_links/group_link_service.rb
@@ -41,7 +41,7 @@ module GroupLinks
       @namespace_group_link.errors.add(:base, e.message)
       @namespace_group_link
     rescue GroupLinks::GroupLinkService::NamespaceGroupLinkGroupError => e
-      @namespace_group_link.errors.add(:group, e.message)
+      @namespace_group_link.errors.add(:group_id, e.message)
       @namespace_group_link
     end
 

--- a/app/services/group_links/group_link_service.rb
+++ b/app/services/group_links/group_link_service.rb
@@ -4,6 +4,7 @@ module GroupLinks
   # Service used to Create NamespaceGroupLinks
   class GroupLinkService < BaseService
     NamespaceGroupLinkError = Class.new(StandardError)
+    NamespaceGroupLinkGroupError = Class.new(StandardError)
     attr_accessor :group_id, :namespace, :namespace_group_link
 
     def initialize(user, namespace, params)
@@ -21,13 +22,15 @@ module GroupLinks
       authorize! namespace, to: :link_namespace_with_group?
 
       if group_id == namespace.id
-        raise NamespaceGroupLinkError,
+        raise NamespaceGroupLinkGroupError,
               I18n.t('services.groups.share.group_self_reference', group_id:)
       end
 
+      raise NamespaceGroupLinkGroupError, I18n.t('services.groups.share.group_required') if group_id.blank?
+
       group = Group.find_by(id: group_id)
 
-      raise NamespaceGroupLinkError, I18n.t('services.groups.share.group_not_found', group_id:) if group.nil?
+      raise NamespaceGroupLinkGroupError, I18n.t('services.groups.share.group_not_found', group_id:) if group.nil?
 
       namespace_group_link.save
 
@@ -36,6 +39,9 @@ module GroupLinks
       namespace_group_link
     rescue GroupLinks::GroupLinkService::NamespaceGroupLinkError => e
       @namespace_group_link.errors.add(:base, e.message)
+      @namespace_group_link
+    rescue GroupLinks::GroupLinkService::NamespaceGroupLinkGroupError => e
+      @namespace_group_link.errors.add(:group, e.message)
       @namespace_group_link
     end
 

--- a/app/views/groups/group_links/_invite_group_modal.html.erb
+++ b/app/views/groups/group_links/_invite_group_modal.html.erb
@@ -1,6 +1,5 @@
 <%= viral_dialog(open: open, classes: ["overflow-visible"]) do |dialog| %>
   <% dialog.with_header(title: I18n.t("groups.group_links.new.title")) %>
-  <%= turbo_frame_tag("invite-group-alert") %>
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= I18n.t(
@@ -10,9 +9,21 @@
     </p>
   </div>
 
-  <%= form_with(model: new_group_link, url: group_group_links_path(@namespace, tab: @tab), data: {controller: "viral--select2"}) do |form| %>
+  <%= form_with(model: new_group_link, url: group_group_links_path(@namespace, tab: @tab), data: {controller: "viral--select2"}, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
-      <div class="form-field">
+      <%= if new_group_link.errors.any?
+        viral_alert(
+          type: "alert",
+          message: I18n.t(:"general.form.error_notification"),
+          aria: {
+            live: "assertive",
+          },
+        )
+      end %>
+
+      <%= render partial: "shared/form/required_field_legend" %>
+      <% invalid_group_id = new_group_link.errors.include?(:group) %>
+      <div class="form-field <%= 'invalid' if invalid_group_id %>">
         <% form_id = "invite-group-select2" %>
         <label
           for="<%= form_id %>"
@@ -21,7 +32,7 @@
         >
           <%= t("groups.group_links.new.label.group_id") %>
         </label>
-        <%= viral_select2(form:, name: :group_id, id: form_id) do |select| %>
+        <%= viral_select2(form:, name: :group_id, id: form_id, selected_value: new_group_link.group_id, aria_invalid: invalid_group_id, field_hint: true) do |select| %>
           <% @namespace_linkable_groups.each do |group| %>
             <% select.with_option(
                       value: group.id,
@@ -41,11 +52,17 @@
             <%= t(:"groups.group_links.new.empty_state") %>
           <% end %>
         <% end %>
+        <% if invalid_group_id %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:group_id, "error"),
+          errors: new_group_link.errors[:group] %>
+        <% end %>
         <p id="<%= form.field_id(:group_id, "hint") %>" class="field-hint">
           <%= t("groups.group_links.new.group_hint") %>
         </p>
       </div>
-      <div class="form-field">
+      <% invalid_group_access_level = new_group_link.errors.include?(:group_access_level) %>
+      <div class="form-field <%= 'invalid' if invalid_group_access_level %>">
         <%= form.label I18n.t("groups.group_links.new.label.group_access_level"),
                    data: {
                      required: true,
@@ -55,12 +72,32 @@
                       @access_levels,
                       new_group_link.group_access_level,
                     ),
-                    required: true,
-                    aria: {
-                      label:
-                        t(:"groups.group_links.index.aria_labels.group_access_level"),
+                    {},
+                    {
                       required: true,
+                      aria: {
+                        describedby: [
+                          (
+                            if invalid_group_access_level
+                              form.field_id(:group_access_level, "error")
+                            else
+                              nil
+                            end
+                          ),
+                          form.field_id(:group_access_level, "hint"),
+                        ].join(" "),
+                        invalid: invalid_group_access_level,
+                        required: true,
+                      },
+                      autofocus: invalid_group_access_level,
+                      value: new_group_link.group_access_level,
                     } %>
+
+        <% if invalid_group_access_level %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:group_access_level, "error"),
+          errors: new_group_link.errors.full_messages_for(:group_access_level) %>
+        <% end %>
         <p id="<%= form.field_id(:group_access_level, "hint") %>" class="field-hint">
           <%= t("groups.group_links.new.access_level_hint") %>
         </p>

--- a/app/views/groups/group_links/_invite_group_modal.html.erb
+++ b/app/views/groups/group_links/_invite_group_modal.html.erb
@@ -22,7 +22,7 @@
       end %>
 
       <%= render partial: "shared/form/required_field_legend" %>
-      <% invalid_group_id = new_group_link.errors.include?(:group) %>
+      <% invalid_group_id = new_group_link.errors.include?(:group_id) %>
       <div class="form-field <%= 'invalid' if invalid_group_id %>">
         <% form_id = "invite-group-select2" %>
         <label
@@ -55,7 +55,7 @@
         <% if invalid_group_id %>
           <%= render "shared/form/field_errors",
           id: form.field_id(:group_id, "error"),
-          errors: new_group_link.errors[:group] %>
+          errors: new_group_link.errors[:group_id] %>
         <% end %>
         <p id="<%= form.field_id(:group_id, "hint") %>" class="field-hint">
           <%= t("groups.group_links.new.group_hint") %>

--- a/app/views/groups/group_links/create.turbo_stream.erb
+++ b/app/views/groups/group_links/create.turbo_stream.erb
@@ -15,9 +15,7 @@
                         new_group_link: @created_namespace_group_link,
                       } %>
 
-  <% if @created_namespace_group_link.errors.any? %>
-    <%= turbo_stream.update "invite-group-alert", viral_alert(type:, message:) %>
-  <% else %>
+  <% if @created_namespace_group_link.errors.none? %>
     <%= turbo_stream.append "flashes" do %>
       <%= viral_flash(type:, data: message) %>
     <% end %>

--- a/app/views/projects/group_links/_invite_group_modal.html.erb
+++ b/app/views/projects/group_links/_invite_group_modal.html.erb
@@ -22,7 +22,7 @@
       end %>
 
       <%= render partial: "shared/form/required_field_legend" %>
-      <% invalid_group_id = new_group_link.errors.include?(:group) %>
+      <% invalid_group_id = new_group_link.errors.include?(:group_id) %>
       <div class="form-field <%= 'invalid' if invalid_group_id %>">
         <% form_id = "share_group_id_input" %>
         <label
@@ -59,7 +59,7 @@
         <% if invalid_group_id %>
           <%= render "shared/form/field_errors",
           id: form.field_id(:group_id, "error"),
-          errors: new_group_link.errors[:group] %>
+          errors: new_group_link.errors[:group_id] %>
         <% end %>
         <p id="<%= form.field_id(:group_id, "hint") %>" class="field-hint">
           <%= t("projects.group_links.new.group_hint") %>

--- a/app/views/projects/group_links/_invite_group_modal.html.erb
+++ b/app/views/projects/group_links/_invite_group_modal.html.erb
@@ -1,6 +1,5 @@
 <%= viral_dialog(open: open,classes: ["overflow-visible"]) do |dialog| %>
   <% dialog.with_header(title: I18n.t("projects.group_links.new.title")) %>
-  <%= turbo_frame_tag("invite-group-alert") %>
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= I18n.t(
@@ -10,9 +9,21 @@
     </p>
   </div>
 
-  <%= form_with(model: new_group_link, url: namespace_project_group_links_path(@namespace.parent, @namespace.project, tab: @tab), method: :post, data: {remote: true, controller: "viral--select2"}) do |form| %>
+  <%= form_with(model: new_group_link, url: namespace_project_group_links_path(@namespace.parent, @namespace.project, tab: @tab), method: :post, data: {remote: true, controller: "viral--select2"}, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
-      <div class="form-field">
+      <%= if new_group_link.errors.any?
+        viral_alert(
+          type: "alert",
+          message: I18n.t(:"general.form.error_notification"),
+          aria: {
+            live: "assertive",
+          },
+        )
+      end %>
+
+      <%= render partial: "shared/form/required_field_legend" %>
+      <% invalid_group_id = new_group_link.errors.include?(:group) %>
+      <div class="form-field <%= 'invalid' if invalid_group_id %>">
         <% form_id = "share_group_id_input" %>
         <label
           for="<%= form_id %>"
@@ -22,7 +33,7 @@
 
           <%= t("projects.group_links.new.label.shared_group") %>
         </label>
-        <%= viral_select2(form:, name: :group_id, id: form_id) do |select| %>
+        <%= viral_select2(form:, name: :group_id, id: form_id, selected_value: new_group_link.group_id, aria_invalid: invalid_group_id, field_hint: true) do |select| %>
           <% @namespace_linkable_groups.each do |group| %>
             <% select.with_option(
                       value: group.id,
@@ -45,11 +56,17 @@
             <%= t(:"projects.group_links.new.empty_state") %>
           <% end %>
         <% end %>
+        <% if invalid_group_id %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:group_id, "error"),
+          errors: new_group_link.errors[:group] %>
+        <% end %>
         <p id="<%= form.field_id(:group_id, "hint") %>" class="field-hint">
           <%= t("projects.group_links.new.group_hint") %>
         </p>
       </div>
-      <div class="form-field">
+      <% invalid_group_access_level = new_group_link.errors.include?(:group_access_level) %>
+      <div class="form-field <%= 'invalid' if invalid_group_access_level %>">
         <%= form.label I18n.t("projects.group_links.new.label.group_access_level"),
                    data: {
                      required: true,
@@ -59,12 +76,31 @@
                       @access_levels,
                       new_group_link.group_access_level,
                     ),
-                    required: true,
-                    aria: {
-                      label:
-                        t(:"projects.group_links.index.aria_labels.group_access_level"),
+                    {},
+                    {
                       required: true,
+                      aria: {
+                        describedby: [
+                          (
+                            if invalid_group_access_level
+                              form.field_id(:group_access_level, "error")
+                            else
+                              nil
+                            end
+                          ),
+                          form.field_id(:group_access_level, "hint"),
+                        ].join(" "),
+                        invalid: invalid_group_access_level,
+                        required: true,
+                      },
+                      autofocus: invalid_group_access_level,
+                      value: new_group_link.group_access_level,
                     } %>
+        <% if invalid_group_access_level %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:group_access_level, "error"),
+          errors: new_group_link.errors.full_messages_for(:group_access_level) %>
+        <% end %>
         <p id="<%= form.field_id(:group_access_level, "hint") %>" class="field-hint">
           <%= t("projects.group_links.new.access_level_hint") %>
         </p>

--- a/app/views/projects/group_links/create.turbo_stream.erb
+++ b/app/views/projects/group_links/create.turbo_stream.erb
@@ -15,9 +15,7 @@
                         new_group_link: @created_namespace_group_link,
                       } %>
 
-  <% if @created_namespace_group_link&.errors.any? %>
-    <%= turbo_stream.update "invite-group-alert", viral_alert(type:, message:) %>
-  <% else %>
+  <% if @created_namespace_group_link.errors.none? %>
     <%= turbo_stream.append "flashes" do %>
       <%= viral_flash(type:, data: message) %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1052,7 +1052,6 @@ en:
           unlink_aria_label: 'Unlink namespace from group: %{member}'
         aria_labels:
           expires_at: Group access expiration
-          group_access_level: Group Access Level
         empty_state:
           description: There are no groups that have been delegated access to this group
           title: No groups
@@ -2041,6 +2040,7 @@ en:
     groups:
       share:
         group_not_found: Group with id %{group_id} to share namespace with cannot be found.
+        group_required: Group is required
         group_self_reference: Group cannot be shared with itself.
         invalid_namespace_type: Invalid namespace type
       transfer:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1052,7 +1052,6 @@ fr:
           unlink_aria_label: 'Dissocier l’espace de noms du groupe : %{member}'
         aria_labels:
           expires_at: Expiration de l’accès du groupe
-          group_access_level: Niveau d’accès du groupe
         empty_state:
           description: Aucun groupe n'a reçu d'accès délégué à ce groupe
           title: Aucun groupe
@@ -2041,6 +2040,7 @@ fr:
     groups:
       share:
         group_not_found: Le groupe avec l’identifiant %{group_id} avec lequel partager l’espace de noms est introuvable.
+        group_required: Group is required
         group_self_reference: Le groupe ne peut pas être partagé avec lui-même.
         invalid_namespace_type: Type d’espace de noms non valide
       transfer:

--- a/test/services/group_links/group_link_service_test.rb
+++ b/test/services/group_links/group_link_service_test.rb
@@ -40,7 +40,7 @@ module GroupLinks
 
       assert_difference -> { NamespaceGroupLink.count } => 0 do
         namespace_group_link = GroupLinks::GroupLinkService.new(@user, group, params).execute
-        assert namespace_group_link.errors.full_messages.include? I18n.t('services.groups.share.group_self_reference')
+        assert namespace_group_link.errors[:group].include? I18n.t('services.groups.share.group_self_reference')
       end
 
       assert_enqueued_emails 0

--- a/test/services/group_links/group_link_service_test.rb
+++ b/test/services/group_links/group_link_service_test.rb
@@ -40,7 +40,7 @@ module GroupLinks
 
       assert_difference -> { NamespaceGroupLink.count } => 0 do
         namespace_group_link = GroupLinks::GroupLinkService.new(@user, group, params).execute
-        assert namespace_group_link.errors[:group].include? I18n.t('services.groups.share.group_self_reference')
+        assert namespace_group_link.errors[:group_id].include? I18n.t('services.groups.share.group_self_reference')
       end
 
       assert_enqueued_emails 0


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in visual indicators for required fields and error display with informative error messages when fields are left blank.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2560" height="1473" alt="image" src="https://github.com/user-attachments/assets/ab8d6719-a703-499b-84c7-2f0c1dc28923" />

<img width="2560" height="1209" alt="image" src="https://github.com/user-attachments/assets/ce0528d2-2698-48f1-8ff3-1cc09dda9f73" />

<img width="2560" height="1473" alt="image" src="https://github.com/user-attachments/assets/680edf4a-fb75-4292-8aee-dc52daccc32e" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Try to share a namespace with a group (Members -> Invite Group) to a project and group but leave the access level blank
2. Verify that error messages are displayed and linked to the inputs via aria-describedby
3. The `Share` button is disabled if the group isn't selected. From the chrome inspect, remove the disabled attribute on the button and click the button
4. Verify that error messages are displayed and linked to the inputs via aria-describedby
5. Repeat 1-4 but this time share namespace with a group successfully, then try to share the namespace with the same group

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
