### PR TITLE
Accessibility: Devise layout language selection overlap

### DIFF
--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -39,7 +39,7 @@
               </div>
             </div>
 
-            <div class="flex flex-col items-center justify-between mt-10">
+            <div class="flex flex-col items-center justify-between max-sm:mt-14">
               <%= render Viral::IconComponent.new(
                 name: "beaker",
                 classes: "w-20 h-20 text-green-500 rotate-12",

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -39,7 +39,7 @@
               </div>
             </div>
 
-            <div class="flex flex-col items-center justify-between">
+            <div class="flex flex-col items-center justify-between mt-10">
               <%= render Viral::IconComponent.new(
                 name: "beaker",
                 classes: "w-20 h-20 text-green-500 rotate-12",


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Fixed devise view reflow where the language selection button when focused and viewed at 400% zoom caused an overlap with the IRIDA Next icon

Addresses: 
[STRY0018490](https://publichealthprod.service-now.com/rm_story.do?sys_id=2f5b552e339e621061dd45659d5c7b15)


## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**100% previous**

<img width="1280" height="881" alt="image" src="https://github.com/user-attachments/assets/e835d969-41b2-4bc2-bfde-46feebe65771" />


**400% previous**

<img width="1280" height="881" alt="image" src="https://github.com/user-attachments/assets/5174eceb-3b70-4a4d-aa9c-a35be6e34968" />


**100% current**

<img width="1280" height="881" alt="image" src="https://github.com/user-attachments/assets/21dfd367-5769-4732-98e5-01feede36b34" />

**400% current**

<img width="1280" height="881" alt="image" src="https://github.com/user-attachments/assets/8c058a71-1c9e-4127-8e78-6893803cb99e" />



## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Verify the language selection button/dropdown when `Francais` is selected and keyboard focused does not overlap with the IRIDA Next icon when the viewport is set to 1280x1024 and zoomed to 400%

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
