### PR TITLE
Application Settings: Personal Access Tokens

### DIFF
--- a/app/components/datepicker/v1/calendar/footer_component.html.erb
+++ b/app/components/datepicker/v1/calendar/footer_component.html.erb
@@ -7,7 +7,10 @@
   <% end %>
 
   <% unless @max_date.nil? %>
-    <div class="text-center text-sm text-slate-900 dark:text-white" data-datepicker--calendar-target="maxDateMessage"></div>
+    <div
+      class="text-center text-sm text-slate-900 dark:text-white"
+      data-datepicker--v1--calendar-target="maxDateMessage"
+    ></div>
   <% end %>
 
   <div class="mt-2 flex space-x-2 rtl:space-x-reverse">

--- a/app/components/datepicker/v1/calendar/footer_component.html.erb
+++ b/app/components/datepicker/v1/calendar/footer_component.html.erb
@@ -6,6 +6,10 @@
     ></div>
   <% end %>
 
+  <% unless @max_date.nil? %>
+    <div class="text-center text-sm text-slate-900 dark:text-white" data-datepicker--calendar-target="maxDateMessage"></div>
+  <% end %>
+
   <div class="mt-2 flex space-x-2 rtl:space-x-reverse">
     <button
       type="button"

--- a/app/components/datepicker/v1/calendar/footer_component.rb
+++ b/app/components/datepicker/v1/calendar/footer_component.rb
@@ -5,7 +5,8 @@ module Datepicker
     module Calendar
       # Renders the calendar footer (today / clear buttons).
       class FooterComponent < ::Component
-        def initialize(min_date:)
+        def initialize(min_date:, max_date:)
+          @max_date = max_date
           @min_date = min_date
         end
       end

--- a/app/components/datepicker/v1/calendar/header_component.html.erb
+++ b/app/components/datepicker/v1/calendar/header_component.html.erb
@@ -30,7 +30,7 @@
         data-action="change->datepicker--v1--calendar#changeYear"
         type="number"
         autocomplete="off"
-        max="9999"
+        max="<%= @max_year %>"
         min="<%= @min_year %>"
         class="
           ml-1 w-22 rounded-lg border-slate-300 text-slate-900 sm:text-sm dark:border-slate-600 dark:bg-slate-800

--- a/app/components/datepicker/v1/calendar/header_component.html.erb
+++ b/app/components/datepicker/v1/calendar/header_component.html.erb
@@ -47,6 +47,7 @@
         hover:text-slate-900 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600 dark:hover:text-white
       "
       data-action="click->datepicker--v1--calendar#nextMonth"
+      data-datepicker--v1--calendar-target="forwardButton"
       aria-label="<%= t("components.datepicker.aria_label.next_month_button") %>"
     >
       <%= icon(:arrow_right, color: nil, size: nil, class: "size-6") %>

--- a/app/components/datepicker/v1/calendar/header_component.rb
+++ b/app/components/datepicker/v1/calendar/header_component.rb
@@ -5,8 +5,9 @@ module Datepicker
     module Calendar
       # Renders the calendar header (month select and year input).
       class HeaderComponent < ::Component
-        def initialize(min_year:, months:)
+        def initialize(min_year:, max_year:, months:)
           @min_year = min_year
+          @max_year = max_year
           @months = months
         end
       end

--- a/app/components/datepicker/v1/calendar_component.html.erb
+++ b/app/components/datepicker/v1/calendar_component.html.erb
@@ -1,7 +1,7 @@
 <template data-datepicker--v1--input-target="calendarTemplate">
   <%= render Viral::BaseComponent.new(**@calendar_arguments) do %>
     <div class="inline-block rounded-lg bg-white p-4 shadow-sm max-[384px]:p-1 dark:bg-slate-700">
-      <%= render Datepicker::V1::Calendar::HeaderComponent.new(min_year: @min_year, months: @months) %>
+      <%= render Datepicker::V1::Calendar::HeaderComponent.new(min_year: @min_year, max_year: @max_year, months: @months) %>
       <%= render Datepicker::V1::Calendar::GridComponent.new(days_of_the_week: @days_of_the_week) %>
       <%= render Datepicker::V1::Calendar::FooterComponent.new(min_date: @min_date, max_date: @max_date) %>
     </div>

--- a/app/components/datepicker/v1/calendar_component.html.erb
+++ b/app/components/datepicker/v1/calendar_component.html.erb
@@ -3,7 +3,7 @@
     <div class="inline-block rounded-lg bg-white p-4 shadow-sm max-[384px]:p-1 dark:bg-slate-700">
       <%= render Datepicker::V1::Calendar::HeaderComponent.new(min_year: @min_year, months: @months) %>
       <%= render Datepicker::V1::Calendar::GridComponent.new(days_of_the_week: @days_of_the_week) %>
-      <%= render Datepicker::V1::Calendar::FooterComponent.new(min_date: @min_date) %>
+      <%= render Datepicker::V1::Calendar::FooterComponent.new(min_date: @min_date, max_date: @max_date) %>
     </div>
   <% end %>
 </template>

--- a/app/components/datepicker/v1/calendar_component.rb
+++ b/app/components/datepicker/v1/calendar_component.rb
@@ -4,13 +4,16 @@ module Datepicker
   module V1
     # Renders the datepicker calendar popup.
     class CalendarComponent < ::Component
-      def initialize(calendar_arguments:, days_of_the_week:, months:, min_year:, min_date:)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(calendar_arguments:, days_of_the_week:, months:, min_year:, min_date:, max_date:)
         @calendar_arguments = calendar_arguments
         @days_of_the_week = days_of_the_week
         @months = months
         @min_year = min_year
         @min_date = min_date
+        @max_date = max_date
       end
+      # rubocop:enable Metrics/ParameterLists
     end
   end
 end

--- a/app/components/datepicker/v1/calendar_component.rb
+++ b/app/components/datepicker/v1/calendar_component.rb
@@ -4,16 +4,23 @@ module Datepicker
   module V1
     # Renders the datepicker calendar popup.
     class CalendarComponent < ::Component
-      # rubocop:disable Metrics/ParameterLists
-      def initialize(calendar_arguments:, days_of_the_week:, months:, min_year:, min_date:, max_date:)
+      def initialize(calendar_arguments:, days_of_the_week:, months:, min_date:, max_date:)
         @calendar_arguments = calendar_arguments
         @days_of_the_week = days_of_the_week
         @months = months
-        @min_year = min_year
         @min_date = min_date
         @max_date = max_date
+        @min_year = calculate_min_year
+        @max_year = calculate_max_year
       end
-      # rubocop:enable Metrics/ParameterLists
+
+      def calculate_min_year
+        @min_date.nil? ? '1' : @min_date.to_s.split('-')[0]
+      end
+
+      def calculate_max_year
+        @max_date.nil? ? '9999' : @max_date.to_s.split('-')[0]
+      end
     end
   end
 end

--- a/app/components/datepicker/v1/component.html.erb
+++ b/app/components/datepicker/v1/component.html.erb
@@ -26,7 +26,6 @@
       calendar_arguments: @calendar_arguments,
       days_of_the_week: @days_of_the_week,
       months: @months,
-      min_year: @min_year,
       min_date: @min_date,
       max_date: @max_date
     ) %>

--- a/app/components/datepicker/v1/component.html.erb
+++ b/app/components/datepicker/v1/component.html.erb
@@ -6,6 +6,10 @@
       <%= render Datepicker::V1::MinDateComponent.new(min_date: @min_date) %>
     <% end %>
 
+    <% unless @max_date.nil? %>
+      <%= render Datepicker::V1::MaxDateComponent.new(max_date: @max_date) %>
+    <% end %>
+
     <%= render Datepicker::V1::InputFieldComponent.new(
       label: @label,
       input_id: @input_id,
@@ -24,6 +28,7 @@
       months: @months,
       min_year: @min_year,
       min_date: @min_date,
+      max_date: @max_date
     ) %>
   <% end %>
 </fieldset>

--- a/app/components/datepicker/v1/component.rb
+++ b/app/components/datepicker/v1/component.rb
@@ -44,6 +44,7 @@ module Datepicker
         @required = required
         @errored = errored
         @min_date = min_date
+        @max_date = max_date
         @system_arguments = system_arguments
         @calendar_arguments = calendar_arguments
         @min_year = calculate_min_year
@@ -110,6 +111,8 @@ module Datepicker
         @system_arguments[:data]['datepicker--v1--input-autosubmit-value'] = @autosubmit
         @system_arguments[:data]['datepicker--v1--input-invalid-date-value'] =
           I18n.t('components.datepicker.errors.invalid_date')
+        @system_arguments[:data]['datepicker--v1--input-invalid-max-date-value'] =
+          I18n.t('components.datepicker.errors.max_date_error')
         @system_arguments[:data]['datepicker--v1--input-invalid-min-date-value'] =
           I18n.t('components.datepicker.errors.min_date_error')
         @system_arguments[:data]['datepicker--v1--input-calendar-id-value'] = @calendar_id
@@ -138,6 +141,14 @@ module Datepicker
         @calendar_arguments[:data]['datepicker--v1--calendar-datepicker--v1--input-outlet'] =
           "##{@container_id}"
         @calendar_arguments[:data]['datepicker--v1--calendar-months-value'] = @months
+      end
+
+      def max_date
+        if Irida::CurrentSettings.require_personal_access_token_expiry?
+          return Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days
+        end
+
+        nil
       end
     end
   end

--- a/app/components/datepicker/v1/component.rb
+++ b/app/components/datepicker/v1/component.rb
@@ -22,8 +22,12 @@ module Datepicker
       # @param min_date [String] A minimum date the user can input.
       # @param selected_date [String] The already selected date if it exists.
       # @param autosubmit [Boolean] Submits the date upon selection if true
+<<<<<<< HEAD
       # @param required [Boolean] Sets aria-required="true" on input_field_component if true
       # @param errored [Boolean] Initializes the datepicker in an error state if true (determined by backend validation)
+=======
+      # @param type [String] The type of datepicker, which can affect behavior such as max_date calculation.
+>>>>>>> 78be9ca25 (Updated datepicker to accept a type which accepts a string so we can differentiate between regular datepicker vs the personal access token datepicker since we can set a max date for personal access tokens)
       # @param calendar_arguments [Hash] HTML attributes for the datepicker
       # @param system_arguments [Hash] HTML attributes for the main container (<div>).
       # @raise [ArgumentError] if id is not provided.
@@ -31,8 +35,12 @@ module Datepicker
 
       # rubocop:disable Metrics/ParameterLists
       def initialize(id:, input_name:, label: nil, input_aria_label: nil, min_date: 1.day.from_now, # rubocop:disable Metrics/MethodLength
+<<<<<<< HEAD
                      selected_date: nil, autosubmit: false, required: false, errored: false,
                      calendar_arguments: {}, **system_arguments)
+=======
+                     selected_date: nil, autosubmit: false, type: 'default', calendar_arguments: {}, **system_arguments)
+>>>>>>> 78be9ca25 (Updated datepicker to accept a type which accepts a string so we can differentiate between regular datepicker vs the personal access token datepicker since we can set a max date for personal access tokens)
         raise ArgumentError, 'id is required' if id.blank?
         raise ArgumentError, 'input_name is required' if input_name.blank?
 
@@ -40,6 +48,7 @@ module Datepicker
         @input_name = input_name
         @input_aria_label = input_aria_label
         @selected_date = selected_date
+        @type = type
         @autosubmit = autosubmit
         @required = required
         @errored = errored
@@ -144,7 +153,7 @@ module Datepicker
       end
 
       def max_date
-        if Irida::CurrentSettings.require_personal_access_token_expiry?
+        if @type == 'personal_access_token' && Irida::CurrentSettings.require_personal_access_token_expiry?
           return Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days
         end
 

--- a/app/components/datepicker/v1/component.rb
+++ b/app/components/datepicker/v1/component.rb
@@ -19,15 +19,12 @@ module Datepicker
       # @param input_name [String] The name attribute for the date input. This is required.
       # @param label [String] A label for the input (optional).
       # @param input_aria_label [String] Aria label for the input. Necessary for accessibility if no label is passed.
+      # @param max_date [String] A maximum date the user can input.
       # @param min_date [String] A minimum date the user can input.
       # @param selected_date [String] The already selected date if it exists.
       # @param autosubmit [Boolean] Submits the date upon selection if true
-<<<<<<< HEAD
       # @param required [Boolean] Sets aria-required="true" on input_field_component if true
       # @param errored [Boolean] Initializes the datepicker in an error state if true (determined by backend validation)
-=======
-      # @param type [String] The type of datepicker, which can affect behavior such as max_date calculation.
->>>>>>> 78be9ca25 (Updated datepicker to accept a type which accepts a string so we can differentiate between regular datepicker vs the personal access token datepicker since we can set a max date for personal access tokens)
       # @param calendar_arguments [Hash] HTML attributes for the datepicker
       # @param system_arguments [Hash] HTML attributes for the main container (<div>).
       # @raise [ArgumentError] if id is not provided.
@@ -35,12 +32,8 @@ module Datepicker
 
       # rubocop:disable Metrics/ParameterLists
       def initialize(id:, input_name:, label: nil, input_aria_label: nil, min_date: 1.day.from_now, # rubocop:disable Metrics/MethodLength
-<<<<<<< HEAD
-                     selected_date: nil, autosubmit: false, required: false, errored: false,
+                     max_date: nil, selected_date: nil, autosubmit: false, required: false, errored: false,
                      calendar_arguments: {}, **system_arguments)
-=======
-                     selected_date: nil, autosubmit: false, type: 'default', calendar_arguments: {}, **system_arguments)
->>>>>>> 78be9ca25 (Updated datepicker to accept a type which accepts a string so we can differentiate between regular datepicker vs the personal access token datepicker since we can set a max date for personal access tokens)
         raise ArgumentError, 'id is required' if id.blank?
         raise ArgumentError, 'input_name is required' if input_name.blank?
 
@@ -48,7 +41,6 @@ module Datepicker
         @input_name = input_name
         @input_aria_label = input_aria_label
         @selected_date = selected_date
-        @type = type
         @autosubmit = autosubmit
         @required = required
         @errored = errored
