### PR TITLE
Boolean component accessibility

### DIFF
--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -113,13 +113,35 @@
                 <% end %>
               <% else %>
                 <div>
-                  <%= fields.label name, :id => "#{fields.field_id(name)}_label" ,:class => "block mb-2 text-sm font-medium text-slate-900 dark:text-white" do %>
-                    <%= text_for(property[:description]) %>
-                    <% if property[:required] %>
-                      <%= viral_pill(text: t(:"components.nextflow.required"), color: :primary) %>
+                  <% if property[:type] != 'boolean' %>
+                    <%= fields.label name, :class => "block mb-2 text-sm font-medium text-slate-900 dark:text-white" do %>
+                      <%= text_for(property[:description]) %>
+                      <% if property[:required] %>
+                        <%= viral_pill(text: t(:"components.nextflow.required"), color: :primary) %>
+                      <% end %>
+                    <% end %>
+                    <%= form_input(fields, name, property, property[:required], instance) %>
+                  <% else %>
+                    <% value =
+                      (
+                        if instance.present?
+                          instance["workflow_params"][name.to_s]
+                        else
+                          property[:default]
+                        end
+                      ) %>
+                    <%= viral_prefixed_boolean(form: fields, name:, value: ActiveModel::Type::Boolean.new.cast(value)) do |input| %>
+                      <%= input.with_prefix do %>
+                        <%= format_name_as_arg(name) %>
+                      <% end %>
+                      <%= input.with_legend(classes: 'block mb-2 text-sm font-medium text-slate-900 dark:text-white') do %>
+                        <%= text_for(property[:description]) %>
+                        <% if property[:required] %>
+                          <%= viral_pill(text: t(:"components.nextflow.required"), color: :primary) %>
+                        <% end %>
+                      <% end %>
                     <% end %>
                   <% end %>
-                  <%= form_input(fields, name, property, property[:required], instance) %>
                   <% if property[:help_text].present? %>
                     <%= viral_help_text do %>
                       <%= text_for(property[:help_text]) %>

--- a/app/components/nextflow_component.html.erb
+++ b/app/components/nextflow_component.html.erb
@@ -113,7 +113,7 @@
                 <% end %>
               <% else %>
                 <div>
-                  <%= fields.label name, :class => "block mb-2 text-sm font-medium text-slate-900 dark:text-white" do %>
+                  <%= fields.label name, :id => "#{fields.field_id(name)}_label" ,:class => "block mb-2 text-sm font-medium text-slate-900 dark:text-white" do %>
                     <%= text_for(property[:description]) %>
                     <% if property[:required] %>
                       <%= viral_pill(text: t(:"components.nextflow.required"), color: :primary) %>

--- a/app/components/viral/form/prefixed/boolean_component.html.erb
+++ b/app/components/viral/form/prefixed/boolean_component.html.erb
@@ -2,6 +2,7 @@
   <%= legend %>
   <div class="flex">
     <span
+      id="<%=name%>-prefix"
       class="
         inline-flex items-center px-3 text-sm text-slate-900 bg-slate-200 border
         rounded-e-0 border-slate-300 rounded-s-lg dark:bg-slate-600 dark:text-slate-300
@@ -17,8 +18,20 @@
       "
     >
       <div class="flex gap-4 items-center">
-        <%= form.radio_button name, "true", label: t(".true"), checked: value %>
-        <%= form.radio_button name, "false", label: t(".false"), checked: !value %>
+        <%= form.radio_button name,
+                          "true",
+                          label: t(".true"),
+                          checked: value,
+                          aria: {
+                            describedby: "#{name}-prefix",
+                          } %>
+        <%= form.radio_button name,
+                          "false",
+                          label: t(".false"),
+                          checked: !value,
+                          aria: {
+                            describedby: "#{name}-prefix",
+                          } %>
       </div>
     </div>
   </div>

