### PR TITLE
Metadata template form accessibility

### DIFF
--- a/app/components/metadata_templates/table_component.html.erb
+++ b/app/components/metadata_templates/table_component.html.erb
@@ -57,7 +57,7 @@
                 classes: class_names('px-3 py-3', '2xl:sticky left-0 bg-slate-50 dark:bg-slate-900': index.zero?)
               ) do %>
                 <% if column == :name %>
-                  <span class="text-slate-900 dark:text-slate-100 font-semibold hover:underline">
+                  <span class="text-slate-900 dark:text-slate-100 font-semibold">
                     <%= metadata_template.name %>
                   </span>
                 <% elsif column == :description %>

--- a/app/controllers/concerns/metadata_template_actions.rb
+++ b/app/controllers/concerns/metadata_template_actions.rb
@@ -23,7 +23,7 @@ module MetadataTemplateActions # rubocop:disable Metrics/ModuleLength
 
   def new
     authorize! @namespace, to: :create_metadata_templates?
-    @new_template = MetadataTemplate.new(namespace_id: @namespace.id)
+    @metadata_template = MetadataTemplate.new(namespace_id: @namespace.id)
 
     respond_to do |format|
       format.turbo_stream do
@@ -52,18 +52,23 @@ module MetadataTemplateActions # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  def create
-    @new_template = MetadataTemplates::CreateService.new(
+  def create # rubocop:disable Metrics/MethodLength
+    @metadata_template = MetadataTemplates::CreateService.new(
       current_user, @namespace, metadata_template_params
     ).execute
 
     respond_to do |format|
       format.turbo_stream do
-        if @new_template.persisted?
+        if @metadata_template.persisted?
           render_success(I18n.t('concerns.metadata_template_actions.create.success',
-                                template_name: @new_template.name))
+                                template_name: @metadata_template.name))
         else
-          render_error(error_message(@new_template))
+          error_msg = if @metadata_template.errors.size == 1 && @metadata_template.errors[:fields].any?
+                        error_message(@metadata_template)
+                      else
+                        t(:'general.form.error_notification')
+                      end
+          render_error(error_msg)
         end
       end
     end

--- a/app/views/shared/metadata_templates/_create.turbo_stream.erb
+++ b/app/views/shared/metadata_templates/_create.turbo_stream.erb
@@ -1,11 +1,11 @@
 <%= turbo_stream.update "metadata_template_modal",
                     partial: "shared/metadata_templates/new_template_dialog",
                     locals: {
-                      open: @new_template.errors.any? ? true : false,
+                      open: @metadata_template.errors.any? ? true : false,
                       create_path: create_path,
                     } %>
 
-<% if @new_template.persisted? %>
+<% if @metadata_template.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>
   <% end %>

