### PR TITLE
A11y: Dialog trigger refocus on close or disconnect/connect if open

### DIFF
--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -45,7 +45,6 @@ export default class extends Controller {
 
   close() {
     this.openValue = false;
-    this.dialogTarget.close();
     this.#focusTrap.deactivate();
     this.dialogTarget.close();
     if (this.hasTriggerTarget) {

--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -27,9 +27,11 @@ export default class extends Controller {
     this.#focusTrap.deactivate();
     if (this.openValue) {
       this.close();
-      // re-add refocusTrigger on save
-      // (this is so that turbo page loads that replace the open dialog with a closed one will refocus the trigger)
-      savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: true });
+      if (this.hasTriggerTarget) {
+        // re-add refocusTrigger on save
+        // (this is so that turbo page loads that replace the open dialog with a closed one will refocus the trigger)
+        savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: true });
+      }
     }
   }
 

--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -1,6 +1,9 @@
 import { Controller } from "@hotwired/stimulus";
 import { createFocusTrap } from "focus-trap";
 
+// persistent dialog state between connect/disconnects
+const savedDialogStates = new Map();
+
 export default class extends Controller {
   static targets = ["dialog", "trigger"];
   static values = { open: Boolean };
@@ -12,16 +15,30 @@ export default class extends Controller {
       onDeactivate: () => this.dialogTarget.classList.remove("focus-trap"),
     });
 
-    if (this.openValue) this.open();
+    if (this.openValue) {
+      this.open();
+    } else {
+      this.restoreFocusState();
+    }
     this.element.setAttribute("data-controller-connected", "true");
   }
 
   disconnect() {
-    this.close();
+    this.#focusTrap.deactivate();
+    if (this.openValue) {
+      this.close();
+      // re-add refocusTrigger on save
+      // (this is so that turbo page loads that replace the open dialog with a closed one will refocus the trigger)
+      savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: true });
+    }
   }
 
   open() {
     this.openValue = true;
+    if (this.hasTriggerTarget) {
+      // once a dialog has been opened we need to save it to the state to refocus the trigger if the controller is disconnected before close
+      savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: true });
+    }
     this.dialogTarget.showModal();
     this.#focusTrap.activate();
   }
@@ -30,18 +47,24 @@ export default class extends Controller {
     this.openValue = false;
     this.dialogTarget.close();
     this.#focusTrap.deactivate();
+    this.dialogTarget.close();
+    if (this.hasTriggerTarget) {
+      // close will refocus the trigger so we don't need to save it to refocus on next connect
+      savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: false });
+      this.triggerTarget.focus();
+    }
   }
 
   handleEsc(event) {
     event.preventDefault();
   }
 
-  refocus(event) {
-    console.log(event.target);
-    console.log(event.detail);
-    if (event.target === this.dialogTarget) {
-      console.log(event.target.hasAttribute("open"));
-      console.log(event.detail.newElement.open);
+  restoreFocusState() {
+    const state = savedDialogStates.get(this.dialogTarget.id);
+    console.log(state);
+    if (state && state.refocusTrigger) {
+      this.triggerTarget.focus();
+      savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: false });
     }
   }
 }

