### PR TITLE
A11y: Action link aria label

### DIFF
--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -250,6 +250,9 @@
                     <%= link_to(
                       t(".preview"),
                       attachment_path(attachment),
+                      aria: {
+                        label: t(".preview_aria_label", name: attachment.file.filename.to_s),
+                      },
                       data: {
                         turbo_stream: true,
                       },
@@ -261,6 +264,24 @@
                     <%= button_to(
                       t(".delete"),
                       destroy_path(attachment.id),
+                      aria: {
+                        label:
+                          t(
+                            ".delete_aria_label",
+                            count: attachment.associated_attachment ? 2 : 1,
+                            name:
+                              (
+                                if attachment.associated_attachment
+                                  [
+                                    attachment.file.filename.to_s,
+                                    attachment.associated_attachment.file.filename.to_s,
+                                  ].to_sentence
+                                else
+                                  attachment.file.filename.to_s
+                                end
+                              ),
+                          ),
+                      },
                       data: {
                         turbo_stream: true,
                       },

--- a/app/components/bots/table_component.html.erb
+++ b/app/components/bots/table_component.html.erb
@@ -43,7 +43,11 @@
         },
         method: :get,
         aria: {
-          label: t("bots.index.table.actions.generate_new_token_aria_label"),
+          label:
+            t(
+              "bots.index.table.actions.generate_new_token_aria_label",
+              name: row.user.email,
+            ),
         },
         class:
           "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer mr-2" %>
@@ -56,7 +60,7 @@
         },
         method: :get,
         aria: {
-          label: t("bots.index.table.actions.destroy_aria_label"),
+          label: t("bots.index.table.actions.destroy_aria_label", name: row.user.email),
         },
         class:
           "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer" %>

--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -31,6 +31,9 @@
       revoke_path(row),
       data: revoke_data_attributes,
       method: revoke_http_method,
+      aria: {
+        label: t(:"personal_access_tokens.table.revoke_aria_label", name: row[:name]),
+      },
       class:
         "px-3 py-2 bg-white dark:bg-slate-800 font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer" %>
     <% end %>

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -145,23 +145,37 @@
                 <div class="bg-white w-full dark:bg-slate-800 text-right px-3 py-2.5 space-x-2">
                   <% if !workflow_execution.shared_with_namespace || @namespace.nil? %>
                     <% if workflow_execution.cancellable? && @row_actions.key?(:cancel) %>
-                      <%= button_to t(:"workflow_executions.index.actions.cancel_button"),
+                      <%= button_to t(:"workflow_executions.actions.cancel"),
                       cancel_path(workflow_execution),
                       data: {
                         turbo_method: :put,
-                        turbo_confirm: t(:"workflow_executions.index.actions.cancel_confirm"),
+                        turbo_confirm: t(:"workflow_executions.actions.cancel_confirm"),
                       },
                       method: :put,
+                      aria: {
+                        label:
+                          t(
+                            :"workflow_executions.actions.cancel_aria_label",
+                            name: workflow_execution.name,
+                          ),
+                      },
                       class:
                         "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer" %>
                     <% end %>
                     <% if workflow_execution.deletable? && @row_actions.key?(:destroy) %>
-                      <%= button_to t(:"workflow_executions.index.actions.delete_button"),
+                      <%= button_to t(:"workflow_executions.actions.delete"),
                       destroy_confirmation_path(workflow_execution),
                       data: {
                         turbo_stream: :true,
                       },
                       method: :get,
+                      aria: {
+                        label:
+                          t(
+                            :"workflow_executions.actions.delete_aria_label",
+                            name: workflow_execution.name,
+                          ),
+                      },
                       class:
                         "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer" %>
                     <% end %>

--- a/app/views/groups/members/_current_user_is_member.html.erb
+++ b/app/views/groups/members/_current_user_is_member.html.erb
@@ -7,7 +7,7 @@ data: {
 },
 method: :delete,
 aria: {
-  label: t(:"groups.members.index.actions.link_leave_group_aria_label"),
+  label: t(:"groups.members.index.actions.leave_group_aria_label"),
 },
 class:
   "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer" %>

