### PR TITLE
User Personal Access Tokens: Rotate UI

### DIFF
--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -47,8 +47,7 @@
 
     <% if !@actions.empty? %>
       <% table.with_column(t("personal_access_tokens.table.header.action"),
-          sticky_key: :right,
-          padding: false
+          classes: "flex justify-start"
         ) do |row| %>
         <% if @actions[:revoke] %>
           <%= button_to t("personal_access_tokens.table.revoke"),
@@ -59,7 +58,19 @@
             label: t(:"personal_access_tokens.table.revoke_aria_label", name: row[:name]),
           },
           class:
-            "px-3 py-2 bg-white dark:bg-slate-800 font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer" %>
+            "bg-white dark:bg-slate-800 font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer mr-2" %>
+        <% end %>
+
+        <% if @actions[:rotate] %>
+          <%= button_to t("personal_access_tokens.table.rotate"),
+          rotate_path(row),
+          data: rotate_data_attributes,
+          method: :put,
+          aria: {
+            label: t(:"personal_access_tokens.table.rotate_aria_label", name: row[:name]),
+          },
+          class:
+            "bg-white dark:bg-slate-800 font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer" %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/personal_access_tokens/table_component.rb
+++ b/app/components/personal_access_tokens/table_component.rb
@@ -61,11 +61,31 @@ module PersonalAccessTokens
       end
     end
 
+    def rotate_path(token)
+      if @namespace.is_a?(Group)
+        rotate_group_bot_personal_access_token_path(
+          bot_id: @bot_account.id,
+          id: token.id
+        )
+      elsif @namespace.is_a?(Namespaces::ProjectNamespace)
+        rotate_namespace_project_bot_personal_access_token_path(
+          bot_id: @bot_account.id,
+          id: token.id
+        )
+      else
+        rotate_profile_personal_access_token_path(id: token.id)
+      end
+    end
+
+    def rotate_data_attributes
+      { 'turbo-stream': true, turbo_confirm: t('personal_access_tokens.table.rotate_confirmation') }
+    end
+
     def actions
       @actions = if @revoked_pats || @expired_pats
                    {}
                  else
-                   { revoke: true }
+                   { revoke: true, rotate: true }
                  end
     end
 

--- a/app/services/personal_access_tokens/rotate_service.rb
+++ b/app/services/personal_access_tokens/rotate_service.rb
@@ -16,7 +16,7 @@ module PersonalAccessTokens
       @bot_user = bot_user
     end
 
-    def execute # rubocop:disable Metrics/AbcSize
+    def execute # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       authorize! @existing_personal_access_token.user, to: :rotate_personal_access_token? if bot_user.nil?
       authorize! namespace, to: :rotate_bot_personal_access_token? unless bot_user.nil?
 
@@ -29,6 +29,7 @@ module PersonalAccessTokens
       @new_personal_access_token = @existing_personal_access_token.dup.tap do |token|
         token.token_digest = nil
         token.last_used_at = nil
+        token.revoked = false
       end
 
       @new_personal_access_token.save

--- a/app/views/profiles/personal_access_tokens/rotate.turbo_stream.erb
+++ b/app/views/profiles/personal_access_tokens/rotate.turbo_stream.erb
@@ -1,4 +1,4 @@
-<% if new_personal_access_token %>
+<% if defined?(new_personal_access_token) %>
   <%= turbo_stream.replace "access-token-section",
                        partial: "access_token_section",
                        locals: {
@@ -12,8 +12,11 @@
                          title: t("profiles.personal_access_tokens.table.empty_state.active.title"),
                          description: t("profiles.personal_access_tokens.table.empty_state.active.description")
                        } %>
-<% end %>
-
-<%= turbo_stream.replace "token-information-component" do %>
-  <%= render PersonalAccessTokens::InformationComponent.new(current_user: current_user) %>
+  <%= turbo_stream.replace "token-information-component" do %>
+    <%= render PersonalAccessTokens::InformationComponent.new(current_user: current_user) %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.append "flashes" do %>
+    <%= viral_flash(type: :error, data: message) %>
+  <% end %>
 <% end %>

--- a/app/views/profiles/personal_access_tokens/rotate.turbo_stream.erb
+++ b/app/views/profiles/personal_access_tokens/rotate.turbo_stream.erb
@@ -1,1 +1,19 @@
+<% if new_personal_access_token %>
+  <%= turbo_stream.replace "access-token-section",
+                       partial: "access_token_section",
+                       locals: {
+                         token: new_personal_access_token.token,
+                       } %>
+  <%= turbo_stream.replace "personal_access_tokens",
+                       partial: "table",
+                       locals: {
+                         personal_access_token: new_personal_access_token,
+                         access_tokens: @active_access_tokens,
+                         title: t("profiles.personal_access_tokens.table.empty_state.active.title"),
+                         description: t("profiles.personal_access_tokens.table.empty_state.active.description")
+                       } %>
+<% end %>
 