--- a/app/components/viral/form/prefixed/boolean_component.html.erb
+++ b/app/components/viral/form/prefixed/boolean_component.html.erb
@@ -1,26 +1,25 @@
-<div class="flex">
-  <span
-    class="
-      inline-flex items-center px-3 text-sm text-slate-900 bg-slate-200 border
-      rounded-e-0 border-slate-300 rounded-s-lg dark:bg-slate-600 dark:text-slate-300
-      dark:border-slate-600 font-mono
-    "
-  >
-    <%= prefix %>
-  </span>
-  <div
-    class="
-      rounded-none rounded-e-lg bg-slate-50 border block flex-1 min-w-0 w-full
-      border-slate-300 p-2.5 dark:bg-slate-700 dark:border-slate-600
-    "
-  >
-    <div
-      class="flex gap-4 items-center"
-      role="radiogroup"
-      aria-labelledby="<%= form.field_id(name)%>_label"
+<fieldset>
+  <%= legend %>
+  <div class="flex">
+    <span
+      class="
+        inline-flex items-center px-3 text-sm text-slate-900 bg-slate-200 border
+        rounded-e-0 border-slate-300 rounded-s-lg dark:bg-slate-600 dark:text-slate-300
+        dark:border-slate-600 font-mono
+      "
     >
-      <%= form.radio_button name, "true", label: "True", checked: value %>
-      <%= form.radio_button name, "false", label: "False", checked: !value %>
+      <%= prefix %>
+    </span>
+    <div
+      class="
+        rounded-none rounded-e-lg bg-slate-50 border block flex-1 min-w-0 w-full
+        border-slate-300 p-2.5 dark:bg-slate-700 dark:border-slate-600
+      "
+    >
+      <div class="flex gap-4 items-center" role="radiogroup">
+        <%= form.radio_button name, "true", label: "True", checked: value %>
+        <%= form.radio_button name, "false", label: "False", checked: !value %>
+      </div>
     </div>
   </div>
-</div>
+</fieldset>

--- a/app/components/viral/form/prefixed/boolean_component.html.erb
+++ b/app/components/viral/form/prefixed/boolean_component.html.erb
@@ -14,7 +14,11 @@
       border-slate-300 p-2.5 dark:bg-slate-700 dark:border-slate-600
     "
   >
-    <div class="flex gap-4 items-center" role="radiogroup">
+    <div
+      class="flex gap-4 items-center"
+      role="radiogroup"
+      aria-labelledby="<%= form.field_id(name)%>_label"
+    >
       <%= form.radio_button name, "true", label: "True", checked: value %>
       <%= form.radio_button name, "false", label: "False", checked: !value %>
     </div>

--- a/app/components/viral/form/prefixed/boolean_component.html.erb
+++ b/app/components/viral/form/prefixed/boolean_component.html.erb
@@ -16,9 +16,9 @@
         border-slate-300 p-2.5 dark:bg-slate-700 dark:border-slate-600
       "
     >
-      <div class="flex gap-4 items-center" role="radiogroup">
-        <%= form.radio_button name, "true", label: "True", checked: value %>
-        <%= form.radio_button name, "false", label: "False", checked: !value %>
+      <div class="flex gap-4 items-center">
+        <%= form.radio_button name, "true", label: t(".true"), checked: value %>
+        <%= form.radio_button name, "false", label: t(".false"), checked: !value %>
       </div>
     </div>
   </div>

--- a/app/components/viral/form/prefixed/boolean_component.rb
+++ b/app/components/viral/form/prefixed/boolean_component.rb
@@ -8,6 +8,9 @@ module Viral
         attr_reader :form, :name, :value
 
         renders_one :prefix
+        renders_one :legend, lambda { |classes: nil, &block|
+          content_tag :legend, class: classes, &block
+        }
 
         def initialize(form:, name:, value:)
           @form = form

--- a/app/helpers/nextflow_helper.rb
+++ b/app/helpers/nextflow_helper.rb
@@ -2,20 +2,8 @@
 
 # Helper to render a Nextflow pipeline form
 module NextflowHelper
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def form_input(container, name, property, required, instance)
     value = instance.present? ? instance['workflow_params'][name.to_s] : property[:default]