--- a/app/views/groups/members/_current_user_is_not_member.html.erb
+++ b/app/views/groups/members/_current_user_is_not_member.html.erb
@@ -8,7 +8,7 @@ method: :delete,
 aria: {
   label:
     t(
-      :"groups.members.index.actions.link_remove_aria_label",
+      :"groups.members.index.actions.remove_aria_label",
       member: member.user.email,
     ),
 },

--- a/app/views/projects/automated_workflow_executions/_table.html.erb
+++ b/app/views/projects/automated_workflow_executions/_table.html.erb
@@ -31,7 +31,7 @@
         classes: "flex justify-start"
       ) do |row| %>
       <% unless row.disabled %>
-        <%= button_to t(:"projects.automated_workflow_executions.actions.edit_button"),
+        <%= button_to t(:"projects.automated_workflow_executions.actions.edit"),
         edit_namespace_project_automated_workflow_execution_path(
           @project.parent,
           @project,
@@ -41,10 +41,17 @@
           turbo_stream: true,
         },
         method: :get,
+        aria: {
+          label:
+            t(
+              :"projects.automated_workflow_executions.actions.edit_aria_label",
+              name: row[:name],
+            ),
+        },
         class:
           "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer mr-2" %>
       <% end %>
-      <%= button_to t(:"projects.automated_workflow_executions.actions.delete_button"),
+      <%= button_to t(:"projects.automated_workflow_executions.actions.delete"),
       namespace_project_automated_workflow_execution_path(
         @project.parent,
         @project,
@@ -56,6 +63,13 @@
           t(:"projects.automated_workflow_executions.actions.delete_confirm"),
       },
       method: :delete,
+      aria: {
+        label:
+          t(
+            :"projects.automated_workflow_executions.actions.delete_aria_label",
+            name: row[:name],
+          ),
+      },
       class:
         "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer" %>
     <% end %>

--- a/app/views/projects/automated_workflow_executions/_table.html.erb
+++ b/app/views/projects/automated_workflow_executions/_table.html.erb
@@ -45,7 +45,7 @@
           label:
             t(
               :"projects.automated_workflow_executions.actions.edit_aria_label",
-              name: row[:name],
+              name: (row[:name].nil? ? row[:id] : row[:name]),
             ),
         },
         class:
@@ -67,7 +67,7 @@
         label:
           t(
             :"projects.automated_workflow_executions.actions.delete_aria_label",
-            name: row[:name],
+            name: (row[:name].nil? ? row[:id] : row[:name]),
           ),
       },
       class:

--- a/app/views/projects/members/_current_user_is_member.html.erb
+++ b/app/views/projects/members/_current_user_is_member.html.erb
@@ -7,7 +7,7 @@ data: {
 },
 method: :delete,
 aria: {
-  label: t(:"projects.members.index.actions.link_leave_project_aria_label"),
+  label: t(:"projects.members.index.actions.leave_project_aria_label"),
 },
 class:
   "font-medium text-blue-600 underline dark:text-blue-400 hover:no-underline cursor-pointer" %>

--- a/app/views/projects/members/_current_user_is_not_member.html.erb
+++ b/app/views/projects/members/_current_user_is_not_member.html.erb
@@ -8,7 +8,7 @@ method: :delete,
 aria: {
   label:
     t(
-      :"projects.members.index.actions.link_remove_aria_label",
+      :"projects.members.index.actions.remove_aria_label",
       member: member.user.email,
     ),
 },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,6 +441,9 @@ en:
         selected: Selected
       created_at: Uploaded
       delete: Delete
+      delete_aria_label:
+        one: 'Delete file: %{name}'
+        other: 'Delete files: %{name}'
       delete_confirm: Are you sure you would like to delete attachment '%{name}'?
       filename: Filename
       format: Format
@@ -448,6 +451,7 @@ en:
       limit:
         item: Attachments
       preview: Preview
+      preview_aria_label: 'Preview attachment: %{name}'
       select_page: Select / Deselect visible attachments
       type: Type
   auth:
@@ -472,9 +476,9 @@ en:
           level_50: Owner
         actions:
           destroy: Delete
-          destroy_aria_label: Delete bot account
+          destroy_aria_label: 'Delete bot account: %{name}'
           generate_new_token: Generate new token