@@ -150,14 +142,6 @@ module Datepicker
         @calendar_arguments[:data]['datepicker--v1--calendar-datepicker--v1--input-outlet'] =
           "##{@container_id}"
         @calendar_arguments[:data]['datepicker--v1--calendar-months-value'] = @months
-      end
-
-      def max_date
-        if @type == 'personal_access_token' && Irida::CurrentSettings.require_personal_access_token_expiry?
-          return Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days
-        end
-
-        nil
       end
     end
   end

--- a/app/components/datepicker/v1/component.rb
+++ b/app/components/datepicker/v1/component.rb
@@ -48,7 +48,6 @@ module Datepicker
         @max_date = max_date
         @system_arguments = system_arguments
         @calendar_arguments = calendar_arguments
-        @min_year = calculate_min_year
         @months = load_months
         @days_of_the_week = load_days_of_week
         # rubocop:enable Metrics/ParameterLists
@@ -83,10 +82,6 @@ module Datepicker
          I18n.t('components.datepicker.days_of_week.thursday'),
          I18n.t('components.datepicker.days_of_week.friday'),
          I18n.t('components.datepicker.days_of_week.saturday')]
-      end
-
-      def calculate_min_year
-        @min_date.nil? ? '1' : @min_date.to_s.split('-')[0]
       end
 
       def setup_ids(id)

--- a/app/components/datepicker/v1/max_date_component.html.erb
+++ b/app/components/datepicker/v1/max_date_component.html.erb
@@ -1,0 +1,3 @@
+<%# add a hidden div so we can process min_date in local time with the local_time gem, this is then processed %>
+<%# by datepicker--input_controller and then removed %>
+<div class="hidden" data-datepicker--input-target="maxDate"><%= helpers.local_date(@max_date, "%Y-%m-%d") %></div>

--- a/app/components/datepicker/v1/max_date_component.rb
+++ b/app/components/datepicker/v1/max_date_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Datepicker
+  module V1
+    # Renders a hidden div holding the max_date value for the datepicker Stimulus controller.
+    class MaxDateComponent < ::Component
+      def initialize(max_date:)
+        @max_date = max_date
+      end
+    end
+  end
+end

--- a/app/components/datepicker/v2/calendar/footer_component.html.erb
+++ b/app/components/datepicker/v2/calendar/footer_component.html.erb
@@ -6,6 +6,13 @@
     ></div>
   <% end %>
 
+  <% unless @max_date.nil? %>
+    <div
+      class="text-center text-sm text-slate-900 dark:text-white"
+      data-datepicker--v2--calendar-target="maxDateMessage"
+    ></div>
+  <% end %>
+
   <div class="mt-2 flex space-x-2 rtl:space-x-reverse">
     <button
       type="button"

--- a/app/components/datepicker/v2/calendar/footer_component.rb
+++ b/app/components/datepicker/v2/calendar/footer_component.rb
@@ -5,8 +5,9 @@ module Datepicker
     module Calendar
       # Renders the calendar footer (today / clear buttons).
       class FooterComponent < ::Component
-        def initialize(min_date:)
+        def initialize(min_date:, max_date:)
           @min_date = min_date
+          @max_date = max_date
         end
       end
     end

--- a/app/components/datepicker/v2/calendar/header_component.html.erb
+++ b/app/components/datepicker/v2/calendar/header_component.html.erb
@@ -29,7 +29,7 @@
       data-action="change->datepicker--v2--calendar#changeYear"
       type="number"
       autocomplete="off"
-      max="9999"
+      max="<%= @max_year %>"
       min="<%= @min_year %>"
       class="
         ml-1 w-22 rounded-lg border-slate-300 text-slate-900 sm:text-sm dark:border-slate-600 dark:bg-slate-800

--- a/app/components/datepicker/v2/calendar/header_component.html.erb
+++ b/app/components/datepicker/v2/calendar/header_component.html.erb
@@ -46,6 +46,7 @@
       hover:text-slate-900 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600 dark:hover:text-white
     "
     data-action="click->datepicker--v2--calendar#nextMonth"
+    data-datepicker--v2--calendar-target="forwardButton"
     aria-label="<%= t("components.datepicker.aria_label.next_month_button") %>"
   >
     <%= icon(:arrow_right, color: nil, size: nil, class: "size-6") %>

--- a/app/components/datepicker/v2/calendar/header_component.rb
+++ b/app/components/datepicker/v2/calendar/header_component.rb
@@ -5,8 +5,9 @@ module Datepicker
     module Calendar
       # Renders the calendar header (month select and year input).
       class HeaderComponent < ::Component
-        def initialize(min_year:, months:)
+        def initialize(min_year:, max_year:, months:)
           @min_year = min_year
+          @max_year = max_year
           @months = months
         end
       end

--- a/app/components/datepicker/v2/calendar_component.html.erb
+++ b/app/components/datepicker/v2/calendar_component.html.erb
@@ -3,7 +3,7 @@
     <div class="inline-block rounded-lg bg-white p-4 shadow-sm max-[384px]:p-1 dark:bg-slate-700">
       <%= render Datepicker::V2::Calendar::HeaderComponent.new(min_year: @min_year, months: @months) %>
       <%= render Datepicker::V2::Calendar::GridComponent.new(days_of_the_week: @days_of_the_week) %>
-      <%= render Datepicker::V2::Calendar::FooterComponent.new(min_date: @min_date) %>
+      <%= render Datepicker::V2::Calendar::FooterComponent.new(min_date: @min_date, max_date: @max_date) %>
     </div>
   <% end %>
 </template>

--- a/app/components/datepicker/v2/calendar_component.html.erb
+++ b/app/components/datepicker/v2/calendar_component.html.erb
@@ -1,7 +1,7 @@
 <template data-datepicker--v2--input-target="calendarTemplate">
   <%= render Viral::BaseComponent.new(**@calendar_arguments) do %>
     <div class="inline-block rounded-lg bg-white p-4 shadow-sm max-[384px]:p-1 dark:bg-slate-700">
-      <%= render Datepicker::V2::Calendar::HeaderComponent.new(min_year: @min_year, months: @months) %>
+      <%= render Datepicker::V2::Calendar::HeaderComponent.new(min_year: @min_year, max_year: @max_year, months: @months) %>
       <%= render Datepicker::V2::Calendar::GridComponent.new(days_of_the_week: @days_of_the_week) %>
       <%= render Datepicker::V2::Calendar::FooterComponent.new(min_date: @min_date, max_date: @max_date) %>
     </div>

--- a/app/components/datepicker/v2/calendar_component.rb
+++ b/app/components/datepicker/v2/calendar_component.rb
@@ -4,16 +4,23 @@ module Datepicker
   module V2
     # Renders the datepicker calendar popup.
     class CalendarComponent < ::Component
-      # rubocop:disable Metrics/ParameterLists
-      def initialize(calendar_arguments:, days_of_the_week:, months:, min_year:, min_date:, max_date:)
+      def initialize(calendar_arguments:, days_of_the_week:, months:, min_date:, max_date:)
         @calendar_arguments = calendar_arguments
         @days_of_the_week = days_of_the_week
         @months = months
-        @min_year = min_year
         @min_date = min_date
         @max_date = max_date
+        @min_year = calculate_min_year
+        @max_year = calculate_max_year
       end
-      # rubocop:enable Metrics/ParameterLists
+
+      def calculate_min_year
+        @min_date.nil? ? '1' : @min_date.to_s.split('-')[0]
+      end
+
+      def calculate_max_year
+        @max_date.nil? ? '9999' : @max_date.to_s.split('-')[0]
+      end
     end
   end
 end

--- a/app/components/datepicker/v2/calendar_component.rb
+++ b/app/components/datepicker/v2/calendar_component.rb
@@ -4,13 +4,16 @@ module Datepicker
   module V2
     # Renders the datepicker calendar popup.
     class CalendarComponent < ::Component
-      def initialize(calendar_arguments:, days_of_the_week:, months:, min_year:, min_date:)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(calendar_arguments:, days_of_the_week:, months:, min_year:, min_date:, max_date:)
         @calendar_arguments = calendar_arguments
         @days_of_the_week = days_of_the_week
         @months = months
         @min_year = min_year
         @min_date = min_date
+        @max_date = max_date
       end
+      # rubocop:enable Metrics/ParameterLists
     end
   end
 end

--- a/app/components/datepicker/v2/component.html.erb
+++ b/app/components/datepicker/v2/component.html.erb
@@ -6,6 +6,10 @@
       <%= render Datepicker::V2::MinDateComponent.new(min_date: @min_date) %>
     <% end %>
 
+    <% unless @max_date.nil? %>
+      <%= render Datepicker::V2::MaxDateComponent.new(max_date: @max_date) %>
+    <% end %>
+
     <%= render Datepicker::V2::InputFieldComponent.new(
       label: @label,
       input_id: @input_id,
@@ -24,6 +28,7 @@
       months: @months,
       min_year: @min_year,
       min_date: @min_date,
+      max_date: @max_date
     ) %>
   <% end %>
 </fieldset>

--- a/app/components/datepicker/v2/component.html.erb
+++ b/app/components/datepicker/v2/component.html.erb
@@ -26,7 +26,6 @@
       calendar_arguments: @calendar_arguments,
       days_of_the_week: @days_of_the_week,
       months: @months,
-      min_year: @min_year,
       min_date: @min_date,
       max_date: @max_date
     ) %>

--- a/app/components/datepicker/v2/component.rb
+++ b/app/components/datepicker/v2/component.rb
@@ -47,7 +47,6 @@ module Datepicker
         @min_date = min_date
         @system_arguments = system_arguments
         @calendar_arguments = calendar_arguments
-        @min_year = calculate_min_year
         @months = load_months
         @days_of_the_week = load_days_of_week
         # rubocop:enable Metrics/ParameterLists
@@ -82,10 +81,6 @@ module Datepicker
          I18n.t('components.datepicker.days_of_week.thursday'),
          I18n.t('components.datepicker.days_of_week.friday'),
          I18n.t('components.datepicker.days_of_week.saturday')]
-      end
-
-      def calculate_min_year
-        @min_date.nil? ? '1' : @min_date.to_s.split('-')[0]
       end
 
       def setup_ids(id)

--- a/app/components/datepicker/v2/component.rb
+++ b/app/components/datepicker/v2/component.rb
@@ -31,7 +31,7 @@ module Datepicker
 
       # rubocop:disable Metrics/ParameterLists
       def initialize(id:, input_name:, label: nil, input_aria_label: nil, min_date: 1.day.from_now, # rubocop:disable Metrics/MethodLength
-                     selected_date: nil, autosubmit: false, required: false, errored: false,
+                     max_date: nil, selected_date: nil, autosubmit: false, required: false, errored: false,
                      calendar_arguments: {},  **system_arguments)
         raise ArgumentError, 'id is required' if id.blank?
         raise ArgumentError, 'input_name is required' if input_name.blank?
@@ -43,6 +43,7 @@ module Datepicker
         @autosubmit = autosubmit
         @required = required
         @errored = errored
+        @max_date = max_date
         @min_date = min_date
         @system_arguments = system_arguments
         @calendar_arguments = calendar_arguments
@@ -110,6 +111,8 @@ module Datepicker
         @system_arguments[:data]['datepicker--v2--input-autosubmit-value'] = @autosubmit
         @system_arguments[:data]['datepicker--v2--input-invalid-date-value'] =
           I18n.t('components.datepicker.errors.invalid_date')
+        @system_arguments[:data]['datepicker--v2--input-invalid-max-date-value'] =
+          I18n.t('components.datepicker.errors.max_date_error')
         @system_arguments[:data]['datepicker--v2--input-invalid-min-date-value'] =
           I18n.t('components.datepicker.errors.min_date_error')
         @system_arguments[:data]['datepicker--v2--input-calendar-id-value'] = @calendar_id

--- a/app/components/datepicker/v2/max_date_component.html.erb
+++ b/app/components/datepicker/v2/max_date_component.html.erb
@@ -1,3 +1,3 @@
 <%# add a hidden div so we can process min_date in local time with the local_time gem, this is then processed %>
 <%# by datepicker--input_controller and then removed %>
-<div class="hidden" data-datepicker--v1--input-target="maxDate"><%= helpers.local_date(@max_date, "%Y-%m-%d") %></div>
+<div class="hidden" data-datepicker--v2--input-target="maxDate"><%= helpers.local_date(@max_date, "%Y-%m-%d") %></div>

--- a/app/components/datepicker/v2/max_date_component.rb
+++ b/app/components/datepicker/v2/max_date_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Datepicker
+  module V2
+    # Renders a hidden div holding the max_date value for the datepicker Stimulus controller.
+    class MaxDateComponent < ::Component
+      def initialize(max_date:)
+        @max_date = max_date
+      end
+    end
+  end
+end

--- a/app/controllers/integration_access_token_controller.rb
+++ b/app/controllers/integration_access_token_controller.rb
@@ -58,7 +58,7 @@ class IntegrationAccessTokenController < ApplicationController
     {
       name: SecureRandom.uuid.to_s,
       scopes: ['api'],
-      expires_at: token_lifespan.days.from_now,
+      expires_at: token_lifespan.days.from_now.to_date,
       integration: true,
       integration_host: caller_identifier
     }

--- a/app/helpers/application_settings_helper.rb
+++ b/app/helpers/application_settings_helper.rb
@@ -5,5 +5,6 @@ module ApplicationSettingsHelper
   delegate :allow_signup?,
            :password_authentication_enabled?,
            :user_opt_in_features,
+           :require_personal_access_token_expiry?,
            to: :'Irida::CurrentSettings.current_application_settings'
 end

--- a/app/javascript/controllers/datepicker/constants.js
+++ b/app/javascript/controllers/datepicker/constants.js
@@ -46,10 +46,9 @@ export const CALENDAR_CLASSES = {
     "text-slate-500",
     "dark:text-slate-300",
   ],
