### PR TITLE
Remove GitHub reliance for pipelines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,6 +159,9 @@ gem 'flipper-ui', flipper_version
 # Expression calculator
 gem 'dentaku'
 
+# Git interaction
+gem 'git'
+
 group :development, :rubocop do
   # rubocop
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,11 @@ GEM
     fx (0.10.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
+    git (4.3.2)
+      activesupport (>= 5.0)
+      addressable (~> 2.8)
+      process_executer (~> 4.0)
+      rchardet (~> 1.9)
     globalid (1.3.0)
       activesupport (>= 6.1)
     good_job (4.14.2)
@@ -516,6 +521,8 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
+    process_executer (4.0.2)
+      track_open_instances (~> 0.1)
     propshaft (1.3.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -593,6 +600,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rchardet (1.10.0)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -698,6 +706,7 @@ GEM
     thruster (0.1.20-x86_64-linux)
     timecop (0.9.10)
     timeout (0.6.1)
+    track_open_instances (0.1.15)
     trailblazer-option (0.1.2)
     treetop (1.6.14)
       polyglot (~> 0.3)
@@ -779,6 +788,7 @@ DEPENDENCIES
   flipper-active_record (~> 1.4.0)
   flipper-ui (~> 1.4.0)
   fx
+  git
   good_job (~> 4.14.2)
   google-cloud-storage (~> 1.59)
   graphiql-rails

--- a/lib/irida/pipeline_repository.rb
+++ b/lib/irida/pipeline_repository.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'git'
+
+module Irida
+  # Handles Git repository operations for pipeline cloning and verification
+  class PipelineRepository
+    def self.clone_repo(uri, sha, clone_dir)
+      new(uri, sha).clone(clone_dir)
+    end
+
+    def initialize(uri, sha)
+      @uri = uri
+      @sha = sha
+      @remote = uri.to_s
+    end
+
+    def clone(clone_dir)
+      if sha_exists_on_remote?
+        Git.clone(@remote, clone_dir, depth: 1, branch: @sha)
+      else
+        repo = Git.clone(@remote, clone_dir)
+        repo.checkout(@sha)
+      end
+    end
+
+    private
+
+    def sha_exists_on_remote?
+      remote_ref_includes?(Git.ls_remote(@remote), @sha)
+    end
+
+    def remote_ref_includes?(refs, query)
+      case refs
+      when Hash
+        refs.any? { |key, value| key.to_s == query || remote_ref_includes?(value, query) }
+      when Array
+        refs.any? { |value| remote_ref_includes?(value, query) }
+      else
+        refs.to_s == query
+      end
+    end
+  end
+end

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -82,8 +82,6 @@ module Irida
 
       Pipeline.new(pipeline_id, entry, version, nextflow_schema_location, schema_input_location)
     rescue PipelinesInvalidUrlException => e
-      raise e if e.code == '503' # re-raise error to force crash
-
       if e.previously_fetched # log error and mark pipeline as non executable
         Rails.logger.error("Pipeline #{pipeline_id}_#{version['name']} could not be updated")
         version['executable'] = false
@@ -105,6 +103,15 @@ module Irida
       end
 
       [nextflow_schema_location, schema_input_location]
+    rescue Git::Error => e
+      previously_fetched = pipeline_schema_files_exist?(uri, version)
+      raise PipelinesInvalidUrlException.new('404', previously_fetched), e.message
+    end
+
+    def pipeline_schema_files_exist?(uri, version)
+      pipeline_schema_files_path = File.join(@pipeline_schema_file_dir, uri.path, version['name'])
+      File.exist?(File.join(pipeline_schema_files_path, 'nextflow_schema.json')) ||
+        File.exist?(File.join(pipeline_schema_files_path, 'assets', 'schema_input.json'))
     end
 
     # read in the json pipeline config

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'open-uri'
 require 'uri'
-require 'net/http'
+require 'git'
+require 'tmpdir'
 require 'irida/pipeline'
+require 'irida/pipeline_repository'
 
 module Irida
   # Class that reads a workflow config file and registers the available pipelines
-  class Pipelines # rubocop:disable Metrics/ClassLength
+  class Pipelines
     class PipelinesJsonFormatException < StandardError
     end
 
@@ -21,20 +22,14 @@ module Irida
       end
     end
     PIPELINES_JSON_SCHEMA = Rails.root.join('config/schemas/pipelines_schema.json')
-    UNKNOWN_PIPELINE_ENTRY = {
-      'name' => 'UNKNOWN WORKFLOW',
-      'description' => 'UNKNOWN WORKFLOW'
-    }.freeze
-    UNKNOWN_PIPELINE_VERSION = {
-      'executable' => false
-    }.freeze
+    UNKNOWN_PIPELINE_ENTRY = { 'name' => 'UNKNOWN WORKFLOW', 'description' => 'UNKNOWN WORKFLOW' }.freeze
+    UNKNOWN_PIPELINE_VERSION = { 'executable' => false }.freeze
 
     class_attribute :instance
 
     def initialize(**params)
       @pipeline_config_file = params.fetch(:pipeline_config_file, 'config/pipelines/pipelines.json')
       @pipeline_schema_file_dir = params.fetch(:pipeline_schema_file_dir, 'private/pipelines')
-      @pipeline_schema_status_file = params.fetch(:pipeline_schema_status_file, 'status.json')
       @pipelines = {}
 
       register_pipelines
@@ -82,9 +77,8 @@ module Irida
     end
 
     def create_pipeline(pipeline_id, entry, version)
-      uri = get_uri_from_entry(entry, pipeline_id)
-      nextflow_schema_location = prepare_schema_download(uri, version, 'nextflow_schema')
-      schema_input_location = prepare_schema_download(uri, version, 'schema_input')
+      uri = URI.parse(entry['url'])
+      nextflow_schema_location, schema_input_location = clone_and_prepare_schema_locations(uri, version)
 
       Pipeline.new(pipeline_id, entry, version, nextflow_schema_location, schema_input_location)
     rescue PipelinesInvalidUrlException => e
@@ -100,6 +94,19 @@ module Irida
       end
     end
 
+    def clone_and_prepare_schema_locations(uri, version)
+      nextflow_schema_location = nil
+      schema_input_location = nil
+
+      Dir.mktmpdir('irida_pipeline') do |clone_dir|
+        PipelineRepository.clone_repo(uri, version['name'], clone_dir)
+        nextflow_schema_location = copy_schema_file(clone_dir, uri, version, 'nextflow_schema')
+        schema_input_location = copy_schema_file(clone_dir, uri, version, 'schema_input')
+      end
+
+      [nextflow_schema_location, schema_input_location]
+    end
+
     # read in the json pipeline config
     def read_json_config
       path = @pipeline_config_file
@@ -112,119 +119,22 @@ module Irida
       data
     end
 
-    def get_uri_from_entry(entry, pipeline_id)
-      uri = URI.parse(entry['url'])
-
-      unless uri.scheme == 'https' && uri.host == 'github.com'
-        Rails.logger.warn("Pipeline with id '#{pipeline_id}' specifies a url not hosted on 'https://github.com'")
-      end
-
-      uri
-    end
-
-    # Sets up the file names, paths, and urls to be used
-    # by the write_schema_file method
-    def prepare_schema_download(uri, version, type)
-      filename = "#{type}.json"
+    def copy_schema_file(clone_dir, uri, version, type)
+      filename = type == 'nextflow_schema' ? "#{type}.json" : "assets/#{type}.json"
+      source_path = File.join(clone_dir, filename)
 
       pipeline_schema_files_path = File.join(@pipeline_schema_file_dir, uri.path, version['name'])
+      schema_location = Rails.root.join(pipeline_schema_files_path, filename)
 
-      schema_file_url = if type == 'nextflow_schema'
-                          "https://raw.githubusercontent.com#{uri.path}/#{version['name']}/#{filename}"
-                        else
-                          "https://raw.githubusercontent.com#{uri.path}/#{version['name']}/assets/#{filename}"
-                        end
-
-      schema_location =
-        Rails.root.join(pipeline_schema_files_path, filename)
-
-      write_schema_file(schema_file_url, schema_location, pipeline_schema_files_path, type)
-
+      write_schema_file(source_path, schema_location)
       schema_location
     end
 
-    # Create directory if it doesn't exist and write the schema file unless the resource etag matches
-    # the currently stored resource etag
-    def write_schema_file(schema_file_url, schema_location, pipeline_schema_files_path, type)
-      dir = Rails.root.join(pipeline_schema_files_path)
+    def write_schema_file(source_path, schema_location)
+      dir = File.dirname(schema_location)
       FileUtils.mkdir_p(dir) unless File.directory?(dir)
 
-      return if resource_etag_exists(schema_file_url, pipeline_schema_files_path, type)
-
-      IO.copy_stream(URI.parse(schema_file_url).open, schema_location)
-    end
-
-    # Checks if the current local stored resource etag matches the etag of
-    # the resource at the url. If not we overwrite the existing etag for the
-    # local stored file, otherwise we just write the new etag to the status.json
-    # file
-    def resource_etag_exists(resource_url, status_file_location, etag_type) # rubocop:disable Naming/PredicateMethod
-      status_file_location = Rails.root.join(status_file_location, @pipeline_schema_status_file)
-
-      # File etag if it currently exists, nil otherwise
-      existing_etag = get_existing_etag(status_file_location, etag_type)
-      # File currently at pipeline url
-      current_file_etag = fetch_resource_etag(resource_url, !existing_etag.nil?)
-
-      return true if current_file_etag == existing_etag
-
-      update_status_file(status_file_location, { etag_type.to_s => current_file_etag })
-      false
-    end
-
-    def update_status_file(status_file_location, new_data)
-      if File.exist?(status_file_location)
-        status_file = File.read(status_file_location)
-        data = JSON.parse(status_file)
-        data_to_write = data.merge(new_data).to_json
-      else
-        data_to_write = new_data.to_json
-      end
-
-      File.open(status_file_location, 'w') { |output_file| output_file << data_to_write }
-    end
-
-    # File etag if it currently exists, false otherwise
-    def get_existing_etag(status_file_location, etag_type)
-      if File.exist?(status_file_location)
-        status_file = File.read(status_file_location)
-        data = JSON.parse(status_file)
-        return data[etag_type] if data.key?(etag_type) && data[etag_type].present?
-      end
-      nil
-    end
-
-    # Get the etag from headers which will be used to check if newer
-    # schema files are required to be downloaded for a pipeline
-    def fetch_resource_etag(resource_url, previously_fetched)
-      url = URI(resource_url)
-      headers = retrieve_headers(url, previously_fetched)
-
-      # Handle Redirects
-      if headers['location']
-        response_location = headers['location'].join
-        url = URI("#{url.scheme}://#{url.host}#{response_location}")
-
-        headers = retrieve_headers(url, previously_fetched)
-      end
-
-      headers['etag'].join.scan(/"([^"]*)"/).join
-    end
-
-    # Get the headers for the resource
-    def retrieve_headers(url, previously_fetched)
-      request_options = { use_ssl: url.scheme == 'https' }
-      Net::HTTP.start(url.host, url.port, request_options) do |http|
-        resp = http.head(url.path)
-
-        unless resp.code == '200'
-          message = "Schema url `#{url.path}` returned http `#{resp.code}`. Previously fetched successfully: #{previously_fetched}" # rubocop:disable Layout/LineLength
-          Rails.logger.error(message)
-          raise PipelinesInvalidUrlException.new(resp.code, previously_fetched), message
-        end
-
-        resp.to_hash
-      end
+      FileUtils.cp(source_path, schema_location)
     end
   end
 end

--- a/lib/tasks/pipeline_json_validator.rake
+++ b/lib/tasks/pipeline_json_validator.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'git'
+
 # Rake task to validate pipeline JSON configuration files against a JSON schema
 # USAGE:
 #  rake pipeline_json_validator:validate path/to/PIPELINES_JSON_CONFIG_FILE
@@ -126,21 +128,50 @@ namespace :pipeline_json_validator do # rubocop:disable Metrics/BlockLength
       pipeline_hash['versions'].each do |version|
         next unless version.key?('name')
 
-        filename = 'nextflow_schema.json'
-        uri = URI.parse(base_url)
-        url = URI("https://raw.githubusercontent.com#{uri.path}/#{version['name']}/#{filename}")
-
         begin
-          response = Net::HTTP.get_response(URI(url))
-          unless response.is_a?(Net::HTTPSuccess)
-            @errors << "URL is NOT reachable (Status: #{response.code}): #{url}. Please check if version/branch exists at source." # rubocop:disable Layout/LineLength
-          end
-        rescue StandardError => e
-          @errors << "Error reaching URL #{url}: #{e.message}"
+          refs = Git.ls_remote(base_url)
+          version_exists = version_exists_in_remote?(refs, version['name'])
+
+          # If version not found in remote refs, try cloning and checking
+          version_exists ||= check_version_in_cloned_repo(base_url, version['name'])
+
+          @errors << "Version/branch '#{version['name']}' not found in repository: #{base_url}" unless version_exists
+        rescue Git::Error => e
+          @errors << "Repository not accessible at #{base_url}: #{e.message}"
         end
       end
       progressbar.increment
     end
+  end
+
+  # Check if a version/branch exists in the remote references
+  def version_exists_in_remote?(refs, query)
+    case refs
+    when Hash
+      refs.any? { |key, value| key.to_s.include?(query) || version_exists_in_remote?(value, query) }
+    when Array
+      refs.any? { |value| version_exists_in_remote?(value, query) }
+    else
+      refs.to_s.include?(query)
+    end
+  end
+
+  # Check if version exists by cloning the repository and attempting checkout
+  def check_version_in_cloned_repo(base_url, version_name)
+    Dir.mktmpdir('irida_pipeline_validate') do |clone_dir|
+      try_clone_and_checkout(base_url, version_name, clone_dir)
+    end
+  rescue Git::Error
+    false
+  end
+
+  # Attempt to clone and checkout a specific version
+  def try_clone_and_checkout(base_url, version_name, clone_dir)
+    repo = Git.clone(base_url, clone_dir)
+    repo.checkout(version_name)
+    true
+  rescue Git::Error
+    false
   end
 
   # Verify that all required translation keys are present

--- a/test/lib/irida/pipelines_overrides_test.rb
+++ b/test/lib/irida/pipelines_overrides_test.rb
@@ -2,47 +2,37 @@
 
 require 'test_helper'
 require 'webmock/minitest'
+require 'mocha/minitest'
 
 class PipelinesOverrides < ActiveSupport::TestCase
   setup do
     @pipeline_schema_file_dir = "#{ActiveStorage::Blob.service.root}/pipelines"
 
     # Read in schema file to json
-    body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json')
-    nextflow_fastmatch_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema_fastmatch.json')
+    body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json').read
+    nextflow_fastmatch_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema_fastmatch.json').read
     nextflow_samplesheet_fastmatch_body = Rails.root.join(
       'test/fixtures/files/nextflow/samplesheet_schema_fastmatch.json'
-    )
+    ).read
 
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/2.0.2/nextflow_schema.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"a1Ab"]' })
+    # Mock clone_repo to simulate Git operations
+    clone_repo_impl = lambda do |_uri, sha, clone_dir|
+      FileUtils.mkdir_p(clone_dir)
+      if ['2.0.2', '2.0.1', '2.0.0'].include?(sha)
+        # iridanextexample
+        File.write(File.join(clone_dir, 'nextflow_schema.json'), body)
+        FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
+        File.write(File.join(clone_dir, 'assets', 'schema_input.json'), body)
+      elsif ['0.4.1', '0.4.0'].include?(sha)
+        # fastmatchirida
+        File.write(File.join(clone_dir, 'nextflow_schema.json'), nextflow_fastmatch_body)
+        FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
+        File.write(File.join(clone_dir, 'assets', 'schema_input.json'), nextflow_samplesheet_fastmatch_body)
+      end
+      nil
+    end
 
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/2.0.2/assets/schema_input.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"b1Bc"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/2.0.1/nextflow_schema.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"c1Cd"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/2.0.1/assets/schema_input.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"d1De"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/2.0.0/nextflow_schema.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"e1Ef"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/2.0.0/assets/schema_input.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"f1Fg"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/fastmatchirida/0.4.1/nextflow_schema.json')
-      .to_return(status: 200, body: nextflow_fastmatch_body, headers: { etag: '[W/"g1gh"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/fastmatchirida/0.4.1/assets/schema_input.json')
-      .to_return(status: 200, body: nextflow_samplesheet_fastmatch_body, headers: { etag: '[W/"h1hi"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/fastmatchirida/0.4.0/nextflow_schema.json')
-      .to_return(status: 200, body: nextflow_fastmatch_body, headers: { etag: '[W/"i1ij"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/fastmatchirida/0.4.0/assets/schema_input.json')
-      .to_return(status: 200, body: nextflow_samplesheet_fastmatch_body, headers: { etag: '[W/"j1kl"]' })
+    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
   end
 
   teardown do

--- a/test/lib/irida/pipelines_test.rb
+++ b/test/lib/irida/pipelines_test.rb
@@ -2,31 +2,26 @@
 
 require 'test_helper'
 require 'webmock/minitest'
+require 'mocha/minitest'
 
 class PipelinesTest < ActiveSupport::TestCase
   setup do
     @pipeline_schema_file_dir = "#{ActiveStorage::Blob.service.root}/pipelines"
+    @test_schema_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json').read
 
-    # Read in schema file to json
-    body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json')
+    # Use a closure to capture @test_schema_body for the clone_repo implementation
+    schema_body = @test_schema_body
+    clone_repo_impl = lambda do |_uri, _sha, clone_dir|
+      FileUtils.mkdir_p(clone_dir)
+      File.write(File.join(clone_dir, 'nextflow_schema.json'), schema_body)
 
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.2/nextflow_schema.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"a1Ab"]' })
+      # Create assets/schema_input.json
+      FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
+      File.write(File.join(clone_dir, 'assets', 'schema_input.json'), schema_body)
+      nil
+    end
 
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.2/assets/schema_input.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"b1Bc"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.1/nextflow_schema.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"c1Cd"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.1/assets/schema_input.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"d1De"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.0/nextflow_schema.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"e1Ef"]' })
-
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.0/assets/schema_input.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"f1Fg"]' })
+    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
 
     @pipelines = Irida::Pipelines.new(pipeline_config_file: 'test/config/pipelines/pipelines.json',
                                       pipeline_schema_file_dir: @pipeline_schema_file_dir)