-          generate_new_token_aria_label: Generate a new personal access token for bot account
+          generate_new_token_aria_label: 'Generate a new personal access token for bot account: %{name}'
         empty_state:
           description: There are no associated bot accounts.
           title: No bot accounts
@@ -1044,7 +1048,7 @@ en:
     group_links:
       index:
         actions:
-          unlink_aria_label: Unlink namespace from group %{member} button
+          unlink_aria_label: 'Unlink namespace from group: %{member}'
         aria_labels:
           expires_at: Group access expiration
           group_access_level: Group Access Level
@@ -1083,8 +1087,8 @@ en:
         aria_label: Access Level
       index:
         actions:
-          link_leave_group_aria_label: Leave group button
-          link_remove_aria_label: Remove group member %{member} link
+          leave_group_aria_label: Leave group
+          remove_aria_label: 'Remove group member: %{member}'
         add: Add New Member
         invite_group: Invite Group
         invited_groups: Invited Groups
@@ -1344,10 +1348,10 @@ en:
       created_at: Created Date
       created_by_email: Created By
       description: Description
-      edit_aria_label: Edit metadata template %{template_name}
+      edit_aria_label: 'Edit metadata template: %{template_name}'
       edit_button: Edit
       name: Template Name
-      remove_aria_label: Delete metadata template %{template_name}
+      remove_aria_label: 'Delete metadata template: %{template_name}'
       remove_button: Delete
       remove_confirmation: Are you sure you want to delete metadata template %{template_name}?
       spinner_message: Loading metadata templates...
@@ -1402,6 +1406,7 @@ en:
         scopes: Scopes
       never: Never
       revoke: Revoke
+      revoke_aria_label: 'Revoke personal access token: %{name}'
       revoke_confirmation: Are you sure you want to revoke this personal access token?
   profiles:
     accounts:
@@ -1493,9 +1498,11 @@ en:
           title: No Files
     automated_workflow_executions:
       actions:
-        delete_button: Delete
+        delete: Delete
+        delete_aria_label: 'Delete automated pipeline: %{name}'
         delete_confirm: Are you sure that you want to delete this automated pipeline?
-        edit_button: Edit
+        edit: Edit
+        edit_aria_label: 'Edit automated pipeline: %{name}'
       create:
         error: Could not create an automated pipeline for %{workflow_name}
         success: Automated pipeline for %{workflow_name} was successfully created
@@ -1630,7 +1637,7 @@ en:
           level_40: Maintainer
           level_50: Owner
         actions:
-          unlink_aria_label: Unlink namespace from group %{member} button
+          unlink_aria_label: 'Unlink namespace from group: %{member}'
         aria_labels:
           expires_at: Group access expiration
           group_access_level: Group Access Level
@@ -1671,8 +1678,8 @@ en:
         aria_label: Access Level
       index:
         actions:
-          link_leave_project_aria_label: Leave project link
-          link_remove_aria_label: Remove project member %{member} link
+          leave_project_aria_label: Leave project
+          remove_aria_label: 'Remove project member: %{member}'
         add: Add New Member
         invite_group: Invite group
         invited_groups: Invited Groups
@@ -2314,6 +2321,12 @@ en:
       no_template: No template
       remove_all: Remove all
   workflow_executions:
+    actions:
+      cancel: Cancel
+      cancel_aria_label: 'Cancel workflow execution: %{name}'
+      cancel_confirm: Are you sure you want to cancel this workflow execution?
+      delete: Delete
+      delete_aria_label: 'Delete workflow execution: %{name}'
     create:
       error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
@@ -2346,10 +2359,6 @@ en:
       search:
         placeholder: Filter by PUID or Filename
     index:
-      actions:
-        cancel_button: Cancel
-        cancel_confirm: Are you sure you want to cancel this workflow execution?
-        delete_button: Delete
       create_export_button: Create Export
       delete_workflows_button: Delete Workflow Executions
       deselect_all_button: Deselect All

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -441,6 +441,9 @@ fr:
         selected: Sélectionné
       created_at: Créé à
       delete: Supprimer
+      delete_aria_label:
+        one: 'Delete file: %{name}'
+        other: 'Delete files: %{name}'
       delete_confirm: Êtes-vous sûr de vouloir supprimer la pièce jointe '%{name}'?
       filename: Nom du fichier
       format: Format
