### PR TITLE
Updated aria labels for treegrid row component

### DIFF
--- a/app/components/treegrid_component.rb
+++ b/app/components/treegrid_component.rb
@@ -2,6 +2,8 @@
 
 # Treegrid component
 class TreegridComponent < Component
+  include NamespaceRowHelper
+
   erb_template <<-ERB
     <%= tag.div(**@system_arguments) do %>
       <% rows.each do |row| %>

--- a/app/components/treegrid_component.rb
+++ b/app/components/treegrid_component.rb
@@ -2,8 +2,6 @@
 
 # Treegrid component
 class TreegridComponent < Component
-  include NamespaceRowHelper
-
   erb_template <<-ERB
     <%= tag.div(**@system_arguments) do %>
       <% rows.each do |row| %>

--- a/app/helpers/namespace_row_helper.rb
+++ b/app/helpers/namespace_row_helper.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Helper for namespace row component
+module NamespaceRowHelper
+  def namespace_row_aria_label(namespace)
+    if namespace.group_namespace?
+      group_aria_label(namespace)
+    elsif namespace.project_namespace?
+      project_aria_label(namespace)
+    end
+  end
+
+  private
+
+  def effective_access_level(namespace)
+    t(
+      :"members.access_levels.level_#{Member.effective_access_level(namespace, Current.user)}"
+    )
+  end
+
+  def group_aria_label(namespace)
+    t(:'components.treegrid.row.group.aria_label',
+      name: namespace.name, puid: namespace.puid,
+      role: effective_access_level(namespace),
+      subgroups_count: namespace.children.count,
+      group_projects_count: namespace.project_namespaces.count,
+      samples_count: namespace.aggregated_samples_count)
+  end
+
+  def project_aria_label(namespace)
+    t(:'components.treegrid.row.project.aria_label',
+      name: namespace.name, puid: namespace.puid,
+      role: effective_access_level(namespace),
+      samples_count: namespace.project.samples.count)
+  end
+end

--- a/app/views/dashboard/groups/group.turbo_stream.erb
+++ b/app/views/dashboard/groups/group.turbo_stream.erb
@@ -1,12 +1,12 @@
 <%= turbo_stream.replace dom_id(@group), method: :morph do %>
-  <%= render Treegrid::RowComponent.new(tabindex: @tabindex, expandable: @group.children_of_type?(Group.sti_name), expanded: true, level: @level, posinset: @posinset, setsize: @setsize, aria: { label: @group.name }, id: dom_id(@group)) do %>
+  <%= render Treegrid::RowComponent.new(tabindex: @tabindex, expandable: @group.children_of_type?(Group.sti_name), expanded: true, level: @level, posinset: @posinset, setsize: @setsize, aria: { label: namespace_row_aria_label(@group) }, id: dom_id(@group)) do %>
     <%= render NamespaceRow::ContentsComponent.new(
       namespace: @group,
       icon_size: :medium,
     ) %>
   <% end %>
   <% @children.each_with_index do |group, group_index| %>
-    <%= render Treegrid::RowComponent.new(tabindex: -1, expandable: group.children_of_type?(Group.sti_name), level: @level + 1, posinset: group_index + 1, setsize: @children.size, aria: { label: group.name }, button_arguments: {data: {"toggle-url": public_send("dashboard_groups_url", { parent_id: group.id, collapse: false, level: @level + 1, posinset: group_index + 1, setsize: @children.size })}}, id: dom_id(group)) do %>
+    <%= render Treegrid::RowComponent.new(tabindex: -1, expandable: group.children_of_type?(Group.sti_name), level: @level + 1, posinset: group_index + 1, setsize: @children.size, aria: { label: namespace_row_aria_label(group) }, button_arguments: {data: {"toggle-url": public_send("dashboard_groups_url", { parent_id: group.id, collapse: false, level: @level + 1, posinset: group_index + 1, setsize: @children.size })}}, id: dom_id(group)) do %>
       <%= render NamespaceRow::ContentsComponent.new(namespace: group, icon_size: :medium) %>
     <% end %>
   <% end %>

