### PR TITLE
Spinner Component: Change role to alert

### DIFF
--- a/app/components/spinner_component.html.erb
+++ b/app/components/spinner_component.html.erb
@@ -16,7 +16,7 @@
         rounded-lg shadow-sm rtl:space-x-reverse rtl:divide-x-reverse dark:text-gray-400
         dark:divide-gray-700 dark:bg-gray-800
       "
-      role="status"
+      role="alert"
     >
       <%= pathogen_icon(ICON::LOADING, color: :primary) %>
       <span


### PR DESCRIPTION
## What does this PR do and why?
Fixes [STRY0018335](https://publichealthprod.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3Dc92f250a474e6610f24c0c21516d4357%26sysparm_view%3Dscrum%26sysparm_record_target%3Drm_story%26sysparm_record_row%3D2%26sysparm_record_rows%3D10%26sysparm_record_list%3Dassignment_group%253D9efb9efb47765a50f24c0c21516d4374%255Eshort_descriptionSTARTSWITHART-%255Estate%253D2%255EORDERBYpriority%26sysparm_view%3Dscrum)

Our spinner component was not announcing the message within. This was due to the spinner component generally being 'injected' into the DOM, which has some weird/unexpected behaviour where `role=status` does not get announced (https://github.com/nvaccess/nvda/issues/14591 https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/). The same applies for `aria-live`, as it would need some JavaScript manipulation to properly announce the message.

Therefore, switching role to `alert` on the spinner seems like a simpler solution for now (and the spinner is also somewhat of an alert).

This also fixes the spinner announcing its message in other parts of the application, such as `Loading samples` when doing an `Advanced Search` on a samples table.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Open NVDA and in Chrome and Edge, launch a worflow, verify NVDA reads out the preparing X number of samples message

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