-
-    if property[:type] == 'boolean'
-      return viral_prefixed_boolean(
-        form: container, name:,
-        value: ActiveModel::Type::Boolean.new.cast(value)
-      ) do |input|
-               input.with_prefix do
-                 format_name_as_arg(name)
-               end
-             end
-    end
 
     if property[:enum].present?
       return viral_prefixed_select(form: container, name:, options: property[:enum],
@@ -33,8 +21,6 @@ module NextflowHelper
       end
     end
   end
-
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   def checkbox_input(fields, name, property)
     viral_checkbox(

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -123,7 +123,9 @@ export default class extends Controller {
       );
       this.selectPageTarget.checked = uncheckedBoxes.length === 0;
       this.selectPageTarget.indeterminate = !(
-        uncheckedBoxes.length === 0 || uncheckedBoxes.length === this.totalValue
+        uncheckedBoxes.length === 0 ||
+        uncheckedBoxes.length === this.totalValue ||
+        this.rowSelectionTargets.length - uncheckedBoxes.length === 0
       );
     }
   }

--- a/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
+++ b/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
@@ -13,85 +13,87 @@
       <input type="hidden" name="format" value="turbo_stream"/>
       <div class="flex flex-col min-h-0 mb-2 table-container shrink">
         <div class="overflow-auto scrollbar">
-          <table
-            class='
-              w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
-              whitespace-nowrap
-            '
-          >
-            <thead
+          <fieldset>
+            <legend><%= t(".select_file") %></legend>
+            <table
               class='
-                sticky top-0 z-10 text-xs uppercase border text-slate-700 bg-slate-50
-                dark:bg-slate-700 dark:text-slate-300 border-slate-200 dark:border-slate-700
+                w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
+                whitespace-nowrap
               '
             >
-              <tr>
-                <th class="pr-3 pl-10.5 py-3 bg-slate-50 dark:bg-slate-700">
-                  <%= t(".headers.filename") %>
-                </th>
-                <th class="p-3">
-                  <%= t(".headers.format") %>
-                </th>
-                <th class="p-3">
-                  <%= t(".headers.type") %>
-                </th>
-                <th class="p-3">
-                  <%= t(".headers.size") %>
-                </th>
-                <th class="p-3">
-                  <%= t(".headers.created_at") %>
-                </th>
-              </tr>
-            </thead>
-
-            <tbody
-              class='
-                overflow-y-auto bg-white border dark:bg-slate-800 border-slate-200
-                dark:border-slate-700
-              '
-            >
-              <% @listing_attachments.each do |attachment| %>
-                <tr
-                  class="
-                    bg-white border-b border-slate-200 dark:bg-slate-800 dark:border-slate-700
-                  "
-                >
-                  <td class="p-3 bg-white dark:bg-slate-800">
-                    <%= form.radio_button "attachment_id",
-                                      attachment[:id],
-                                      label: attachment[:filename],
-                                      checked:
-                                        file_selector_params["selected_id"] &&
-                                          file_selector_params["selected_id"] == attachment[:id] %>
-                  </td>
-                  <td class="p-3"><%= viral_pill(
-                      text: attachment[:metadata]["format"],
-                      color: find_pill_color_for_attachment(attachment, "format"),
-                    ) %></td>
-                  <td class="p-3"><%= viral_pill(
-                      text: attachment[:metadata]["type"],
-                      color: find_pill_color_for_attachment(attachment, "type"),
-                    ) %></td>
-                  <td class="p-3">
-                    <%= number_to_human_size(attachment[:byte_size]) %>
-                  </td>
-                  <td class="p-3">
-                    <%= local_time_ago(attachment[:created_at]) %>
-                  </td>
+              <thead
+                class='
+                  sticky top-0 z-10 text-xs uppercase border text-slate-700 bg-slate-50
+                  dark:bg-slate-700 dark:text-slate-300 border-slate-200 dark:border-slate-700
+                '
+              >
+                <tr>
+                  <th scope="col" class="pr-3 pl-10.5 py-3 bg-slate-50 dark:bg-slate-700">
+                    <%= t(".headers.filename") %>
+                  </th>
+                  <th scope="col" class="p-3">
+                    <%= t(".headers.format") %>
+                  </th>
+                  <th scope="col" class="p-3">
+                    <%= t(".headers.type") %>
+                  </th>
+                  <th scope="col" class="p-3">
+                    <%= t(".headers.size") %>
+                  </th>
+                  <th scope="col" class="p-3">
+                    <%= t(".headers.created_at") %>
+                  </th>
                 </tr>
