### PR TITLE
A11y: Update dialog component to toggle data-turbo-permanent on open/close

### DIFF
--- a/app/components/viral/dialog_component.html.erb
+++ b/app/components/viral/dialog_component.html.erb
@@ -1,7 +1,6 @@
 <%= render Viral::BaseComponent.new(tag: :div, data: {
   controller: "viral--dialog",
-  "viral--dialog-open-value": open,
-  "turbo-permanent": true
+  "viral--dialog-open-value": open
 }) do %>
 
   <% if trigger.present? %>

--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -36,6 +36,7 @@ export default class extends Controller {
   }
 
   open() {
+    this.element.setAttribute("data-turbo-permanent", "");
     this.openValue = true;
     if (this.hasTriggerTarget) {
       // once a dialog has been opened we need to save it to the state to refocus the trigger if the controller is disconnected before close
@@ -46,6 +47,7 @@ export default class extends Controller {
   }
 
   close() {
+    this.element.removeAttribute("data-turbo-permanent");
     this.openValue = false;
     this.#focusTrap.deactivate();
     this.dialogTarget.close();


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updates the Dialog component to dynamically set `data-turbo-permanent` on open/close within the dialog_controller.js

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
