### PR TITLE
A11y: Dialog reflow followup

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -486,7 +486,9 @@ input[type="search"] {
   }
 
   dialog div.dialog--contents {
-    @apply h-full w-full max-sm:overflow-y-auto sm:overflow-y-hidden;
+    @apply max-sm:overflow-y-auto sm:overflow-y-hidden;
+    max-height: inherit;
+    max-width: inherit;
   }
 
   .dialog--size-sm {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -482,7 +482,11 @@ input[type="search"] {
 
   /* VIRAL DIALOG */
   dialog {
-    @apply max-w-screen -translate-1/2 backdrop-blur-xs left-1/2 top-1/2 max-h-screen w-full rounded-lg bg-white p-0 shadow-sm backdrop:bg-slate-200/40 max-sm:overflow-y-auto sm:overflow-y-hidden dark:bg-slate-800 dark:backdrop:bg-slate-600/40;
+    @apply -translate-1/2 backdrop-blur-xs max-w-screen left-1/2 top-1/2 max-h-screen w-full rounded-lg bg-white shadow-sm backdrop:bg-slate-200/40 dark:bg-slate-800 dark:backdrop:bg-slate-600/40;
+  }
+
+  dialog div.dialog--contents {
+    @apply h-full w-full max-sm:overflow-y-auto sm:overflow-y-hidden;
   }
 
   .dialog--size-sm {

--- a/app/components/viral/dialog_component.html.erb
+++ b/app/components/viral/dialog_component.html.erb
@@ -8,31 +8,33 @@
     <%= trigger %>
   <% end %>
   <div class="contents">
-    <%= render Viral::BaseComponent.new(tag: :dialog, id: id, classes: [dialog_size], **system_arguments) do %>
-      <% if header.present? %>
-        <%= header %>
-      <% end %>
+    <%= render Viral::BaseComponent.new(tag: :dialog, classes: ["overflow-visible", @dialog_size], data: { 'viral--dialog-target': 'dialog'}) do %>
+      <%= render Viral::BaseComponent.new(tag: :div, id: id, **system_arguments) do %>
+        <% if header.present? %>
+          <%= header %>
+        <% end %>
 
-      <div class="dialog--section border-t border-slate-200 dark:border-slate-600">
-        <%= content %>
-      </div>
-
-      <% if render_footer? %>
-        <div
-          class="
-            flex items-center p-5 space-x-2 border-t rounded-b-lg border-slate-200
-            dark:border-slate-600
-          "
-        >
-          <% if primary_action? %>
-            <%= primary_action %>
-          <% end %>
-          <% if secondary_actions? %>
-            <% secondary_actions.each do |action| %>
-              <%= action %>
-            <% end %>
-          <% end %>
+        <div class="dialog--section border-t border-slate-200 dark:border-slate-600">
+          <%= content %>
         </div>
+
+        <% if render_footer? %>
+          <div
+            class="
+              flex items-center p-5 space-x-2 border-t rounded-b-lg border-slate-200
+              dark:border-slate-600
+            "
+          >
+            <% if primary_action? %>
+              <%= primary_action %>
+            <% end %>
+            <% if secondary_actions? %>
+              <% secondary_actions.each do |action| %>
+                <%= action %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/components/viral/dialog_component.rb
+++ b/app/components/viral/dialog_component.rb
@@ -23,7 +23,7 @@ module Viral
 
     renders_one :trigger
 
-    def initialize(id: 'dialog', title: '', size: SIZE_DEFAULT, open: false, closable: true, header_system_arguments: {}, **system_arguments) # rubocop:disable Metrics/ParameterLists,Layout/LineLength,Metrics/MethodLength
+    def initialize(id: 'dialog', title: '', size: SIZE_DEFAULT, open: false, closable: true, header_system_arguments: {}, **system_arguments) # rubocop:disable Metrics/ParameterLists,Layout/LineLength
       @id = id
       @title = title
       @open = open
@@ -34,20 +34,13 @@ module Viral
 
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
-        dialog_size
+        'dialog--contents'
       )
-
-      @system_arguments[:data] = if @system_arguments.key?(:data)
-                                   @system_arguments[:data].merge({ 'viral--dialog-target' => 'dialog' })
-                                 else
-                                   { 'viral--dialog-target' => 'dialog' }
-                                 end
 
       return if closable
 
-      @system_arguments[:data].merge!({
-                                        action: 'keydown.esc->viral--dialog#handleEsc'
-                                      })
+      @system_arguments[:data] ||= {}
+      @system_arguments[:data].merge!({ action: 'keydown.esc->viral--dialog#handleEsc' })
     end
 
     def render_footer?

--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -4,6 +4,8 @@ require 'application_system_test_case'
 
 module Dashboard
   class ProjectsTest < ApplicationSystemTestCase
+    include ActionView::Helpers::SanitizeHelper
+
     def setup
       @user = users(:john_doe)
       login_as @user
@@ -77,8 +79,10 @@ module Dashboard
       assert_selector '.treegrid-row', count: 20
 
       fill_in I18n.t(:'dashboard.projects.index.search.placeholder'), with: @project.name
-      find('input.t-search-component').native.send_keys(:return)
+      click_button I18n.t(:'dashboard.projects.index.search.label')
 
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 12, count: 12,
+                                                                           locale: @user.locale))
       assert_selector '.treegrid-row', count: 12
       assert_no_selector 'a',
                          exact_text: I18n.t(:'viral.pagy.pagination_component.previous')
