### PR TITLE
Clean up dark mode error visibility for reset password

### DIFF
--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -62,9 +62,8 @@ export default class extends Controller {
 
   /**
    * Handles input events on the email field
-   * @param {Event} event - The input event
    */
-  handleInput(event) {
+  handleInput() {
     this.debouncedValidate();
   }
 

--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -11,11 +11,8 @@ export default class extends Controller {
   static targets = ["form", "emailField", "errorContainer"];
 
   static values = {
-    emailMissing: { type: String, default: "Email is required" },
-    emailFormat: {
-      type: String,
-      default: "Please enter a valid email address",
-    },
+    emailMissing: { type: String },
+    emailFormat: { type: String }
   };
 
   connect() {

--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -1,112 +1,205 @@
+/**
+ * Email Input Controller
+ *
+ * A Stimulus controller for handling email input validation with accessibility support.
+ * Validates email format, displays appropriate error messages, and manages form submission.
+ */
 import { Controller } from "@hotwired/stimulus";
-import { FIELD_CLASSES } from "utilities/styles";
+import _ from "lodash";
 
 export default class extends Controller {
-  static targets = [
-    "form",
-    "submit",
-    "emailError",
-    "emailFieldDiv",
-    "emailField",
-  ];
+  static targets = ["form", "emailField", "errorContainer", "errorMessage"];
+
   static values = {
-    emailMissing: { type: String },
-    emailFormat: { type: String },
+    emailMissing: { type: String, default: "Email is required" },
+    emailFormat: {
+      type: String,
+      default: "Please enter a valid email address",
+    },
   };
 
-  #emailError = "";
+  connect() {
+    // Initialize field state
+    this.isSubmitting = false;
 
-  connect() {}
+    // Set up debounced validation for typing
+    this.debouncedValidate = _.debounce(
+      this.validateEmailSilently.bind(this),
+      300,
+    );
 
-  idempotentConnect() {}
-
-  submit(event) {
-    event.preventDefault();
-    setTimeout(() => {
-      let emailValid = this.#validateEmail();
-
-      if (emailValid) {
-        this.formTarget.submit();
-      }
-    }, 50);
+    // Add input event listener for real-time validation
+    this.emailFieldTarget.addEventListener(
+      "input",
+      this.handleInput.bind(this),
+    );
   }
 
-  #validateEmail() {
-    let email = this.emailFieldTarget;
-    let hasErrors = false;
+  disconnect() {
+    // Clean up event listeners
+    this.emailFieldTarget.removeEventListener(
+      "input",
+      this.handleInput.bind(this),
+    );
+  }
 
-    if (email.value === "") {
-      this.#emailError = this.emailMissingValue;
-      hasErrors = true;
+  /**
+   * Handles form submission with validation
+   * @param {Event} event - The submission event
+   */
+  submit(event) {
+    event.preventDefault();
+
+    // Prevent double submission
+    if (this.isSubmitting) return;
+
+    this.isSubmitting = true;
+
+    if (this.validateEmail()) {
+      // Use requestAnimationFrame instead of setTimeout for better performance
+      requestAnimationFrame(() => {
+        this.formTarget.submit();
+      });
     } else {
-      if (!this.#validateEmailFormat(email.value)) {
-        this.#emailError = this.emailFormatValue;
-        hasErrors = true;
-      }
+      this.isSubmitting = false;
+    }
+  }
+
+  /**
+   * Handles input events on the email field
+   * @param {Event} event - The input event
+   */
+  handleInput(event) {
+    this.debouncedValidate();
+  }
+
+  /**
+   * Validates email silently (without focus or submission effects)
+   * Used during typing for real-time feedback
+   */
+  validateEmailSilently() {
+    const email = this.emailFieldTarget.value.trim();
+
+    if (!email) {
+      // Don't show missing error during typing
+      return false;
     }
 
-    if (hasErrors) {
-      this.#addEmailFieldErrorState();
+    if (!this.isValidEmailFormat(email)) {
+      this.showError(this.emailFormatValue, false);
       return false;
-    } else {
-      this.#removeEmailFieldErrorState();
+    }
+
+    this.clearError();
+    return true;
+  }
+
+  /**
+   * Validates email with full error handling
+   * @returns {boolean} - Whether the email is valid
+   */
+  validateEmail() {
+    const email = this.emailFieldTarget.value.trim();
+
+    if (!email) {
+      this.showError(this.emailMissingValue, true);
+      return false;
+    }
+
+    if (!this.isValidEmailFormat(email)) {
+      this.showError(this.emailFormatValue, true);
+      return false;
+    }
+
+    this.clearError();
+    return true;
+  }
+
+  /**
+   * Shows error message and updates field styling
+   * @param {string} message - The error message to display
+   * @param {boolean} shouldFocus - Whether to focus the field
+   */
+  showError(message, shouldFocus = true) {
+    // Update error message
+    this.errorMessageTarget.textContent = message;
+    this.errorContainerTarget.classList.remove("hidden");
+
+    // Generate a unique ID for ARIA attributes if needed
+    const errorId = this.errorContainerTarget.id || `email-error-${Date.now()}`;
+    if (!this.errorContainerTarget.id) {
+      this.errorContainerTarget.id = errorId;
+    }
+
+    // Set validity using the Constraint Validation API
+    // This makes the :invalid pseudo-class active, which Tailwind's invalid: prefix uses
+    this.emailFieldTarget.setCustomValidity(message);
+
+    // Update accessibility attributes
+    this.emailFieldTarget.setAttribute("aria-invalid", "true");
+    this.emailFieldTarget.setAttribute("aria-describedby", errorId);
+
+    if (shouldFocus) {
+      this.emailFieldTarget.focus();
+    }
+  }
+
+  /**
+   * Clears error messages and resets field styling
+   */
+  clearError() {
+    this.errorContainerTarget.classList.add("hidden");
+    this.errorMessageTarget.textContent = "";
+
+    // Clear validity using the Constraint Validation API
+    // This removes the :invalid pseudo-class, which Tailwind's invalid: prefix uses
+    this.emailFieldTarget.setCustomValidity("");
+
+    // Update accessibility attributes
+    this.emailFieldTarget.setAttribute("aria-invalid", "false");
+    this.emailFieldTarget.removeAttribute("aria-describedby");
+  }
+
+  /**
+   * Validates an email address format according to RFC standards
+   * @param {string} email - The email to validate
+   * @returns {boolean} - Whether the email format is valid
+   */
+  isValidEmailFormat(email) {
+    // Comprehensive RFC 5322 compatible regex
+    // Covers most valid email formats while rejecting obvious mistakes
+    const emailRegex =
+      /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+    if (!emailRegex.test(email)) {
+      return false;
+    }
+
+    // Additional validation for reasonable lengths
+    const [localPart, domain] = email.split("@");
+
+    // RFC 5321 SMTP limits
+    if (!localPart || !domain || localPart.length > 64 || domain.length > 255) {
+      return false;
+    }
+
+    // Domain format validation (must have at least one period and valid TLD)
+    const domainParts = domain.split(".");
+    if (
+      domainParts.length < 2 ||
+      domainParts[domainParts.length - 1].length < 2
+    ) {
+      return false;
     }
 
     return true;
   }
 
-  #addEmailFieldErrorState() {
-    let emailError = this.emailErrorTarget.lastElementChild;
-    let emailErrorSpan = emailError.getElementsByClassName("grow")[0];
-    let email = this.emailFieldTarget;
-    let emailField = this.emailFieldDivTarget;
-
-    email.setAttribute("autofocus", true);
-    email.setAttribute("aria-invalid", true);
-    email.setAttribute("aria-describedBy", "forgot_password_email_error");
-    email.classList.remove(...FIELD_CLASSES["VALID"]);
-    email.classList.add(...FIELD_CLASSES["ERROR"]);
-    emailError.classList.remove("hidden");
-    emailErrorSpan.innerHTML = this.#emailError;
-    emailErrorSpan.classList.add(...FIELD_CLASSES["ERROR_SPAN"]);
-    emailField.classList.add("invalid");
-  }
-
-  #removeEmailFieldErrorState() {
-    let emailError = this.emailErrorTarget.lastElementChild;
-    let emailErrorSpan = emailError.getElementsByClassName("grow")[0];
-    let email = this.emailFieldTarget;
-    let emailField = this.emailFieldDivTarget;
-
-    email.removeAttribute("autofocus", false);
-    email.removeAttribute("aria-invalid");
-    email.removeAttribute("aria-describedBy");
-    email.classList.remove(...FIELD_CLASSES["ERROR"]);
-    email.classList.add(...FIELD_CLASSES["VALID"]);
-    emailError.classList.add("hidden");
-    emailErrorSpan.innerHTML = "";
-    emailErrorSpan.classList.remove(...FIELD_CLASSES["ERROR_SPAN"]);
-    emailField.classList.remove("invalid");
-  }
-
-  #validateEmailFormat(email) {
-    // Basic format check
-    const basicEmailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!basicEmailRegex.test(email)) {
-      return false;
-    }
-
-    // Additional validation
-    const [localPart, domain] = email.split("@");
-
-    // Reasonable length checks
-    if (localPart.length > 64 || domain.length > 253) {
-      return false;
-    }
-
-    // Domain format check
-    const domainRegex =
-      /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
-    return domainRegex.test(domain);
+  /**
+   * Handles blur event on the email field
+   * Forces validation when the user leaves the field
+   */
+  blur() {
+    this.validateEmail();
   }
 }

--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -8,7 +8,7 @@ import { Controller } from "@hotwired/stimulus";
 import _ from "lodash";
 
 export default class extends Controller {
-  static targets = ["form", "emailField", "errorContainer", "errorMessage"];
+  static targets = ["form", "emailField", "errorContainer"];
 
   static values = {
     emailMissing: { type: String, default: "Email is required" },
@@ -121,8 +121,10 @@ export default class extends Controller {
    * @param {boolean} shouldFocus - Whether to focus the field
    */
   showError(message, shouldFocus = true) {
+    const messageTextSpan =
+      this.errorContainerTarget.querySelector("span.grow");
     // Update error message
-    this.errorMessageTarget.textContent = message;
+    messageTextSpan.textContent = message;
     this.errorContainerTarget.classList.remove("hidden");
 
     // Generate a unique ID for ARIA attributes if needed
@@ -149,7 +151,6 @@ export default class extends Controller {
    */
   clearError() {
     this.errorContainerTarget.classList.add("hidden");
-    this.errorMessageTarget.textContent = "";
 
     // Clear validity using the Constraint Validation API
     // This removes the :invalid pseudo-class, which Tailwind's invalid: prefix uses
@@ -193,13 +194,5 @@ export default class extends Controller {
     }
 
     return true;
-  }
-
-  /**
-   * Handles blur event on the email field
-   * Forces validation when the user leaves the field
-   */
-  blur() {
-    this.validateEmail();
   }
 }

--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -19,6 +19,9 @@ export default class extends Controller {
     // Initialize field state
     this.isSubmitting = false;
 
+    // Validate required Stimulus values
+    this.#validateRequiredValues();
+
     // Set up debounced validation for typing
     this.debouncedValidate = _.debounce(
       () => this.validateEmail(false, false),
@@ -167,5 +170,18 @@ export default class extends Controller {
     }
 
     return true;
+  }
+
+  /**
+   * Validates that required Stimulus values are provided
+   * @throws {Error} If a required value is missing
+   */
+  #validateRequiredValues() {
+    if (this.emailMissingValue === undefined) {
+      throw new Error("email-missing value is required");
+    }
+    if (this.emailFormatValue === undefined) {
+      throw new Error("email-format value is required");
+    }
   }
 }

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -3,17 +3,29 @@
   data-email-input-email-missing-value="<%= t('devise.passwords.new.email.required_error') %>"
   data-email-input-email-format-value="<%= t('devise.passwords.new.email.format_error') %>"
 >
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), data: {email_input_target: "form"}, html: { method: :post, class: "space-y-4" }) do |f| %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), data: {
+    email_input_target: "form",
+    action: "submit->email-input#submit"
+    }, html: { method: :post, class: "space-y-4" }) do |f| %>
     <div class="space-y-4">
       <%= render "devise/shared/hidden_locale_input" %>
+      <!-- Error messages container -->
+      <div
+        data-email-input-target="errorContainer"
+        class="
+          hidden bg-red-50 border-l-4 border-red-300 dark:bg-slate-800 dark:border-red-800
+          dark:text-red-400 flex items-center p-4 text-red-800
+        "
+        role="alert"
+      >
+        <div>
+          <span class="font-semibold" data-email-input-target="errorMessage"></span>
+        </div>
+      </div>
 
       <%= render partial: "shared/form/required_field_legend" %>
 
-      <div
-        id="forgot_password_email_field"
-        data-email-input-target="emailFieldDiv"
-        class="form-field"
-      >
+      <div class="form-field">
         <%= f.label :email, data: { required: true } %>
         <%= f.email_field :email,
                       autofocus: true,
@@ -21,25 +33,18 @@
                         required: true,
                       },
                       autocomplete: "email",
+                      class: "
+                        border-slate-300 focus:ring-blue-500 focus:border-blue-500
+                        invalid:border-red-500 invalid:focus:border-red-500 invalid:focus:ring-red-500
+                      ",
                       data: {
                         email_input_target: "emailField",
+                        action: "blur->email-input#blur input->email-input#handleInput",
                       } %>
-        <div
-          id="forgot_password_email_error"
-          data-email-input-target="emailError"
-          class="mt-2 text-sm"
-        >
-          <%= viral_help_text(state: :error, classes: "hidden") %>
-        </div>
       </div>
 
       <div>
-        <%= f.submit t(".submit_button"),
-                 class: "button button-primary w-full",
-                 data: {
-                   input_target: "submit",
-                   action: "click->email-input#submit",
-                 } %>
+        <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>
       </div>
     </div>
   <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -22,27 +22,25 @@
                       autocomplete: "email",
                       class:
                         "
-                                border-slate-300 focus:ring-blue-500 focus:border-blue-500
-                                invalid:border-red-500 invalid:focus:border-red-500 invalid:focus:ring-red-500
-                              ",
+                                  border-slate-300 focus:ring-blue-500 focus:border-blue-500
+                                  invalid:border-red-500 invalid:focus:border-red-500 invalid:focus:ring-red-500
+                                ",
                       data: {
                         email_input_target: "emailField",
-                        action: "blur->email-input#blur input->email-input#handleInput",
+                        action: "input->email-input#handleInput",
                       } %>
       </div>
       <!-- Error messages container -->
-      <div
+      <ul
         data-email-input-target="errorContainer"
         class="
-          hidden bg-red-50 border-l-4 border-red-300 dark:bg-slate-800 dark:border-red-800
-          dark:text-red-400 flex items-center p-4 text-red-800
+          max-w-md text-sm text-slate-500 list-inside dark:text-slate-400 hidden
         "
-        role="alert"
       >
-        <div>
-          <span class="font-semibold" data-email-input-target="errorMessage"></span>
-        </div>
-      </div>
+        <li>
+          <%= viral_help_text(state: :error) %>
+        </li>
+      </ul>
 
       <div>
         <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,6 +9,27 @@
     }, html: { method: :post, class: "space-y-4" }) do |f| %>
     <div class="space-y-4">
       <%= render "devise/shared/hidden_locale_input" %>