-              <% end %>
-              <% unless file_selector_params["required_properties"].present? && file_selector_params["required_properties"].include?(file_selector_params["property"]) %>
-                <tr class="bg-white border-b dark:bg-slate-800 dark:border-slate-700">
-                  <td class="p-3 bg-white dark:bg-slate-800">
-                    <%= form.radio_button "attachment_id",
-                                      "no_attachment",
-                                      label: t(".no_file"),
-                                      checked: file_selector_params["selected_id"].empty? %>
-                  </td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
+              </thead>
+              <tbody
+                class='
+                  overflow-y-auto bg-white border dark:bg-slate-800 border-slate-200
+                  dark:border-slate-700
+                '
+              >
+                <% @listing_attachments.each do |attachment| %>
+                  <tr
+                    class="
+                      bg-white border-b border-slate-200 dark:bg-slate-800 dark:border-slate-700
+                    "
+                  >
+                    <td class="p-3 bg-white dark:bg-slate-800">
+                      <%= form.radio_button "attachment_id",
+                                        attachment[:id],
+                                        label: attachment[:filename],
+                                        checked:
+                                          file_selector_params["selected_id"] &&
+                                            file_selector_params["selected_id"] == attachment[:id] %>
+                    </td>
+                    <td class="p-3"><%= viral_pill(
+                        text: attachment[:metadata]["format"],
+                        color: find_pill_color_for_attachment(attachment, "format"),
+                      ) %></td>
+                    <td class="p-3"><%= viral_pill(
+                        text: attachment[:metadata]["type"],
+                        color: find_pill_color_for_attachment(attachment, "type"),
+                      ) %></td>
+                    <td class="p-3">
+                      <%= number_to_human_size(attachment[:byte_size]) %>
+                    </td>
+                    <td class="p-3">
+                      <%= local_time_ago(attachment[:created_at]) %>
+                    </td>
+                  </tr>
+                <% end %>
+                <% unless file_selector_params["required_properties"].present? && file_selector_params["required_properties"].include?(file_selector_params["property"]) %>
+                  <tr class="bg-white border-b dark:bg-slate-800 dark:border-slate-700">
+                    <td class="p-3 bg-white dark:bg-slate-800">
+                      <%= form.radio_button "attachment_id",
+                                        "no_attachment",
+                                        label: t(".no_file"),
+                                        checked: file_selector_params["selected_id"].empty? %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </fieldset>
         </div>
       </div>
       <% unless @listing_attachments.empty? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2343,6 +2343,11 @@ en:
     data_table_component:
       header:
         action: Action
+    form:
+      prefixed:
+        boolean_component:
+          'false': 'False'
+          'true': 'True'
     pagy:
       limit_component:
         item_aria_label: Show %{items} items per page

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2343,6 +2343,11 @@ fr:
     data_table_component:
       header:
         action: Mesure
+    form:
+      prefixed:
+        boolean_component:
+          'false': Faux
+          'true': Vrai
     pagy:
       limit_component:
         item_aria_label: Show %{items} items per page