--- a/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
@@ -2,63 +2,12 @@
   <% dialog.with_header(title: t("metadata_templates.edit_template_dialog.title")) %>
   <%= turbo_frame_tag "metadata_template_error_alert" %>
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>
-    <div
-      data-controller="viral--sortable-lists--two-lists-selection"
-      data-viral--sortable-lists--two-lists-selection-selected-list-value="<%=  t("metadata_templates.edit_template_dialog.selected") %>"
-      data-viral--sortable-lists--two-lists-selection-available-list-value="<%= t("metadata_templates.edit_template_dialog.available") %>"
-      data-viral--sortable-lists--two-lists-selection-field-name-value="metadata_template[fields][]"
-      class="font-normal text-slate-500 dark:text-slate-400"
-    >
-      <%= form_for(@metadata_template, url: update_path, method: :patch
-            ) do |form| %>
-        <div class="grid gap-4">
-          <div class="mt-2 form-field">
-            <%= form.label :name %>
-            <%= form.text_field :name,
-                            class: "form-control",
-                            required: true,
-                            value: @metadata_template.name %>
-          </div>
-          <div class="mt-2 form-field">
-            <%= form.label :description %>
-            <%= form.text_area :description,
-                           class: "form-control",
-                           value: @metadata_template.description %>
-          </div>
-          <div
-            class="hidden"
-            data-viral--sortable-lists--two-lists-selection-target="field"
-          ></div>
-          <%= viral_sortable_lists(
-                  title: t("metadata_templates.edit_template_dialog.metadata"),
-                  description: t("metadata_templates.edit_template_dialog.description"),
-                  ) do |sortable_lists| %>
-            <%= sortable_lists.with_list(
-              id: t("metadata_templates.edit_template_dialog.available"),
-              title: t("metadata_templates.edit_template_dialog.available"),
-              list_items: @available_metadata_fields,
-              group: "metadata_selection",
-            ) %>
-            <%= sortable_lists.with_list(
-              id: t("metadata_templates.edit_template_dialog.selected"),
-              title: t("metadata_templates.edit_template_dialog.selected"),
-              list_items: @current_template_fields,
-              group: "metadata_selection",
-            ) %>
-          <% end %>
-          <div class="mt-4">
-            <%= form.submit t("metadata_templates.edit_template_dialog.update_button"),
-                        data: {
-                          turbo_frame: "_top",
-                          action:
-                            "click->viral--sortable-lists--two-lists-selection#constructParams",
-                          "viral--sortable-lists--two-lists-selection-target": "submitBtn",
-                        },
-                        class: "button button-primary",
-                        disabled: true %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <%= render partial: "shared/metadata_templates/form",
+    locals: {
+      template_path: update_path,
+      method: :patch,
+      submit_button_text:
+        t("metadata_templates.edit_template_dialog.update_button"),
+    } %>
   <% end %>
 <% end %>

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -1,0 +1,94 @@
+<div
+  data-controller="viral--sortable-lists--two-lists-selection"
+  data-viral--sortable-lists--two-lists-selection-selected-list-value="<%= t("metadata_templates.form.selected") %>"
+  data-viral--sortable-lists--two-lists-selection-available-list-value="<%= t("metadata_templates.form.available") %>"
+  data-viral--sortable-lists--two-lists-selection-field-name-value="metadata_template[fields][]"
+  class="font-normal text-slate-500 dark:text-slate-400"
+>
+  <%= form_for(@metadata_template, url: template_path, method:, html: { novalidate: true }) do |form| %>
+    <%= render partial: "shared/form/required_field_legend" %>
+    <% invalid_name = @metadata_template.errors&.include?(:name) %>
+    <div class="grid gap-4">
+      <div class="mt-2 form-field <%= 'invalid' if invalid_name %>">
+        <%= form.label :name, data: { required: true } %>
+        <%= form.text_field :name,
+                        required: true,
+                        class: "form-control",
+                        aria: {
+                          describedby:
+                            (
+                              if invalid_name
+                                form.field_id(:name, "error")
+                              else
+                                nil
+                              end
+                            ),
+                          invalid: invalid_name,
+                          required: true,
+                        },
+                        autofocus: invalid_name %>
+        <% if invalid_name %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:name, "error"),
+          errors: @metadata_template.errors.full_messages_for(:name) %>
+        <% end %>
+      </div>
+      <% invalid_description = @metadata_template.errors&.include?(:description) %>
+      <div class="mt-2 form-field <%= 'invalid' if invalid_description %>">
+        <%= form.label :description %>
+        <%= form.text_area :description,
+                       class: "form-control",
+                       aria: {
+                         describedby:
+                           (
+                             if invalid_description
+                               form.field_id(:description, "error")
+                             else
+                               nil
+                             end
+                           ),
+                         invalid: invalid_description,
+                       },
+                       autofocus: invalid_description %>
+        <% if invalid_description %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:description, "error"),
+          errors: @metadata_template.errors.full_messages_for(:description) %>
+        <% end %>
+      </div>
+      <div
+        class="hidden"
+        data-viral--sortable-lists--two-lists-selection-target="field"
+      ></div>
+      <%= viral_sortable_lists(
+                  title: t("metadata_templates.form.metadata"),
+                  description: t("metadata_templates.form.description"),
+                  ) do |sortable_lists| %>
+        <%= sortable_lists.with_list(
+          id: t("metadata_templates.form.available"),
+          title: t("metadata_templates.form.available"),
+          list_items: @available_metadata_fields,
+          group: "metadata_selection",
+        ) %>
+        <%= sortable_lists.with_list(
+          id: t("metadata_templates.form.selected"),
+          title: t("metadata_templates.form.selected"),
+          list_items: @current_template_fields,
+          group: "metadata_selection",
+          required: true,
+        ) %>
+      <% end %>
+      <div class="mt-4">
+        <%= form.submit submit_button_text,
+                    data: {
+                      turbo_frame: "_top",
+                      action:
+                        "click->viral--sortable-lists--two-lists-selection#constructParams",
+                      "viral--sortable-lists--two-lists-selection-target": "submitBtn",
+                    },
+                    class: "button button-primary",
+                    disabled: true %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/metadata_templates/_new_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_new_template_dialog.html.erb
@@ -2,65 +2,11 @@
   <% dialog.with_header(title: t("metadata_templates.new_template_dialog.title")) %>
   <%= turbo_frame_tag "metadata_template_error_alert" %>
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>
-    <div
-      data-controller="viral--sortable-lists--two-lists-selection"
-      data-viral--sortable-lists--two-lists-selection-selected-list-value="<%= t("metadata_templates.new_template_dialog.selected") %>"
-      data-viral--sortable-lists--two-lists-selection-available-list-value="<%= t("metadata_templates.new_template_dialog.available") %>"
-      data-viral--sortable-lists--two-lists-selection-field-name-value="metadata_template[fields][]"
-      class="font-normal text-slate-500 dark:text-slate-400"
-    >
-      <div class="grid gap-4">
-        <%= form_for(:metadata_template, url: create_path, method: :post
-            ) do |form| %>
-          <div class="grid gap-4">
-            <div class="mt-2 form-field">
-              <%= form.label :name %>
-              <%= form.text_field :name,
-                              class: "form-control",
-                              required: true,
-                              value: @new_template&.name %>
-            </div>
-            <div class="mt-2 form-field">
-              <%= form.label :description %>
-              <%= form.text_area :description,
-                             class: "form-control",
-                             value: @new_template&.description %>
-            </div>
-            <div
-              class="hidden"
-              data-viral--sortable-lists--two-lists-selection-target="field"
-            ></div>
-            <%= viral_sortable_lists(
-            title: t("metadata_templates.new_template_dialog.metadata"),
-            description: t("metadata_templates.new_template_dialog.description")
-            ) do |sortable_lists| %>
-              <%= sortable_lists.with_list(
-                id: t("metadata_templates.new_template_dialog.available"),
-                title: t("metadata_templates.new_template_dialog.available"),
-                list_items: @available_metadata_fields,
-                group: "metadata_selection",
-              ) %>
-              <%= sortable_lists.with_list(
-                id: t("metadata_templates.new_template_dialog.selected"),
-                title: t("metadata_templates.new_template_dialog.selected"),
-                list_items: @current_template_fields,
-                group: "metadata_selection",
-              ) %>
-            <% end %>
-            <div class="mt-4">
-              <%= form.submit t("metadata_templates.new_template_dialog.submit_button"),
-                          data: {
-                            turbo_frame: "_top",
-                            action:
-                              "click->viral--sortable-lists--two-lists-selection#constructParams",
-                            "viral--sortable-lists--two-lists-selection-target": "submitBtn",
-                          },
-                          class: "button button-primary",
-                          disabled: true %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    </div>
+    <%= render partial: "shared/metadata_templates/form",
+    locals: {
+      template_path: create_path,
+      method: :post,
+      submit_button_text: t("metadata_templates.new_template_dialog.submit_button"),
+    } %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1101,17 +1101,14 @@ en:
       user_email: Username
   metadata_templates:
     edit_template_dialog:
+      title: Edit Metadata Template
+      update_button: Update
+    form:
       available: Available
       description: Select the metadata fields for the template by moving the metadata fields from the available list to the selected list and vice versa. The template's fields ordering will be determined by the ordering of the selected list.
       metadata: Metadata
       selected: Selected
-      title: Edit Metadata Template
-      update_button: Update
     new_template_dialog:
-      available: Available
-      description: Select the metadata fields for new template by moving the metadata fields from the available list to the selected list. The template's fields ordering will be determined by the ordering of the selected list.
-      metadata: Metadata
-      selected: Selected
       submit_button: Submit
       title: New Metadata Template
     table:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1105,17 +1105,14 @@ fr:
       user_email: Nom d’utilisateur
   metadata_templates:
     edit_template_dialog:
+      title: Modifier le modèle de métadonnées
+      update_button: Mise à jour
+    form:
       available: Disponible
       description: Sélectionnez les champs de métadonnées du modèle en déplaçant les champs de métadonnées de la liste disponible à la liste sélectionnée et vice versa. L’ordre des champs du modèle sera déterminé par l’ordre de la liste sélectionnée.
       metadata: Métadonnées
       selected: Sélectionné
-      title: Modifier le modèle de métadonnées
-      update_button: Mise à jour
     new_template_dialog:
