### PR TITLE
A11y: Dialog component reflow

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -393,34 +393,6 @@ input[type="search"] {
   }
 }
 
-@utility dialog--size-sm {
-  @apply sm:max-w-md;
-}
-
-@utility dialog--size-md {
-  @apply sm:max-w-xl;
-}
-
-@utility dialog--size-lg {
-  @apply sm:max-w-3xl;
-}
-
-@utility dialog--size-xl {
-  @apply sm:max-w-7xl;
-}
-
-@utility dialog--title {
-  @apply text-xl font-semibold text-slate-900 dark:text-white;
-}
-
-@utility dialog--close {
-  @apply ml-auto inline-flex items-center rounded-lg bg-transparent p-1.5 text-sm text-slate-400 hover:bg-slate-200 hover:text-slate-900 dark:hover:bg-slate-600 dark:hover:text-white;
-}
-
-@utility dialog--section {
-  @apply p-5;
-}
-
 @utility avatar {
   @apply relative inline-flex flex-none items-center justify-center overflow-hidden rounded-lg text-slate-800 dark:text-white;
   --tw-avatar-bg-lightness: 35%;
@@ -506,25 +478,35 @@ input[type="search"] {
 
   /* VIRAL DIALOG */
   dialog {
-    @apply max-h-full w-full max-w-2xl overflow-y-hidden rounded-lg bg-white p-0 shadow-sm dark:bg-slate-800;
-    top: 50%;
-    left: 50%;
-    -webkit-transform: translateX(-50%) translateY(-50%);
-    -moz-transform: translateX(-50%) translateY(-50%);
-    -ms-transform: translateX(-50%) translateY(-50%);
-    transform: translateX(-50%) translateY(-50%);
+    @apply max-w-screen -translate-1/2 backdrop-blur-xs left-1/2 top-1/2 max-h-screen w-full rounded-lg bg-white p-0 shadow-sm backdrop:bg-slate-200/40 max-sm:overflow-y-auto sm:overflow-y-hidden dark:bg-slate-800 dark:backdrop:bg-slate-600/40;
   }
 
-  dialog::backdrop {
-    @apply backdrop-blur-xs bg-slate-200/40;
+  .dialog--size-sm {
+    @apply sm:max-w-md;
   }
 
-  .dark dialog::backdrop {
-    @apply backdrop-blur-xs bg-slate-600/40;
+  .dialog--size-md {
+    @apply sm:max-w-xl;
+  }
+
+  .dialog--size-lg {
+    @apply sm:max-w-3xl;
+  }
+
+  .dialog--size-xl {
+    @apply sm:max-w-7xl;
+  }
+
+  .dialog--title {
+    @apply text-xl font-semibold text-slate-900 dark:text-white;
+  }
+
+  .dialog--close {
+    @apply ml-auto inline-flex items-center rounded-lg bg-transparent p-1.5 text-sm text-slate-400 hover:bg-slate-200 hover:text-slate-900 dark:hover:bg-slate-600 dark:hover:text-white;
   }
 
   .dialog--section {
-    @apply sm:max-h-(--dialog-section-max-height) p-5 sm:overflow-y-auto;
+    @apply sm:max-h-(--dialog-section-max-height) wrap-break-word p-5 sm:overflow-y-auto;
   }
 
   strong {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -18,6 +18,7 @@
   --color-primary-950: #052e16;
   --color-primary: #16a34a;
   --layout-body-columns: 280px 1fr;
+  --dialog-section-max-height: calc(75vh - 1.25rem - 3.5rem);
 }
 
 /* Hide search clear button across all browsers */
@@ -392,24 +393,20 @@ input[type="search"] {
   }
 }
 
-@utility dialog--size {
-  @apply relative max-h-full w-full;
-}
-
 @utility dialog--size-sm {
-  @apply max-w-md;
+  @apply sm:max-w-md;
 }
 
 @utility dialog--size-md {
-  @apply max-w-xl;
+  @apply sm:max-w-xl;
 }
 
 @utility dialog--size-lg {
-  @apply max-w-3xl;
+  @apply sm:max-w-3xl;
 }
 
 @utility dialog--size-xl {
-  @apply max-w-7xl;
+  @apply sm:max-w-7xl;
 }
 
 @utility dialog--title {
@@ -527,8 +524,7 @@ input[type="search"] {
   }
 
   .dialog--section {
-    max-height: calc(75vh - 1.25rem - 3.5rem);
-    @apply overflow-y-auto p-5;
+    @apply sm:max-h-(--dialog-section-max-height) p-5 sm:overflow-y-auto;
   }
 
   strong {

--- a/app/components/activities/dialogs/activity_list_dialog_component.html.erb
+++ b/app/components/activities/dialogs/activity_list_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :large, classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(title: @title) %>
   <div
     data-controller="activities--extended_details"

--- a/app/components/activities/dialogs/activity_table_listing_dialog_component.html.erb
+++ b/app/components/activities/dialogs/activity_table_listing_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :extra_large, classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: true, size: :extra_large) do |dialog| %>
   <% dialog.with_header(title: @title) %>
   <div
     data-controller="activities--extended_details"

--- a/app/components/viral/dialog_component.html.erb
+++ b/app/components/viral/dialog_component.html.erb
@@ -7,7 +7,7 @@
   <% if trigger.present? %>
     <%= trigger %>
   <% end %>
-  <div style="height: 0px">
+  <div class="contents">
     <%= render Viral::BaseComponent.new(tag: :dialog, id: id, classes: [dialog_size], **system_arguments) do %>
       <% if header.present? %>
         <%= header %>

--- a/app/components/viral/dialog_component.rb
+++ b/app/components/viral/dialog_component.rb
@@ -33,11 +33,8 @@ module Viral
       @system_arguments = system_arguments
 
       @system_arguments[:classes] = class_names(
-        'max-sm:overflow-y-auto',
         @system_arguments[:classes],
-        dialog_size,
-        'max-sm:w-screen',
-        'max-sm:h-screen'
+        dialog_size
       )
 
       @system_arguments[:data] = if @system_arguments.key?(:data)

--- a/app/components/viral/dialog_component.rb
+++ b/app/components/viral/dialog_component.rb
@@ -33,9 +33,11 @@ module Viral
       @system_arguments = system_arguments
 
       @system_arguments[:classes] = class_names(
-        'overflow-visible',
+        'max-sm:overflow-y-auto',
         @system_arguments[:classes],
-        dialog_size
+        dialog_size,
+        'max-sm:w-screen',
+        'max-sm:h-screen'
       )
 
       @system_arguments[:data] = if @system_arguments.key?(:data)

--- a/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open,classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/groups/group_links/_invite_group_modal.html.erb
+++ b/app/views/groups/group_links/_invite_group_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(title: I18n.t("groups.group_links.new.title")) %>
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">

--- a/app/views/groups/members/_create_modal.html.erb
+++ b/app/views/groups/members/_create_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(title: t(:"groups.members.new.title")) %>
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">

--- a/app/views/groups/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/groups/workflow_executions/_edit_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open,classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open,classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/projects/group_links/_invite_group_modal.html.erb
+++ b/app/views/projects/group_links/_invite_group_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open,classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(title: I18n.t("projects.group_links.new.title")) %>
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">

--- a/app/views/projects/members/_create_modal.html.erb
+++ b/app/views/projects/members/_create_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(title: t(:"projects.members.new.title")) %>
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">

--- a/app/views/projects/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/projects/workflow_executions/_edit_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open,classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/workflow_executions/_edit_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open,classes: ["overflow-visible"]) do |dialog| %>
+<%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(title: t("workflow_executions.edit_dialog.title")) %>
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the styling for the Dialog component to reflow when zooming in. That involves switching from dialog section scroll to entire dialog being scrollable when viewport is `<48rem`. In addition, dialog size classes have been updated to only apply their max width when viewport is `>=48rem`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Login then click on an button that launches a dialog
3. In viewport of 1280 x 1024 zoom in to 250%
4. Confirm that modal takes up full screen width and whole modal scrolls instead of just the section
5. Optionally confirm with the lookbook previews

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
