### PR TITLE
Fix: Breadcrumbs reflow

### DIFF
--- a/app/components/layout/breadcrumb_component.html.erb
+++ b/app/components/layout/breadcrumb_component.html.erb
@@ -28,7 +28,7 @@
     </li>
     <!-- Dynamic breadcrumb items -->
     <% @links.each_with_index do |link, index| %>
-      <li class="whitespace-nowrap m-2" data-breadcrumb-target="crumb">
+      <li class="whitespace-nowrap p-2" data-breadcrumb-target="crumb">
         <% if index == @links.length - 1 %>
           <!-- Current page (last item) -->
           <span

--- a/app/javascript/controllers/breadcrumb_controller.js
+++ b/app/javascript/controllers/breadcrumb_controller.js
@@ -34,8 +34,10 @@ export default class extends Controller {
    * @public
    */
   connect() {
-    this.#resizeObserver = new ResizeObserver(() => this.#updateLayout());
+    this.boundUpdateLayout = this.#updateLayout.bind(this);
+    this.#resizeObserver = new ResizeObserver(this.boundUpdateLayout);
     this.#resizeObserver.observe(this.listTarget);
+    document.addEventListener("turbo:morph", this.boundUpdateLayout);
   }
 
   /**
@@ -47,6 +49,7 @@ export default class extends Controller {
       this.#resizeObserver.disconnect();
       this.#resizeObserver = null;
     }
+    document.removeEventListener("turbo:morph", this.boundUpdateLayout);
   }
 
   /**


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Updates breadcrumb items to use `p-2` instead of `m-2`, which fixes width calc (margin not included in width, but padding is). Update breadcrumb to reflow on `turbo:morph`.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
