### PR TITLE
Fix: Editable Cell focus, connection, and clearing

### DIFF
--- a/app/components/samples/editable_cell.html.erb
+++ b/app/components/samples/editable_cell.html.erb
@@ -1,9 +1,7 @@
 <%= render Viral::BaseComponent.new(
   tag: "td",
   classes: class_names("px-3 py-3"),
-  data: {
-    "editable-cell-target": "editableCell",
-  },
+  **@system_arguments
 ) do %>
   <%= @sample.metadata.fetch(@field, "") %>
 <% end %>

--- a/app/components/samples/editable_cell.rb
+++ b/app/components/samples/editable_cell.rb
@@ -3,10 +3,13 @@
 module Samples
   # Component for rendering an editable cell
   class EditableCell < Component
-    def initialize(field:, sample:, autofocus: false)
+    def initialize(field:, sample:, autofocus: false, **system_arguments)
       @sample = sample
       @field = field
       @autofocus = autofocus
+      @system_arguments = system_arguments
+      @system_arguments[:data] ||= {}
+      @system_arguments[:data][:'editable-cell-target'] = 'editableCell'
     end
   end
 end

--- a/app/controllers/samples/metadata_controller.rb
+++ b/app/controllers/samples/metadata_controller.rb
@@ -191,7 +191,7 @@ module Samples
       @timestamp = @sample.updated_at + 1.second
       render turbo_stream: [
         turbo_stream.replace(
-          cell_id, Samples::EditableCell.new(field: @field, sample: @sample)
+          cell_id, Samples::EditableCell.new(field: @field, sample: @sample, data: { refocus: 'true' })
         ),
         turbo_stream.append(
           'flashes',

--- a/app/javascript/controllers/editable_cell_controller.js
+++ b/app/javascript/controllers/editable_cell_controller.js
@@ -17,10 +17,16 @@ export default class extends Controller {
   }
 
   editableCellTargetConnected(element) {
-    this.#originalCellContent[this.#elementId(element)] = element.innerText;
+    element.id = this.#elementId(element);
+
+    this.#originalCellContent[element.id] = element.innerText;
     element.addEventListener("blur", this.boundBlur);
     element.addEventListener("keydown", this.boundKeydown);
     element.setAttribute("contenteditable", true);
+
+    if (element.hasAttribute("data-refocus")) {
+      element.focus();
+    }
   }
 
   editableCellTargetDisconnected(element) {
@@ -37,7 +43,6 @@ export default class extends Controller {
     let field = element
       .closest("table")
       .querySelector(`th:nth-child(${element.cellIndex + 1})`).dataset.fieldId;
-    element.id = this.#elementId(element);
 
     // Get the parent DOM ID to extract the item ID
     // Use a regular expression to match the part after the last underscore
@@ -143,6 +148,10 @@ export default class extends Controller {
   }
 
   #elementId(element) {
-    return `${element.cellIndex}_${element.parentNode.rowIndex}`;
+    const field = element
+      .closest("table")
+      .querySelector(`th:nth-child(${element.cellIndex + 1})`)
+      .dataset.fieldId.replaceAll(" ", "SPACE");
+    return `${field}_${element.parentNode.rowIndex}`;
   }
 }

--- a/app/services/samples/metadata/fields/update_service.rb
+++ b/app/services/samples/metadata/fields/update_service.rb
@@ -62,7 +62,7 @@ module Samples
             raise SampleMetadataKeyValidationError, I18n.t('services.samples.metadata.update_fields.key_required')
           end
 
-          if @value_update.values[0].blank?
+          if @value_update.values[0].nil?
             raise SampleMetadataValueValidationError,
                   I18n.t('services.samples.metadata.update_fields.value_required')
           end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the editable cell to properly reconnect on page size changes, page navigation, metadata display toggling. In addition cell is refocused on update automatically, and user now has the ability to clear the value (prior they were given an error message).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Navigate to a Group Samples page
2. Toggle metadata display
3. Ensure metadata cells are interact-able
4. Change the page size
5. Ensure that metadata cells are interact-able
6. Change to a metadata template
7. Ensure that metadata cells are interact-table
8. Navigate to a different page
9. Ensure that metadata cells are interact-able

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