@@ -66,12 +61,22 @@ class PipelinesTest < ActiveSupport::TestCase
   end
 
   test 'fail on trying to get new etag for cached pipeline' do
-    # The regular pipelines have already been loaded once and files written to the pipeline schema file dir.
-    # This simulates a restart where the init checks to fetch a fresh etag to compare versions, but fails
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.2/nextflow_schema.json')
-      .to_return(status: 404)
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.2/assets/schema_input.json')
-      .to_return(status: 404)
+    # Pre-create the cached schema files so they exist before trying to fetch new ones
+    schema_body = @test_schema_body
+    cached_path = File.join(@pipeline_schema_file_dir, 'github.com/phac-nml/iridanextexample', '1.0.2')
+    FileUtils.mkdir_p(File.join(cached_path, 'assets'))
+    File.write(File.join(cached_path, 'nextflow_schema.json'), schema_body)
+    File.write(File.join(cached_path, 'assets', 'schema_input.json'), schema_body)
+
+    # Mock Rails.logger.error to capture the call
+    Rails.logger.expects(:error).with('Pipeline phac-nml/iridanextexample_1.0.2 could not be updated').once
+
+    # Override the mock to raise an exception for this test (simulating fetch failure)
+    clone_repo_impl = lambda do |_uri, _sha, _clone_dir|
+      raise Git::Error, 'Failed to clone'
+    end
+
+    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
 
     pipeline_refresh = Irida::Pipelines.new(
       pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_cached_pipeline/pipelines.json',
@@ -81,52 +86,35 @@ class PipelinesTest < ActiveSupport::TestCase
     pl = pipeline_refresh.pipelines['phac-nml/iridanextexample_1.0.2']
     assert_not_nil pl
     assert_not pl.executable
+
+    # Restore the original mock
+    clone_repo_impl_default = lambda do |_uri, _sha, clone_dir|
+      FileUtils.mkdir_p(clone_dir)
+      File.write(File.join(clone_dir, 'nextflow_schema.json'), schema_body)
+      FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
+      File.write(File.join(clone_dir, 'assets', 'schema_input.json'), schema_body)
+      nil
+    end
+    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl_default)
   end
 
