### PR TITLE
Fixes: Datepicker

### DIFF
--- a/app/javascript/controllers/pathogen/datepicker/calendar_controller.js
+++ b/app/javascript/controllers/pathogen/datepicker/calendar_controller.js
@@ -284,11 +284,12 @@ export default class extends Controller {
   }
 
   #onLastDate() {
-    if (this.#todaysMonthIndex === 1) {
-      return this.#getFebLastDate(this.#todaysYear) === DAYS_IN_MONTH[1];
-    } else {
-      return this.#todaysDate === DAYS_IN_MONTH[this.#todaysMonthIndex];
-    }
+    const lastDate =
+      this.#todaysMonthIndex === 1
+        ? this.#getFebLastDate(this.#todaysYear)
+        : DAYS_IN_MONTH[this.#todaysMonthIndex];
+    console.log(this.#todaysDate === lastDate);
+    return this.#todaysDate === lastDate;
   }
 
   #getRelativeYearAndMonth(relativePosition) {
@@ -540,6 +541,7 @@ export default class extends Controller {
     }
 
     this.pathogenDatepickerInputOutlet.hideCalendar();
+    this.pathogenDatepickerInputOutlet.focusNextFocusableElement();
   }
 
   // clear selection by clicking clear button
@@ -551,6 +553,7 @@ export default class extends Controller {
     }
 
     this.pathogenDatepickerInputOutlet.hideCalendar();
+    this.pathogenDatepickerInputOutlet.focusNextFocusableElement();
   }
 
   // handles ArrowLeft/Right keyboard navigation

--- a/app/javascript/controllers/pathogen/datepicker/input_controller.js
+++ b/app/javascript/controllers/pathogen/datepicker/input_controller.js
@@ -239,7 +239,7 @@ export default class extends Controller {
     ) {
       event.preventDefault();
       this.hideCalendar();
-      this.#nextFocusableElementAfterInput.focus();
+      this.focusNextFocusableElement();
       return;
     }
 
@@ -369,5 +369,9 @@ export default class extends Controller {
   // used by pathogen/datepicker/calendar.js
   focusDatepickerInput() {
     this.datepickerInputTarget.focus();
+  }
+
+  focusNextFocusableElement() {
+    this.#nextFocusableElementAfterInput.focus();
   }
 }


### PR DESCRIPTION
## What does this PR do and why?
Add focus to next element after datepicker interaction and fixes `onLastDate()` where February logic was not correct

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Test interacting with the datepicker and then tabbing afterwards. Focus should be set to the next element after making a datepicker selection/selecting clear selection
Note: When using mouse to interact, focus is set to the next element but the styling does not appear. This is browser related and we may fix it in the future

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