--- a/test/components/previews/viral_form_prefixed_boolean_component_preview/default.html.erb
+++ b/test/components/previews/viral_form_prefixed_boolean_component_preview/default.html.erb
@@ -1,5 +1,8 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_boolean(form: form, name: "prefixed", value: true) do |checkbox| %>
+  <%= viral_prefixed_boolean(form: form, name: "prefixed" , value: true) do |checkbox| %>
+    <%= checkbox.with_legend do %>
+      This is the group legend
+    <% end %>
     <%= checkbox.with_prefix do %>
       --prefix
     <% end %>

--- a/test/components/previews/viral_form_prefixed_boolean_component_preview/with_false_value.html.erb
+++ b/test/components/previews/viral_form_prefixed_boolean_component_preview/with_false_value.html.erb
@@ -1,5 +1,8 @@
 <%= form_with url: '#' do |form| %>
   <%= viral_prefixed_boolean(form: form, name: "prefixed", value: false) do |checkbox| %>
+    <%= checkbox.with_legend do %>
+      This is the group legend
+    <% end %>
     <%= checkbox.with_prefix do %>
       --prefix
     <% end %>

--- a/test/components/previews/viral_form_prefixed_boolean_component_preview/with_icon.html.erb
+++ b/test/components/previews/viral_form_prefixed_boolean_component_preview/with_icon.html.erb
@@ -1,5 +1,8 @@
 <%= form_with url: '#' do |form| %>
   <%= viral_prefixed_boolean(form: form, name: "prefixed", value: true) do |checkbox| %>
+    <%= checkbox.with_legend do %>
+      This is the group legend
+    <% end %>
     <%= checkbox.with_prefix do %>
       <%= pathogen_icon(ICON::WARNING_CIRCLE, size: :sm, color: :warning) %>
     <% end %>

--- a/test/components/viral/form/prefixed/boolean_component_test.rb
+++ b/test/components/viral/form/prefixed/boolean_component_test.rb
@@ -8,6 +8,7 @@ module Viral
       class BooleanComponentTest < ViewComponentTestCase
         test 'default' do
           render_preview(:default)
+          assert_selector 'fieldset > legend', text: 'This is the group legend', count: 1
           assert_selector 'span.font-mono', text: '--prefix', count: 1
           assert_selector 'input[type="radio"]', count: 2
           assert_selector 'input[type="radio"][value="true"][checked="checked"]', count: 1
@@ -16,6 +17,7 @@ module Viral
 
         test 'with_icon' do
           render_preview(:with_icon)
+          assert_selector 'fieldset > legend', text: 'This is the group legend', count: 1
           assert_selector 'svg.warning-circle-icon', count: 1
           assert_selector 'input[type="radio"]', count: 2
           assert_selector 'input[type="radio"][value="true"][checked="checked"]', count: 1
@@ -24,6 +26,7 @@ module Viral
 
         test 'with_false_value' do
           render_preview(:with_false_value)
+          assert_selector 'fieldset > legend', text: 'This is the group legend', count: 1
           assert_selector 'span.font-mono', text: '--prefix', count: 1
           assert_selector 'input[type="radio"]', count: 2
           assert_no_selector 'input[type="radio"][value="true"][checked="checked"]'


### PR DESCRIPTION
## What does this PR do and why?
Fixes the srceenreader not announcing the group label for a group of radio buttons.
[STY0018336](https://publichealthprod.service-now.com/rm_story.do?sys_id=703f6dc6474e6610f24c0c21516d43da)

## Screenshots or screen recordings
Before:
<img width="2553" height="1343" alt="radio_button_accessibility_before" src="https://github.com/user-attachments/assets/3e87d417-b4d6-4479-bb98-aac361e714f9" />

After:
<img width="2554" height="1344" alt="prefixed-boolean-component-2" src="https://github.com/user-attachments/assets/1c438471-7574-45c0-8b23-7e659eca9f83" />

## How to set up and validate locally
1. Start a screenreader and open a browser.
1. Launch a workflow within irida-next or view a preview within [lookbook](http://localhost:3000/rails/lookbook/inspect/viral_form_prefixed_boolean).
1. Tab through a boolean component.
1. Verify the group label is announced.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