-  test 'fail on trying to get etag for new pipeline' do
-    # ok pipeline, no cache
-    body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json')
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.8/nextflow_schema.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"e1Ef"]' })
+  test 'raises exception and logs error on git repo not accessible' do
+    # Mock Rails.logger.error to capture the call
+    Rails.logger.expects(:error).with('Pipeline phac-nml/iridanextexample_1.0.2 could not be registered').once
 
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.8/assets/schema_input.json')
-      .to_return(status: 200, body:, headers: { etag: '[W/"f1Fg"]' })
+    # Override the clone_repo to raise a 503 error
+    clone_repo_impl = lambda do |_uri, _sha, _clone_dir|
+      raise Irida::Pipelines::PipelinesInvalidUrlException.new('503', false)
+    end
 
-    # pipeline that should fail, no cache
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.9/nextflow_schema.json')
-      .to_return(status: 404)
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.9/assets/schema_input.json')
-      .to_return(status: 404)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
 
-    pipeline_refresh = Irida::Pipelines.new(
-      pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_new_pipeline/pipelines.json',
+    pipelines = Irida::Pipelines.new(
+      pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_cached_pipeline/pipelines.json',
       pipeline_schema_file_dir: @pipeline_schema_file_dir
     )
 
-    pl8 = pipeline_refresh.pipelines['phac-nml/iridanextexample_1.0.8']
-    pl9 = pipeline_refresh.pipelines['phac-nml/iridanextexample_1.0.9']
-
-    # ok pipeline
-    assert_not_nil pl8
-    assert pl8.executable
-    # failed pipeline
-    assert_nil pl9
-  end
-
-  test 'fail on github not accessible' do
-    # if github is inaccessible we want to hard crash with a custom exception
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.2/nextflow_schema.json')
-      .to_return(status: 503)
-    stub_request(:any, 'https://raw.githubusercontent.com/phac-nml/iridanextexample/1.0.2/assets/schema_input.json')
-      .to_return(status: 503)
-
-    error = assert_raises(Irida::Pipelines::PipelinesInvalidUrlException) do
-      Irida::Pipelines.new(
-        pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_cached_pipeline/pipelines.json',
-        pipeline_schema_file_dir: @pipeline_schema_file_dir
-      )
-    end
-
-    assert_equal '503', error.code
+    # For non-cached, the pipeline should not be registered
+    assert_nil pipelines.pipelines['phac-nml/iridanextexample_1.0.2']
   end
 end

--- a/test/lib/tasks/fixtures/valid_pipeline.json
+++ b/test/lib/tasks/fixtures/valid_pipeline.json
@@ -17,6 +17,9 @@
       {
         "name": "1.0.0",
         "executable": false
+      },
+      {
+        "name": "2a94c3c"
       }
     ]
   }

--- a/test/lib/tasks/pipeline_json_validator_test.rb
+++ b/test/lib/tasks/pipeline_json_validator_test.rb
@@ -70,7 +70,7 @@ class PipelineJsonValidatorTest < ActiveSupport::TestCase
 
     # Check for URL error
     output = stdout + stderr
-    assert_includes output, 'URL is NOT reachable'
+    assert_includes output, 'Repository not accessible'
   end
 
   test 'detects missing translations' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR refactors pipeline registration and validation to use git operations instead of using github urls. This will allow registration of pipelines for any https git url (e.g. bitbucket, gitlab, azure devops, etc).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Since this change is within pipeline registration and validation, the test suite sufficiently covers it. But if you want to, just starting up the server is good enough validation, as pipelines are automatically registered. You could then validate that the pipeline are available to run.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