--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -60,7 +60,6 @@ export default class extends Controller {
 
   restoreFocusState() {
     const state = savedDialogStates.get(this.dialogTarget.id);
-    console.log(state);
     if (state && state.refocusTrigger) {
       this.triggerTarget.focus();
       savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: false });

--- a/test/components/viral/dialog_component_test.rb
+++ b/test/components/viral/dialog_component_test.rb
@@ -1,43 +1,60 @@
 # frozen_string_literal: true
 
-require 'view_component_test_case'
+require 'application_system_test_case'
 
 module Viral
-  class DialogComponentTest < ViewComponentTestCase
+  class DialogComponentTest < ApplicationSystemTestCase
     test 'confirmation dialog' do
-      render_preview(:confirmation)
+      visit('rails/view_components/viral_dialog_component/confirmation')
     end
 
     test 'default dialog' do
-      render_preview(:default)
+      visit('rails/view_components/viral_dialog_component/default')
     end
 
     test 'small dialog' do
-      render_preview(:small)
+      visit('rails/view_components/viral_dialog_component/small')
     end
 
     test 'large dialog' do
-      render_preview(:large)
+      visit('rails/view_components/viral_dialog_component/large')
     end
 
     test 'extra_large dialog' do
-      render_preview(:extra_large)
+      visit('rails/view_components/viral_dialog_component/extra_large')
     end
 
     test 'with_action_buttons dialog' do
-      render_preview(:with_action_buttons)
+      visit('rails/view_components/viral_dialog_component/with_action_buttons')
     end
 
     test 'with_trigger dialog' do
-      render_preview(:with_trigger)
+      visit('rails/view_components/viral_dialog_component/with_trigger')
+      within 'div[data-controller-connected="true"]' do
+        click_button 'Open dialog'
+        within 'dialog' do
+          # verify accessibility
+          assert_accessible
+
+          # verify the dialog has a close button
+          assert_button I18n.t('components.dialog.close')
+
+          click_button I18n.t('components.dialog.close')
+        end
+
+        assert_button 'Open dialog', focused: true
+      end
     end
 
     test 'non closable dialog' do
-      render_preview(:non_closable)
+      visit('rails/view_components/viral_dialog_component/non_closable')
+      within 'div[data-controller-connected="true"]' do
+        within 'dialog' do
+          assert_selector '.dialog--header'
 
-      assert_selector 'dialog' do
-        assert_selector '.dialog--header'
-        assert_no_selector ".dialog--header button[aria-label='#{I18n.t('components.dialog.close')}']"
+          # verify the dialog does not have a close button
+          assert_no_selector ".dialog--header button[aria-label='#{I18n.t('components.dialog.close')}']"
+        end
       end
     end
   end

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -629,7 +629,7 @@ module Groups
         click_button I18n.t(:'advanced_search_component.apply_filter_button')
       end
 
-      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']"
+      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']", focused: true
 
       within '#samples-table table tbody' do
         assert_selector 'tr', count: 2
@@ -645,7 +645,7 @@ module Groups
         click_button I18n.t(:'advanced_search_component.clear_filter_button')
       end
 
-      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']"
+      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']", focused: true
 
       within '#samples-table table tbody' do
         assert_selector "tr[id='#{dom_id(@sample1)}']"

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -3188,7 +3188,7 @@ module Projects
         click_button I18n.t(:'advanced_search_component.apply_filter_button')
       end
 
-      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']"
+      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']", focused: true
 
       within '#samples-table table tbody' do
         assert_selector 'tr', count: 1
@@ -3204,7 +3204,7 @@ module Projects
         click_button I18n.t(:'advanced_search_component.clear_filter_button')
       end
 
-      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']"
+      assert_selector "button[aria-label='#{I18n.t(:'advanced_search_component.title')}']", focused: true
 
       within '#samples-table table tbody' do
         assert_selector 'tr', count: 3


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the dialog_controller.js to refocus the trigger on close, or refocus the trigger on subsequent disconnect and connect if the dialog was previously open (e.g. advanced search submit or clear).

Note: Dialogs without a trigger defined, e.g. click a button that does turbo request to retrieve dialog will not refocus. This behaviour will have to be updated later by refactoring those server rendered dialogs in a separate PR.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

[Peek 2025-08-19 09-41.webm](https://github.com/user-attachments/assets/fa77d879-3735-4874-a041-ef877c0b47de)


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Navigate to a Project or Group samples page of your choice
3. Tab to `Advanced search `button and hit enter, then hit enter on close (verify focus on `Advanced search` button).
4. Hit enter again and fill out an advanced search and then hit enter on `Apply filter` (verify focus on `Advanced search` button).
5. Hit enter again and tab to `Clear filter` and then hit enter (verify focus on `Advanced search` button).

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