--- a/app/views/dashboard/groups/index.html.erb
+++ b/app/views/dashboard/groups/index.html.erb
@@ -44,7 +44,7 @@
     <div class="flex flex-col gap-2" id="groups_tree">
       <%= render TreegridComponent.new do |component| %>
         <% @groups.each_with_index do |group, group_index| %>
-          <%= component.with_row(tabindex: (group_index.zero? ? 0 : -1), expandable: !@render_flat_list && group.children_of_type?(Group.sti_name), posinset: group_index + 1, setsize: @groups.size, aria: { label: group.name}, button_arguments: {data: {"toggle-url": public_send("dashboard_groups_url", { parent_id: group.id, collapse: false, level: 1, posinset: group_index + 1, setsize: @groups.size })}}, id: dom_id(group)) do %>
+          <%= component.with_row(tabindex: (group_index.zero? ? 0 : -1), expandable: !@render_flat_list && group.children_of_type?(Group.sti_name), posinset: group_index + 1, setsize: @groups.size, aria: { label: namespace_row_aria_label(group)}, button_arguments: {data: {"toggle-url": public_send("dashboard_groups_url", { parent_id: group.id, collapse: false, level: 1, posinset: group_index + 1, setsize: @groups.size })}}, id: dom_id(group)) do %>
             <%= render NamespaceRow::ContentsComponent.new(
               namespace: group,
               full_name: @render_flat_list,

--- a/app/views/dashboard/projects/index.html.erb
+++ b/app/views/dashboard/projects/index.html.erb
@@ -57,7 +57,7 @@
 
         <%= render TreegridComponent.new do | component | %>
           <% @projects.each_with_index do |project, project_index| %>
-            <%= component.with_row(tabindex: (project_index.zero? ? 0 : -1), expandable: false, posinset: project_index + 1, setsize: @projects.size, aria: { label: project.name }, button_arguments: { data: { "toggle-url": public_send("dashboard_projects_url", { parent_id: project.id, collapse: false, level: 1, posinset: project_index + 1, setsize: @projects.size }) } }, id: dom_id(project)) do %>
+            <%= component.with_row(tabindex: (project_index.zero? ? 0 : -1), expandable: false, posinset: project_index + 1, setsize: @projects.size, aria: { label: namespace_row_aria_label(project.namespace) }, button_arguments: { data: { "toggle-url": public_send("dashboard_projects_url", { parent_id: project.id, collapse: false, level: 1, posinset: project_index + 1, setsize: @projects.size }) } }, id: dom_id(project)) do %>
               <%= render NamespaceRow::ContentsComponent.new(
                 namespace: project.namespace,
                 full_name: true,

--- a/app/views/groups/_shared_namespaces.html.erb
+++ b/app/views/groups/_shared_namespaces.html.erb
@@ -7,7 +7,7 @@
           expandable: !@render_flat_list && namespace.children_of_type?([Group.sti_name, Namespaces::ProjectNamespace.sti_name]),
           posinset: namespace_index + 1,
           setsize: @namespaces.size,
-          aria: { label: namespace.name},
+          aria: { label: namespace_row_aria_label(namespace)},
           button_arguments: {data: {"toggle-url": public_send("group_subgroups_url", { group_id: @group.full_path, parent_id: namespace.id, collapse: false, level: 1, posinset: namespace_index + 1, setsize: @namespaces.size })}},
           id: dom_id(namespace)
         ) do %>

--- a/app/views/groups/_subgroups_and_projects.html.erb
+++ b/app/views/groups/_subgroups_and_projects.html.erb
@@ -7,7 +7,7 @@
           expandable: !@render_flat_list && namespace.children_of_type?([Group.sti_name, Namespaces::ProjectNamespace.sti_name]),
           posinset: namespace_index + 1,
           setsize: @namespaces.size,
-          aria: { label: namespace.name},
+          aria: { label: namespace_row_aria_label(namespace)},
           button_arguments: {data: {"toggle-url": public_send("group_subgroups_url", { group_id: @group.full_path, parent_id: namespace.id, collapse: false, level: 1, posinset: namespace_index + 1, setsize: @namespaces.size })}},
           id: dom_id(namespace)
         ) do %>

