### PR TITLE
Added exception handling to DataExports CreateJob

### DIFF
--- a/app/jobs/data_exports/create_job.rb
+++ b/app/jobs/data_exports/create_job.rb
@@ -14,7 +14,7 @@ module DataExports
       end
     end
 
-    def perform(data_export)
+    def perform(data_export) # rubocop:disable Metrics/MethodLength
       begin
         initialize_manifest(data_export.export_type) unless data_export.export_type == 'linelist'
 

--- a/app/jobs/data_exports/create_job.rb
+++ b/app/jobs/data_exports/create_job.rb
@@ -28,12 +28,12 @@ module DataExports
 
         data_export.save
       rescue StandardError => e
-        Rails.logger.error "Server encountered the following error while trying to create data export '#{e.message}'"
+        Rails.logger.error "While trying to create data export '#{data_export.id}', the following error occurred '#{e.message}'" # rubocop:disable Layout/LineLength
         raise DataExports::CreateService::DataExportCreateError, I18n.t('data_exports.create.error')
       end
 
       unless data_export.persisted?
-        Rails.logger.error 'Data export was unable to save (persisted) due to being malformed.'
+        Rails.logger.error "Data export '#{data_export.id}' was unable to save (persisted) due to being malformed."
         raise DataExports::CreateService::DataExportCreateError, I18n.t('data_exports.create.error')
       end
 

--- a/app/jobs/data_exports/create_job.rb
+++ b/app/jobs/data_exports/create_job.rb
@@ -15,15 +15,26 @@ module DataExports
     end
 
     def perform(data_export)
-      initialize_manifest(data_export.export_type) unless data_export.export_type == 'linelist'
+      begin
+        initialize_manifest(data_export.export_type) unless data_export.export_type == 'linelist'
 
-      Tempfile.create(binmode: true) do |temp_export_file|
-        create_export(data_export, temp_export_file)
-        temp_export_file.rewind
-        attach_export(data_export, temp_export_file)
+        Tempfile.create(binmode: true) do |temp_export_file|
+          create_export(data_export, temp_export_file)
+          temp_export_file.rewind
+          attach_export(data_export, temp_export_file)
+        end
+
+        assign_data_export_attributes(data_export)
+
+        data_export.save
+      rescue StandardError => e
+        raise DataExports::CreateService::DataExportCreateError,
+              I18n.t('data_exports.create.error', message: e.message)
       end
 
-      assign_data_export_attributes(data_export)
+      unless data_export.persisted?
+        raise DataExports::CreateService::DataExportCreateError, I18n.t('data_exports.create.malformed')
+      end
 
       DataExportMailer.export_ready(data_export).deliver_later if data_export.email_notification?
     end
@@ -40,21 +51,20 @@ module DataExports
       end
     end
 
-    def attach_export(data_export, export)
+    def attach_export(data_export, temp_export_file)
       filename = if data_export.export_type == 'linelist'
                    "#{data_export.id}.#{data_export.export_parameters['linelist_format']}"
                  else
                    "#{data_export.id}.zip"
                  end
 
-      data_export.file.attach(io: export, filename:)
+      data_export.file.attach(io: temp_export_file, filename:)
     end
 
     def assign_data_export_attributes(data_export)
       data_export.manifest = @manifest.to_json unless data_export.export_type == 'linelist'
       data_export.expires_at = ApplicationController.helpers.add_business_days(DateTime.current, 3)
       data_export.status = 'ready'
-      data_export.save
     end
 
     # Functions used by both sample and analysis exports-------------------------------------------------

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,8 +796,7 @@ en:
         title: Projects
   data_exports:
     create:
-      error: Server encountered the following error while trying to create data export '%{message}'
-      malformed: Data export was unable to save due to being malformed.
+      error: An error occurred while trying to create the data export. Please contact your system administrator if this error persists.'
       success: Data export '%{name}' was successfully started.
     destroy:
       error: Data export '%{name}' could not be deleted.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,6 +796,8 @@ en:
         title: Projects
   data_exports:
     create:
+      error: Server encountered the following error while trying to create data export '%{message}'
+      malformed: Data export was unable to save due to being malformed.
       success: Data export '%{name}' was successfully started.
     destroy:
       error: Data export '%{name}' could not be deleted.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -796,6 +796,8 @@ fr:
         title: Projets
   data_exports:
     create:
+      error: Server encountered the following error while trying to create data export '%{message}'
+      malformed: Data export was unable to save due to being malformed.
       success: L’exportation de données '%{name}' a été lancée avec succès.
     destroy:
       error: L’exportation de données '%{name}' n’a pas pu être supprimée.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -796,8 +796,7 @@ fr:
         title: Projets
   data_exports:
     create:
-      error: Server encountered the following error while trying to create data export '%{message}'
-      malformed: Data export was unable to save due to being malformed.
+      error: An error occurred while trying to create the data export. Please contact your system administrator if this error persists.'
       success: L’exportation de données '%{name}' a été lancée avec succès.
     destroy:
       error: L’exportation de données '%{name}' n’a pas pu être supprimée.

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'minitest/mock'
 require 'test_helper'
 module DataExports
   class CreateJobTest < ActiveJob::TestCase
@@ -568,6 +569,33 @@ module DataExports
       assert_turbo_stream_broadcasts [user, :data_exports], count: 3 do
         DataExports::CreateJob.perform_now(@data_export2)
       end
+    end
+
+    test 'tempfile raises exception' do
+      assert @data_export2.status = 'processing'
+      assert_not @data_export2.file.valid?
+      # class Tempfile; def create; end end
+
+      Tempfile.stub :create, ->(_args) { raise(Errno::ENOSPC) } do
+        error = assert_raises DataExports::CreateService::DataExportCreateError do
+          DataExports::CreateJob.perform_now(@data_export2)
+        end
+
+        assert_match I18n.t('data_exports.create.error', message: 'No space left on device'), error.message
+      end
+
+      assert @data_export2.status = 'processing'
+      assert_not @data_export2.file.valid?
+    end
+
+    test 'invalid starting export object raises exception' do
+      class DataExportStub < DataExport; def persisted? = false end # rubocop:disable Lint/ConstantDefinitionInBlock
+
+      error = assert_raises DataExports::CreateService::DataExportCreateError do
+        DataExports::CreateJob.perform_now(DataExportStub.new)
+      end
+
+      assert_match I18n.t('data_exports.create.malformed'), error.message
     end
   end
 end

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -595,7 +595,7 @@ module DataExports
         DataExports::CreateJob.perform_now(DataExportStub.new)
       end
 
-      assert_match I18n.t('data_exports.create.malformed'), error.message
+      assert_match I18n.t('data_exports.create.error'), error.message
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._
Fixes #1154 

DataExports::CreateJob now correctly raises errors when data export cannot be saved, and when underlying libraries (such as Tempfile) throw errors that cannot be recovered from.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
