### PR TITLE
Blacklist PAT updated_at

### DIFF
--- a/db/migrate/20250826161932_modify_personal_access_token_logidze_trigger_v03.rb
+++ b/db/migrate/20250826161932_modify_personal_access_token_logidze_trigger_v03.rb
@@ -6,7 +6,11 @@ class ModifyPersonalAccessTokenLogidzeTriggerV03 < ActiveRecord::Migration[8.0]
     update_trigger :logidze_on_personal_access_tokens, on: :personal_access_tokens, version: 3
 
     execute <<-SQL.squish
-      UPDATE "personal_access_tokens" as t SET log_data = logidze_snapshot(to_jsonb(t), 'created_at', '{"created_at"}');
+      UPDATE "personal_access_tokens" as t SET log_data = logidze_snapshot(to_jsonb(t), 'created_at', '{"created_at", "updated_at"}');
     SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20250826161932_modify_personal_access_token_logidze_trigger_v03.rb
+++ b/db/migrate/20250826161932_modify_personal_access_token_logidze_trigger_v03.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Migration to modify personal access token logidze trigger
+class ModifyPersonalAccessTokenLogidzeTriggerV03 < ActiveRecord::Migration[8.0]
+  def up
+    update_trigger :logidze_on_personal_access_tokens, on: :personal_access_tokens, version: 3
+
+    execute <<-SQL.squish
+      UPDATE "personal_access_tokens" as t SET log_data = logidze_snapshot(to_jsonb(t), 'created_at', '{"created_at"}');
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,13 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
 -- Name: numeric; Type: COLLATION; Schema: public; Owner: -
 --
 
@@ -1845,7 +1838,7 @@ CREATE TRIGGER logidze_on_namespaces BEFORE INSERT OR UPDATE ON public.namespace
 -- Name: personal_access_tokens logidze_on_personal_access_tokens; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION public.logidze_logger('null', 'updated_at', '{last_used_at}');
+CREATE TRIGGER logidze_on_personal_access_tokens BEFORE INSERT OR UPDATE ON public.personal_access_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION public.logidze_logger('null', 'updated_at', '{last_used_at,updated_at}');
 
 
 --
