### PR TITLE
Fixed wrapping on long activity words on the project details page

### DIFF
--- a/app/components/activities/list_item_component.html.erb
+++ b/app/components/activities/list_item_component.html.erb
@@ -1,6 +1,7 @@
 <li
   class="
     mb-4 ms-4 activity text-base font-normal text-slate-500 dark:text-slate-400
+    wrap-anywhere
   "
 >
   <div


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Fixed wrapping on long activity words on the project details page.  Fixes: [STRY0018276](https://publichealthprod.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3Ddccffad14742e210f24c0c21516d436f%26sysparm_view%3Dscrum)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Before:**
<img width="1219" height="1098" alt="image" src="https://github.com/user-attachments/assets/5a3efac5-d71c-4cfd-b7e9-2417b89aa46c" />

**After:**
<img width="1219" height="518" alt="image" src="https://github.com/user-attachments/assets/4a514a0e-4fe4-4c13-93ee-35ff75a38ac4" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Add a bot account to a project since their email address are long.  Test at different zoom levels on the project details page to ensure it all fits and does not force horizontal scroll.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
