### PR TITLE
Fix: Project/Group edit reflow

### DIFF
--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -8,14 +8,14 @@
         </p>
         <%= render partial: "shared/form/required_field_legend" %>
         <% invalid_path = @group.errors.include?(:path) %>
-        <div class="form-field prefixed <%= 'invalid' if invalid_path %>">
+        <div class="@container form-field <%= 'invalid' if invalid_path %>">
           <%= form.label :path, data: { required: true } %>
-          <div class="flex whitespace-nowrap items-center">
+          <div class="flex flex-row @max-md:flex-col">
             <div
               class="
-                inline-flex items-center px-3 py-2.5 text-sm text-slate-600 bg-slate-200 border
-                border-r-0 border-slate-300 rounded-l-lg dark:bg-slate-600 dark:text-slate-400
-                dark:border-slate-600
+                text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
+                bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
+                @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
               "
             >
               <%= root_url %>
@@ -25,24 +25,27 @@
                 </strong>
               <% end %>
             </div>
-            <%= form.text_field :path,
-                            pattern: Irida::PathRegex::PATH_REGEX_STR,
-                            required: true,
-                            title: t(:"groups.create.path_help"),
-                            aria: {
-                              describedby:
-                                invalid_path ? form.field_id(:path, "error") : nil,
-                              invalid: invalid_path,
+            <div class="flex-grow-1">
+              <%= form.text_field :path,
+                              pattern: Irida::PathRegex::PATH_REGEX_STR,
                               required: true,
-                            },
-                            autofocus: invalid_path,
-                            class: "prefixed" %>
+                              title: t(:"groups.create.path_help"),
+                              class:
+                                "border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
+                              aria: {
+                                describedby:
+                                  invalid_path ? form.field_id(:path, "error") : nil,
+                                invalid: invalid_path,
+                                required: true,
+                              },
+                              autofocus: invalid_path %>
+              <% if invalid_path %>
+                <%= render "shared/form/field_errors",
+                id: form.field_id(:path, "error"),
+                errors: @group.errors.full_messages_for(:path) %>
+              <% end %>
+            </div>
           </div>
-          <% if invalid_path %>
-            <%= render "shared/form/field_errors",
-            id: form.field_id(:path, "error"),
-            errors: @group.errors.full_messages_for(:path) %>
-          <% end %>
         </div>
         <div>
           <%= form.submit t(:"groups.edit.advanced.path.submit"),

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -17,36 +17,46 @@
                   text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
                   bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
                   @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
+                  whitespace-nowrap max-w-96
                 "
+                title="<%= "#{root_url}#{@group&.parent&.full_path}" %>"
               >
-                <%= root_url %>
+
                 <% if @group.parent %>
-                  <strong>
+                  <%= root_url %>
+                  <span class="font-bold">
                     <%= @group.parent.full_path + "/" %>
-                  </strong>
+                  </span>
+                <% else %>
+                  <%= root_url %>
                 <% end %>
               </div>
-              <div class="flex-grow-1">
+              <div class="grow">
                 <%= form.text_field :path,
                                 pattern: Irida::PathRegex::PATH_REGEX_STR,
                                 required: true,
-                                title: t(:"groups.create.path_help"),
+                                title: @group.path,
                                 class:
                                   "text-ellipsis overflow-hidden border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
                                 aria: {
-                                  describedby:
+                                  describedby: [
                                     invalid_path ? form.field_id(:path, "error") : nil,
+                                    form.field_id(:path, "hint"),
+                                  ].join(" "),
                                   invalid: invalid_path,
                                   required: true,
                                 },
                                 autofocus: invalid_path %>
-                <% if invalid_path %>
-                  <%= render "shared/form/field_errors",
-                  id: form.field_id(:path, "error"),
-                  errors: @group.errors.full_messages_for(:path) %>
-                <% end %>
               </div>
             </div>
+            <% if invalid_path %>
+              <%= render "shared/form/field_errors",
+              id: form.field_id(:path, "error"),
+              errors: @group.errors.full_messages_for(:path) %>
+            <% end %>
+            <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
+              <%== t(:"groups.create.path_help") %>
+            </span>
           </div>
         </div>
         <div>

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -8,42 +8,44 @@
         </p>
         <%= render partial: "shared/form/required_field_legend" %>
         <% invalid_path = @group.errors.include?(:path) %>