@@ -2052,6 +2045,7 @@ ALTER TABLE ONLY public.workflow_executions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250826161932'),
 ('20250605171908'),
 ('20250424155356'),
 ('20250416191422'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -431,19 +431,6 @@ CREATE FUNCTION public.logidze_version(v bigint, data jsonb, ts timestamp with t
 $$;
 
 
---
--- Name: action_cable_large_payloads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.action_cable_large_payloads_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -453,10 +440,10 @@ SET default_table_access_method = heap;
 --
 
 CREATE TABLE public.active_storage_attachments (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying NOT NULL,
     record_type character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     record_id uuid NOT NULL,
     blob_id uuid NOT NULL
 );
@@ -467,7 +454,6 @@ CREATE TABLE public.active_storage_attachments (
 --
 
 CREATE TABLE public.active_storage_blobs (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     key character varying NOT NULL,
     filename character varying NOT NULL,
     content_type character varying,
@@ -475,7 +461,8 @@ CREATE TABLE public.active_storage_blobs (
     service_name character varying NOT NULL,
     byte_size bigint NOT NULL,
     checksum character varying,
-    created_at timestamp(6) without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL
 );
 
 
@@ -484,8 +471,8 @@ CREATE TABLE public.active_storage_blobs (
 --
 
 CREATE TABLE public.active_storage_variant_records (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     variation_digest character varying NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     blob_id uuid NOT NULL
 );
 
@@ -540,13 +527,13 @@ CREATE TABLE public.ar_internal_metadata (
 --
 
 CREATE TABLE public.attachments (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
     deleted_at timestamp(6) without time zone,
     attachable_type character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     log_data jsonb,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     attachable_id uuid NOT NULL,
     puid character varying NOT NULL
 );
@@ -673,13 +660,13 @@ ALTER SEQUENCE public.flipper_gates_id_seq OWNED BY public.flipper_gates.id;
 --
 
 CREATE TABLE public.members (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     access_level integer,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     log_data jsonb,
     deleted_at timestamp(6) without time zone,
     expires_at date,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid NOT NULL,
     namespace_id uuid NOT NULL,
     created_by_id uuid NOT NULL
@@ -724,7 +711,6 @@ CREATE TABLE public.namespace_bots (
 --
 
 CREATE TABLE public.namespace_group_links (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     expires_at date,
     group_access_level integer NOT NULL,
     namespace_type character varying,
@@ -732,6 +718,7 @@ CREATE TABLE public.namespace_group_links (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
     log_data jsonb,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     group_id uuid NOT NULL,
     namespace_id uuid NOT NULL
 );
@@ -742,7 +729,6 @@ CREATE TABLE public.namespace_group_links (
 --
 
 CREATE TABLE public.namespaces (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying COLLATE public."numeric",
     path character varying,
     type character varying,
@@ -752,6 +738,7 @@ CREATE TABLE public.namespaces (
     log_data jsonb,
     deleted_at timestamp(6) without time zone,
     metadata_summary jsonb DEFAULT '{}'::jsonb,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     owner_id uuid,
     parent_id uuid,
     puid character varying NOT NULL,
@@ -765,7 +752,6 @@ CREATE TABLE public.namespaces (
 --
 
 CREATE TABLE public.personal_access_tokens (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     scopes character varying,
     name character varying,
     revoked boolean DEFAULT false NOT NULL,
@@ -776,6 +762,7 @@ CREATE TABLE public.personal_access_tokens (
     updated_at timestamp(6) without time zone NOT NULL,
     log_data jsonb,
     deleted_at timestamp(6) without time zone,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid NOT NULL
 );
 
@@ -785,10 +772,10 @@ CREATE TABLE public.personal_access_tokens (
 --
 
 CREATE TABLE public.projects (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     creator_id uuid NOT NULL,
     namespace_id uuid NOT NULL,
     samples_count integer
@@ -800,13 +787,13 @@ CREATE TABLE public.projects (
 --
 
 CREATE TABLE public.routes (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     path character varying,
     name character varying,
     source_type character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     source_id uuid NOT NULL
 );
 
@@ -816,7 +803,6 @@ CREATE TABLE public.routes (
 --
 
 CREATE TABLE public.samples (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     name character varying COLLATE public."numeric",
     description text,
     created_at timestamp(6) without time zone NOT NULL,
@@ -826,6 +812,7 @@ CREATE TABLE public.samples (
     metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
     metadata_provenance jsonb DEFAULT '{}'::jsonb NOT NULL,
     puid character varying NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     project_id uuid NOT NULL,
     attachments_updated_at timestamp(6) without time zone
 );
@@ -836,11 +823,11 @@ CREATE TABLE public.samples (
 --
 
 CREATE TABLE public.samples_workflow_executions (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     samplesheet_params jsonb DEFAULT '{}'::jsonb NOT NULL,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     workflow_execution_id uuid,
     sample_id uuid,
     attachments_updated_at timestamp(6) without time zone,
@@ -894,7 +881,6 @@ ALTER SEQUENCE public.sessions_id_seq OWNED BY public.sessions.id;
 --
 
 CREATE TABLE public.users (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
     reset_password_token character varying,
@@ -909,6 +895,7 @@ CREATE TABLE public.users (
     first_name character varying,
     last_name character varying,
     locale character varying DEFAULT 'en'::character varying,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_type integer DEFAULT 0
 );
 
@@ -918,7 +905,6 @@ CREATE TABLE public.users (
 --
 
 CREATE TABLE public.workflow_executions (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
     metadata jsonb DEFAULT '{"workflow_name": "", "workflow_version": ""}'::jsonb NOT NULL,
     workflow_params jsonb DEFAULT '{}'::jsonb NOT NULL,
     workflow_type character varying,
@@ -931,6 +917,7 @@ CREATE TABLE public.workflow_executions (
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     submitter_id uuid NOT NULL,
     attachments_updated_at timestamp(6) without time zone,
     blob_run_directory character varying,
@@ -942,8 +929,8 @@ CREATE TABLE public.workflow_executions (
     name character varying,
     namespace_id uuid,
     cleaned boolean DEFAULT false NOT NULL,
-    log_data jsonb,
-    shared_with_namespace boolean DEFAULT false NOT NULL
+    shared_with_namespace boolean DEFAULT false NOT NULL,
+    log_data jsonb
 );
 
 
@@ -2066,7 +2053,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250108200329'),
 ('20250107194839'),
 ('20250106153442'),
-('20241212164410'),
 ('20241120173553'),
 ('20241017164233'),
 ('20241004162923'),

--- a/db/triggers/logidze_on_personal_access_tokens_v03.sql
+++ b/db/triggers/logidze_on_personal_access_tokens_v03.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE TRIGGER "logidze_on_personal_access_tokens"
+BEFORE UPDATE OR INSERT ON "personal_access_tokens" FOR EACH ROW
+WHEN (coalesce(current_setting('logidze.disabled', true), '') <> 'on')
+-- Parameters: history_size_limit (integer), timestamp_column (text), filtered_columns (text[]),
+-- include_columns (boolean), debounce_time_ms (integer)
+EXECUTE PROCEDURE logidze_logger(null, 'updated_at', '{last_used_at,updated_at}');


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in a db trigger to blacklist `updated_at` from personal access tokens log data.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. On main, create a person access token and revoke
2. In the rails console run `PersonalAccessToken.last.reload_log_data`
3. Verify that the created_at and updated_at are listed in the changelogs
4. Switch to this branch, run the migration
5. Repeat step 2 and 3 but verify that `created_at` and `updated_at` no longer are listed. created_at is obtained from the timestamp of the first changelog entry.

**Note: The log data has been reset for personal access tokens**

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