@@ -448,6 +451,7 @@ fr:
       limit:
         item: Pièces jointes
       preview: Aperçu
+      preview_aria_label: 'Preview attachment: %{name}'
       select_page: Sélectionner/Désélectionner les pièces jointes visibles
       type: Type
   auth:
@@ -472,9 +476,9 @@ fr:
           level_50: Propriétaire
         actions:
           destroy: Supprimer
-          destroy_aria_label: Supprimer le compte de bot
+          destroy_aria_label: 'Supprimer le compte de bot : %{name}'
           generate_new_token: Générer un nouveau jeton
-          generate_new_token_aria_label: Générer un nouveau jeton d’accès personnel pour le compte de bot
+          generate_new_token_aria_label: 'Générer un nouveau jeton d’accès personnel pour le compte de bot : %{name}'
         empty_state:
           description: Il n’y a pas de comptes de bot associés.
           title: Aucun compte de bot
@@ -1044,7 +1048,7 @@ fr:
     group_links:
       index:
         actions:
-          unlink_aria_label: Dissocier l’espace de noms du groupe de boutons %{member}
+          unlink_aria_label: 'Dissocier l’espace de noms du groupe : %{member}'
         aria_labels:
           expires_at: Expiration de l’accès du groupe
           group_access_level: Niveau d’accès du groupe
@@ -1083,8 +1087,8 @@ fr:
         aria_label: Niveau d’accès
       index:
         actions:
-          link_leave_group_aria_label: Bouton Quitter le groupe
-          link_remove_aria_label: Supprimer le lien %{member} du membre du groupe
+          leave_group_aria_label: Bouton Quitter le groupe
+          remove_aria_label: 'Supprimer le membre du groupe : %{member}'
         add: Ajouter un nouveau membre
         invite_group: Inviter le groupe
         invited_groups: Invited Groups
@@ -1344,10 +1348,10 @@ fr:
       created_at: Date de création
       created_by_email: Créé par
       description: Description
-      edit_aria_label: Modifier le modèle de métadonnées %{template_name}
+      edit_aria_label: 'Modifier le modèle de métadonnées : %{template_name}'
       edit_button: Modifier
       name: Nom du modèle
-      remove_aria_label: Supprimer le modèle de métadonnées %{template_name}
+      remove_aria_label: 'Supprimer le modèle de métadonnées : %{template_name}'
       remove_button: Supprimer
       remove_confirmation: Êtes-vous sûr de vouloir supprimer le modèle de métadonnées %{template_name}?
       spinner_message: Chargement des modèles de métadonnées...
@@ -1402,6 +1406,7 @@ fr:
         scopes: Portées
       never: Jamais
       revoke: Révoquer
+      revoke_aria_label: 'Revoke personal access token: %{name}'
       revoke_confirmation: Êtes-vous sûr de vouloir révoquer ce jeton d’accès personnel?
   profiles:
     accounts:
@@ -1493,9 +1498,11 @@ fr:
           title: Aucun fichier
     automated_workflow_executions:
       actions:
-        delete_button: Supprimer
+        delete: Supprimer
+        delete_aria_label: 'Delete automated pipeline: %{name}'
         delete_confirm: Êtes-vous sûr de vouloir supprimer ce pipeline automatisé?
-        edit_button: Modifier
+        edit: Modifier
+        edit_aria_label: 'Edit automated pipeline: %{name}'
       create:
         error: Impossible de créer un pipeline automatisé pour %{workflow_name}
         success: Le pipeline automatisé pour %{workflow_name} a été créé avec succès
@@ -1630,7 +1637,7 @@ fr:
           level_40: Responsable
           level_50: Propriétaire
         actions:
-          unlink_aria_label: Dissocier l’espace de noms du groupe de boutons %{member}
+          unlink_aria_label: 'Dissocier l’espace de noms du groupe : %{member}'
         aria_labels:
           expires_at: Expiration de l’accès du groupe
           group_access_level: Niveau d’accès du groupe
@@ -1671,8 +1678,8 @@ fr:
         aria_label: Niveau d’accès
       index:
         actions:
