### PR TITLE
Workflow Launch and Nextflow Reflow

### DIFF
--- a/app/components/viral/form/prefixed/boolean_component.html.erb
+++ b/app/components/viral/form/prefixed/boolean_component.html.erb
@@ -1,21 +1,25 @@
 <fieldset>
   <%= legend %>
-  <div class="flex flex-col @sm:flex-row">
+  <div
+    class="
+      flex flex-col @md:flex-row border border-slate-300 dark:border-slate-600
+      rounded-lg bg-slate-300 dark:bg-slate-600
+    "
+  >
     <span
       id="<%=name%>-prefix"
       class="
-        inline-flex items-center px-3 text-sm text-slate-900 bg-slate-200 border
-        border-slate-300 rounded-t-lg @sm:rounded-tr-none @sm:rounded-l-lg
-        dark:bg-slate-600 dark:text-slate-300 dark:border-slate-600 font-mono
+        inline-flex items-center px-3 text-sm text-slate-900 dark:text-slate-300
+        font-mono rounded-t-lg @md:rounded-l-lg @md:rounded-tr-none py-2
       "
     >
       <%= prefix %>
     </span>
     <div
       class="
-        bg-slate-50 border block flex-1 min-w-0 w-full border-slate-300 p-2.5
-        dark:bg-slate-700 dark:border-slate-600 rounded-b-lg @sm:rounded-bl-none
-        @sm:rounded-r-lg
+        bg-slate-50 border-none text-slate-900 block flex-1 min-w-0 w-full text-sm p-2.5
+        dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white focus-visible:z-10
+        rounded-b-lg @md:rounded-bl-none @md:rounded-r-lg
       "
     >
       <div class="flex gap-4 items-center">

--- a/app/components/viral/form/prefixed/select_component.html.erb
+++ b/app/components/viral/form/prefixed/select_component.html.erb
@@ -1,9 +1,13 @@
-<div class="flex flex-col @sm:flex-row">
+<div
+  class="
+    flex flex-col @md:flex-row border border-slate-300 dark:border-slate-600
+    rounded-lg bg-slate-300 dark:bg-slate-600
+  "
+>
   <span
     class="
-      inline-flex items-center px-3 text-sm text-slate-900 bg-slate-200 border
-      border-slate-300 rounded-t-lg @sm:rounded-tr-none @sm:rounded-l-lg
-      dark:bg-slate-600 dark:text-slate-300 dark:border-slate-600 font-mono
+      inline-flex items-center px-3 text-sm text-slate-900 dark:text-slate-300
+      font-mono rounded-t-lg @md:rounded-l-lg @md:rounded-tr-none py-2
     "
   >
     <%= prefix %>
@@ -12,5 +16,5 @@
               options,
               { selected: selected_value },
               class:
-                "rounded-b-lg @sm:rounded-bl-none @sm:rounded-r-lg bg-slate-50 border text-slate-900 block flex-1 min-w-0 w-full text-sm border-slate-300 p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white" %>
+                "bg-slate-50 border-none text-slate-900 block flex-1 min-w-0 w-full text-sm p-2.5 dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white focus-visible:z-10 rounded-b-lg @md:rounded-bl-none @md:rounded-r-lg" %>
 </div>

--- a/app/components/viral/form/prefixed/text_input_component.html.erb
+++ b/app/components/viral/form/prefixed/text_input_component.html.erb
@@ -1,9 +1,13 @@
-<div class="flex flex-col @sm:flex-row">
+<div
+  class="
+    flex flex-col @md:flex-row border border-slate-300 dark:border-slate-600
+    rounded-lg bg-slate-300 dark:bg-slate-600
+  "
+>
   <span
     class="
-      inline-flex items-center px-3 text-sm text-slate-900 bg-slate-200 border
-      border-slate-300 rounded-t-lg @sm:rounded-tr-none @sm:rounded-l-lg
-      dark:bg-slate-600 dark:text-slate-300 dark:border-slate-600 font-mono
+      inline-flex items-center px-3 text-sm text-slate-900 dark:text-slate-300
+      font-mono rounded-t-lg @md:rounded-l-lg @md:rounded-tr-none py-2
     "
   >
     <%= prefix %>
@@ -17,6 +21,6 @@
                     "metadata-header-name": metadata_header?(value) ? value : nil,
                   },
                   class:
-                    "rounded-b-lg @sm:rounded-bl-none @sm:rounded-r-lg bg-slate-50 border text-slate-900 block flex-1 min-w-0 w-full text-sm border-slate-300 p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white" %>
+                    "bg-slate-50 border-none text-slate-900 block flex-1 min-w-0 w-full text-sm p-2.5 dark:bg-slate-700 dark:placeholder-slate-400 dark:text-white focus-visible:z-10 rounded-b-lg @md:rounded-bl-none @md:rounded-r-lg" %>
 
 </div>

--- a/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
+++ b/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
@@ -30,7 +30,7 @@
                   ICON::ROCKET_LAUNCH,
                   color: :nil,
                   class:
-                    "dark:text-slate-500 group-hover:-rotate-45 transition-rotate-45 group-hover:duration-500 group-hover:ease-in-out",
+                    "dark:text-slate-500 group-hover:-rotate-45 transition-rotate-45 delay-150 duration-300 ease-in-out",
                 ) %>
               </span>
               <span class="flex-1 min-w-0 text-left group-hover:stroke-slate-100">


### PR DESCRIPTION
## What does this PR do and why?
Fixes [STRY0018340](https://publichealthprod.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3Dd37fe10a474e6610f24c0c21516d4300%26sysparm_view%3Dscrum)

Fixes the follow:
- Overhaul workflow selection styling
- Changes flex behaviour at high zoom for workflow params

## Screenshots or screen recordings
Before:
<img width="2465" height="1035" alt="image" src="https://github.com/user-attachments/assets/ea27dffd-e274-46fd-9e0b-64b2395f1eaa" />
<img width="2465" height="1035" alt="image" src="https://github.com/user-attachments/assets/f0cb42be-bcaf-4357-bcc6-f575e282a730" />
<img width="2465" height="1035" alt="image" src="https://github.com/user-attachments/assets/353588e9-f255-4b21-b721-1609451ffb96" />

Now:
<img width="1148" height="1195" alt="image" src="https://github.com/user-attachments/assets/c1bc8e2c-ba9e-431d-9340-717e0ad14237" />
<img width="2395" height="1802" alt="image" src="https://github.com/user-attachments/assets/d71ddb26-3251-4f3a-b2fd-c77af35bc5b6" />
<img width="1185" height="629" alt="image" src="https://github.com/user-attachments/assets/a9d7a719-df12-4b60-ade0-31e59f5f57c9" />
<img width="1185" height="629" alt="image" src="https://github.com/user-attachments/assets/76a71c9c-25f6-48fd-82f1-c69b7c6c69b6" />


## How to set up and validate locally
1. At high zoom, verify launching a workflow and the workflow's params are no longer cut off and the dialog does not have horizontal scroll.
2. Verify all types of workflow params are adjusted at high zoom (boolean, select, and text).

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
