### PR TITLE
feat: fetch sample metadata for linelist export

### DIFF
--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -1,6 +1,8 @@
 <% linelist_data = {
   controller: "linelist-export",
   "linelist-export-worker-url-value": asset_path("workers/linelist_export_worker.js"),
+  "linelist-export-graphql-url-value": graphql_url,
+  "linelist-export-sample-graphql-id-prefix-value": sample_graphql_id_prefix,
   "linelist-export-minimum-visible-duration-ms-value": 3500,
   "linelist-export-no-selection-error-message-value": t("data_exports.new_linelist_export_dialog.no_selection"),
   "linelist-export-selected-count-message-value": t("data_exports.new_linelist_export_dialog.selected_count"),

--- a/app/components/data_exports/linelist_export_dialog/v2/component.rb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.rb
@@ -12,6 +12,14 @@ module DataExports
           @templates = templates
           @system_arguments = system_arguments
         end
+
+        def graphql_url
+          helpers.api_graphql_path
+        end
+
+        def sample_graphql_id_prefix
+          "gid://#{GlobalID.app}/#{Sample.name}/"
+        end
       end
     end
   end

--- a/app/components/data_exports/linelist_export_dialog/v2/component.rb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.rb
@@ -18,7 +18,7 @@ module DataExports
         end
 
         def sample_graphql_id_prefix
-          "gid://#{GlobalID.app}/#{Sample.name}/"
+          "gid://#{GlobalID.app}/Sample/"
         end
       end
     end

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -4,6 +4,8 @@ export default class extends Controller {
   static targets = ["sampleStatus", "progressTemplate"];
   static values = {
     workerUrl: String,
+    graphqlUrl: String,
+    sampleGraphqlIdPrefix: String,
     minimumVisibleDurationMs: {
       type: Number,
       default: 3500,
@@ -69,6 +71,8 @@ export default class extends Controller {
     const metadataFields = this.selectedMetadataFields();
     const format = this.selectedFormat();
     const namespaceId = this.selectedNamespaceId();
+    const graphqlUrl = this.selectedGraphqlUrl();
+    const sampleGraphqlIdPrefix = this.selectedSampleGraphqlIdPrefix();
     const selectedCount = sampleIds.length;
 
     if (!selectedCount) {
@@ -109,6 +113,8 @@ export default class extends Controller {
         sample_ids: sampleIds,
         metadata_fields: metadataFields,
         namespace_id: namespaceId,
+        graphql_url: graphqlUrl,
+        sample_graphql_id_prefix: sampleGraphqlIdPrefix,
         format,
         filename,
         total_count: totalCount,
@@ -291,6 +297,18 @@ export default class extends Controller {
     } catch {
       return [];
     }
+  }
+
+  selectedGraphqlUrl() {
+    return this.hasGraphqlUrlValue && this.graphqlUrlValue
+      ? this.graphqlUrlValue
+      : "/api/graphql";
+  }
+
+  selectedSampleGraphqlIdPrefix() {
+    return this.hasSampleGraphqlIdPrefixValue && this.sampleGraphqlIdPrefixValue
+      ? this.sampleGraphqlIdPrefixValue
+      : "";
   }
 
   selectionStorageKey() {

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -114,6 +114,7 @@ export default class extends Controller {
         metadata_fields: metadataFields,
         namespace_id: namespaceId,
         graphql_url: graphqlUrl,
+        csrf_token: this.csrfToken(),
         sample_graphql_id_prefix: sampleGraphqlIdPrefix,
         format,
         filename,
@@ -301,6 +302,11 @@ export default class extends Controller {
 
   graphqlUrl() {
     return this.graphqlUrlValue;
+  }
+
+  csrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta?.getAttribute("content") || "";
   }
 
   sampleGraphqlIdPrefix() {

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -71,8 +71,8 @@ export default class extends Controller {
     const metadataFields = this.selectedMetadataFields();
     const format = this.selectedFormat();
     const namespaceId = this.selectedNamespaceId();
-    const graphqlUrl = this.selectedGraphqlUrl();
-    const sampleGraphqlIdPrefix = this.selectedSampleGraphqlIdPrefix();
+    const graphqlUrl = this.graphqlUrl();
+    const sampleGraphqlIdPrefix = this.sampleGraphqlIdPrefix();
     const selectedCount = sampleIds.length;
 
     if (!selectedCount) {
@@ -299,16 +299,12 @@ export default class extends Controller {
     }
   }
 
-  selectedGraphqlUrl() {
-    return this.hasGraphqlUrlValue && this.graphqlUrlValue
-      ? this.graphqlUrlValue
-      : "/api/graphql";
+  graphqlUrl() {
+    return this.graphqlUrlValue;
   }
 
-  selectedSampleGraphqlIdPrefix() {
-    return this.hasSampleGraphqlIdPrefixValue && this.sampleGraphqlIdPrefixValue
-      ? this.sampleGraphqlIdPrefixValue
-      : "";
+  sampleGraphqlIdPrefix() {
+    return this.sampleGraphqlIdPrefixValue;
   }
 
   selectionStorageKey() {

--- a/app/javascript/workers/linelist_export_worker.js
+++ b/app/javascript/workers/linelist_export_worker.js
@@ -38,7 +38,7 @@ const chunk = (items, size) => {
 };
 
 const toSampleGraphqlId = (sampleId, sampleGraphqlIdPrefix) => {
-  const id = String(sampleId || "");
+  const id = String(sampleId ?? "");
 
   if (id.startsWith("gid://")) return id;
   if (sampleGraphqlIdPrefix) return `${sampleGraphqlIdPrefix}${id}`;
@@ -108,7 +108,7 @@ self.onmessage = async (event) => {
     return;
   }
 
-  if (format !== "csv" && format !== undefined && format !== null) {
+  if (format != null && format !== "csv") {
     self.postMessage({
       type: "error",
       message: "Unsupported linelist format for this flow.",

--- a/app/javascript/workers/linelist_export_worker.js
+++ b/app/javascript/workers/linelist_export_worker.js
@@ -1,16 +1,104 @@
-self.onmessage = (event) => {
+const SAMPLE_CHUNK_SIZE = 100;
+
+const LINELIST_SAMPLES_QUERY = `
+  query LinelistSamples($ids: [ID!]!, $metadataKeys: [String!]) {
+    nodes(ids: $ids) {
+      id
+      __typename
+      ... on Sample {
+        puid
+        name
+        metadata(keys: $metadataKeys)
+        project {
+          puid
+        }
+      }
+    }
+  }
+`;
+
+const escapeCsv = (value) => {
+  const text = String(value ?? "");
+
+  if (text.includes(",") || text.includes('"') || text.includes("\n")) {
+    return '"' + text.replace(/"/g, '""') + '"';
+  }
+
+  return text;
+};
+
+const chunk = (items, size) => {
+  const chunks = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
+};
+
+const toSampleGraphqlId = (sampleId, sampleGraphqlIdPrefix) => {
+  const id = String(sampleId || "");
+
+  if (id.startsWith("gid://")) return id;
+  if (sampleGraphqlIdPrefix) return `${sampleGraphqlIdPrefix}${id}`;
+
+  throw new Error("Unable to build GraphQL sample IDs for export.");
+};
+
+const postGraphql = async ({ graphqlUrl, query, variables, operationName }) => {
+  let response;
+
+  try {
+    response = await fetch(graphqlUrl, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/graphql-response+json, application/json",
+      },
+      body: JSON.stringify({ query, variables, operationName }),
+    });
+  } catch (error) {
+    throw new Error(
+      `Network error while loading samples: ${error?.message || "request failed"}`,
+      { cause: error },
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(`GraphQL request failed (${response.status}).`);
+  }
+
+  let payload;
+
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("GraphQL response was not valid JSON.");
+  }
+
+  if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+    const firstMessage = payload.errors[0]?.message;
+    throw new Error(firstMessage || "GraphQL request failed.");
+  }
+
+  return payload;
+};
+
+self.onmessage = async (event) => {
   const {
     sample_ids: sampleIds,
     metadata_fields: metadataFields,
-    namespace_id: namespaceId,
-    total_count: totalCount,
+    graphql_url: graphqlUrl,
+    sample_graphql_id_prefix: sampleGraphqlIdPrefix,
     filename,
     format,
   } = event.data || {};
 
   const fields = Array.isArray(metadataFields) ? metadataFields : [];
   const ids = Array.isArray(sampleIds) ? sampleIds : [];
-  const rows = Math.max(ids.length, Number(totalCount) || 0);
+  const rows = ids.length;
 
   if (!rows) {
     self.postMessage({
@@ -28,51 +116,93 @@ self.onmessage = (event) => {
     return;
   }
 
-  const header = [
-    "SAMPLE PUID",
-    "SAMPLE NAME",
-    "PROJECT PUID",
-    ...fields.map((field) => String(field).toUpperCase()),
-  ];
-  const lines = [header.join(",")];
-  const progressInterval = Math.max(1, Math.floor(rows / 250));
-
-  const escape = (value) => {
-    const text = String(value ?? "");
-
-    if (text.includes(",") || text.includes('"') || text.includes("\n")) {
-      return '"' + text.replace(/"/g, '""') + '"';
-    }
-
-    return text;
-  };
-
-  for (let i = 0; i < rows; i += 1) {
-    const sampleId = String(ids[i]);
-
-    const row = [escape(sampleId), "", escape(namespaceId)];
-
-    fields.forEach((field) => {
-      row.push(escape(`value-${field}-${sampleId}`));
+  if (!graphqlUrl) {
+    self.postMessage({
+      type: "error",
+      message: "Missing GraphQL endpoint for linelist export.",
     });
-
-    lines.push(row.join(","));
-
-    if ((i + 1) % progressInterval === 0 || i + 1 === rows) {
-      const percentage = ((i + 1) / rows) * 100;
-
-      self.postMessage({
-        type: "progress",
-        current: i + 1,
-        total: rows,
-        percentage,
-      });
-    }
+    return;
   }
 
-  self.postMessage({
-    type: "done",
-    filename,
-    content: lines.join("\n"),
-  });
+  try {
+    const sampleGraphqlIds = ids.map((id) =>
+      toSampleGraphqlId(id, sampleGraphqlIdPrefix),
+    );
+
+    const sampleById = new Map();
+    let fetched = 0;
+    const idChunks = chunk(sampleGraphqlIds, SAMPLE_CHUNK_SIZE);
+
+    for (const idChunk of idChunks) {
+      const payload = await postGraphql({
+        graphqlUrl,
+        query: LINELIST_SAMPLES_QUERY,
+        variables: { ids: idChunk, metadataKeys: fields },
+        operationName: "LinelistSamples",
+      });
+
+      const nodes = payload?.data?.nodes;
+
+      if (!Array.isArray(nodes)) {
+        throw new Error("GraphQL response did not include sample nodes.");
+      }
+
+      nodes.forEach((node) => {
+        if (node?.__typename === "Sample" && node.id) {
+          sampleById.set(node.id, node);
+        }
+      });
+
+      fetched += idChunk.length;
+      self.postMessage({
+        type: "progress",
+        current: Math.min(fetched, rows),
+        total: rows,
+        percentage: (Math.min(fetched, rows) / rows) * 100,
+      });
+    }
+
+    const header = [
+      "SAMPLE PUID",
+      "SAMPLE NAME",
+      "PROJECT PUID",
+      ...fields.map((field) => String(field).toUpperCase()),
+    ];
+    const lines = [header.join(",")];
+
+    sampleGraphqlIds.forEach((sampleGraphqlId) => {
+      const sample = sampleById.get(sampleGraphqlId);
+
+      if (!sample) {
+        throw new Error(
+          "One or more selected samples were not returned by GraphQL.",
+        );
+      }
+
+      const metadata = sample.metadata || {};
+
+      const row = [
+        escapeCsv(sample.puid),
+        escapeCsv(sample.name),
+        escapeCsv(sample.project?.puid),
+      ];
+
+      fields.forEach((field) => {
+        row.push(escapeCsv(metadata[field]));
+      });
+
+      lines.push(row.join(","));
+    });
+
+    self.postMessage({
+      type: "done",
+      filename,
+      content: lines.join("\n"),
+    });
+  } catch (error) {
+    self.postMessage({
+      type: "error",
+      message: error?.message || "Unexpected error while generating export.",
+    });
+  }
 };

--- a/app/javascript/workers/linelist_export_worker.js
+++ b/app/javascript/workers/linelist_export_worker.js
@@ -46,7 +46,13 @@ const toSampleGraphqlId = (sampleId, sampleGraphqlIdPrefix) => {
   throw new Error("Unable to build GraphQL sample IDs for export.");
 };
 
-const postGraphql = async ({ graphqlUrl, query, variables, operationName }) => {
+const postGraphql = async ({
+  graphqlUrl,
+  query,
+  variables,
+  operationName,
+  csrfToken,
+}) => {
   let response;
 
   try {
@@ -56,6 +62,7 @@ const postGraphql = async ({ graphqlUrl, query, variables, operationName }) => {
       headers: {
         "Content-Type": "application/json",
         Accept: "application/graphql-response+json, application/json",
+        ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
       },
       body: JSON.stringify({ query, variables, operationName }),
     });
@@ -91,6 +98,7 @@ self.onmessage = async (event) => {
     sample_ids: sampleIds,
     metadata_fields: metadataFields,
     graphql_url: graphqlUrl,
+    csrf_token: csrfToken,
     sample_graphql_id_prefix: sampleGraphqlIdPrefix,
     filename,
     format,
@@ -139,6 +147,7 @@ self.onmessage = async (event) => {
         query: LINELIST_SAMPLES_QUERY,
         variables: { ids: idChunk, metadataKeys: fields },
         operationName: "LinelistSamples",
+        csrfToken,
       });
 
       const nodes = payload?.data?.nodes;

--- a/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
+++ b/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'view_component_test_case'
+
+module DataExports
+  module LinelistExportDialog
+    module V2
+      class ComponentTest < ViewComponentTestCase
+        test 'renders graphql worker data attributes' do
+          project = projects(:project1)
+
+          render_inline(
+            Component.new(
+              open: true,
+              namespace_id: project.namespace.id,
+              namespace: project.namespace,
+              templates: []
+            )
+          )
+
+          graphql_path = Rails.application.routes.url_helpers.api_graphql_path
+
+          assert_selector "[data-controller='linelist-export']"
+          assert_selector "[data-linelist-export-graphql-url-value='#{graphql_path}']"
+          assert_selector "[data-linelist-export-sample-graphql-id-prefix-value='gid://#{GlobalID.app}/Sample/']"
+        end
+      end
+    end
+  end
+end

--- a/test/graphql/nodes_query_test.rb
+++ b/test/graphql/nodes_query_test.rb
@@ -44,6 +44,22 @@ class NodesQueryTest < ActiveSupport::TestCase
     }
   GRAPHQL
 
+  NODES_SAMPLES_LINELIST_QUERY = <<~GRAPHQL
+    query($ids: [ID!]!, $metadataKeys: [String!]) {
+      nodes(ids: $ids) {
+        id
+        ... on Sample {
+          puid
+          name
+          project {
+            puid
+          }
+          metadata(keys: $metadataKeys)
+        }
+      }
+    }
+  GRAPHQL
+
   NODES_USERS_QUERY = <<~GRAPHQL
     query($ids: [ID!]!) {
       nodes(ids: $ids) {
@@ -255,6 +271,27 @@ class NodesQueryTest < ActiveSupport::TestCase
     assert_equal 1, data.length
 
     assert_equal sample.name, data[0]['name']
+  end
+
+  test 'nodes query for sample should return linelist fields with metadata keys filter' do
+    sample = samples(:sample30)
+
+    result = IridaSchema.execute(
+      NODES_SAMPLES_LINELIST_QUERY,
+      context: { current_user: @user },
+      variables: { ids: [sample.to_global_id.to_s], metadataKeys: ['metadatafield1'] }
+    )
+
+    assert_nil result['errors'], 'should work and have no errors.'
+
+    data = result['data']['nodes']
+
+    assert_not_empty data, 'nodes type should work'
+    assert_equal 1, data.length
+    assert_equal sample.puid, data[0]['puid']
+    assert_equal sample.name, data[0]['name']
+    assert_equal sample.project.puid, data[0]['project']['puid']
+    assert_equal({ 'metadatafield1' => 'value1' }, data[0]['metadata'])
   end
 
   test 'nodes query for user should be able to return user attributes' do


### PR DESCRIPTION
## What does this PR do and why?
This PR updates linelist export to use GraphQL-backed sample lookup and emits real metadata in exported rows instead of mocked placeholder values.

- Passes the GraphQL endpoint and sample GlobalID prefix into the linelist export component as data attributes.
- Updates the Stimulus controller to send `graphql_url` and `sample_graphql_id_prefix` with export requests.
- Refactors the web worker to query `nodes` in chunks and read `puid`, `name`, `project.puid`, and requested metadata keys.
- Builds CSV rows from fetched sample fields, preserving existing field-selection behavior.
- Adds error handling for missing GraphQL endpoint and invalid GraphQL responses.
- Adds tests for the new component data attributes and GraphQL nodes query metadata filtering.

## Screenshots or screen recordings
No visual changes.

## How to set up and validate locally

1. Check out `linelist-worker-graphql-plan` and pull latest origin.
2. Run tests for updated coverage: 
   - `bin/rails test test/components/data_exports/linelist_export_dialog/v2/component_test.rb test/graphql/nodes_query_test.rb`
   - Expected: both tests pass.
3. Open a project with the linelist export dialog and create an export.
   - Expected: downloaded CSV includes real sample `puid`, `name`, `project.puid`, and selected metadata values.
4. Validate failure handling by reproducing an empty/missing sample list.
   - Expected: export flow reports a clear error without generating a partial file.

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