-          link_leave_project_aria_label: Laisser le lien du projet
-          link_remove_aria_label: Supprimer le lien du membre du projet %{member}
+          leave_project_aria_label: Laisser le lien du projet
+          remove_aria_label: 'Supprimer le lien du membre du projet : %{member}'
         add: Ajouter un nouveau membre
         invite_group: Inviter le groupe
         invited_groups: Invited Groups
@@ -2314,6 +2321,12 @@ fr:
       no_template: Pas de modèle
       remove_all: Supprimer tout
   workflow_executions:
+    actions:
+      cancel: Annuler
+      cancel_aria_label: 'Cancel workflow execution: %{name}'
+      cancel_confirm: Êtes-vous sûr de vouloir annuler cette exécution de flux de travail?
+      delete: Supprimer
+      delete_aria_label: 'Delete workflow execution: %{name}'
     create:
       error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
     edit_dialog:
@@ -2346,10 +2359,6 @@ fr:
       search:
         placeholder: Filtrer par PUID ou nom de fichier
     index:
-      actions:
-        cancel_button: Annuler
-        cancel_confirm: Êtes-vous sûr de vouloir annuler cette exécution de flux de travail?
-        delete_button: Supprimer
       create_export_button: Créer une exportation
       delete_workflows_button: Delete Workflow Executions
       deselect_all_button: Désélectionner tout

--- a/test/system/projects/automated_workflow_executions_test.rb
+++ b/test/system/projects/automated_workflow_executions_test.rb
@@ -82,7 +82,7 @@ module Projects
       assert_selector 'span', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
 
       within('table tbody tr:first-child') do
-        click_button I18n.t(:'projects.automated_workflow_executions.actions.delete_button')
+        click_button I18n.t(:'projects.automated_workflow_executions.actions.delete')
       end
 
       within('#turbo-confirm[open]') do
@@ -99,7 +99,7 @@ module Projects
       assert_selector 'span', text: I18n.t(:'projects.automated_workflow_executions.index.subtitle')
 
       within('table tbody tr:first-child') do
-        click_button I18n.t(:'projects.automated_workflow_executions.actions.edit_button')
+        click_button I18n.t(:'projects.automated_workflow_executions.actions.edit')
       end
 
       within('dialog[open].dialog--size-xl') do
@@ -125,8 +125,8 @@ module Projects
                         text: disabled_automated_pipeline.id
 
         within("tr[id='#{dom_id(disabled_automated_pipeline)}'] td:last-child") do
-          assert_text I18n.t('projects.automated_workflow_executions.actions.delete_button')
-          assert_no_text I18n.t('projects.automated_workflow_executions.actions.edit_button')
+          assert_text I18n.t('projects.automated_workflow_executions.actions.delete')
+          assert_no_text I18n.t('projects.automated_workflow_executions.actions.edit')
         end
       end
     end

--- a/test/system/projects/workflow_executions_test.rb
+++ b/test/system/projects/workflow_executions_test.rb
@@ -109,13 +109,13 @@ module Projects
       assert_selector "tr[id='#{dom_id(workflow_execution1)}']"
       within("tr[id='#{dom_id(workflow_execution1)}'] td:last-child") do
         assert_no_link I18n.t(:'workflow_executions.index.actions.cancel_button')
-        assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_no_link I18n.t(:'workflow_executions.actions.delete')
       end
 
       assert_selector "tr[id='#{dom_id(workflow_execution2)}']"
       within("tr[id='#{dom_id(workflow_execution2)}'] td:last-child") do
         assert_no_link I18n.t(:'workflow_executions.index.actions.cancel_button')
-        assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_no_link I18n.t(:'workflow_executions.actions.delete')
       end
     end
 
@@ -172,7 +172,7 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-        assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_no_link I18n.t(:'workflow_executions.actions.delete')
       end
     end
 
@@ -189,7 +189,7 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-        assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_no_link I18n.t(:'workflow_executions.actions.delete')
       end
     end
 
@@ -213,8 +213,8 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{@workflow_execution1.state}")
-        assert_button I18n.t(:'workflow_executions.index.actions.delete_button'), count: 1
-        click_button I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_button I18n.t(:'workflow_executions.actions.delete'), count: 1
+        click_button I18n.t(:'workflow_executions.actions.delete')
       end
 
       assert_text I18n.t(:'shared.workflow_executions.destroy_confirmation_dialog.title')