--- a/app/views/groups/subgroups/subgroup.turbo_stream.erb
+++ b/app/views/groups/subgroups/subgroup.turbo_stream.erb
@@ -6,7 +6,7 @@
     level: @level,
     posinset: @posinset,
     setsize: @setsize,
-    aria: { label: @group.name },
+    aria: { label: namespace_row_aria_label(@group) },
     id: dom_id(@group)
   ) do %>
     <%= render NamespaceRow::ContentsComponent.new(
@@ -21,7 +21,7 @@
       level: @level + 1,
       posinset: namespace_index + 1,
       setsize: @children.size,
-      aria: { label: namespace.name },
+      aria: { label: namespace_row_aria_label(namespace) },
       button_arguments: {data: {"toggle-url": public_send("group_subgroups_url", { group_id: @group.full_path, parent_id: namespace.id, collapse: false, level: @level + 1, posinset: namespace_index + 1, setsize: @children.size })}},
       id: dom_id(namespace)
     ) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,9 +694,9 @@ en:
         collapse: Collapse
         expand: Expand
         group:
-          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, subgroups: %{subgroups_count}, projects: %{group_projects_count}, samples: %{samples_count}"
+          aria_label: "%{name}, puid: %{puid}, role: %{role}, subgroups: %{subgroups_count}, projects: %{group_projects_count}, samples: %{samples_count}"
         project:
-          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, samples: %{samples_count}"
+          aria_label: "%{name}, puid: %{puid}, role: %{role}, samples: %{samples_count}"
     viral:
       pagy:
         empty_state:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -693,6 +693,10 @@ en:
       row:
         collapse: Collapse
         expand: Expand
+        group:
+          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, subgroups: %{subgroups_count}, projects: %{group_projects_count}, samples: %{samples_count}"
+        project:
+          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, samples: %{samples_count}"
     viral:
       pagy:
         empty_state:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -694,9 +694,9 @@ fr:
         collapse: Développer
         expand: Réduire
         group:
-          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, subgroups: %{subgroups_count}, projects: %{group_projects_count}, samples: %{samples_count}"
+          aria_label: "%{name}, puid: %{puid}, role: %{role}, subgroups: %{subgroups_count}, projects: %{group_projects_count}, samples: %{samples_count}"
         project:
-          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, samples: %{samples_count}"
+          aria_label: "%{name}, puid: %{puid}, role: %{role}, samples: %{samples_count}"
     viral:
       pagy:
         empty_state:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -693,6 +693,10 @@ fr:
       row:
         collapse: Développer
         expand: Réduire
+        group:
+          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, subgroups: %{subgroups_count}, projects: %{group_projects_count}, samples: %{samples_count}"
+        project:
+          aria_label: "%{name}, persistent unique id: %{puid}, role: %{role}, samples: %{samples_count}"
     viral:
       pagy:
         empty_state:


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the treegrid row component aria labels to read out the name, puid, role, and any additional attributes on the row. Addresses:

[STRY0018213](https://publichealthprod.service-now.com/rm_story.do?sys_id=c44b928b47bd2a50f24c0c21516d439f)

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch NVDA
2. Create a group `Group A`, `Group B` and project `Project 1`
3. Verify the screenreader reads out all the data for a row on the projects/groups dashboard when the row is focused
4. Share a `Group A` with `Group B`
5. Visit `Group B`
6. Verify the screenreader reads out all the data for a row on the shared namespaces tab
7. Create a group and project within `Group A`
9. Verify the screenreader reads out all the data for a row on the subgroups and projects tab

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