+
+      <%= render partial: "shared/form/required_field_legend" %>
+
+      <div class="form-field">
+        <%= f.label :email, data: { required: true } %>
+        <%= f.email_field :email,
+                      autofocus: true,
+                      aria: {
+                        required: true,
+                      },
+                      autocomplete: "email",
+                      class:
+                        "
+                                border-slate-300 focus:ring-blue-500 focus:border-blue-500
+                                invalid:border-red-500 invalid:focus:border-red-500 invalid:focus:ring-red-500
+                              ",
+                      data: {
+                        email_input_target: "emailField",
+                        action: "blur->email-input#blur input->email-input#handleInput",
+                      } %>
+      </div>
       <!-- Error messages container -->
       <div
         data-email-input-target="errorContainer"
@@ -21,26 +42,6 @@
         <div>
           <span class="font-semibold" data-email-input-target="errorMessage"></span>
         </div>
-      </div>
-
-      <%= render partial: "shared/form/required_field_legend" %>
-
-      <div class="form-field">
-        <%= f.label :email, data: { required: true } %>
-        <%= f.email_field :email,
-                      autofocus: true,
-                      aria: {
-                        required: true,
-                      },
-                      autocomplete: "email",
-                      class: "
-                        border-slate-300 focus:ring-blue-500 focus:border-blue-500
-                        invalid:border-red-500 invalid:focus:border-red-500 invalid:focus:ring-red-500
-                      ",
-                      data: {
-                        email_input_target: "emailField",
-                        action: "blur->email-input#blur input->email-input#handleInput",
-                      } %>
       </div>
 
       <div>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

1. Currently, the password reset error message has a contrast rating of 3.83, which is below the criteria for AA.  After this update, it will match other error styles and have a 5.1 rating, which is AA.
2. Clean up `email_input_controller`.  Proper handling of form submission, handles blur and updates email address validation.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Before**

<img width="1280" height="518" alt="image" src="https://github.com/user-attachments/assets/b8d43038-3bae-43ad-9196-c3517ce2659d" />

<img width="1279" height="539" alt="image" src="https://github.com/user-attachments/assets/44cb5be3-e378-4973-a5c4-b4659085627a" />


**After**

<img width="1281" height="535" alt="image" src="https://github.com/user-attachments/assets/b7746618-a0f6-4f37-a215-c464befe5704" />

<img width="1282" height="554" alt="image" src="https://github.com/user-attachments/assets/74eb6d09-d96e-47fa-92a3-7eef1384ca08" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