@@ -251,8 +251,8 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-        assert_button I18n.t(:'workflow_executions.index.actions.delete_button'), count: 1
-        click_button I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_button I18n.t(:'workflow_executions.actions.delete'), count: 1
+        click_button I18n.t(:'workflow_executions.actions.delete')
       end
 
       assert_text I18n.t(:'shared.workflow_executions.destroy_confirmation_dialog.title')
@@ -274,7 +274,7 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-        assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_no_link I18n.t(:'workflow_executions.actions.delete')
       end
     end
 
@@ -291,8 +291,8 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-        assert_button I18n.t(:'workflow_executions.index.actions.delete_button'), count: 1
-        click_button I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_button I18n.t(:'workflow_executions.actions.delete'), count: 1
+        click_button I18n.t(:'workflow_executions.actions.delete')
       end
 
       assert_text I18n.t(:'shared.workflow_executions.destroy_confirmation_dialog.title')
@@ -314,7 +314,7 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-        assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_no_link I18n.t(:'workflow_executions.actions.delete')
       end
     end
 
@@ -331,7 +331,7 @@ module Projects
       within tr do
         assert_selector "td:nth-child(#{@state_col})",
                         text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-        assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+        assert_no_link I18n.t(:'workflow_executions.actions.delete')
       end
     end
 

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -124,7 +124,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_selector "tr[id='#{dom_id(workflow_execution)}']"
     within("tr[id='#{dom_id(workflow_execution)}'] td:last-child") do
-      assert_button I18n.t(:'workflow_executions.index.actions.cancel_button')
+      assert_button I18n.t(:'workflow_executions.actions.cancel')
     end
   end
 
@@ -179,7 +179,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_no_link I18n.t(:'workflow_executions.actions.delete')
     end
   end
 
@@ -195,7 +195,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_no_link I18n.t(:'workflow_executions.actions.delete')
     end
   end
 
@@ -211,7 +211,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_no_link I18n.t(:'workflow_executions.actions.delete')
     end
   end
 
@@ -234,8 +234,8 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{@workflow_execution1.state}")
-      assert_button I18n.t(:'workflow_executions.index.actions.delete_button'), count: 1
-      click_button I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_button I18n.t(:'workflow_executions.actions.delete'), count: 1
+      click_button I18n.t(:'workflow_executions.actions.delete')
     end
 
     assert_text I18n.t(:'shared.workflow_executions.destroy_confirmation_dialog.title')
@@ -271,8 +271,8 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_button I18n.t(:'workflow_executions.index.actions.delete_button'), count: 1
-      click_button I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_button I18n.t(:'workflow_executions.actions.delete'), count: 1
+      click_button I18n.t(:'workflow_executions.actions.delete')
     end
 
     assert_text I18n.t(:'shared.workflow_executions.destroy_confirmation_dialog.title')
@@ -293,7 +293,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_no_link I18n.t(:'workflow_executions.actions.delete')
     end
   end
 
@@ -309,8 +309,8 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_button I18n.t(:'workflow_executions.index.actions.delete_button'), count: 1
-      click_button I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_button I18n.t(:'workflow_executions.actions.delete'), count: 1
+      click_button I18n.t(:'workflow_executions.actions.delete')
     end
 
     assert_text I18n.t(:'shared.workflow_executions.destroy_confirmation_dialog.title')
@@ -331,7 +331,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_no_link I18n.t(:'workflow_executions.actions.delete')
     end
   end
 
@@ -347,7 +347,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within tr do
       assert_selector "td:nth-child(#{@state_col})",
                       text: I18n.t(:"workflow_executions.state.#{workflow_execution.state}")
-      assert_no_link I18n.t(:'workflow_executions.index.actions.delete_button')
+      assert_no_link I18n.t(:'workflow_executions.actions.delete')
     end
   end
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds `aria-label` to each action link contained with a table to better convey purpose to screen reader users, and distinguish links from each other.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

e.g.
<img width="1003" height="643" alt="image" src="https://github.com/user-attachments/assets/96396750-5d22-42b9-ab46-6f0d6d4b969a" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Go to each table that has action(s) column and ensure that each link has an `aria-label` set that includes the name in the row.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