+<%= turbo_stream.replace "token-information-component" do %>
+  <%= render PersonalAccessTokens::InformationComponent.new(current_user: current_user) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1233,6 +1233,9 @@ en:
       revoke: Revoke
       revoke_aria_label: 'Revoke personal access token: %{name}'
       revoke_confirmation: Are you sure you want to revoke this personal access token?
+      rotate: Rotate
+      rotate_aria_label: 'Rotate personal access token: %{name}'
+      rotate_confirmation: Are you sure you want to rotate this personal access token?
       status:
         active: Active
         expired: Expired

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1237,6 +1237,9 @@ fr:
       revoke: Révoquer
       revoke_aria_label: 'Révoquer le jeton d’accès personnel : %{name}'
       revoke_confirmation: Êtes-vous sûr de vouloir révoquer ce jeton d’accès personnel?
+      rotate: Faire pivoter
+      rotate_aria_label: 'Faire pivoter le jeton d''accès personnel : %{name}'
+      rotate_confirmation: Êtes-vous sûr de vouloir faire pivoter ce jeton d'accès personnel?
       status:
         active: Actif
         expired: Expiré

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -187,6 +187,98 @@ class ProfileTest < ApplicationSystemTestCase
                     count: @active_token_count - 1)
   end
 
+  test 'can rotate active personal access tokens' do
+    visit profile_path
+    click_link I18n.t(:'profiles.sidebar.access_tokens')
+
+    token_to_rotate = personal_access_tokens(:john_doe_non_expirable_pat)
+
+    assert_selector(:xpath, "//span[contains(@class, 'token-status')]",
+                    count: @active_token_count)
+
+    within('#access-tokens-table') do
+      assert_text token_to_rotate.name
+    end
+
+    click_button 'View revoked tokens'
+
+    within('#access-tokens-table') do
+      assert_no_text token_to_rotate.name
+    end
+
+    click_button 'View active tokens'
+
+    within %(tr[id="#{dom_id(token_to_rotate)}"]) do
+      click_button I18n.t(:'personal_access_tokens.table.rotate')
+    end
+
+    within('#turbo-confirm[open]') do
+      click_button I18n.t('common.controls.confirm')
+    end
+
+    assert_text I18n.t(:'profiles.personal_access_tokens.access_token_section.label')
+    assert_text I18n.t(:'profiles.personal_access_tokens.access_token_section.description')
+
+    within('#access-tokens-table') do
+      assert_text token_to_rotate.name
+    end
+
+    click_button 'View revoked tokens'
+
+    within('#access-tokens-table') do
+      assert_text token_to_rotate.name
+    end
+
+    click_button 'View active tokens'
+
+    assert_selector(:xpath, "//span[contains(@class, 'token-status')]",
+                    count: @active_token_count)
+  end
+
+  test 'cannot rotate revoked personal access tokens' do
+    visit profile_path
+    click_link I18n.t(:'profiles.sidebar.access_tokens')
+
+    revoked_token_count = @user.personal_access_tokens.revoked.count
+
+    token_to_rotate = personal_access_tokens(:john_doe_revoked_pat)
+
+    click_button 'View revoked tokens'
+
+    assert_selector(:xpath, "//span[contains(@class, 'token-status')]",
+                    count: revoked_token_count)
+
+    within('#access-tokens-table') do
+      assert_text token_to_rotate.name
+    end
+
+    within %(tr[id="#{dom_id(token_to_rotate)}"]) do
+      assert_no_button I18n.t(:'personal_access_tokens.table.rotate')
+    end
+  end
+
+  test 'cannot rotate expired personal access tokens' do
+    visit profile_path
+    click_link I18n.t(:'profiles.sidebar.access_tokens')
+
+    expired_token_count = @user.personal_access_tokens.expired.count
+
+    token_to_rotate = personal_access_tokens(:john_doe_expired_pat)
+
+    click_button 'View expired tokens'
+
+    assert_selector(:xpath, "//span[contains(@class, 'token-status')]",
+                    count: expired_token_count)
+
+    within('#access-tokens-table') do
+      assert_text token_to_rotate.name
+    end
+
+    within %(tr[id="#{dom_id(token_to_rotate)}"]) do
+      assert_no_button I18n.t(:'personal_access_tokens.table.rotate')
+    end
+  end
+
   test 'empty personal access tokens state' do
     login_as users(:empty_doe)
     visit profile_path


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in the UI for a user to rotate a personal access token.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1600" height="750" alt="image" src="https://github.com/user-attachments/assets/c7c69792-2962-4ed0-bea7-b069d84a3573" />

<img width="1606" height="711" alt="image" src="https://github.com/user-attachments/assets/0d5bd9dc-c262-415e-8f28-a2e23a565004" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Log in as a user and go to the profile -> personal access tokens page for the user
2. Create an access token
3. Refresh the page so that the access token section is not displaying the token for you to copy
4. Click the `Rotate` button and then confirm
5. Verify that the access token section now displays a token for you to copy
6. Verify that the revoked tokens count has increased and displays the token that was rotated out

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