-        <div class="@container form-field <%= 'invalid' if invalid_path %>">
-          <%= form.label :path, data: { required: true } %>
-          <div class="flex flex-row @max-md:flex-col">
-            <div
-              class="
-                text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
-                bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
-                @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
-              "
-            >
-              <%= root_url %>
-              <% if @group.parent %>
-                <strong>
-                  <%= @group.parent.full_path + "/" %>
-                </strong>
-              <% end %>
-            </div>
-            <div class="flex-grow-1">
-              <%= form.text_field :path,
-                              pattern: Irida::PathRegex::PATH_REGEX_STR,
-                              required: true,
-                              title: t(:"groups.create.path_help"),
-                              class:
-                                "border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
-                              aria: {
-                                describedby:
-                                  invalid_path ? form.field_id(:path, "error") : nil,
-                                invalid: invalid_path,
+        <div class="form-field <%= 'invalid' if invalid_path %>">
+          <div class="@container">
+            <%= form.label :path, data: { required: true } %>
+            <div class="flex flex-row @max-md:flex-col">
+              <div
+                class="
+                  text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
+                  bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
+                  @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
+                "
+              >
+                <%= root_url %>
+                <% if @group.parent %>
+                  <strong>
+                    <%= @group.parent.full_path + "/" %>
+                  </strong>
+                <% end %>
+              </div>
+              <div class="flex-grow-1">
+                <%= form.text_field :path,
+                                pattern: Irida::PathRegex::PATH_REGEX_STR,
                                 required: true,
-                              },
-                              autofocus: invalid_path %>
-              <% if invalid_path %>
-                <%= render "shared/form/field_errors",
-                id: form.field_id(:path, "error"),
-                errors: @group.errors.full_messages_for(:path) %>
-              <% end %>
+                                title: t(:"groups.create.path_help"),
+                                class:
+                                  "text-ellipsis overflow-hidden border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
+                                aria: {
+                                  describedby:
+                                    invalid_path ? form.field_id(:path, "error") : nil,
+                                  invalid: invalid_path,
+                                  required: true,
+                                },
+                                autofocus: invalid_path %>
+                <% if invalid_path %>
+                  <%= render "shared/form/field_errors",
+                  id: form.field_id(:path, "error"),
+                  errors: @group.errors.full_messages_for(:path) %>
+                <% end %>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -17,7 +17,7 @@
                   text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
                   bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
                   @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
-                  whitespace-nowrap max-w-96
+                  whitespace-nowrap max-w-md
                 "
                 title="<%= "#{root_url}#{@group&.parent&.full_path}" %>"
               >

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -20,39 +20,47 @@
                     text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
                     bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
                     @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
+                    whitespace-nowrap max-w-96
                   "
-                ><%= root_url %>
+                  title="<%= "#{root_url}#{@project&.parent&.full_path}" %>"
+                >
+
                   <% if @project.parent %>
-
-                    <strong>
+                    <%= root_url %>
+                    <span class="font-bold">
                       <%= @project.parent.full_path + "/" %>
-                    </strong>
-
+                    </span>
+                  <% else %>
+                    <%= root_url %>
                   <% end %>
                 </div>
-                <div class="flex-grow-1">
-
+                <div class="grow">
                   <%= builder.text_field :path,
                                      pattern: Irida::PathRegex::PATH_REGEX_STR,
                                      required: true,
-                                     title: t(:"projects.edit.advanced.path.help"),
+                                     title: @project.path,
                                      class:
                                        "text-ellipsis overflow-hidden border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
                                      aria: {
-                                       describedby:
+                                       describedby: [
                                          invalid_path ? form.field_id(:path, "error") : nil,
+                                         form.field_id(:path, "hint"),
+                                       ].join(" "),
                                        invalid: invalid_path,
                                        required: true,
                                      },
                                      autofocus: invalid_path %>
 
-                  <% if invalid_path %>
-                    <%= render "shared/form/field_errors",
-                    id: builder.field_id(:path, "error"),
-                    errors: @project.namespace.errors.full_messages_for(:path) %>
-                  <% end %>
                 </div>
               </div>
+              <% if invalid_path %>
+                <%= render "shared/form/field_errors",
+                id: builder.field_id(:path, "error"),
+                errors: @project.namespace.errors.full_messages_for(:path) %>
+              <% end %>
+              <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
+                <%== t(:"projects.edit.advanced.path.help") %>
+              </span>
             </div>
           </div>
 

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -8,41 +8,52 @@
             <%= t(:"projects.edit.advanced.path.description") %>
           </p>
           <%= render partial: "shared/form/required_field_legend" %>
+
           <% invalid_path = @project.namespace.errors.include?(:path) %>
-          <div class="form-field prefixed <%= 'invalid' if invalid_path %>">
+
+          <div class="@container form-field <%= 'invalid' if invalid_path %>">
             <%= builder.label :path, data: { required: true } %>
-            <div class="flex whitespace-nowrap items-center">
+            <div class="flex flex-row @max-md:flex-col">
               <div
                 class="
-                  inline-flex items-center px-3 py-2.5 text-sm text-slate-600 bg-slate-200 border
-                  border-r-0 border-slate-300 rounded-l-lg dark:bg-slate-600 dark:text-slate-400
-                  dark:border-slate-600
+                  text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
+                  bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
+                  @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
                 "
-              >
-                <%= root_url %>
+              ><%= root_url %>
                 <% if @project.parent %>
+
                   <strong>
                     <%= @project.parent.full_path + "/" %>
                   </strong>
+
                 <% end %>
               </div>