@@ -97,7 +101,10 @@ module Dashboard
       assert_selector '.treegrid-row', count: 20
 
       fill_in I18n.t(:'dashboard.projects.index.search.placeholder'), with: @project.puid
-      find('input.t-search-component').native.send_keys(:return)
+      click_button I18n.t(:'dashboard.projects.index.search.label')
+
+      assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 1, count: 1,
+                                                                           locale: @user.locale))
       assert_selector '.treegrid-row', count: 1
       assert_text @project.puid
     end

--- a/test/system/groups/group_links_test.rb
+++ b/test/system/groups/group_links_test.rb
@@ -36,6 +36,8 @@ module Groups
         click_button I18n.t(:'groups.group_links.new.button.submit')
       end
 
+      assert_no_selector 'dialog[open]'
+
       assert_selector 'tr', count: (@group_links_count + 1) + header_row_count
     end
 

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -1169,6 +1169,9 @@ module Groups
 
       assert_no_selector 'dialog[open]'
 
+      # verify page has finished loading
+      assert_no_selector 'html[aria-busy="true"]'
+
       assert_selector '#samples-table table thead tr th', count: 10
       ### VERIFY END ###
     end
@@ -1273,6 +1276,9 @@ module Groups
       end
 
       assert_no_selector 'dialog[open]'
+
+      # verify page has finished loading
+      assert_no_selector 'html[aria-busy="true"]'
 
       assert_selector '#samples-table table thead tr th', count: 10
       within('#samples-table table') do
@@ -2009,6 +2015,9 @@ module Groups
 
       assert_no_selector 'dialog[open]'
 
+      # verify page has finished loading
+      assert_no_selector 'html[aria-busy="true"]'
+
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 25,
                                                                            locale: @user.locale))
 
@@ -2194,6 +2203,9 @@ module Groups
       end
 
       assert_no_selector 'dialog[open]'
+
+      # verify page has finished loading
+      assert_no_selector 'html[aria-busy="true"]'
 
       # verify sample1 and 2 transferred, sample 28, sample 30 did not
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 2, count: 2,
@@ -2423,6 +2435,9 @@ module Groups
 
       assert_no_selector 'dialog[open]'
 
+      # verify page has finished loading
+      assert_no_selector 'html[aria-busy="true"]'
+
       # samples table now contains both original and cloned samples
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 28,
                                                                            locale: @user.locale))
@@ -2581,6 +2596,9 @@ module Groups
       # verify dialog is closed
       assert_no_selector 'dialog[open]'
 
+      # verify page has finished loading
+      assert_no_selector 'html[aria-busy="true"]'
+
       # verify samples table updates with cloned samples
       assert_text strip_tags(I18n.t(:'viral.pagy.limit_component.summary', from: 1, to: 20, count: 47,
                                                                            locale: @user.locale))
@@ -2666,6 +2684,9 @@ module Groups
       end
 
       assert_no_selector 'dialog[open]'
+
+      # verify page has finished loading
+      assert_no_selector 'html[aria-busy="true"]'
 
       # verify no samples selected anymore
       within 'tfoot' do

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -454,12 +454,14 @@ module Projects
       end
 
       # confirm destroy bot
-      assert_selector '#dialog'
-      within('#dialog') do
+      assert_selector 'dialog[open]'
+      within('dialog[open]') do
         assert_text I18n.t('bots.destroy_confirmation.description', bot_name: @project_bot.user.email)
         click_button I18n.t('bots.destroy_confirmation.submit_button')
       end
       ### ACTIONS END ###
+
+      assert_no_selector 'dialog[open]'
 
       ### VERIFY START ###
       # confirm bot destroyed

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -1959,6 +1959,7 @@ module Projects
       within %(turbo-frame[id="samples_dialog"]) do
         assert_text I18n.t('shared.progress_bar.in_progress')
         perform_enqueued_jobs only: [::Samples::MetadataImportJob]
+        assert_no_text I18n.t('shared.progress_bar.in_progress')
 
         # sample 3 does not exist in current project
         assert_text I18n.t('services.samples.metadata.import_file.sample_not_found_within_project',


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR is a followup to #1195 and refactors the component to allow select2 and datepicker to overflow properly.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before:

[Screencast from 2025-08-22 09-11-16.webm](https://github.com/user-attachments/assets/1ecccea1-7597-456b-a73e-426d93d45128)

After:

[Screencast from 2025-08-22 09-12-10.webm](https://github.com/user-attachments/assets/9656e255-f5a7-46ef-9cae-090d4130bc80)

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server
2. Open browser with viewport 1280 x 1024
3. Navigate to Group Members page of your choice
4. Click on `Invite group` to launch modal
5. Try `Group` dropdown and `Datepicker` input
6. Then zoom to 200%
7. Repeat step 5
8. Verify that both components display outside of the dialog

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
