### PR TITLE
Metadata template error messages fix

### DIFF
--- a/app/services/metadata_templates/create_service.rb
+++ b/app/services/metadata_templates/create_service.rb
@@ -3,7 +3,6 @@
 module MetadataTemplates
   # Service used to Create Metadata Templates
   class CreateService < BaseService
-    MetadataTemplateCreateError = Class.new(StandardError)
     attr_accessor :namespace
 
     def initialize(user, namespace, params = {})
@@ -18,29 +17,11 @@ module MetadataTemplates
 
     def execute
       authorize! namespace, to: :create_metadata_templates?
-
-      validate_params
-
       save_template
-      @metadata_template
-    rescue MetadataTemplates::CreateService::MetadataTemplateCreateError => e
-      @metadata_template.errors.add(:base, e.message)
       @metadata_template
     end
 
     private
-
-    def validate_params
-      if @params[:name].blank?
-        raise MetadataTemplateCreateError,
-              I18n.t('services.metadata_templates.create.required.name')
-      end
-
-      return unless @params[:fields].blank? || !@params[:fields].is_a?(Array)
-
-      raise MetadataTemplateCreateError,
-            I18n.t('services.metadata_templates.create.required.fields')
-    end
 
     def save_template
       @metadata_template.save

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1853,11 +1853,6 @@ en:
       update:
         cannot_update_self: You cannot update your own %{namespace_type} role
         role_not_allowed: A maintainer can only update a member's role up to the Maintainer role
-    metadata_templates:
-      create:
-        required:
-          fields: Unable to create metadata template as the fields are required and must be an array of strings
-          name: Unable to create metadata template as the name is required
     personal_access_tokens:
       create:
         required:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1857,11 +1857,6 @@ fr:
       update:
         cannot_update_self: Vous ne pouvez pas mettre à jour votre propre rôle %{namespace_type}
         role_not_allowed: Un responsable ne peut mettre à jour le rôle d’un membre que jusqu’au rôle de responsable
-    metadata_templates:
-      create:
-        required:
-          fields: Impossible de créer un modèle de métadonnées puisque les champs sont obligatoires et doivent être un tableau de chaînes
-          name: Impossible de créer un modèle de métadonnées puisque le nom est obligatoire
     personal_access_tokens:
       create:
         required:

--- a/test/services/metadata_templates/create_service_test.rb
+++ b/test/services/metadata_templates/create_service_test.rb
@@ -30,7 +30,9 @@ module MetadataTemplates
         MetadataTemplates::CreateService.new(@user, @namespace, invalid_params).execute
       end
 
-      assert new_template.errors.full_messages.include?(I18n.t('services.metadata_templates.create.required.name'))
+      assert new_template.errors.full_messages.to_sentence.include?(
+        I18n.t('errors.messages.blank')
+      )
     end
 
     test 'metadata template not created due to missing fields' do
@@ -42,7 +44,7 @@ module MetadataTemplates
         MetadataTemplates::CreateService.new(@user, @namespace, invalid_params).execute
       end
 
-      assert new_template.errors.full_messages.include?(I18n.t('services.metadata_templates.create.required.fields'))
+      assert new_template.errors.full_messages.include?('Fields array size at root is less than: 1')
     end
 
     test 'raises unauthorized error when user lacks permission' do
@@ -110,7 +112,7 @@ module MetadataTemplates
         MetadataTemplates::CreateService.new(@user, @namespace, invalid_params).execute
       end
 
-      assert new_template.errors.full_messages.include?(I18n.t('services.metadata_templates.create.required.fields'))
+      assert new_template.errors.full_messages.include?('Fields value at root is not an array')
     end
 
     test 'prevents duplicate template names within same namespace' do


### PR DESCRIPTION
## What does this PR do and why?
Fix for the `Name can't be blank` error message was not being displayed. 

## Screenshots or screen recordings
Before:
<img width="784" height="704" alt="image" src="https://github.com/user-attachments/assets/a61de34c-3fbe-48c7-9e97-e4b82748f04e" />

After:
<img width="799" height="721" alt="image" src="https://github.com/user-attachments/assets/0b3bab46-3c92-4df1-a39c-96f8eed8cc19" />

## How to set up and validate locally
1. Navigate to a project and/or group that the logged in user has at least maintainer access.
1. Click `Settings` -> `Metadata Templates` within the main menu.
1. Try creating or updating a metadata template with no name.
1. Verify a `Name can't be blank` error message is displayed.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