-      available: Disponible
-      description: Sélectionnez les champs de métadonnées du nouveau modèle en déplaçant les champs de métadonnées de la liste disponible à la liste sélectionnée. L’ordre des champs du modèle sera déterminé par l’ordre de la liste sélectionnée.
-      metadata: Métadonnées
-      selected: Sélectionné
       submit_button: Envoyer
       title: Nouveau modèle de métadonnées
     table:

--- a/test/system/groups/metadata_templates_test.rb
+++ b/test/system/groups/metadata_templates_test.rb
@@ -157,9 +157,9 @@ module Groups
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -167,7 +167,7 @@ module Groups
           assert_selector 'li', count: 4
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -219,9 +219,9 @@ module Groups
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -229,7 +229,7 @@ module Groups
           assert_selector 'li', count: 4
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -263,11 +263,10 @@ module Groups
       assert_selector '#dialog'
 
       within('div[data-controller-connected="true"] dialog') do
-        assert_accessible
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -275,7 +274,7 @@ module Groups
           assert_selector 'li', count: 4
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -314,9 +313,9 @@ module Groups
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -324,7 +323,7 @@ module Groups
           assert_selector 'li', count: 4
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -365,9 +364,9 @@ module Groups
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -375,7 +374,7 @@ module Groups
           assert_selector 'li', count: 4
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -416,9 +415,9 @@ module Groups
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -426,7 +425,7 @@ module Groups
           assert_selector 'li', count: 4
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -441,7 +440,7 @@ module Groups
 
         click_button I18n.t('components.viral.sortable_list.list_component.add')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -449,7 +448,7 @@ module Groups
           assert_no_selector 'li'
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -464,7 +463,7 @@ module Groups
 
         click_button I18n.t('components.viral.sortable_list.list_component.remove')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -472,7 +471,7 @@ module Groups
           assert_selector 'li', count: 4
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -514,7 +513,7 @@ module Groups
       within('div[data-controller-connected="true"] dialog') do
         assert_text I18n.t('metadata_templates.edit_template_dialog.title')
 
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_text 'unique.metadata.field'
@@ -523,7 +522,7 @@ module Groups
         end
 
         # fields currently in template fixture
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_text 'field_1'
           assert_text 'field_2'
           assert_text 'field_3'
