### PR TITLE
Accessibility: Profile main settings

### DIFF
--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,20 +1,69 @@
-<%= form_with(model: user, url: profile_path, method: :patch) do |f| %>
-  <% invalidemail = user.errors.include?(:email) %>
-  <% invalidfn = user.errors.include?(:first_name) %>
-  <% invalidln = user.errors.include?(:last_name) %>
-  <div class="form-field <%= 'invalid' if invalidemail %>">
-    <%= f.label :email, t(:"profiles.show.email_address") %>
-    <%= f.email_field :email, required: true, autocomplete: "email" %>
+<%= form_with(model: user, url: profile_path, method: :patch, html: { novalidate: true }) do |f| %>
+
+  <%= if user.errors.any?
+    viral_alert(
+      type: "alert",
+      message: I18n.t(:"general.form.error_notification"),
+      aria: {
+        live: "assertive",
+      },
+    )
+  end %>
+
+  <%= render partial: "shared/form/required_field_legend" %>
+
+  <% invalid_email = user.errors.include?(:email) %>
+  <div class="form-field <%= 'invalid' if invalid_email %> mt-2">
+    <%= f.label :email, t(:"profiles.show.email_address"), data: { required: true } %>
+    <%= f.email_field :email,
+                  required: true,
+                  autocomplete: "email",
+                  aria: {
+                    describedby: invalid_email ? f.field_id(:email, "error") : nil,
+                    invalid: invalid_email,
+                    required: true,
+                  } %>
+    <%= if invalid_email
+      render "shared/form/field_errors",
+      id: f.field_id(:email, "error"),
+      errors: user.errors.full_messages_for(:email)
+    end %>
   </div>
   <br/>
-  <div class="form-field <%= 'invalid' if invalidfn %>">
-    <%= f.label :first_name, t(:"profiles.show.first_name") %>
-    <%= f.text_field :first_name, required: true, autocomplete: "given-name" %>
+  <% invalid_fn = user.errors.include?(:first_name) %>
+  <div class="form-field <%= 'invalid' if invalid_fn %>">
+    <%= f.label :first_name, t(:"profiles.show.first_name"), data: { required: true } %>
+    <%= f.text_field :first_name,
+                 required: true,
+                 autocomplete: "given-name",
+                 aria: {
+                   describedby: invalid_fn ? f.field_id(:first_name, "error") : nil,
+                   invalid: invalid_fn,
+                   required: true,
+                 } %>
+    <%= if invalid_fn
+      render "shared/form/field_errors",
+      id: f.field_id(:first_name, "error"),
+      errors: user.errors.full_messages_for(:first_name)
+    end %>
   </div>
   <br/>
-  <div class="form-field <%= 'invalid' if invalidln %>">
-    <%= f.label :last_name, t(:"profiles.show.last_name") %>
-    <%= f.text_field :last_name, required: true, autocomplete: "family-name" %>
+  <% invalid_ln = user.errors.include?(:last_name) %>
+  <div class="form-field <%= 'invalid' if invalid_ln %>">
+    <%= f.label :last_name, t(:"profiles.show.last_name"), data: { required: true } %>
+    <%= f.text_field :last_name,
+                 required: true,
+                 autocomplete: "family-name",
+                 aria: {
+                   describedby: invalid_ln ? f.field_id(:last_name, "error") : nil,
+                   invalid: invalid_ln,
+                   required: true,
+                 } %>
+    <%= if invalid_ln
+      render "shared/form/field_errors",
+      id: f.field_id(:last_name, "error"),
+      errors: user.errors.full_messages_for(:last_name)
+    end %>
   </div>
   <br/>
   <div class="my-2">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -7,6 +7,7 @@
       aria: {
         live: "assertive",
       },
+      classes: "mb-2",
     )
   end %>
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the profile main settings form to display visual cues for required fields and linked error messages to input fields. 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1809" height="680" alt="image" src="https://github.com/user-attachments/assets/1e175de0-af9e-471f-8465-731a2fb297a4" />

<img width="1800" height="691" alt="image" src="https://github.com/user-attachments/assets/6926e49b-f541-41b5-84c1-fd75a7b267c3" />

<img width="1826" height="651" alt="image" src="https://github.com/user-attachments/assets/0045327d-afd8-493b-b484-0a0b6de66b6a" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Try editing the user profile -> main settings (leaving some blank etc)
2. Verify error messages are displayed and are linked to the input(s) via aria-describedby

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
