### PR TITLE
Improves focus state on advanced search component

### DIFF
--- a/app/components/advanced_search_component.html.erb
+++ b/app/components/advanced_search_component.html.erb
@@ -9,7 +9,7 @@
       <div class="flex flex-row rounded-lg" role="group">
         <button
           type="button"
-          class="<%= class_names("button button-default w-full", { "rounded-e-none border-e-0": @status }) %>"
+          class="<%= class_names("button button-default w-full focus:z-10", { "rounded-e-none border-e-0": @status }) %>"
           data-viral--dialog-target="trigger"
           data-action="advanced-search#idempotentConnect viral--dialog#open"
           aria-label="<%= t("components.advanced_search_component.title") %>"


### PR DESCRIPTION
# What does this PR do and why?
_Describe in detail what your merge request does and why._

Fixes z-indexing on the advanced search component when the button to open the modal is focused

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Before**
<img width="1283" height="336" alt="image" src="https://github.com/user-attachments/assets/365c2334-1b2b-49ba-8035-2565bcb0e1fc" />

**After**
<img width="1283" height="336" alt="image" src="https://github.com/user-attachments/assets/9aba210f-b398-48e6-b4ae-eb407be8209b" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Go to a project samples page
2. Complete an advanced search, and observe how the focus state is.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
