### PR TITLE
Fix: Scrolling on delete sample metadata/file dialogs and Edit Workflow buttons

### DIFF
--- a/app/views/projects/samples/attachments/deletions/_modal.html.erb
+++ b/app/views/projects/samples/attachments/deletions/_modal.html.erb
@@ -9,6 +9,7 @@
   >
     <p class="mb-4"><%= t(".description") %></p>
     <div
+      class="overflow-auto scrollbar"
       data-controller="projects--samples--attachments--files"
       data-projects--samples--attachments--files-target="field"
     ></div>

--- a/app/views/projects/samples/metadata/deletions/_modal.html.erb
+++ b/app/views/projects/samples/metadata/deletions/_modal.html.erb
@@ -4,7 +4,10 @@
 
   <div class="mb-4 font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4"><%= t(".description") %></p>
-    <div data-controller="projects--samples--metadata--delete-listing">
+    <div
+      data-controller="projects--samples--metadata--delete-listing"
+      class="overflow-auto scrollbar"
+    >
       <table class="w-full text-sm text-left text-slate-500 dark:text-slate-400 mb-4">
         <thead class="text-slate-700 bg-slate-50 dark:bg-slate-900 dark:text-slate-400">
           <tr>

--- a/app/views/projects/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/projects/workflow_executions/_edit_dialog.html.erb
@@ -32,16 +32,11 @@
 
     <div class="mt-4">
       <%= form.submit t("projects.workflow_executions.edit_dialog.submit_button"),
-                  class:
-                    "text-sm text-white bg-primary-700 hover:bg-primary-800 rounded-lg p-2 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 cursor-pointer" %>
+                  class: "button button-primary" %>
 
       <button
         type="button"
-        class="
-          p-2 text-sm bg-white border rounded-lg text-slate-900 border-slate-200
-          hover:bg-slate-100 hover:text-slate-950 dark:text-white dark:bg-slate-600
-          dark:hover:bg-slate-700
-        "
+        class="button button-default"
         data-action="click->viral--dialog#close"
       >
         <%= t("projects.workflow_executions.edit_dialog.cancel_button") %>

--- a/app/views/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/workflow_executions/_edit_dialog.html.erb
@@ -38,18 +38,11 @@
 
     <div class="mt-4 space-x-2">
       <%= form.submit t("workflow_executions.edit_dialog.submit_button"),
-                  class:
-                    "inline-flex w-1/2 cursor-pointer items-center justify-center rounded-lg border focus-visible:z-10 sm:w-auto px-5 py-2.5 text-sm border-primary-800 bg-primary-700 hover:bg-primary-800 dark:bg-primary-800 dark:border-primary-900 dark:hover:bg-primary-700 text-white dark:text-white" %>
+                  class: "button button-primary" %>
 
       <button
         type="button"
-        class="
-          inline-flex w-1/2 cursor-pointer items-center justify-center rounded-lg border
-          text-sm focus-visible:z-10 sm:w-auto px-5 py-2.5 border-slate-200 bg-white
-          text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-slate-600
-          dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700
-          dark:hover:text-white
-        "
+        class="button button-default"
         data-action="click->viral--dialog#close"
       >
         <%= t("workflow_executions.edit_dialog.cancel_button") %>


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes:
- Removes horizontal scrolling of the dialog within the delete sample files and metadata dialogs, moving the scroll to the table
- Edit workflow buttons

## Screenshots or screen recordings
Delete sample files:
<img width="2501" height="1844" alt="image" src="https://github.com/user-attachments/assets/226ce467-3778-443a-bc6a-d35b5a9393b0" />

<img width="2501" height="1844" alt="image" src="https://github.com/user-attachments/assets/793c7fc8-4383-426a-9306-1e626bcdcd44" />

Delete metadata:
<img width="2501" height="1844" alt="image" src="https://github.com/user-attachments/assets/19a24065-eaa7-4b83-850d-a26516a5280e" />

<img width="2501" height="1844" alt="image" src="https://github.com/user-attachments/assets/c6b99195-2691-426c-b60d-b2097cb7dbe0" />

Edit Workflow button reflow:
<img width="2501" height="1844" alt="image" src="https://github.com/user-attachments/assets/7ef21b29-a531-4253-80bc-eb55e8ba9e14" />

<img width="2501" height="1844" alt="image" src="https://github.com/user-attachments/assets/493e38d3-10a4-4962-90a1-5193e3c5d2a5" />


## How to set up and validate locally
1. Navigate to a sample and delete its files, and verify the table has a horizontal scrollbar and the dialog does not.
2. Delete a sample's metadata (make sure you have metadata with a long name or value), and verify the table has a horizontal scrollbar and the dialog does not
3. Edit a workflow execution and verify the buttons reflow properly at 400%

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
