### PR TITLE
Accessibility: Search Field Component

### DIFF
--- a/app/components/search_component.html.erb
+++ b/app/components/search_component.html.erb
@@ -1,6 +1,6 @@
 <div role="status" class="sr-only"><%= results_message if search_term? %></div>
 
-<%= search_form_for @query, url: @url, **kwargs do |f| %>
+<%= search_form_for @query, url: @url, html: {role: "search"}, **kwargs do |f| %>
   <%= render Ransack::HiddenSortFieldComponent.new(@query) %>
   <%= render SearchFieldComponent.new(
     form: f,

--- a/app/components/search_component.html.erb
+++ b/app/components/search_component.html.erb
@@ -1,6 +1,6 @@
 <div role="status" class="sr-only"><%= results_message if search_term? %></div>
 
-<%= search_form_for @query, url: @url, html: {role: "search"}, **kwargs do |f| %>
+<%= search_form_for @query, url: @url, html: { role: "search" }, **kwargs do |f| %>
   <%= render Ransack::HiddenSortFieldComponent.new(@query) %>
   <%= render SearchFieldComponent.new(
     form: f,

--- a/app/components/search_field_component.html.erb
+++ b/app/components/search_field_component.html.erb
@@ -8,7 +8,8 @@
                        class:
                          "t-search-component h-full w-full placeholder-shown:field-sizing-content block p-2.5 pr-11.5 text-sm text-slate-900 border border-slate-300 rounded-lg bg-slate-50 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-300 dark:text-white",
                        aria: {
-                         label: t("components.search_field_component.instructions"),
+                         description:
+                           t("components.search_field_component.instructions"),
                        },
                        placeholder: @placeholder,
                        value: @value %>

--- a/app/views/groups/samples/_table_filter.html.erb
+++ b/app/views/groups/samples/_table_filter.html.erb
@@ -1,6 +1,6 @@
 <div role="status" class="sr-only"><%= @results_message %></div>
 
-<%= form_with model: @query, scope: :q, url: search_group_samples_url, method: :post, data: {
+<%= form_with model: @query, html: { role: "search" }, scope: :q, url: search_group_samples_url, method: :post, data: {
   turbo_action: 'replace',
   controller: "filters metadata-toggle",
   "metadata-toggle-page-value": @pagy&.page,

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -1,6 +1,6 @@
 <div role="status" class="sr-only"><%= @results_message %></div>
 
-<%= form_with model: @query, scope: :q, url: search_namespace_project_samples_url, method: :post, data: { turbo_stream: true, turbo_action: 'replace', controller: "filters metadata-toggle", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters contents" do |f| %>
+<%= form_with model: @query, html: {role: "search"}, scope: :q, url: search_namespace_project_samples_url, method: :post, data: { turbo_stream: true, turbo_action: 'replace', controller: "filters metadata-toggle", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters contents" do |f| %>
   <div class="max-sm:grow">
     <%= render SearchFieldComponent.new(
       label: t(".search.label"),

--- a/app/views/projects/samples/_table_filter.html.erb
+++ b/app/views/projects/samples/_table_filter.html.erb
@@ -1,6 +1,6 @@
 <div role="status" class="sr-only"><%= @results_message %></div>
 
-<%= form_with model: @query, html: {role: "search"}, scope: :q, url: search_namespace_project_samples_url, method: :post, data: { turbo_stream: true, turbo_action: 'replace', controller: "filters metadata-toggle", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters contents" do |f| %>
+<%= form_with model: @query, html: { role: "search" }, scope: :q, url: search_namespace_project_samples_url, method: :post, data: { turbo_stream: true, turbo_action: 'replace', controller: "filters metadata-toggle", "metadata-toggle-page-value": @pagy&.page, "filters-selection-outlet": "#samples-table" }, class: "filters contents" do |f| %>
   <div class="max-sm:grow">
     <%= render SearchFieldComponent.new(
       label: t(".search.label"),


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR enhances the search field component accessibility so that screenreaders will also read out the label for the search field

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1280" height="672" alt="image" src="https://github.com/user-attachments/assets/dd7d9d19-1e19-4cb7-9fe5-5461a16e2f0e" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Verify that screenreader reads out the label of the search field when focused

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