-              <%= builder.text_field :path,
-                                 pattern: Irida::PathRegex::PATH_REGEX_STR,
-                                 required: true,
-                                 title: t(:"projects.edit.advanced.path.help"),
-                                 class: "prefixed",
-                                 aria: {
-                                   describedby:
-                                     invalid_path ? builder.field_id(:path, "error") : nil,
-                                   invalid: invalid_path,
+              <div class="flex-grow-1">
+
+                <%= builder.text_field :path,
+                                   pattern: Irida::PathRegex::PATH_REGEX_STR,
                                    required: true,
-                                 },
-                                 autofocus: invalid_path %>
+                                   title: t(:"projects.edit.advanced.path.help"),
+                                   class:
+                                     "border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
+                                   aria: {
+                                     describedby:
+                                       invalid_path ? form.field_id(:path, "error") : nil,
+                                     invalid: invalid_path,
+                                     required: true,
+                                   },
+                                   autofocus: invalid_path %>
+
+                <% if invalid_path %>
+                  <%= render "shared/form/field_errors",
+                  id: builder.field_id(:path, "error"),
+                  errors: @project.namespace.errors.full_messages_for(:path) %>
+                <% end %>
+              </div>
             </div>
-            <%= render "shared/form/field_errors",
-            id: builder.field_id(:path, "error"),
-            errors: @project.namespace.errors.full_messages_for(:path) %>
           </div>
+
           <div>
             <%= form.submit t(:"projects.edit.advanced.path.submit"),
                         data: {

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -11,45 +11,47 @@
 
           <% invalid_path = @project.namespace.errors.include?(:path) %>
 
-          <div class="@container form-field <%= 'invalid' if invalid_path %>">
-            <%= builder.label :path, data: { required: true } %>
-            <div class="flex flex-row @max-md:flex-col">
-              <div
-                class="
-                  text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
-                  bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
-                  @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
-                "
-              ><%= root_url %>
-                <% if @project.parent %>
+          <div class="form-field <%= 'invalid' if invalid_path %>">
+            <div class="@container">
+              <%= builder.label :path, data: { required: true } %>
+              <div class="flex flex-row @max-md:flex-col">
+                <div
+                  class="
+                    text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
+                    bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
+                    @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
+                  "
+                ><%= root_url %>
+                  <% if @project.parent %>
 
-                  <strong>
-                    <%= @project.parent.full_path + "/" %>
-                  </strong>
+                    <strong>
+                      <%= @project.parent.full_path + "/" %>
+                    </strong>
 
-                <% end %>
-              </div>
-              <div class="flex-grow-1">
+                  <% end %>
+                </div>
+                <div class="flex-grow-1">
 
-                <%= builder.text_field :path,
-                                   pattern: Irida::PathRegex::PATH_REGEX_STR,
-                                   required: true,
-                                   title: t(:"projects.edit.advanced.path.help"),
-                                   class:
-                                     "border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
-                                   aria: {
-                                     describedby:
-                                       invalid_path ? form.field_id(:path, "error") : nil,
-                                     invalid: invalid_path,
+                  <%= builder.text_field :path,
+                                     pattern: Irida::PathRegex::PATH_REGEX_STR,
                                      required: true,
-                                   },
-                                   autofocus: invalid_path %>
+                                     title: t(:"projects.edit.advanced.path.help"),
+                                     class:
+                                       "text-ellipsis overflow-hidden border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
+                                     aria: {
+                                       describedby:
+                                         invalid_path ? form.field_id(:path, "error") : nil,
+                                       invalid: invalid_path,
+                                       required: true,
+                                     },
+                                     autofocus: invalid_path %>
 
-                <% if invalid_path %>
-                  <%= render "shared/form/field_errors",
-                  id: builder.field_id(:path, "error"),
-                  errors: @project.namespace.errors.full_messages_for(:path) %>
-                <% end %>
+                  <% if invalid_path %>
+                    <%= render "shared/form/field_errors",
+                    id: builder.field_id(:path, "error"),
+                    errors: @project.namespace.errors.full_messages_for(:path) %>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -20,7 +20,7 @@
                     text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
                     bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
                     @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
-                    whitespace-nowrap max-w-96
+                    whitespace-nowrap max-w-md
                   "
                   title="<%= "#{root_url}#{@project&.parent&.full_path}" %>"
                 >


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes reflow issues on the project/group edit pages which caused content to overflow resulting in both a horizontal and vertical scroll. Addresses:

[STRY0018426](https://publichealthprod.service-now.com/rm_story.do?sys_id=b3fdc44547966250f24c0c21516d43ea)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Edit Group**


**100%**

<img width="1225" height="387" alt="image" src="https://github.com/user-attachments/assets/dd3cf4fe-a62d-4532-9a4c-f3ceb17be137" />

**400%**

<img width="1212" height="856" alt="image" src="https://github.com/user-attachments/assets/5df7dd21-bea6-4974-bee4-046313756d92" />


**Edit Project**

**100%**

<img width="1163" height="389" alt="image" src="https://github.com/user-attachments/assets/da569095-e565-4457-9fbe-dade44f47558" />

**400%**

<img width="1196" height="860" alt="image" src="https://github.com/user-attachments/assets/b6c7f554-ae24-4982-8a6a-384129a70daa" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Set browser to 1280x1024
2. Visit the general settings page for a project
3. Zoom in slowly up to 400% and ensure there is no loss of content
4. Repeat for editing a group

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