-  BACK_BUTTON_DISABLED: ["text-slate-400", "dark:text-slate-500"],
-  BACK_BUTTON_ENABLED: ["text-slate-900", "dark:text-slate-100"],
-  FORWARD_BUTTON_DISABLED: ["text-slate-400", "dark:text-slate-500"],
-  FORWARD_BUTTON_ENABLED: ["text-slate-900", "dark:text-slate-100"],
+
+  MONTH_NAV_BUTTON_DISABLED: ["text-slate-400", "dark:text-slate-500"],
+  MONTH_NAV_BUTTON_ENABLED: ["text-slate-900", "dark:text-slate-100"],
 };
 
 export const INPUT_CLASSES = {

--- a/app/javascript/controllers/datepicker/constants.js
+++ b/app/javascript/controllers/datepicker/constants.js
@@ -48,6 +48,8 @@ export const CALENDAR_CLASSES = {
   ],
   BACK_BUTTON_DISABLED: ["text-slate-400", "dark:text-slate-500"],
   BACK_BUTTON_ENABLED: ["text-slate-900", "dark:text-slate-100"],
+  FORWARD_BUTTON_DISABLED: ["text-slate-400", "dark:text-slate-500"],
+  FORWARD_BUTTON_ENABLED: ["text-slate-900", "dark:text-slate-100"],
 };
 
 export const INPUT_CLASSES = {

--- a/app/javascript/controllers/datepicker/v1/calendar_controller.js
+++ b/app/javascript/controllers/datepicker/v1/calendar_controller.js
@@ -747,7 +747,7 @@ export default class extends Controller {
     // get all date nodes that are 'inMonth' and focus the last node
     const allInMonthDatesNodes = Array.from(
       this.calendarTarget.querySelectorAll(
-        '[data-date-within-month-position="inMonth"]',
+        '[data-date-within-month-position="inMonth"]:not([aria-disabled="true"])',
       ),
     );
 

--- a/app/javascript/controllers/datepicker/v1/calendar_controller.js
+++ b/app/javascript/controllers/datepicker/v1/calendar_controller.js
@@ -457,12 +457,16 @@ export default class extends Controller {
     // we disable the back button so user can't navigate further back
     if (this.#preventPreviousMonthNavigation()) {
       backButton.disabled = true;
-      backArrow.classList.remove(...CALENDAR_CLASSES["BACK_BUTTON_ENABLED"]);
-      backArrow.classList.add(...CALENDAR_CLASSES["BACK_BUTTON_DISABLED"]);
+      backArrow.classList.remove(
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"],
+      );
+      backArrow.classList.add(...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"]);
     } else {
       backButton.disabled = false;
-      backArrow.classList.add(...CALENDAR_CLASSES["BACK_BUTTON_ENABLED"]);
-      backArrow.classList.remove(...CALENDAR_CLASSES["BACK_BUTTON_DISABLED"]);
+      backArrow.classList.add(...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"]);
+      backArrow.classList.remove(
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"],
+      );
     }
   }
 
@@ -473,16 +477,18 @@ export default class extends Controller {
     if (this.#preventNextMonthNavigation()) {
       forwardButton.disabled = true;
       forwardArrow.classList.remove(
-        ...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"],
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"],
       );
       forwardArrow.classList.add(
-        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"],
       );
     } else {
       forwardButton.disabled = false;
-      forwardArrow.classList.add(...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"]);
+      forwardArrow.classList.add(
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"],
+      );
       forwardArrow.classList.remove(
-        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"],
       );
     }
   }

--- a/app/javascript/controllers/datepicker/v1/calendar_controller.js
+++ b/app/javascript/controllers/datepicker/v1/calendar_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
   static outlets = ["datepicker--v1--input"];
   static targets = [
     "backButton",
+    "forwardButton",
     "monthsArray",
     "monthSelect",
     "monthSelectContainer",
@@ -26,6 +27,7 @@ export default class extends Controller {
     "outOfMonthDateTemplate",
     "disabledDateTemplate",
     "clearButton",
+    "maxDateMessage",
     "minDateMessage",
   ];
 
@@ -44,6 +46,8 @@ export default class extends Controller {
   #selectedYear;
   #selectedMonthIndex;
 
+  #maxDate;
+  #maxDateMessage;
   #minDate;
   #minDateMessage;
   #autosubmit;
@@ -56,6 +60,10 @@ export default class extends Controller {
     this.yearTarget.value = this.#selectedYear;
     if (this.hasMinDateMessageTarget) {
       this.minDateMessageTarget.innerText = this.#minDateMessage;
+    }
+
+    if (this.hasMaxDateMessageTarget) {
+      this.maxDateMessageTarget.innerText = this.#maxDateMessage;
     }
     this.#loadCalendar();
   }
@@ -77,6 +85,18 @@ export default class extends Controller {
         this.#selectedMonthIndex = minDateMonthIndex;
       }
     }
+
+    if (this.#maxDate && this.#maxDate.includes(this.#selectedYear)) {
+      const maxDateMonthIndex = new Date(this.#maxDate).getUTCMonth();
+      for (let i = maxDateMonthIndex + 1; i < 12; i++) {
+        monthSelect.lastElementChild.remove();
+      }
+
+      if (this.#selectedMonthIndex > maxDateMonthIndex) {
+        this.#selectedMonthIndex = maxDateMonthIndex;
+      }
+    }
+
     this.monthSelectContainerTarget.appendChild(monthSelect);
   }
 
@@ -89,6 +109,8 @@ export default class extends Controller {
     this.#selectedDate = params["selectedDate"];
     this.#selectedYear = params["selectedYear"];
     this.#selectedMonthIndex = params["selectedMonthIndex"];
+    this.#maxDate = params["maxDate"];
+    this.#maxDateMessage = params["maxDateMessage"];
     this.#minDate = params["minDate"];
     this.#minDateMessage = params["minDateMessage"];
     this.#autosubmit = params["autosubmit"];
@@ -118,6 +140,8 @@ export default class extends Controller {
     this.#setTabIndex();
     // disable month's 'back' button if we're on first allowable month
     this.#setBackButton();
+    // disable month's 'forward' button if we're past allowable month
+    this.#setForwardButton();
   }
 
   #getPreviousMonthsDates() {
@@ -352,6 +376,23 @@ export default class extends Controller {
       }
     }
 
+    // maximum date where dates after will be disabled
+    const maxDate = getDateNode(this.calendarTarget, this.#maxDate);
+
+    if (maxDate) {
+      // get all the date nodes within current calendar, and all dates after the maxDate index will be disabled
+      const allDates = Array.from(
+        this.calendarTarget.querySelectorAll("[data-date]"),
+      );
+      for (let i = allDates.indexOf(maxDate) + 1; i < allDates.length; i++) {
+        this.#replaceDateStyling(
+          allDates[i],
+          CALENDAR_CLASSES["DISABLED_DATE"],
+        );
+        allDates[i].setAttribute("aria-disabled", true);
+      }
+    }
+
     // Keep visual precedence clear: disabled dates should not also look selected/today.
     if (selectedDate && selectedDate.getAttribute("aria-disabled") !== "true") {
       this.#replaceDateStyling(selectedDate, CALENDAR_CLASSES["SELECTED_DATE"]);
@@ -384,6 +425,7 @@ export default class extends Controller {
       this.#todaysFormattedFullDate,
     );
     const selectedDate = getDateNode(this.calendarTarget, this.#selectedDate);
+    const maxDate = getDateNode(this.calendarTarget, this.#maxDate);
     const minDate = getDateNode(this.calendarTarget, this.#minDate);
     // if minimum date and selected or todays date land on same calendar (year/month),
     // prioritize selectedDate > todaysDate > minDate as tabbable
@@ -411,6 +453,7 @@ export default class extends Controller {
   #setBackButton() {
     const backButton = this.backButtonTarget;
     const backArrow = backButton.firstElementChild;
+
     // if minimum date exists in the current selected month (eg: any previous month should be unselectable)
     // we disable the back button so user can't navigate further back
     if (this.#preventPreviousMonthNavigation()) {
@@ -421,6 +464,27 @@ export default class extends Controller {
       backButton.disabled = false;
       backArrow.classList.add(...CALENDAR_CLASSES["BACK_BUTTON_ENABLED"]);
       backArrow.classList.remove(...CALENDAR_CLASSES["BACK_BUTTON_DISABLED"]);
+    }
+  }
+
+  #setForwardButton() {
+    const forwardButton = this.forwardButtonTarget;
+    const forwardArrow = forwardButton.firstElementChild;
+
+    if (this.#preventNextMonthNavigation()) {
+      forwardButton.disabled = true;
+      forwardArrow.classList.remove(
+        ...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"],
+      );
+      forwardArrow.classList.add(
+        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+      );
+    } else {
+      forwardButton.disabled = false;
+      forwardArrow.classList.add(...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"]);
+      forwardArrow.classList.remove(
+        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+      );
     }
   }
 
@@ -473,6 +537,21 @@ export default class extends Controller {
         }
       }
     }
+    // if maxDate exists, check if user tried to hard type in a year amount later than maxDate's year
+    if (this.#maxDate) {
+      const maxDate = new Date(this.#maxDate);
+      const maxYear = maxDate.getFullYear();
+      const maxMonth = maxDate.getUTCMonth();
+      if (this.yearTarget.value > maxYear) {
+        this.yearTarget.value = maxYear;
+        // if maxDate was 2027-03-31 and user was on June 2026 and changes year to 2027, since we don't want
+        // June 2027 to be selectable, we want to set the month to March
+        if (this.#selectedMonthIndex > maxMonth) {
+          this.#selectedMonthIndex = maxMonth;
+        }
+      }
+    }
+
     this.#selectedYear = this.yearTarget.value;
     this.idempotentConnect();
   }
@@ -582,9 +661,10 @@ export default class extends Controller {
 
     // if navigating 'left', check if the minimum date is higher than the target date to prevent navigation
     if (
-      direction === "left" &&
-      this.#minDate &&
-      this.#minDate > targetFullDate
+      (direction === "left" &&
+        this.#minDate &&
+        this.#minDate > targetFullDate) ||
+      (direction === "right" && this.#maxDate && targetFullDate > this.#maxDate)
     ) {
       return;
     }
@@ -624,6 +704,15 @@ export default class extends Controller {
 
     // if navigating 'up', check if the minimum date is higher than the target date to prevent navigation
     if (direction === "up" && this.#minDate && this.#minDate > targetFullDate) {
+      return;
+    }
+
+    // if navigating 'down', check if the maximum date is lower than the target date to prevent navigation
+    if (
+      direction === "down" &&
+      this.#maxDate &&
+      targetFullDate > this.#maxDate
+    ) {
       return;
     }
 
@@ -672,6 +761,8 @@ export default class extends Controller {
   #previousMonthByPageUp() {
     // if we're on the earliest allowed month based on minDate, don't allow us to navigate to the previous month
     if (this.#preventPreviousMonthNavigation()) return;
+
+    if (this.#preventNextMonthNavigation()) return;
     // load previous month onto calendar
     this.previousMonth();
 
@@ -700,6 +791,14 @@ export default class extends Controller {
     if (this.#minDate) {
       const minDateNode = getDateNode(this.calendarTarget, this.#minDate);
       if (minDateNode && verifyDateIsInMonth(minDateNode)) return true;
+    }
+    return false;
+  }
+
+  #preventNextMonthNavigation() {
+    if (this.#maxDate) {
+      const maxDateNode = getDateNode(this.calendarTarget, this.#maxDate);
+      if (maxDateNode && verifyDateIsInMonth(maxDateNode)) return true;
     }
     return false;
   }

--- a/app/javascript/controllers/datepicker/v1/calendar_controller.js
+++ b/app/javascript/controllers/datepicker/v1/calendar_controller.js
@@ -425,7 +425,6 @@ export default class extends Controller {
       this.#todaysFormattedFullDate,
     );
     const selectedDate = getDateNode(this.calendarTarget, this.#selectedDate);
-    const maxDate = getDateNode(this.calendarTarget, this.#maxDate);
     const minDate = getDateNode(this.calendarTarget, this.#minDate);
     // if minimum date and selected or todays date land on same calendar (year/month),
     // prioritize selectedDate > todaysDate > minDate as tabbable

--- a/app/javascript/controllers/datepicker/v1/input_controller.js
+++ b/app/javascript/controllers/datepicker/v1/input_controller.js
@@ -427,6 +427,7 @@ export default class extends Controller {
       minDate: this.#minDate,
       minDateMessage: this.invalidMinDateValue,
       autosubmit: this.autosubmitValue,
+      type: this.typeValue,
     };
     this.datepickerV1CalendarOutlet.shareParamsWithCalendarByInput(
       sharedVariables,

--- a/app/javascript/controllers/datepicker/v1/input_controller.js
+++ b/app/javascript/controllers/datepicker/v1/input_controller.js
@@ -16,12 +16,14 @@ export default class extends Controller {
     "errorMessageTemplate",
     "errorMessage",
     "ariaLive",
+    "maxDate",
   ];
 
   static values = {
     autosubmit: Boolean,
     calendarId: String,
     invalidDate: String,
+    invalidMaxDate: String,
     invalidMinDate: String,
     dateFormatRegex: String,
     errorMessageId: String,
@@ -45,11 +47,16 @@ export default class extends Controller {
 
   #dropdown;
 
+  #maxDate;
   #minDate;
 
   connect() {
     if (this.hasMinDateTarget) {
       this.#setMinDate();
+    }
+
+    if (this.hasMaxDateTarget) {
+      this.#setMaxDate();
     }
 
     this.boundHandleDatepickerInputFocus =
@@ -127,6 +134,12 @@ export default class extends Controller {
     } catch (error) {
       this.#handleError(error, "initializeDropdown");
     }
+  }
+
+  #setMaxDate() {
+    this.#maxDate = this.maxDateTarget.firstElementChild.innerText;
+    this.invalidMaxDateValue = this.invalidMaxDateValue.concat(this.#maxDate);
+    this.maxDateTarget.remove();
   }
 
   #setMinDate() {
@@ -269,7 +282,9 @@ export default class extends Controller {
     event.preventDefault();
     const dateInput = event.target.value;
     if (this.#validateDateInput(dateInput)) {
-      if (this.#minDate && this.#minDate > dateInput) {
+      if (this.#maxDate && dateInput > this.#maxDate) {
+        this.#enableInputErrorState(this.invalidMaxDateValue);
+      } else if (this.#minDate && this.#minDate > dateInput) {
         this.#enableInputErrorState(this.invalidMinDateValue);
       } else {
         if (this.autosubmitValue) {
@@ -407,6 +422,8 @@ export default class extends Controller {
       selectedDate: this.#selectedDate,
       selectedYear: this.#selectedYear,
       selectedMonthIndex: this.#selectedMonthIndex,
+      maxDate: this.#maxDate,
+      maxDateMessage: this.invalidMaxDateValue,
       minDate: this.#minDate,
       minDateMessage: this.invalidMinDateValue,
       autosubmit: this.autosubmitValue,

--- a/app/javascript/controllers/datepicker/v1/input_controller.js
+++ b/app/javascript/controllers/datepicker/v1/input_controller.js
@@ -427,7 +427,6 @@ export default class extends Controller {
       minDate: this.#minDate,
       minDateMessage: this.invalidMinDateValue,
       autosubmit: this.autosubmitValue,
-      type: this.typeValue,
     };
     this.datepickerV1CalendarOutlet.shareParamsWithCalendarByInput(
       sharedVariables,

--- a/app/javascript/controllers/datepicker/v2/calendar_controller.js
+++ b/app/javascript/controllers/datepicker/v2/calendar_controller.js
@@ -455,12 +455,16 @@ export default class extends Controller {
     // we disable the back button so user can't navigate further back
     if (this.#preventPreviousMonthNavigation()) {
       backButton.disabled = true;
-      backArrow.classList.remove(...CALENDAR_CLASSES["BACK_BUTTON_ENABLED"]);
-      backArrow.classList.add(...CALENDAR_CLASSES["BACK_BUTTON_DISABLED"]);
+      backArrow.classList.remove(
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"],
+      );
+      backArrow.classList.add(...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"]);
     } else {
       backButton.disabled = false;
-      backArrow.classList.add(...CALENDAR_CLASSES["BACK_BUTTON_ENABLED"]);
-      backArrow.classList.remove(...CALENDAR_CLASSES["BACK_BUTTON_DISABLED"]);
+      backArrow.classList.add(...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"]);
+      backArrow.classList.remove(
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"],
+      );
     }
   }
 
@@ -471,16 +475,18 @@ export default class extends Controller {
     if (this.#preventNextMonthNavigation()) {
       forwardButton.disabled = true;
       forwardArrow.classList.remove(
-        ...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"],
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"],
       );
       forwardArrow.classList.add(
-        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"],
       );
     } else {
       forwardButton.disabled = false;
-      forwardArrow.classList.add(...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"]);
+      forwardArrow.classList.add(
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_ENABLED"],
+      );
       forwardArrow.classList.remove(
-        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+        ...CALENDAR_CLASSES["MONTH_NAV_BUTTON_DISABLED"],
       );
     }
   }

--- a/app/javascript/controllers/datepicker/v2/calendar_controller.js
+++ b/app/javascript/controllers/datepicker/v2/calendar_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
   static outlets = ["datepicker--v2--input"];
   static targets = [
     "backButton",
+    "forwardButton",
     "monthsArray",
     "monthSelect",
     "monthSelectContainer",
@@ -26,6 +27,7 @@ export default class extends Controller {
     "outOfMonthDateTemplate",
     "disabledDateTemplate",
     "clearButton",
+    "maxDateMessage",
     "minDateMessage",
   ];
 
@@ -44,6 +46,8 @@ export default class extends Controller {
   #selectedYear;
   #selectedMonthIndex;
 
+  #maxDate;
+  #maxDateMessage;
   #minDate;
   #minDateMessage;
   #autosubmit;
@@ -56,6 +60,10 @@ export default class extends Controller {
     this.yearTarget.value = this.#selectedYear;
     if (this.hasMinDateMessageTarget) {
       this.minDateMessageTarget.innerText = this.#minDateMessage;
+    }
+
+    if (this.hasMaxDateMessageTarget) {
+      this.maxDateMessageTarget.innerText = this.#maxDateMessage;
     }
     this.#loadCalendar();
   }
@@ -77,6 +85,18 @@ export default class extends Controller {
         this.#selectedMonthIndex = minDateMonthIndex;
       }
     }
+
+    if (this.#maxDate && this.#maxDate.includes(this.#selectedYear)) {
+      const maxDateMonthIndex = new Date(this.#maxDate).getUTCMonth();
+      for (let i = maxDateMonthIndex + 1; i < 12; i++) {
+        monthSelect.lastElementChild.remove();
+      }
+
+      if (this.#selectedMonthIndex > maxDateMonthIndex) {
+        this.#selectedMonthIndex = maxDateMonthIndex;
+      }
+    }
+
     this.monthSelectContainerTarget.appendChild(monthSelect);
   }
 
@@ -91,6 +111,8 @@ export default class extends Controller {
     this.#selectedMonthIndex = params["selectedMonthIndex"];
     this.#minDate = params["minDate"];
     this.#minDateMessage = params["minDateMessage"];
+    this.#maxDate = params["maxDate"];
+    this.#maxDateMessage = params["maxDateMessage"];
     this.#autosubmit = params["autosubmit"];
     this.#todaysFormattedFullDate = `${this.#getFormattedStringDate(this.#todaysYear, this.#todaysMonthIndex, this.#todaysDate)}`;
     this.idempotentConnect();
@@ -118,6 +140,8 @@ export default class extends Controller {
     this.#setTabIndex();
     // disable month's 'back' button if we're on first allowable month
     this.#setBackButton();
+    // disable month's 'forward' button if we're past allowable month
+    this.#setForwardButton();
   }
 
   #getPreviousMonthsDates() {
@@ -351,6 +375,23 @@ export default class extends Controller {
       }
     }
 
+    // maximum date where dates after will be disabled
+    const maxDate = getDateNode(this.calendarTarget, this.#maxDate);
+
+    if (maxDate) {
+      // get all the date nodes within current calendar, and all dates after the maxDate index will be disabled
+      const allDates = Array.from(
+        this.calendarTarget.querySelectorAll("[data-date]"),
+      );
+      for (let i = allDates.indexOf(maxDate) + 1; i < allDates.length; i++) {
+        this.#replaceDateStyling(
+          allDates[i],
+          CALENDAR_CLASSES["DISABLED_DATE"],
+        );
+        allDates[i].setAttribute("aria-disabled", true);
+      }
+    }
+
     // Keep visual precedence clear: disabled dates should not also look selected/today.
     if (selectedDate && selectedDate.getAttribute("aria-disabled") !== "true") {
       this.#replaceDateStyling(selectedDate, CALENDAR_CLASSES["SELECTED_DATE"]);
@@ -423,6 +464,27 @@ export default class extends Controller {
     }
   }
 
+  #setForwardButton() {
+    const forwardButton = this.forwardButtonTarget;
+    const forwardArrow = forwardButton.firstElementChild;
+
+    if (this.#preventNextMonthNavigation()) {
+      forwardButton.disabled = true;
+      forwardArrow.classList.remove(
+        ...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"],
+      );
+      forwardArrow.classList.add(
+        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+      );
+    } else {
+      forwardButton.disabled = false;
+      forwardArrow.classList.add(...CALENDAR_CLASSES["FORWARD_BUTTON_ENABLED"]);
+      forwardArrow.classList.remove(
+        ...CALENDAR_CLASSES["FORWARD_BUTTON_DISABLED"],
+      );
+    }
+  }
+
   // navigate to previous month by back button on calendar
   previousMonth() {
     this.#selectedMonthIndex =
@@ -472,6 +534,22 @@ export default class extends Controller {
         }
       }
     }
+
+    // if maxDate exists, check if user tried to hard type in a year amount later than maxDate's year
+    if (this.#maxDate) {
+      const maxDate = new Date(this.#maxDate);
+      const maxYear = maxDate.getFullYear();
+      const maxMonth = maxDate.getUTCMonth();
+      if (this.yearTarget.value > maxYear) {
+        this.yearTarget.value = maxYear;
+        // if maxDate was 2027-03-31 and user was on June 2026 and changes year to 2027, since we don't want
+        // June 2027 to be selectable, we want to set the month to March
+        if (this.#selectedMonthIndex > maxMonth) {
+          this.#selectedMonthIndex = maxMonth;
+        }
+      }
+    }
+
     this.#selectedYear = this.yearTarget.value;
     this.idempotentConnect();
   }
@@ -581,9 +659,10 @@ export default class extends Controller {
 
     // if navigating 'left', check if the minimum date is higher than the target date to prevent navigation
     if (
-      direction === "left" &&
-      this.#minDate &&
-      this.#minDate > targetFullDate
+      (direction === "left" &&
+        this.#minDate &&
+        this.#minDate > targetFullDate) ||
+      (direction === "right" && this.#maxDate && targetFullDate > this.#maxDate)
     ) {
       return;
     }
@@ -626,6 +705,15 @@ export default class extends Controller {
       return;
     }
 
+    // if navigating 'down', check if the maximum date is lower than the target date to prevent navigation
+    if (
+      direction === "down" &&
+      this.#maxDate &&
+      targetFullDate > this.#maxDate
+    ) {
+      return;
+    }
+
     // try to retrieve the target date node, and if target week is non-existant (eg: we're going up and we're already
     // currently on the first week), or the dateNode doesn't exist or is not inMonth, change the month based on
     // direction and re-assign dateNode
@@ -658,7 +746,7 @@ export default class extends Controller {
     // get all date nodes that are 'inMonth' and focus the last node
     const allInMonthDatesNodes = Array.from(
       this.calendarTarget.querySelectorAll(
-        '[data-date-within-month-position="inMonth"]',
+        '[data-date-within-month-position="inMonth"]:not([aria-disabled="true"])',
       ),
     );
 
@@ -699,6 +787,14 @@ export default class extends Controller {
     if (this.#minDate) {
       const minDateNode = getDateNode(this.calendarTarget, this.#minDate);
       if (minDateNode && verifyDateIsInMonth(minDateNode)) return true;
+    }
+    return false;
+  }
+
+  #preventNextMonthNavigation() {
+    if (this.#maxDate) {
+      const maxDateNode = getDateNode(this.calendarTarget, this.#maxDate);
+      if (maxDateNode && verifyDateIsInMonth(maxDateNode)) return true;
     }
     return false;
   }

--- a/app/javascript/controllers/datepicker/v2/input_controller.js
+++ b/app/javascript/controllers/datepicker/v2/input_controller.js
@@ -17,12 +17,14 @@ export default class extends Controller {
     "errorMessageTemplate",
     "errorMessage",
     "ariaLive",
+    "maxDate",
   ];
 
   static values = {
     autosubmit: Boolean,
     calendarId: String,
     invalidDate: String,
+    invalidMaxDate: String,
     invalidMinDate: String,
     dateFormatRegex: String,
     errorMessageId: String,
@@ -46,11 +48,16 @@ export default class extends Controller {
 
   #floatingDropdown;
 
+  #maxDate;
   #minDate;
 
   connect() {
     if (this.hasMinDateTarget) {
       this.#setMinDate();
+    }
+
+    if (this.hasMaxDateTarget) {
+      this.#setMaxDate();
     }
 
     this.boundHandleDatepickerInputFocus =
@@ -118,6 +125,12 @@ export default class extends Controller {
     this.#minDate = this.minDateTarget.firstElementChild.innerText;
     this.invalidMinDateValue = this.invalidMinDateValue.concat(this.#minDate);
     this.minDateTarget.remove();
+  }
+
+  #setMaxDate() {
+    this.#maxDate = this.maxDateTarget.firstElementChild.innerText;
+    this.invalidMaxDateValue = this.invalidMaxDateValue.concat(this.#maxDate);
+    this.maxDateTarget.remove();
   }
 
   #addCalendarTemplate() {
@@ -392,6 +405,8 @@ export default class extends Controller {
       selectedDate: this.#selectedDate,
       selectedYear: this.#selectedYear,
       selectedMonthIndex: this.#selectedMonthIndex,
+      maxDate: this.#maxDate,
+      maxDateMessage: this.invalidMaxDateValue,
       minDate: this.#minDate,
       minDateMessage: this.invalidMinDateValue,
       autosubmit: this.autosubmitValue,

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -39,7 +39,7 @@ class ApplicationSetting < ApplicationRecord
   private
 
   def only_one_instance
-    return unless ApplicationSetting.many?
+    return unless ApplicationSetting.count >= 1
 
     errors.add(:base, 'Only one instance of ApplicationSetting is allowed')
   end

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -25,7 +25,6 @@ class ApplicationSetting < ApplicationRecord
 
   def self.build_from_defaults(attributes = {})
     final_attributes = defaults.merge(attributes).stringify_keys.slice(*column_names)
-
     new(final_attributes)
   end
 
@@ -40,7 +39,7 @@ class ApplicationSetting < ApplicationRecord
   private
 
   def only_one_instance
-    return unless ApplicationSetting.count >= 1
+    return unless ApplicationSetting.many?
 
     errors.add(:base, 'Only one instance of ApplicationSetting is allowed')
   end

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -17,7 +17,9 @@ class ApplicationSetting < ApplicationRecord
     {
       signup_enabled: true,
       password_authentication_enabled: true,
-      cleanup_inactive_access_tokens_after_days: 30
+      cleanup_inactive_access_tokens_after_days: 30,
+      require_personal_access_token_expiry: false,
+      max_personal_access_token_lifetime_in_days: 365
     }
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -21,7 +21,9 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :validate_namespace
   validate :higher_access_level_than_group
 
-  validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
+  validates :expires_at, on: %i[create update], date: { greater_than: -> { Time.zone.today } }, if: lambda {
+    (new_record? || expires_at_changed?) && expires_at_before_type_cast.present?
+  }
 
   before_destroy :last_namespace_owner_member
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -21,7 +21,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :validate_namespace
   validate :higher_access_level_than_group
 
-  validates :expires_at, on: %i[create update], date: { allow_nil: true, greater_than: lambda {
+  validates :expires_at, on: %i[create update], date: { allow_empty: true, greater_than: lambda {
     Time.zone.today
   } }, if: -> { (new_record? || expires_at_changed?) && expires_at_before_type_cast.present? }
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -21,9 +21,9 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :validate_namespace
   validate :higher_access_level_than_group
 
-  validates :expires_at, on: %i[create update], date: { greater_than: -> { Time.zone.today } }, if: lambda {
-    (new_record? || expires_at_changed?) && expires_at_before_type_cast.present?
-  }
+  validates :expires_at, on: %i[create update], date: { allow_nil: true, greater_than: lambda {
+    Time.zone.today
+  } }, if: -> { (new_record? || expires_at_changed?) && expires_at_before_type_cast.present? }
 
   before_destroy :last_namespace_owner_member
 

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -24,9 +24,9 @@ class NamespaceGroupLink < ApplicationRecord
               in: [Group.sti_name, Namespaces::ProjectNamespace.sti_name]
             }
 
-  validates :expires_at, on: %i[create update], date: { greater_than: -> { Time.zone.today } }, if: lambda {
-    (new_record? || expires_at_changed?) && expires_at_before_type_cast.present?
-  }
+  validates :expires_at, on: %i[create update], date: { allow_nil: true, greater_than: lambda {
+    Time.zone.today
+  } }, if: -> { (new_record? || expires_at_changed?) && expires_at_before_type_cast.present? }
 
   after_destroy :send_access_revoked_emails
   after_save :send_access_granted_emails, if: :previously_new_record?

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -24,7 +24,9 @@ class NamespaceGroupLink < ApplicationRecord
               in: [Group.sti_name, Namespaces::ProjectNamespace.sti_name]
             }
 
-  validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
+  validates :expires_at, on: %i[create update], date: { greater_than: -> { Time.zone.today } }, if: lambda {
+    (new_record? || expires_at_changed?) && expires_at_before_type_cast.present?
+  }
 
   after_destroy :send_access_revoked_emails
   after_save :send_access_granted_emails, if: :previously_new_record?

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -24,7 +24,7 @@ class NamespaceGroupLink < ApplicationRecord
               in: [Group.sti_name, Namespaces::ProjectNamespace.sti_name]
             }
 
-  validates :expires_at, on: %i[create update], date: { allow_nil: true, greater_than: lambda {
+  validates :expires_at, on: %i[create update], date: { allow_empty: true, greater_than: lambda {
     Time.zone.today
   } }, if: -> { (new_record? || expires_at_changed?) && expires_at_before_type_cast.present? }
 

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -19,10 +19,10 @@ class PersonalAccessToken < ApplicationRecord
   validate :validate_scopes
 
   validates :expires_at, presence: true, comparison: {
-    less_than: Time.zone.today + Irida::CurrentSettings.current_application_settings.max_personal_access_token_lifetime_in_days,
+    less_than: Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days,
     greater_than: Time.zone.today + 1
   }, if: lambda {
-    Irida::CurrentSettings.current_application_settings.require_personal_access_token_expiry?
+    Irida::CurrentSettings.require_personal_access_token_expiry?
   }
 
   scope :active, -> { not_revoked.not_expired }

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -18,8 +18,12 @@ class PersonalAccessToken < ApplicationRecord
   validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
   validate :validate_scopes
 
-  validates :expires_at, presence: true, if: -> { Irida::CurrentSettings.current_application_settings.require_personal_access_token_expiry? }
-  validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
+  validates :expires_at, presence: true, comparison: {
+    less_than: Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days,
+    greater_than: Time.zone.today + 1
+  }, if: lambda {
+    Irida::CurrentSettings.current_application_settings.require_personal_access_token_expiry?
+  }
 
   scope :active, -> { not_revoked.not_expired }
   scope :not_revoked, -> { where(revoked: [false, nil]) }

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -19,6 +19,7 @@ class PersonalAccessToken < ApplicationRecord
   validate :validate_scopes
 
   validates :expires_at, presence: true, if: -> { Irida::CurrentSettings.current_application_settings.require_personal_access_token_expiry? }
+  validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
 
   scope :active, -> { not_revoked.not_expired }
   scope :not_revoked, -> { where(revoked: [false, nil]) }

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -19,7 +19,7 @@ class PersonalAccessToken < ApplicationRecord
   validate :validate_scopes
 
   validates :expires_at, presence: true, comparison: {
-    less_than: Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days,
+    less_than: Time.zone.today + Irida::CurrentSettings.current_application_settings.max_personal_access_token_lifetime_in_days,
     greater_than: Time.zone.today + 1
   }, if: lambda {
     Irida::CurrentSettings.current_application_settings.require_personal_access_token_expiry?

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -18,8 +18,7 @@ class PersonalAccessToken < ApplicationRecord
   validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
   validate :validate_scopes
 
-  validates :expires_at, presence: true, if: Irida::CurrentSettings.require_personal_access_token_expiry?
-  validates :expires_at, comparison: { less_than_or_equal_to: (Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days) }
+  validates :expires_at, presence: true, if: -> { Irida::CurrentSettings.current_application_settings.require_personal_access_token_expiry? }
 
   scope :active, -> { not_revoked.not_expired }
   scope :not_revoked, -> { where(revoked: [false, nil]) }

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -18,9 +18,9 @@ class PersonalAccessToken < ApplicationRecord
   validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
   validate :validate_scopes
 
-  validates :expires_at, presence: true, comparison: {
-    less_than: Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days,
-    greater_than: Time.zone.today + 1
+  validates :expires_at, comparison: {
+    less_than: -> { Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days },
+    greater_than: -> { Time.zone.today + 1 }
   }, if: lambda {
     Irida::CurrentSettings.require_personal_access_token_expiry?
   }

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -18,6 +18,9 @@ class PersonalAccessToken < ApplicationRecord
   validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
   validate :validate_scopes
 
+  validates :expires_at, presence: true, if: Irida::CurrentSettings.require_personal_access_token_expiry?
+  validates :expires_at, comparison: { less_than_or_equal_to: (Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days) }
+
   scope :active, -> { not_revoked.not_expired }
   scope :not_revoked, -> { where(revoked: [false, nil]) }
   scope :revoked, -> { where(revoked: true) }

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -15,15 +15,19 @@ class PersonalAccessToken < ApplicationRecord
 
   validates :name, presence: true
   validates :scopes, presence: true
-  validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
   validate :validate_scopes
 
-  validates :expires_at, comparison: {
-    less_than: -> { Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days },
-    greater_than: -> { Time.zone.today }
-  }, if: lambda {
-    (new_record? || expires_at_changed?) && Irida::CurrentSettings.require_personal_access_token_expiry?
-  }
+  validates :expires_at, on: %i[create update], date: {
+    greater_than: lambda {
+      Time.zone.today
+    },
+    less_than: lambda {
+      if Irida::CurrentSettings.require_personal_access_token_expiry?
+        Time.zone.today +
+          Irida::CurrentSettings.max_personal_access_token_lifetime_in_days
+      end
+    }
+  }, if: -> { new_record? || expires_at_changed? }
 
   scope :active, -> { not_revoked.not_expired }
   scope :not_revoked, -> { where(revoked: [false, nil]) }

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -20,9 +20,9 @@ class PersonalAccessToken < ApplicationRecord
 
   validates :expires_at, comparison: {
     less_than: -> { Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days },
-    greater_than: -> { Time.zone.today + 1 }
+    greater_than: -> { Time.zone.today }
   }, if: lambda {
-    Irida::CurrentSettings.require_personal_access_token_expiry?
+    (new_record? || expires_at_changed?) && Irida::CurrentSettings.require_personal_access_token_expiry?
   }
 
   scope :active, -> { not_revoked.not_expired }

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -17,12 +17,6 @@ class DateValidator < ActiveModel::EachValidator
     # validate if date input is later than today's date
     raise DateValidatorError, I18n.t('common.date.errors.invalid_min_date') if value < Time.zone.today
 
-    if Irida::CurrentSettings.require_personal_access_token_expiry? &&
-       value > (Time.current + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days)
-      raise DateValidatorError,
-            I18n.t('common.date.errors.invalid_max_date')
-    end
-
     true
   rescue DateValidator::DateValidatorError => e
     record.errors.add(:expires_at, e.message)

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -5,7 +5,7 @@ class DateValidator < ActiveModel::EachValidator
   class DateValidatorError < StandardError
   end
 
-  def validate_each(record, attribute, value) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength
+  def validate_each(record, attribute, value)
     return true unless attribute == :expires_at # currently only handles :expires_at
 
     # Value is only present when the input can be coerced into a date.

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -5,7 +5,7 @@ class DateValidator < ActiveModel::EachValidator
   class DateValidatorError < StandardError
   end
 
-  def validate_each(record, attribute, value)
+  def validate_each(record, attribute, value) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength
     return true unless attribute == :expires_at # currently only handles :expires_at
 
     # Value is only present when the input can be coerced into a date.
@@ -16,6 +16,12 @@ class DateValidator < ActiveModel::EachValidator
 
     # validate if date input is later than today's date
     raise DateValidatorError, I18n.t('common.date.errors.invalid_min_date') if value < Time.zone.today
+
+    if Irida::CurrentSettings.require_personal_access_token_expiry? &&
+       value > (Time.current + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days)
+      raise DateValidatorError,
+            I18n.t('common.date.errors.invalid_max_date')
+    end
 
     true
   rescue DateValidator::DateValidatorError => e

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,25 +1,91 @@
 # frozen_string_literal: true
 
-# Validator for date inputs. Currently evaluates expires_at for member, group link, and personal access token models.
+# Validator for date inputs. Currently evaluates expires_at for member, namespace_group_link,
+# and personal access token models.
 class DateValidator < ActiveModel::EachValidator
-  class DateValidatorError < StandardError
-  end
-
   def validate_each(record, attribute, value)
     return true unless attribute == :expires_at # currently only handles :expires_at
+
+    raw_value = record.read_attribute_before_type_cast(:expires_at)
+    return true if raw_value.blank? && (expiration_required?(record) == false)
 
     # Value is only present when the input can be coerced into a date.
     if value.blank?
       record.errors.add(:expires_at, I18n.t('common.date.errors.invalid_input'))
-      return false
-    end
+      false
+    else
+      # validate if date input is later than today's date
+      validate_greater_than(record, value) if options[:greater_than].present?
 
-    # validate if date input is later than today's date
-    raise DateValidatorError, I18n.t('common.date.errors.invalid_min_date') if value < Time.zone.today
+      # validate if date input is within the maximum allowed lifetime
+      validate_less_than(record, value) if options[:less_than].present?
+    end
+  end
+
+  private
+
+  def expiration_required?(record)
+    expiration_value = resolve_value(record, options[:less_than]) if options[:less_than].present?
+    expiration_required = expiration_value.present? || false
+    return false if expiration_required == false
 
     true
-  rescue DateValidator::DateValidatorError => e
-    record.errors.add(:expires_at, e.message)
-    false
+  end
+
+  def option_as_date(record, option_value)
+    parse_as_date(record, resolve_value(record, option_value))
+  end
+
+  def parse_as_date(record, raw_value)
+    case raw_value
+    when Date
+      raw_value
+    when DateTime, ActiveSupport::TimeWithZone
+      raw_value.to_date
+    when nil
+      nil
+    end
+  rescue ArgumentError
+    record.errors.add(:expires_at, 'must be a date or datetime object')
+    nil
+  end
+
+  def resolve_value(record, value) # rubocop:disable Metrics/MethodLength
+    case value
+    when Proc
+      if value.arity == 0 # rubocop:disable Style/NumericPredicate
+        value.call
+      else
+        value.call(record)
+      end
+    when Symbol
+      record.send(value)
+    else
+      if value.respond_to?(:call)
+        value.call(record)
+      else
+        value
+      end
+    end
+  end
+
+  def validate_greater_than(record, value)
+    min_date = option_as_date(record, options[:greater_than])
+
+    return true if min_date.nil?
+    return unless value <= min_date
+
+    record.errors.add(:expires_at, :date_greater_than,
+                      date: min_date)
+  end
+
+  def validate_less_than(record, value)
+    max_date = option_as_date(record, options[:less_than])
+
+    return true if max_date.nil?
+    return unless value >= max_date
+
+    record.errors.add(:expires_at, :date_less_than,
+                      date: max_date)
   end
 end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -25,6 +25,7 @@ class DateValidator < ActiveModel::EachValidator
   private
 
   def expiration_required?(record)
+    expiration_value = nil
     expiration_value = resolve_value(record, options[:less_than]) if options[:less_than].present?
     expiration_required = expiration_value.present? || false
     return false if expiration_required == false

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -22,9 +22,9 @@ class DateValidator < ActiveModel::EachValidator
   private
 
   def expiration_required?(record)
-    allow_nil = nil
-    allow_nil = resolve_value(record, options[:allow_nil]) if options[:allow_nil].present?
-    return false if allow_nil == true
+    allow_empty = nil
+    allow_empty = resolve_value(record, options[:allow_empty]) if options[:allow_empty].present?
+    return false if allow_empty == true
 
     expiration_value = nil
     expiration_value = resolve_value(record, options[:less_than]) if options[:less_than].present?

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,30 +1,31 @@
 # frozen_string_literal: true
 
-# Validator for date inputs. Currently evaluates expires_at for member, namespace_group_link,
-# and personal access token models.
+# Validator for date inputs
 class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return true unless attribute == :expires_at # currently only handles :expires_at
-
-    raw_value = record.read_attribute_before_type_cast(:expires_at)
+    raw_value = record.read_attribute_before_type_cast(attribute)
     return true if raw_value.blank? && (expiration_required?(record) == false)
 
     # Value is only present when the input can be coerced into a date.
     if value.blank?
-      record.errors.add(:expires_at, I18n.t('common.date.errors.invalid_input'))
+      record.errors.add(attribute, I18n.t('common.date.errors.invalid_input'))
       false
     else
       # validate if date input is later than today's date
-      validate_greater_than(record, value) if options[:greater_than].present?
+      validate_greater_than(record, attribute, value) if options[:greater_than].present?
 
       # validate if date input is within the maximum allowed lifetime
-      validate_less_than(record, value) if options[:less_than].present?
+      validate_less_than(record, attribute, value) if options[:less_than].present?
     end
   end
 
   private
 
   def expiration_required?(record)
+    allow_nil = nil
+    allow_nil = resolve_value(record, options[:allow_nil]) if options[:allow_nil].present?
+    return false if allow_nil == true
+
     expiration_value = nil
     expiration_value = resolve_value(record, options[:less_than]) if options[:less_than].present?
     expiration_required = expiration_value.present? || false
@@ -33,11 +34,11 @@ class DateValidator < ActiveModel::EachValidator
     true
   end
 
-  def option_as_date(record, option_value)
-    parse_as_date(record, resolve_value(record, option_value))
+  def option_as_date(record, attribute, option_value)
+    parse_as_date(record, attribute, resolve_value(record, option_value))
   end
 
-  def parse_as_date(record, raw_value)
+  def parse_as_date(record, attribute, raw_value)
     case raw_value
     when Date
       raw_value
@@ -47,7 +48,7 @@ class DateValidator < ActiveModel::EachValidator
       nil
     end
   rescue ArgumentError
-    record.errors.add(:expires_at, 'must be a date or datetime object')
+    record.errors.add(attribute, :date_object_required)
     nil
   end
 
@@ -70,23 +71,23 @@ class DateValidator < ActiveModel::EachValidator
     end
   end
 
-  def validate_greater_than(record, value)
-    min_date = option_as_date(record, options[:greater_than])
+  def validate_greater_than(record, attribute, value)
+    min_date = option_as_date(record, attribute, options[:greater_than])
 
     return true if min_date.nil?
     return unless value <= min_date
 
-    record.errors.add(:expires_at, :date_greater_than,
+    record.errors.add(attribute, :date_greater_than,
                       date: min_date)
   end
 
-  def validate_less_than(record, value)
-    max_date = option_as_date(record, options[:less_than])
+  def validate_less_than(record, attribute, value)
+    max_date = option_as_date(record, attribute, options[:less_than])
 
     return true if max_date.nil?
     return unless value >= max_date
 
-    record.errors.add(:expires_at, :date_less_than,
+    record.errors.add(attribute, :date_less_than,
                       date: max_date)
   end
 end

--- a/app/views/shared/personal_access_tokens/_form_fields.html.erb
+++ b/app/views/shared/personal_access_tokens/_form_fields.html.erb
@@ -46,7 +46,7 @@
     input_name: form.field_name(:expires_at),
     label: t("activerecord.attributes.personal_access_token.expires_at"),
     selected_date: pat[:expires_at],
-    required: false,
+    required: Irida::CurrentSettings.require_personal_access_token_expiry?,
     errored: invalid_expires_at,
     max_date: Irida::CurrentSettings.require_personal_access_token_expiry? ? Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days : nil
   ) %>

--- a/app/views/shared/personal_access_tokens/_form_fields.html.erb
+++ b/app/views/shared/personal_access_tokens/_form_fields.html.erb
@@ -47,7 +47,8 @@
     label: t("activerecord.attributes.personal_access_token.expires_at"),
     selected_date: pat[:expires_at],
     required: false,
-    errored: invalid_expires_at
+    errored: invalid_expires_at,
+    max_date: Irida::CurrentSettings.require_personal_access_token_expiry? ? Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days : nil
   ) %>
 
   <% if invalid_expires_at %>

--- a/config/locales/common.en.yml
+++ b/config/locales/common.en.yml
@@ -21,7 +21,6 @@ en:
     date:
       errors:
         invalid_input: must be in YYYY-MM-DD format (for example, 2026-05-01)
-        invalid_min_date: Date is before minimum date
     labels:
       access_level: Access Level
       actions: Actions

--- a/config/locales/common.fr.yml
+++ b/config/locales/common.fr.yml
@@ -21,6 +21,7 @@ fr:
     date:
       errors:
         invalid_input: Saisie de date invalide
+        invalid_max_date: La date est postérieure à la date maximale
         invalid_min_date: La date est antérieure à la date minimale
     labels:
       access_level: Niveau d’accès

--- a/config/locales/common.fr.yml
+++ b/config/locales/common.fr.yml
@@ -21,7 +21,6 @@ fr:
     date:
       errors:
         invalid_input: Saisie de date invalide
-        invalid_max_date: La date est postérieure à la date maximale
         invalid_min_date: La date est antérieure à la date minimale
     labels:
       access_level: Niveau d’accès

--- a/config/locales/common.fr.yml
+++ b/config/locales/common.fr.yml
@@ -21,7 +21,6 @@ fr:
     date:
       errors:
         invalid_input: Saisie de date invalide
-        invalid_min_date: La date est antérieure à la date minimale
     labels:
       access_level: Niveau d’accès
       actions: Mesures

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -209,6 +209,7 @@ en:
         wednesday: Wed
       errors:
         invalid_date: Invalid date.
+        max_date_error: 'Maximum allowed date: '
         min_date_error: 'Earliest allowed date: '
       months:
         april: April

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -209,6 +209,7 @@ fr:
         wednesday: mer
       errors:
         invalid_date: Date non valide
+        max_date_error: 'Date maximale autorisée : '
         min_date_error: 'Date la plus ancienne autorisée : '
       months:
         april: avril

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -690,6 +690,8 @@ en:
       accepted: must be accepted
       blank: can't be blank
       confirmation: doesn't match %{attribute}
+      date_greater_than: must be after %{date}
+      date_less_than: must be before %{date}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -692,6 +692,7 @@ en:
       confirmation: doesn't match %{attribute}
       date_greater_than: must be after %{date}
       date_less_than: must be before %{date}
+      date_object_required: must be a date or datetime object
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -694,6 +694,7 @@ fr:
       confirmation: ne concorde pas avec %{attribute}
       date_greater_than: doit être après %{date}
       date_less_than: doit être avant %{date}
+      date_object_required: doit être une date ou un objet datetime
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
       even: doit être pair

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -692,6 +692,8 @@ fr:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
       confirmation: ne concorde pas avec %{attribute}
+      date_greater_than: doit être après %{date}
+      date_less_than: doit être avant %{date}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
       even: doit être pair

--- a/db/migrate/20260327212553_add_personal_access_token_settings_to_application_settings.rb
+++ b/db/migrate/20260327212553_add_personal_access_token_settings_to_application_settings.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration adds personal access token settings to the application_settings table.
+# The settings include:
+# - require_personal_access_token_expiry: A boolean that indicates whether personal access token expiry is required.
+# Default false.
+# - max_personal_access_token_lifetime_in_days: An integer that specifies the maximum lifetime of a personal access
+# token in days. Default 365.
+class AddPersonalAccessTokenSettingsToApplicationSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :application_settings, :require_personal_access_token_expiry, :boolean, default: false, null: false
+    add_column :application_settings, :max_personal_access_token_lifetime_in_days, :integer, default: 365, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -520,6 +520,8 @@ CREATE TABLE public.application_settings (
     password_authentication_enabled boolean DEFAULT true NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    require_personal_access_token_expiry boolean DEFAULT false NOT NULL,
+    max_personal_access_token_lifetime_in_days integer DEFAULT 365 NOT NULL,
     cleanup_inactive_access_tokens_after_days integer DEFAULT 30 NOT NULL,
     user_opt_in_features jsonb DEFAULT '{}'::jsonb NOT NULL
 );
@@ -2146,6 +2148,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260424121251'),
 ('20260416173126'),
 ('20260410170502'),
+('20260327212553'),
 ('20260306153207'),
 ('20260223130000'),
 ('20251201162848'),

--- a/test/components/previews/datepicker_component_preview.rb
+++ b/test/components/previews/datepicker_component_preview.rb
@@ -32,6 +32,7 @@ class DatepickerComponentPreview < ViewComponent::Preview
     datepicker(
       id: 'test_id',
       input_name: 'test_input_name',
+      max_date: Time.zone.today + 365.days,
       min_date: nil,
       selected_date: Time.zone.today + 7.days,
       errors: ['error 1', 'error 2'],

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -79,7 +79,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
 
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
-    group_member.save
+    group_member.save(validate: false)
     group = groups(:group_one)
     get group_path(group)
     assert_response :unauthorized
@@ -90,7 +90,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
 
     group_member = members(:group_four_member_david_doe)
     group_member.expires_at = 10.days.ago.to_date
-    group_member.save
+    group_member.save(validate: false)
     group = groups(:david_doe_group_four)
     get group_path(group)
     assert_response :unauthorized

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -80,10 +80,10 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
-    group_member.save
+    group_member.save(validate: false)
     project_member = members(:project_one_member_john_doe)
     project_member.expires_at = 10.days.ago.to_date
-    project_member.save
+    project_member.save(validate: false)
     get namespace_project_path(projects(:project1).namespace.parent, projects(:project1))
     assert_response :unauthorized
   end

--- a/test/jobs/personal_access_tokens/cleanup_job_test.rb
+++ b/test/jobs/personal_access_tokens/cleanup_job_test.rb
@@ -38,6 +38,8 @@ module PersonalAccessTokens
       # DateValidator forbids past expires_at on create; set in DB for an expired date still after the job cutoff.
       token.update_columns(expires_at: (@current_date - 10.days).to_date) # rubocop:disable Rails/SkipsModelValidations
 
+      token.update!(expires_at: (@current_date - 10.days).to_date)
+
       assert_no_difference -> { PersonalAccessToken.where(id: token.id).count } do
         PersonalAccessTokens::CleanupJob.perform_now
       end

--- a/test/models/application_setting_test.rb
+++ b/test/models/application_setting_test.rb
@@ -34,14 +34,18 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     assert_equal true, settings.signup_enabled
     assert_equal true, settings.password_authentication_enabled
     assert_equal 30, settings.cleanup_inactive_access_tokens_after_days
+    assert_equal false, settings.require_personal_access_token_expiry
+    assert_equal 365, settings.max_personal_access_token_lifetime_in_days
   end
 
   test 'build_from_defaults allows overriding defaults' do
-    settings = ApplicationSetting.build_from_defaults(signup_enabled: false)
+    settings = ApplicationSetting.build_from_defaults(signup_enabled: false, require_personal_access_token_expiry: true)
     assert settings.new_record?
     assert_equal false, settings.signup_enabled
     assert_equal true, settings.password_authentication_enabled
     assert_equal 30, settings.cleanup_inactive_access_tokens_after_days
+    assert_equal true, settings.require_personal_access_token_expiry
+    assert_equal 365, settings.max_personal_access_token_lifetime_in_days
   end
 
   test 'create_from_defaults creates and saves a new instance with defaults' do
@@ -50,6 +54,8 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     assert_equal true, settings.signup_enabled
     assert_equal true, settings.password_authentication_enabled
     assert_equal 30, settings.cleanup_inactive_access_tokens_after_days
+    assert_equal false, settings.require_personal_access_token_expiry
+    assert_equal 365, settings.max_personal_access_token_lifetime_in_days
   end
 
   test '#signup_enabled? returns the value of signup_enabled' do
@@ -148,5 +154,19 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     assert_includes error_text, '/data_grid_samples_table/name'
     assert_includes error_text, '/data_grid_samples_table/description'
     assert_includes error_text, 'en'
+  end
+
+  test '#require_personal_access_token_expiry? returns the value of require_personal_access_token_expiry' do
+    settings = ApplicationSetting.create_from_defaults
+    assert_not settings.require_personal_access_token_expiry?
+    settings.update(require_personal_access_token_expiry: true)
+    assert settings.require_personal_access_token_expiry?
+  end
+
+  test '#max_personal_access_token_lifetime_in_days returns the value of max_personal_access_token_lifetime_in_days' do
+    settings = ApplicationSetting.create_from_defaults
+    assert_equal 365, settings.max_personal_access_token_lifetime_in_days
+    settings.update(max_personal_access_token_lifetime_in_days: 20)
+    assert_equal 20, settings.max_personal_access_token_lifetime_in_days
   end
 end

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -35,6 +35,11 @@ class GroupMemberTest < ActiveSupport::TestCase
     assert_not @group_member.valid?
   end
 
+  test 'can unset expires_at' do
+    @group_member.expires_at = nil
+    assert @group_member.valid?
+  end
+
   test '#validates access level in range' do
     valid_access_levels = Member::AccessLevel.all_values_with_owner
 

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -145,7 +145,7 @@ class GroupMemberTest < ActiveSupport::TestCase
     members = Member.for_namespace_and_ancestors(@group).not_expired
     assert_difference(-> { members.count } => -1) do
       @group_member.expires_at = 10.days.ago.to_date
-      @group_member.save
+      @group_member.save(validate: false)
     end
   end
 end

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -35,6 +35,11 @@ class ProjectMemberTest < ActiveSupport::TestCase
     assert_not @project_member.valid?
   end
 
+  test 'can unset expires_at' do
+    @project_member.expires_at = nil
+    assert @project_member.valid?
+  end
+
   test '#validates access level in range' do
     valid_access_levels = Member::AccessLevel.all_values_with_owner
 

--- a/test/models/members/project_member_test.rb
+++ b/test/models/members/project_member_test.rb
@@ -146,7 +146,7 @@ class ProjectMemberTest < ActiveSupport::TestCase
     members = Member.for_namespace_and_ancestors(@project.namespace).not_expired
     assert_difference(-> { members.count } => -1) do
       @project_member.expires_at = 10.days.ago.to_date
-      @project_member.save
+      @project_member.save(validate: false)
     end
   end
 end

--- a/test/models/namespace_group_link_test.rb
+++ b/test/models/namespace_group_link_test.rb
@@ -15,6 +15,12 @@ class NamespaceGroupLinkTest < ActiveSupport::TestCase
     assert group_group_link.valid?
   end
 
+  test 'group link expiration can be unset' do
+    namespace_group_link = namespace_group_links(:namespace_group_link28)
+    namespace_group_link.expires_at = nil
+    assert namespace_group_link.valid?
+  end
+
   test 'cannot create multiple group to group links with the same groups' do
     group_group_link = NamespaceGroupLink.new(group_id: @group_to_share.id, namespace_id: @group.id,
                                               group_access_level: Member::AccessLevel::ANALYST)

--- a/test/models/personal_access_token_test.rb
+++ b/test/models/personal_access_token_test.rb
@@ -92,4 +92,28 @@ class PersonalAccessTokenTest < ActiveSupport::TestCase
   test '#find_by_token' do
     assert_equal @valid_pat, PersonalAccessToken.find_by_token('JQ2w5maQc4zgvC8GGMEp') # rubocop:disable Rails/DynamicFindBy
   end
+
+  test '#expires_at cannot be in the past' do
+    min_date = Time.zone.today
+
+    pat = PersonalAccessToken.new(
+      user: users(:john_doe), name: 'New PAT',
+      expires_at: min_date - 1, scopes: ['api']
+    )
+    assert_not pat.valid?
+    assert_includes pat.errors.full_messages, "Expiration Date must be after #{min_date}"
+  end
+
+  test '#expires_at cannot be more than max lifetime in the future' do
+    ApplicationSetting.current.update!(require_personal_access_token_expiry: true)
+    max_date = Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days
+    pat = PersonalAccessToken.new(
+      user: users(:john_doe), name: 'New PAT',
+      expires_at: max_date + 1, scopes: ['api']
+    )
+
+    assert_not pat.valid?
+    assert_includes pat.errors.full_messages,
+                    "Expiration Date must be before #{max_date}"
+  end
 end

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -157,7 +157,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
   test 'scope with expired group member' do
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
-    group_member.save
+    group_member.save(validate: false)
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
@@ -168,7 +168,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
 
     linked_group_member = members(:namespace_group_link8_member1)
     linked_group_member.expires_at = 10.days.ago.to_date
-    linked_group_member.save
+    linked_group_member.save(validate: false)
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 

--- a/test/policies/namespace_policy_test.rb
+++ b/test/policies/namespace_policy_test.rb
@@ -11,7 +11,7 @@ class NamespacePolicyTest < ActiveSupport::TestCase
   test 'named scope with expired memberships' do
     group_member = members(:group_four_member_david_doe)
     group_member.expires_at = 10.days.ago.to_date
-    group_member.save
+    group_member.save(validate: false)
 
     scoped_namespaces = @policy.apply_scope(Namespace, type: :relation, name: :manageable)
 

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -114,7 +114,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   test 'scope expired memberships' do
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
-    group_member.save
+    group_member.save(validate: false)
 
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
@@ -141,7 +141,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     project_member = members(:project_one_member_john_doe)
     project_member.expires_at = 10.days.ago.to_date
-    project_member.save
+    project_member.save(validate: false)
 
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
@@ -151,7 +151,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     linked_group_member = members(:namespace_group_link8_member1)
     linked_group_member.expires_at = 10.days.ago.to_date
-    linked_group_member.save
+    linked_group_member.save(validate: false)
 
     scoped_projects = @policy.apply_scope(Project, type: :relation)
 
@@ -182,7 +182,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
   test 'manageable scope expired memberships' do
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
-    group_member.save
+    group_member.save(validate: false)
 
     scoped_projects = @policy.apply_scope(Project, type: :relation, name: :manageable)
 
@@ -210,7 +210,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
 
     project_member = members(:project_one_member_john_doe)
     project_member.expires_at = 10.days.ago.to_date
-    project_member.save
+    project_member.save(validate: false)
 
     scoped_projects = @policy.apply_scope(Project, type: :relation, name: :manageable)
 

--- a/test/services/group_links/group_link_update_service_test.rb
+++ b/test/services/group_links/group_link_update_service_test.rb
@@ -26,6 +26,14 @@ module GroupLinks
       end
     end
 
+    test 'update group link expiration to nil' do
+      namespace_group_link = namespace_group_links(:namespace_group_link28)
+      assert_changes -> { namespace_group_link.expires_at }, to: nil do
+        GroupLinks::GroupLinkUpdateService.new(@user, namespace_group_link,
+                                               { expires_at: nil }).execute
+      end
+    end
+
     test 'update group to group share expiration' do
       expiration_date = Date.strptime('2023-08-16', '%Y-%m-%d')
       namespace_group_link = namespace_group_links(:namespace_group_link2)

--- a/test/services/members/update_service_test.rb
+++ b/test/services/members/update_service_test.rb
@@ -60,6 +60,14 @@ module Members
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
     end
 
+    test 'update group member expiration to nil' do
+      valid_params = { user: @group_member.user, expires_at: nil }
+
+      assert_changes -> { @group_member.expires_at }, to: nil do
+        Members::UpdateService.new(@group_member, @group, @user, valid_params).execute
+      end
+    end
+
     test 'update group member to OWNER role when the current user only has the Maintainer role' do
       group_member = members(:group_one_member_ryan_doe)
       valid_params = { user: group_member.user, access_level: Member::AccessLevel::OWNER }
@@ -133,6 +141,14 @@ module Members
       assert_equal Namespaces::ProjectNamespacePolicy, exception.policy
       assert_equal :update_member?, exception.rule
       assert exception.result.reasons.is_a?(::ActionPolicy::Policy::FailureReasons)
+    end
+
+    test 'update project member expiration to nil' do
+      valid_params = { user: @project_member.user, expires_at: nil }
+
+      assert_changes -> { @project_member.expires_at }, to: nil do
+        Members::UpdateService.new(@project_member, @project_namespace, @user, valid_params).execute
+      end
     end
 
     test 'update project member to OWNER role when the current user only has the Maintainer role' do

--- a/test/services/personal_access_tokens/create_service_test.rb
+++ b/test/services/personal_access_tokens/create_service_test.rb
@@ -52,7 +52,7 @@ module PersonalAccessTokens
       Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
 
       # default is 365 days, so we add 1 to get outside the max allowed date
-      expires_at = Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days + 1
+      expires_at = (Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days).to_s
 
       invalid_params = {
         scopes: %w[read_api api],
@@ -114,7 +114,7 @@ module PersonalAccessTokens
       Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
 
       # default is 365 days, so we add 1 to get outside the max allowed date
-      expires_at = Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days + 1
+      expires_at = (Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days).to_s
 
       invalid_params = {
         scopes: %w[read_api api],

--- a/test/services/personal_access_tokens/create_service_test.rb
+++ b/test/services/personal_access_tokens/create_service_test.rb
@@ -52,7 +52,7 @@ module PersonalAccessTokens
       Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
 
       # default is 365 days, so we add 1 to get outside the max allowed date
-      expires_at = (Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days).to_s
+      expires_at = Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days
 
       invalid_params = {
         scopes: %w[read_api api],
@@ -114,7 +114,7 @@ module PersonalAccessTokens
       Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
 
       # default is 365 days, so we add 1 to get outside the max allowed date
-      expires_at = (Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days).to_s
+      expires_at = Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days
 
       invalid_params = {
         scopes: %w[read_api api],

--- a/test/services/personal_access_tokens/create_service_test.rb
+++ b/test/services/personal_access_tokens/create_service_test.rb
@@ -34,6 +34,37 @@ module PersonalAccessTokens
       end
     end
 
+    test 'create new personal access token for bot account with missing mandatory expiration date' do
+      Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+
+      invalid_params = {
+        scopes: %w[read_api api]
+      }
+
+      namespace_bot = namespace_bots(:project1_bot0)
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, invalid_params, @project.namespace, namespace_bot.user).execute
+      end
+    end
+
+    test 'create new personal access token for bot account with expiration date past max allowable date' do
+      Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+
+      # default is 365 days, so we add 1 to get outside the max allowed date
+      expires_at = Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days + 1
+
+      invalid_params = {
+        scopes: %w[read_api api],
+        expires_at: expires_at
+      }
+      namespace_bot = namespace_bots(:project1_bot0)
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, invalid_params, @project.namespace, namespace_bot.user).execute
+      end
+    end
+
     test 'create new personal access token for bot account with missing scopes' do
       valid_params = {
         name: 'Uploader'
@@ -64,6 +95,34 @@ module PersonalAccessTokens
 
       assert_difference -> { PersonalAccessToken.count } => 0 do
         PersonalAccessTokens::CreateService.new(@user, valid_params).execute
+      end
+    end
+
+    test 'create new personal access token for user with missing mandatory expiration date' do
+      Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+
+      invalid_params = {
+        scopes: %w[read_api api]
+      }
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, invalid_params).execute
+      end
+    end
+
+    test 'create new personal access token for user with expiration date past max allowable date' do
+      Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+
+      # default is 365 days, so we add 1 to get outside the max allowed date
+      expires_at = Time.zone.today + Irida::CurrentSettings.max_personal_access_token_lifetime_in_days.days + 1
+
+      invalid_params = {
+        scopes: %w[read_api api],
+        expires_at: expires_at
+      }
+
+      assert_difference -> { PersonalAccessToken.count } => 0 do
+        PersonalAccessTokens::CreateService.new(@user, invalid_params).execute
       end
     end
 

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -163,6 +163,54 @@ module Groups
       ### VERIFY END ###
     end
 
+    test 'can\'t create a new group bot account without missing mandatory expiration date' do
+      Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+
+      ### SETUP START ###
+      visit group_bots_path(groups(:group_two))
+
+      assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
+      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+
+      assert_selector 'a', text: I18n.t(:'groups.bots.index.add_new_bot'), count: 1
+
+      assert_selector 'tr', count: 0
+
+      within('div.empty_state_message') do
+        assert_text I18n.t(:'bots.index.table.empty_state.title')
+        assert_text I18n.t(:'bots.index.table.empty_state.description')
+      end
+      ### SETUP END ###
+
+      ### ACTIONS START ###
+      click_link I18n.t(:'groups.bots.index.add_new_bot')
+
+      assert_selector '#dialog'
+      within('#dialog') do
+        assert_selector 'h1', text: I18n.t(:'groups.bots.index.bot_listing.new_bot_modal.title')
+        assert_selector 'p', text: I18n.t(:'groups.bots.index.bot_listing.new_bot_modal.description')
+
+        fill_in I18n.t(:'activerecord.attributes.personal_access_token.name'), with: 'Uploader'
+        select I18n.t('activerecord.models.member.access_level.analyst'),
+               from: I18n.t(:'activerecord.attributes.member.access_level')
+
+        assert_html5_inputs_valid
+
+        click_button I18n.t('common.controls.submit')
+        ### ACTIONS END ###
+
+        ### VERIFY START ###
+        assert_selector '#new_bot_account-error-alert'
+        within('#new_bot_account-error-alert') do
+          assert_text I18n.t(:'general.form.error_notification')
+        end
+        assert_text I18n.t(:'errors.format',
+                           attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
+                           message: I18n.t(:'errors.messages.blank'))
+      end
+      ### VERIFY END ###
+    end
+
     test 'can delete a group bot account' do
       ### SETUP START ###
       visit group_bots_path(@namespace)

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -195,18 +195,22 @@ module Groups
                from: I18n.t(:'activerecord.attributes.member.access_level')
 
         assert_html5_inputs_valid
+      end
+      ### ACTIONS END ###
 
-        click_button I18n.t('common.controls.submit')
-        ### ACTIONS END ###
+      click_button I18n.t('common.controls.submit')
 
-        ### VERIFY START ###
-        assert_selector '#new_bot_account-error-alert'
-        within('#new_bot_account-error-alert') do
+      ### VERIFY START ###
+      # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
+      within('#bot_modal') do
+        assert_selector '[data-controller="form-error-summary"]'
+        within('[data-controller="form-error-summary"]') do
+          assert_text I18n.t(:'general.form.error_summary.title', count: 2)
           assert_text I18n.t(:'general.form.error_notification')
+          assert_text I18n.t(:'errors.format',
+                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
+                             message: I18n.t(:'errors.messages.blank'))
         end
-        assert_text I18n.t(:'errors.format',
-                           attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
-                           message: I18n.t(:'errors.messages.blank'))
       end
       ### VERIFY END ###
     end

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -207,9 +207,7 @@ module Groups
         within('[data-controller="form-error-summary"]') do
           assert_text I18n.t(:'general.form.error_summary.title', count: 2)
           assert_text I18n.t(:'general.form.error_notification')
-          assert_text I18n.t(:'errors.format',
-                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
-                             message: I18n.t(:'errors.messages.blank'))
+          assert_text I18n.t('common.date.errors.invalid_input')
         end
       end
       ### VERIFY END ###

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -203,8 +203,8 @@ module Groups
       ### VERIFY START ###
       # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
       within('#bot_modal') do
-        assert_selector '[data-controller="form-error-summary"]'
-        within('[data-controller="form-error-summary"]') do
+        assert_selector '[data-controller="form-error-summary"]', match: :first
+        within('[data-controller="form-error-summary"]', match: :first) do
           assert_text I18n.t(:'general.form.error_summary.title', count: 2)
           assert_text I18n.t(:'general.form.error_notification')
           assert_text I18n.t('common.date.errors.invalid_input')

--- a/test/system/groups/group_links_test.rb
+++ b/test/system/groups/group_links_test.rb
@@ -283,8 +283,9 @@ module Groups
       login_as users(:user25)
 
       namespace_group_link = namespace_group_links(:namespace_group_link9)
-      NamespaceGroupLink.where(namespace: namespace_group_link.namespace,
-                               group: namespace_group_link.group).update(expires_at: Time.zone.today - 1)
+
+      namespace_group_link.expires_at = Time.zone.today - 1
+      namespace_group_link.save(validate: false)
 
       visit group_url(namespace_group_link.namespace)
 

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -142,6 +142,27 @@ class ProfileTest < ApplicationSystemTestCase
     assert_text I18n.t('profiles.personal_access_tokens.create.success', name: 'my new token')
   end
 
+  test 'cannot create personal access token without expiration date if require_personal_access_token_expiry is set' do
+    Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+
+    visit profile_path
+    click_link I18n.t(:'profiles.sidebar.access_tokens')
+
+    within %(form[action="/-/profile/personal_access_tokens"]) do
+      fill_in 'Token name', with: 'my new token'
+      check 'api', allow_label_click: true
+      click_button I18n.t(:'profiles.personal_access_tokens.create.submit')
+    end
+
+    assert_no_text 'my new token'
+    assert_text I18n.t(:'profiles.personal_access_tokens.index.active_personal_access_tokens',
+                       count: @active_token_count)
+
+    assert_text I18n.t(:'errors.format',
+                       attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
+                       message: I18n.t(:'errors.messages.blank'))
+  end
+
   test 'cannot create personal access token without scope selection' do
     visit profile_path
     click_link I18n.t(:'profiles.sidebar.access_tokens')

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -148,6 +148,8 @@ class ProfileTest < ApplicationSystemTestCase
     visit profile_path
     click_link I18n.t(:'profiles.sidebar.access_tokens')
 
+    click_button I18n.t(:'profiles.personal_access_tokens.index.add_new_token')
+
     within %(form[action="/-/profile/personal_access_tokens"]) do
       fill_in 'Token name', with: 'my new token'
       check 'api', allow_label_click: true
@@ -155,8 +157,8 @@ class ProfileTest < ApplicationSystemTestCase
     end
 
     assert_no_text 'my new token'
-    assert_text I18n.t(:'profiles.personal_access_tokens.index.active_personal_access_tokens',
-                       count: @active_token_count)
+    assert_selector(:xpath, "//span[contains(@class, 'token-status')]",
+                    count: @active_token_count)
 
     assert_text I18n.t(:'errors.format',
                        attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -160,9 +160,7 @@ class ProfileTest < ApplicationSystemTestCase
     assert_selector(:xpath, "//span[contains(@class, 'token-status')]",
                     count: @active_token_count)
 
-    assert_text I18n.t(:'errors.format',
-                       attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
-                       message: I18n.t(:'errors.messages.blank'))
+    assert_text I18n.t('common.date.errors.invalid_input')
   end
 
   test 'cannot create personal access token without scope selection' do

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -163,6 +163,54 @@ module Projects
       ### VERIFY END ###
     end
 
+    test 'can\'t create a new project bot account without missing mandatory expiration date' do
+      Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+
+      ### SETUP START ###
+      visit namespace_project_bots_path(@namespace, @project2)
+
+      assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
+      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+
+      assert_selector 'button', text: I18n.t(:'projects.bots.index.add_new_bot'), count: 1
+
+      assert_selector 'tr', count: 0
+
+      within('div.empty_state_message') do
+        assert_text I18n.t(:'bots.index.table.empty_state.title')
+        assert_text I18n.t(:'bots.index.table.empty_state.description')
+      end
+      ### SETUP END ###
+
+      ### ACTIONS START ###
+      click_button I18n.t(:'projects.bots.index.add_new_bot')
+
+      assert_selector '#dialog'
+      within('#dialog') do
+        assert_selector 'h1', text: I18n.t(:'projects.bots.index.bot_listing.new_bot_modal.title')
+        assert_selector 'p', text: I18n.t(:'projects.bots.index.bot_listing.new_bot_modal.description')
+
+        fill_in I18n.t(:'activerecord.attributes.personal_access_token.name'), with: 'Uploader'
+        select I18n.t('activerecord.models.member.access_level.analyst'),
+               from: I18n.t(:'activerecord.attributes.member.access_level')
+
+        assert_html5_inputs_valid
+
+        click_button I18n.t('common.controls.submit')
+        ### ACTIONS END ###
+
+        ### VERIFY START ###
+        assert_selector '#new_bot_account-error-alert'
+        within('#new_bot_account-error-alert') do
+          assert_text I18n.t(:'general.form.error_notification')
+        end
+        assert_text I18n.t(:'errors.format',
+                           attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
+                           message: I18n.t(:'errors.messages.blank'))
+      end
+      ### VERIFY END ###
+    end
+
     test 'can delete a project bot account' do
       ### SETUP START ###
       visit namespace_project_bots_path(@namespace, @project)

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -164,7 +164,7 @@ module Projects
     end
 
     test 'can\'t create a new project bot account without missing mandatory expiration date' do
-      Irida::CurrentSettings.current_application_settings.update(require_personal_access_token_expiry: true)
+      ApplicationSetting.current.update(require_personal_access_token_expiry: true)
 
       ### SETUP START ###
       visit namespace_project_bots_path(@namespace, @project2)
@@ -207,9 +207,7 @@ module Projects
         within('[data-controller="form-error-summary"]') do
           assert_text I18n.t(:'general.form.error_summary.title', count: 2)
           assert_text I18n.t(:'general.form.error_notification')
-          assert_text I18n.t(:'errors.format',
-                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
-                             message: I18n.t(:'errors.messages.blank'))
+          assert_text I18n.t('common.date.errors.invalid_input')
         end
       end
       ### VERIFY END ###

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -195,18 +195,22 @@ module Projects
                from: I18n.t(:'activerecord.attributes.member.access_level')
 
         assert_html5_inputs_valid
+      end
+      ### ACTIONS END ###
 
-        click_button I18n.t('common.controls.submit')
-        ### ACTIONS END ###
+      click_button I18n.t('common.controls.submit')
 
-        ### VERIFY START ###
-        assert_selector '#new_bot_account-error-alert'
-        within('#new_bot_account-error-alert') do
+      ### VERIFY START ###
+      # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
+      within('#bot_modal') do
+        assert_selector '[data-controller="form-error-summary"]'
+        within('[data-controller="form-error-summary"]') do
+          assert_text I18n.t(:'general.form.error_summary.title', count: 2)
           assert_text I18n.t(:'general.form.error_notification')
+          assert_text I18n.t(:'errors.format',
+                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
+                             message: I18n.t(:'errors.messages.blank'))
         end
-        assert_text I18n.t(:'errors.format',
-                           attribute: I18n.t(:'activerecord.attributes.personal_access_token.expires_at'),
-                           message: I18n.t(:'errors.messages.blank'))
       end
       ### VERIFY END ###
     end

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -203,8 +203,8 @@ module Projects
       ### VERIFY START ###
       # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
       within('#bot_modal') do
-        assert_selector '[data-controller="form-error-summary"]'
-        within('[data-controller="form-error-summary"]') do
+        assert_selector '[data-controller="form-error-summary"]', match: :first
+        within('[data-controller="form-error-summary"]', match: :first) do
           assert_text I18n.t(:'general.form.error_summary.title', count: 2)
           assert_text I18n.t(:'general.form.error_notification')
           assert_text I18n.t('common.date.errors.invalid_input')

--- a/test/system/projects/group_links_test.rb
+++ b/test/system/projects/group_links_test.rb
@@ -268,7 +268,7 @@ module Projects
       namespace_group_link = namespace_group_links(:namespace_group_link10)
 
       NamespaceGroupLink.where(namespace: [namespace_group_link.namespace, namespace_group_link.namespace.parent],
-                               group: namespace_group_link.group).update(expires_at: Time.zone.today - 1)
+                               group: namespace_group_link.group).update_all(expires_at: Time.zone.today - 1) # rubocop:disable Rails/SkipsModelValidations
 
       visit namespace_project_url(namespace_group_link.namespace.parent,
                                   namespace_group_link.namespace.project)

--- a/test/validators/date_validator_test.rb
+++ b/test/validators/date_validator_test.rb
@@ -28,7 +28,7 @@ class DateValidatorTest < ActiveSupport::TestCase
     member = create_group_member(before_expires_at)
 
     assert_not member.valid?
-    assert_equal(I18n.t('common.date.errors.invalid_min_date'),
+    assert_equal(I18n.t('errors.messages.date_greater_than', date: Time.zone.today.to_date.strftime('%Y-%m-%d')),
                  member.errors[:expires_at].first)
   end
 
@@ -37,7 +37,7 @@ class DateValidatorTest < ActiveSupport::TestCase
     member = create_group_member(invalid_date_format)
 
     assert_not member.valid?
-    assert_equal(I18n.t('common.date.errors.invalid_min_date'),
+    assert_equal(I18n.t('errors.messages.date_greater_than', date: Time.zone.today.to_date.strftime('%Y-%m-%d')),
                  member.errors[:expires_at].first)
   end
 
@@ -68,7 +68,7 @@ class DateValidatorTest < ActiveSupport::TestCase
     group_link = create_group_link(before_expires_at)
 
     assert_not group_link.valid?
-    assert_equal(I18n.t('common.date.errors.invalid_min_date'),
+    assert_equal(I18n.t('errors.messages.date_greater_than', date: Time.zone.today.to_date.strftime('%Y-%m-%d')),
                  group_link.errors[:expires_at].first)
   end
 
@@ -77,7 +77,7 @@ class DateValidatorTest < ActiveSupport::TestCase
     group_link = create_group_link(invalid_date_format)
 
     assert_not group_link.valid?
-    assert_equal(I18n.t('common.date.errors.invalid_min_date'),
+    assert_equal(I18n.t('errors.messages.date_greater_than', date: Time.zone.today.to_date.strftime('%Y-%m-%d')),
                  group_link.errors[:expires_at].first)
   end
 

--- a/test/validators/date_validator_test.rb
+++ b/test/validators/date_validator_test.rb
@@ -91,14 +91,57 @@ class DateValidatorTest < ActiveSupport::TestCase
   end
 
   test 'personal access token with cast expires_at date' do
-    personal_access_token = PersonalAccessToken.new(
-      name: 'Rotated token',
-      scopes: %w[api],
-      expires_at: Time.zone.today + 1.day,
-      user: @user
-    )
+    personal_access_token = create_personal_access_token(Time.zone.today + 1.day)
 
     assert personal_access_token.valid?
+  end
+
+  test 'personal access token with valid expires_at date' do
+    expires_at = (Time.zone.today + 1.day).strftime('%Y-%m-%d')
+    personal_access_token = create_personal_access_token(expires_at)
+
+    assert personal_access_token.valid?
+  end
+
+  test 'personal access token with no expires_at input if expiration is not enabled' do
+    personal_access_token = create_personal_access_token('')
+
+    assert personal_access_token.valid?
+  end
+
+  test 'personal access token with no expires_at input if expiration is enabled' do
+    Irida::CurrentSettings.update!(require_personal_access_token_expiry: true)
+    personal_access_token = create_personal_access_token('')
+
+    assert_not personal_access_token.valid?
+    assert_equal(I18n.t('common.date.errors.invalid_input'), personal_access_token.errors[:expires_at].first)
+  end
+
+  test 'personal access token with valid date format but invalid expires_at date' do
+    expires_at = (Time.zone.today - 10.days).strftime('%Y-%m-%d')
+    personal_access_token = create_personal_access_token(expires_at)
+
+    assert_not personal_access_token.valid?
+    assert_equal(I18n.t('errors.messages.date_greater_than', date: Time.zone.today.to_date.strftime('%Y-%m-%d')),
+                 personal_access_token.errors[:expires_at].first)
+  end
+
+  test 'personal access token expires_at with parseable non-YYYY-MM-DD format' do
+    invalid_date_format = (Time.zone.today - 10.days).strftime('%d-%m-%Y')
+    personal_access_token = create_personal_access_token(invalid_date_format)
+
+    assert_not personal_access_token.valid?
+    assert_equal(I18n.t('errors.messages.date_greater_than', date: Time.zone.today.to_date.strftime('%Y-%m-%d')),
+                 personal_access_token.errors[:expires_at].first)
+  end
+
+  test 'personal access token expires_at with invalid input' do
+    invalid_input = 'this_is_an_invalid_input'
+    personal_access_token = create_personal_access_token(invalid_input)
+
+    assert_not personal_access_token.valid?
+    assert_equal(I18n.t('common.date.errors.invalid_input'),
+                 personal_access_token.errors[:expires_at].first)
   end
 
   private
@@ -120,6 +163,15 @@ class DateValidatorTest < ActiveSupport::TestCase
       group_id: @group_to_group_link.id,
       namespace_id: @group.id,
       namespace_type: 'Group'
+    )
+  end
+
+  def create_personal_access_token(expires_at_date)
+    PersonalAccessToken.new(
+      name: 'New token',
+      scopes: %w[api],
+      expires_at: expires_at_date,
+      user: @user
     )
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the `ApplicationSettings` model to include  two new settings `require_personal_access_token_expiry` and `max_personal_access_token_lifetime_in_days` which allows the system admins to make personal access token expiry mandatory and set its maximum lifetime in days. Current defaults are `require_personal_access_token_expiry: false` and  `max_personal_access_token_lifetime_in_days: 365`. The maximum personal access token lifetime in days is only enforced if the expiration is mandatory.

The datepicker has also been updated to display the maximum allowed date for personal access tokens (bots and user) if it is set by the system admin and the related functionality (display of selectable dates) has been modified for this new setting

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1650" height="550" alt="image" src="https://github.com/user-attachments/assets/06c71cb5-fa18-4e4b-b6af-92dc851216b7" />

<img width="1389" height="606" alt="image" src="https://github.com/user-attachments/assets/3fc6e546-42c9-4e7b-a6c5-aa0c425e43a7" />

<img width="1260" height="959" alt="image" src="https://github.com/user-attachments/assets/674d20ef-5142-4b20-8a46-3aecfb2ca87f" />


<img width="1278" height="1023" alt="image" src="https://github.com/user-attachments/assets/fd7729d9-6aa8-4c3f-9b81-57159bc76655" />


<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/2ec2c3f5-3215-44e9-bbe4-364adba75104" />

<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/7841881b-8e37-41b7-a96d-9329a3ea7ecb" />

<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/0448b145-daf3-4c98-b77f-fb1196de4f56" />

<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/e7eacd01-c240-4d4a-b6c3-eabf64a8d513" />

<img width="804" height="605" alt="image" src="https://github.com/user-attachments/assets/89eea632-38d1-450d-a17d-4f807af27d46" />



## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Checkout this branch and verify that all the datepickers (members, group links, bot accounts, user personal access tokens) work as previously intended with the minimum date displayed
2. In rails console, run `ApplicationSetting.current.update(require_personal_access_token_expiry: true)`
3. For datepickers related to personal access tokens (user and bot accounts), verify that the maximum date allowed is displayed, and the calendar does not allow you to input/select dates past this maximum date
4. For datepickers not related to personal access tokens (members, group links) verify there is no maximum date displayed and all dates past the minimum date are selectable
5. Run step 2 again and change `max_personal_access_token_lifetime_in_days` to a different value other than the default `365`. Verify the user -> personal access token create form and the bot modal create forms display the correct maximum allowed date

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.