@@ -537,7 +536,7 @@ module Groups
 
         click_button I18n.t('components.viral.sortable_list.list_component.add')
 
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_text 'unique.metadata.field'
@@ -545,7 +544,7 @@ module Groups
           assert_no_selector 'li'
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_text 'field_1'
           assert_text 'field_2'
           assert_text 'field_3'

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -162,15 +162,15 @@ module Projects
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
@@ -218,15 +218,15 @@ module Projects
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
@@ -262,15 +262,15 @@ module Projects
       within('div[data-controller-connected="true"] dialog') do
         assert_accessible
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
@@ -303,15 +303,15 @@ module Projects
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
@@ -348,15 +348,15 @@ module Projects
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
@@ -393,15 +393,15 @@ module Projects
 
       within('div[data-controller-connected="true"] dialog') do
         assert_selector 'h1', text: I18n.t('metadata_templates.new_template_dialog.title')
-        assert_text I18n.t('metadata_templates.new_template_dialog.description')
+        assert_text I18n.t('metadata_templates.form.description')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
@@ -412,13 +412,13 @@ module Projects
 
         click_button I18n.t('components.viral.sortable_list.list_component.add')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
@@ -429,13 +429,13 @@ module Projects
 
         click_button I18n.t('components.viral.sortable_list.list_component.remove')
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.new_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
@@ -475,14 +475,14 @@ module Projects
       within('div[data-controller-connected="true"] dialog') do
         assert_text I18n.t('metadata_templates.edit_template_dialog.title')
 
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_text 'metadatafield1'
           assert_text 'metadatafield2'
           assert_selector 'li', count: 2
         end
 
         # fields currently in template fixture
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_text 'field_1'
           assert_text 'field_2'
           assert_text 'field_3'
@@ -494,13 +494,13 @@ module Projects
 
         click_button I18n.t('components.viral.sortable_list.list_component.add')
 
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.available')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.available')}']" do
           assert_no_text 'metadatafield1'
           assert_no_text 'metadatafield2'
           assert_no_selector 'li'
         end
 
-        within "ul[id='#{I18n.t('metadata_templates.edit_template_dialog.selected')}']" do
+        within "ul[id='#{I18n.t('metadata_templates.form.selected')}']" do
           assert_text 'field_1'
           assert_text 'field_2'
           assert_text 'field_3'

--- a/test/test_helpers/axe_helpers.rb
+++ b/test/test_helpers/axe_helpers.rb
@@ -91,14 +91,12 @@ module AxeHelpers
   def fill_in(locator = nil, **kwargs)
     super
 
-    assert_accessible
     w3c_validate content: "<!DOCTYPE html>#{html}"
   end
 
   def visit(path, **attributes)
     super
 
-    assert_accessible
     w3c_validate content: "<!DOCTYPE html>#{html}"
   end
 end

--- a/test/test_helpers/axe_helpers.rb
+++ b/test/test_helpers/axe_helpers.rb
@@ -91,12 +91,14 @@ module AxeHelpers
   def fill_in(locator = nil, **kwargs)
     super
 
+    assert_accessible
     w3c_validate content: "<!DOCTYPE html>#{html}"
   end
 
   def visit(path, **attributes)
     super
 
+    assert_accessible
     w3c_validate content: "<!DOCTYPE html>#{html}"
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
Associating the metadata template name & description error messages with form fields.

## Screenshots or screen recordings
Name & description error messages:
<img width="790" height="704" alt="template_errors" src="https://github.com/user-attachments/assets/97ca5196-350f-4deb-b4d6-dac83c198280" />

Fields error message:
<img width="786" height="704" alt="template_field_errors" src="https://github.com/user-attachments/assets/587121cb-e8bf-4da0-9dd9-019ce44acadb" />

## How to set up and validate locally
1. Navigate to a project and/or group that the logged in user has at least maintainer access.
2. Click `Settings` -> `Metadata Templates` within the main menu.
3. Try creating and updating metadata templates.
5. Verify the correct error messages are displayed after an invalid form entry.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
