### PR TITLE
feat: Form error summary

### DIFF
--- a/app/components/form_error_summary_component.html.erb
+++ b/app/components/form_error_summary_component.html.erb
@@ -1,12 +1,15 @@
 <%= viral_alert(**alert_system_arguments) do %>
-  <section
-    aria-describedby="<%= description_id %>"
-    aria-labelledby="<%= heading_id %>"
-    class="outline-hidden"
-    data-controller="form-error-summary"
-    tabindex="-1"
-  >
-    <h2 id="<%= heading_id %>" class="text-sm font-semibold"><%= title_text %></h2>
+  <div class="outline-hidden" data-controller="form-error-summary">
+    <h2
+      id="<%= heading_id %>"
+      aria-describedby="<%= description_id %>"
+      class="text-sm font-semibold outline-hidden"
+      data-form-error-summary-target="heading"
+      tabindex="-1"
+    >
+      <%= title_text %>
+    </h2>
+
     <p id="<%= description_id %>" class="mt-1"><%= description_text %></p>
 
     <ul class="mt-2 list-disc space-y-1 ps-5">
@@ -22,5 +25,5 @@
         </li>
       <% end %>
     </ul>
-  </section>
+  </div>
 <% end %>

--- a/app/components/form_error_summary_component.html.erb
+++ b/app/components/form_error_summary_component.html.erb
@@ -1,12 +1,6 @@
 <%= viral_alert(**alert_system_arguments) do %>
-  <div class="outline-hidden" data-controller="form-error-summary">
-    <h2
-      id="<%= heading_id %>"
-      aria-describedby="<%= description_id %>"
-      class="text-sm font-semibold outline-hidden"
-      data-form-error-summary-target="heading"
-      tabindex="-1"
-    >
+  <div class="outline-hidden" data-controller="form-error-summary" tabindex="-1">
+    <h2 id="<%= heading_id %>" class="text-sm font-semibold">
       <%= title_text %>
     </h2>
 

--- a/app/components/form_error_summary_component.html.erb
+++ b/app/components/form_error_summary_component.html.erb
@@ -1,0 +1,27 @@
+<%= viral_alert(**alert_system_arguments) do %>
+  <section
+    aria-describedby="<%= description_id %>"
+    aria-labelledby="<%= heading_id %>"
+    class="outline-hidden"
+    data-controller="form-error-summary"
+    data-form-error-summary-announcement-value="<%= announcement_text %>"
+    tabindex="-1"
+  >
+    <h2 id="<%= heading_id %>" class="text-sm font-semibold"><%= title_text %></h2>
+    <p id="<%= description_id %>" class="mt-1"><%= description_text %></p>
+
+    <ul class="mt-2 list-disc space-y-1 ps-5">
+      <% entries.each do |entry| %>
+        <li>
+          <%= link_to entry.message,
+          entry.href,
+          class: "font-medium underline underline-offset-2",
+          data: {
+            action: "form-error-summary#focusField",
+            "form-error-summary-target-id-param": entry.target_id,
+          } %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+<% end %>

--- a/app/components/form_error_summary_component.html.erb
+++ b/app/components/form_error_summary_component.html.erb
@@ -4,7 +4,6 @@
     aria-labelledby="<%= heading_id %>"
     class="outline-hidden"
     data-controller="form-error-summary"
-    data-form-error-summary-announcement-value="<%= announcement_text %>"
     tabindex="-1"
   >
     <h2 id="<%= heading_id %>" class="text-sm font-semibold"><%= title_text %></h2>

--- a/app/components/form_error_summary_component.rb
+++ b/app/components/form_error_summary_component.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Renders an accessible validation summary with linked field errors.
+class FormErrorSummaryComponent < Component
+  attr_reader :entries
+
+  def initialize(entries:, **system_arguments)
+    @entries = Array(entries)
+    @system_arguments = system_arguments
+  end
+
+  def render?
+    entries.any?
+  end
+
+  private
+
+  attr_reader :system_arguments
+
+  def heading_id
+    @heading_id ||= "form-error-summary-heading-#{object_id}"
+  end
+
+  def description_id
+    @description_id ||= "form-error-summary-description-#{object_id}"
+  end
+
+  def title_text
+    I18n.t('general.form.error_summary.title', count: entries.count)
+  end
+
+  def description_text
+    I18n.t('general.form.error_notification')
+  end
+
+  def announcement_text
+    I18n.t('general.form.error_summary.announcement', count: entries.count)
+  end
+
+  def alert_system_arguments
+    {
+      type: :alert,
+      dismissible: false,
+      announce_alert: false,
+      classes: class_names('mb-4', system_arguments[:classes])
+    }
+  end
+end

--- a/app/components/form_error_summary_component.rb
+++ b/app/components/form_error_summary_component.rb
@@ -33,10 +33,6 @@ class FormErrorSummaryComponent < Component
     I18n.t('general.form.error_notification')
   end
 
-  def announcement_text
-    I18n.t('general.form.error_summary.announcement', count: entries.count)
-  end
-
   def alert_system_arguments
     system_arguments.except(:classes).merge(
       type: :alert,

--- a/app/components/form_error_summary_component.rb
+++ b/app/components/form_error_summary_component.rb
@@ -38,11 +38,14 @@ class FormErrorSummaryComponent < Component
   end
 
   def alert_system_arguments
-    {
+    system_arguments.except(:classes).merge(
       type: :alert,
       dismissible: false,
       announce_alert: false,
-      classes: class_names('mb-4', system_arguments[:classes])
-    }
+      classes: class_names(
+        'mb-4 outline-hidden focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-red-600',
+        system_arguments[:classes]
+      )
+    )
   end
 end

--- a/app/components/form_error_summary_entry_builder.rb
+++ b/app/components/form_error_summary_entry_builder.rb
@@ -20,7 +20,7 @@ class FormErrorSummaryEntryBuilder
     errors.attribute_names.uniq.filter_map do |attribute|
       next if attribute == :base
 
-      message = errors.full_messages_for(attribute).first
+      message = errors.full_messages_for(attribute).to_sentence
       target_id = target_id_for(attribute)
       next if message.blank? || target_id.blank?
 

--- a/app/components/form_error_summary_entry_builder.rb
+++ b/app/components/form_error_summary_entry_builder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Builds one linked summary entry per invalid form attribute.
+class FormErrorSummaryEntryBuilder
+  Entry = Data.define(:attribute, :message, :target_id) do
+    def href
+      "##{target_id}"
+    end
+  end
+
+  def initialize(builder:, errors: builder.object&.errors, target_overrides: {})
+    @builder = builder
+    @errors = errors
+    @target_overrides = target_overrides.to_h.transform_keys(&:to_s)
+  end
+
+  def call
+    return [] unless errors&.any?
+
+    errors.attribute_names.uniq.filter_map do |attribute|
+      next if attribute == :base
+
+      message = errors.full_messages_for(attribute).first
+      target_id = target_id_for(attribute)
+      next if message.blank? || target_id.blank?
+
+      Entry.new(attribute:, message:, target_id:)
+    end
+  end
+
+  private
+
+  attr_reader :builder, :errors, :target_overrides
+
+  def target_id_for(attribute)
+    target_overrides.fetch(attribute.to_s) do
+      builder.field_id(attribute)
+    end
+  end
+end

--- a/app/helpers/form_error_summary_helper.rb
+++ b/app/helpers/form_error_summary_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Helper for rendering a reusable, linked validation summary at the top of model-backed forms.
+module FormErrorSummaryHelper
+  # Place this near the top of a model-backed form.
+  # When migrating an existing form, remove invalid-only autofocus from the target fields so the
+  # summary remains the first focus target after a failed submit.
+  def form_error_summary(builder, target_overrides: {}, **system_arguments)
+    entries = FormErrorSummaryEntryBuilder.new(builder:, target_overrides:).call
+    return if entries.blank?
+
+    render FormErrorSummaryComponent.new(entries:, **system_arguments)
+  end
+end

--- a/app/javascript/controllers/form_error_summary_controller.js
+++ b/app/javascript/controllers/form_error_summary_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus";
+import { focusWhenVisible } from "utilities/focus";
+import { announce } from "utilities/live_region";
+
+export default class extends Controller {
+  static values = {
+    announcement: String,
+  };
+
+  connect() {
+    focusWhenVisible(this.element);
+
+    if (this.hasAnnouncementValue) {
+      announce(this.announcementValue, { politeness: "assertive" });
+    }
+  }
+
+  focusField(event) {
+    event.preventDefault();
+
+    const targetId = event.params.targetId;
+    const target = targetId ? document.getElementById(targetId) : null;
+    if (!target) return;
+
+    focusWhenVisible(target);
+    target.scrollIntoView({ block: "center", inline: "nearest" });
+  }
+}

--- a/app/javascript/controllers/form_error_summary_controller.js
+++ b/app/javascript/controllers/form_error_summary_controller.js
@@ -2,12 +2,8 @@ import { Controller } from "@hotwired/stimulus";
 import { focusWhenVisible } from "utilities/focus";
 
 export default class extends Controller {
-  static targets = ["heading"];
-
   connect() {
-    if (this.hasHeadingTarget) {
-      focusWhenVisible(this.headingTarget);
-    }
+    focusWhenVisible(this.element);
   }
 
   focusField(event) {

--- a/app/javascript/controllers/form_error_summary_controller.js
+++ b/app/javascript/controllers/form_error_summary_controller.js
@@ -1,18 +1,9 @@
 import { Controller } from "@hotwired/stimulus";
 import { focusWhenVisible } from "utilities/focus";
-import { announce } from "utilities/live_region";
 
 export default class extends Controller {
-  static values = {
-    announcement: String,
-  };
-
   connect() {
     focusWhenVisible(this.element);
-
-    if (this.hasAnnouncementValue) {
-      announce(this.announcementValue, { politeness: "assertive" });
-    }
   }
 
   focusField(event) {

--- a/app/javascript/controllers/form_error_summary_controller.js
+++ b/app/javascript/controllers/form_error_summary_controller.js
@@ -2,8 +2,12 @@ import { Controller } from "@hotwired/stimulus";
 import { focusWhenVisible } from "utilities/focus";
 
 export default class extends Controller {
+  static targets = ["heading"];
+
   connect() {
-    focusWhenVisible(this.element);
+    if (this.hasHeadingTarget) {
+      focusWhenVisible(this.headingTarget);
+    }
   }
 
   focusField(event) {

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,23 +1,17 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4", novalidate: true }) do |f| %>
-  <%= if resource.errors.any?
-    viral_alert(
-      type: "alert",
-      message: I18n.t(:"general.form.error_notification"),
-      aria: {
-        live: "assertive",
-      },
-    )
-  end %>
+  <%= form_error_summary(f) %>
 
   <%= render partial: "shared/form/required_field_legend" %>
 
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
   <% invalid_email = resource.errors.include?(:email) %>
+
   <div class="form-field <%= 'invalid' if invalid_email %>">
     <%= f.label :email, data: { required: true } %>
+
     <%= f.email_field :email,
-                  autofocus: true,
+                  autofocus: resource.errors.none?,
                   required: true,
                   aria: {
                     describedby: invalid_email ? f.field_id(:email, "error") : nil,
@@ -25,6 +19,7 @@
                     required: true,
                   },
                   autocomplete: "email" %>
+
     <%= if invalid_email
       render "shared/form/field_errors",
       id: f.field_id(:email, "error"),
@@ -33,8 +28,10 @@
   </div>
 
   <% invalid_first_name = resource.errors.include?(:first_name) %>
+
   <div class="form-field <%= 'invalid' if invalid_first_name %>">
     <%= f.label :first_name, data: { required: true } %>
+
     <%= f.text_field :first_name,
                  required: true,
                  aria: {
@@ -44,6 +41,7 @@
                    required: true,
                  },
                  autocomplete: "given-name" %>
+
     <%= if invalid_first_name
       render "shared/form/field_errors",
       id: f.field_id(:first_name, "error"),
@@ -52,8 +50,10 @@
   </div>
 
   <% invalid_last_name = resource.errors.include?(:last_name) %>
+
   <div class="form-field <%= 'invalid' if invalid_last_name %>">
     <%= f.label :last_name, data: { required: true } %>
+
     <%= f.text_field :last_name,
                  required: true,
                  aria: {
@@ -63,6 +63,7 @@
                    required: true,
                  },
                  autocomplete: "family-name" %>
+
     <%= if invalid_last_name
       render "shared/form/field_errors",
       id: f.field_id(:last_name, "error"),
@@ -71,8 +72,10 @@
   </div>
 
   <% invalid_password = resource.errors.include?(:password) %>
+
   <div class="form-field <%= 'invalid' if invalid_password %>">
     <%= f.label :password, data: { required: true } %>
+
     <%= f.password_field :password,
                      required: true,
                      aria: {
@@ -84,8 +87,11 @@
                      autocomplete: "new-password" %>
 
     <% if @minimum_password_length %>
-      <span class="text-sm font-light text-slate-500 dark:text-slate-400"><%= t(".password_hint", minimum_password_length: @minimum_password_length) %></span>
+      <span class="text-sm font-light text-slate-500 dark:text-slate-400">
+        <%= t(".password_hint", minimum_password_length: @minimum_password_length) %>
+      </span>
     <% end %>
+
     <%= if invalid_password
       render "shared/form/field_errors",
       id: f.field_id(:password, "error"),
@@ -94,8 +100,10 @@
   </div>
 
   <% invalid_password_confirmation = resource.errors.include?(:password_confirmation) %>
+
   <div class="form-field <%= 'invalid' if invalid_password_confirmation %>">
     <%= f.label :password_confirmation, data: { required: true } %>
+
     <%= f.password_field :password_confirmation,
                      required: true,
                      aria: {
@@ -122,7 +130,9 @@
   <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>
 <% end %>
 
-<div class="flex"><span class="mr-2 dark:text-white"><%= t(".signed_up") %></span>
+<div class="flex">
+  <span class="mr-2 dark:text-white"><%= t(".signed_up") %></span>
+
   <div class="grid gap-2">
     <%= render "devise/shared/links" %>
   </div>

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -85,7 +85,7 @@
     <% if invalid_namespace %>
       <%= render "shared/form/field_errors",
       id: builder.field_id(:namespace, "error"),
-      errors: @project.namespace.errors.messages.values.flatten %>
+      errors: @project.namespace.errors.full_messages_for(:namespace) %>
     <% end %>
 
     <span id="<%= builder.field_id(:namespace, "hint") %>" class="field-hint">

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -1,18 +1,12 @@
-<%= if @project.namespace.errors.any?
-  viral_alert(
-    type: "alert",
-    message: I18n.t(:"general.form.error_notification"),
-    aria: {
-      live: "assertive",
-    },
-  )
-end %>
+<%= form_error_summary(builder, target_overrides: { namespace: "namespace-select" }) %>
 
 <%= render partial: "shared/form/required_field_legend" %>
 
 <% invalid_name = @project.namespace.errors.include?(:name) %>
+
 <div class="form-field <%= 'invalid' if invalid_name %>">
   <%= builder.label :name, data: { required: true } %>
+
   <%= builder.text_field :name,
                      data: {
                        "slugify-target": "name",
@@ -20,30 +14,31 @@ end %>
                      },
                      required: true,
                      placeholder: t(:"projects.new.placeholder"),
-                     aria: {
-                       describedby: [
-                         invalid_name ? builder.field_id(:name, "error") : nil,
-                         builder.field_id(:name, "hint"),
-                       ].join(" "),
-                       invalid: invalid_name,
-                       required: true,
-                     },
-                     autofocus: invalid_name %>
+                      aria: {
+                        describedby: [
+                          invalid_name ? builder.field_id(:name, "error") : nil,
+                          builder.field_id(:name, "hint"),
+                        ].join(" "),
+                        invalid: invalid_name,
+                        required: true,
+                      } %>
 
   <% if invalid_name %>
     <%= render "shared/form/field_errors",
     id: builder.field_id(:name, "error"),
     errors: @project.namespace.errors.full_messages_for(:name) %>
   <% end %>
-  <span id="<%= builder.field_id(:name, "hint") %>" class="field-hint">
-    <%== t(:"projects.create.name_help") %>
-  </span>
+
+  <span id="<%= builder.field_id(:name, "hint") %>" class="field-hint"><%== t(:"projects.create.name_help") %></span>
 </div>
-<fieldset class="grid @xs:grid-cols-1 @5xl:grid-cols-2 gap-4 border-0 p-0 m-0">
+
+<fieldset class="m-0 grid gap-4 border-0 p-0 @xs:grid-cols-1 @5xl:grid-cols-2">
   <legend class="sr-only"><%= t(:"projects.create.namespace_and_path") %></legend>
   <% invalid_namespace = @project.namespace.errors.include?(:namespace) %>
+
   <div class="form-field <%= 'invalid' if invalid_namespace %>">
     <% form_id = "namespace-select" %>
+
     <%= builder.label :parent_id,
                   t(
                     "activerecord.attributes.namespaces/project_namespace.parent_id",
@@ -54,9 +49,17 @@ end %>
                   },
                   class:
                     "mb-1 block text-sm font-medium text-slate-900 dark:text-white" %>
+
     <div>
       <% selected_value =
-        params.has_key?(:group_id) ? params[:group_id] : current_user.namespace.id %>
+        if invalid_namespace && builder.object.parent_id.blank?
+          nil
+        elsif params[:group_id].presence
+          params[:group_id]
+        else
+          builder.object.parent_id.presence || current_user.namespace.id
+        end %>
+
       <%= viral_prefixed_select2(form: builder, name: :parent_id, id: form_id, selected_value: selected_value, placeholder: t(:"projects.new.select_namespace"), required: true, aria: { invalid: invalid_namespace,
       describedby: [invalid_namespace ? builder.field_id(:namespace, "error") : nil, builder.field_id(:namespace, "hint")].join(" ") } ) do |select| %>
         <% authorized_namespaces.each do |namespace| %>
@@ -64,24 +67,21 @@ end %>
                       value: namespace.id,
                       label: namespace.full_path,
                     ) do %>
-            <span
-              class="
-                text-slate-900 dark:text-slate-400 font-semibold block pointer-events-none
-              "
-            >
+            <span class="pointer-events-none block font-semibold text-slate-900 dark:text-slate-400">
               <%= namespace.name %>
               <%= render PuidComponent.new(puid: namespace.puid, show_clipboard: false) %>
             </span>
-            <span class="text-slate-600 dark:text-white block pointer-events-none">
-              <%= namespace.full_path %>
-            </span>
+
+            <span class="pointer-events-none block text-slate-600 dark:text-white"><%= namespace.full_path %></span>
           <% end %>
         <% end %>
+
         <%= select.with_empty_state do %>
           <%= t(:"projects.new.empty_state") %>
         <% end %>
       <% end %>
     </div>
+
     <% if invalid_namespace %>
       <%= render "shared/form/field_errors",
       id: builder.field_id(:namespace, "error"),
@@ -94,8 +94,10 @@ end %>
   </div>
 
   <% invalid_path = @project.namespace.errors.include?(:path) %>
+
   <div class="form-field <%= 'invalid' if invalid_path %>">
     <%= builder.label :path, data: { required: true } %>
+
     <%= builder.text_field :path,
                        data: {
                          "slugify-target": "path",
@@ -103,30 +105,30 @@ end %>
                        pattern: Irida::PathRegex::PATH_REGEX_STR,
                        required: true,
                        title: t(:"projects.new.help"),
-                       aria: {
-                         describedby: [
-                           invalid_path ? builder.field_id(:path, "error") : nil,
-                           builder.field_id(:path, "hint"),
-                         ].join(" "),
-                         invalid: invalid_path,
-                         required: true,
-                       },
-                       autofocus: invalid_path %>
+                        aria: {
+                          describedby: [
+                            invalid_path ? builder.field_id(:path, "error") : nil,
+                            builder.field_id(:path, "hint"),
+                          ].join(" "),
+                          invalid: invalid_path,
+                          required: true,
+                        } %>
 
     <% if invalid_path %>
       <%= render "shared/form/field_errors",
       id: builder.field_id(:path, "error"),
       errors: @project.namespace.errors.full_messages_for(:path) %>
     <% end %>
-    <span id="<%= builder.field_id(:path, "hint") %>" class="field-hint">
-      <%= t(:"projects.create.path_help") %>
-    </span>
 
+    <span id="<%= builder.field_id(:path, "hint") %>" class="field-hint"><%= t(:"projects.create.path_help") %></span>
   </div>
 </fieldset>
+
 <% invalid_description = @project.namespace.errors.include?(:description) %>
+
 <div class="form-field <%= 'invalid' if invalid_description %>">
   <%= builder.label :description %>
+
   <%= builder.text_area :description,
                     {
                       :class => "form-control",
@@ -139,15 +141,16 @@ end %>
                           end
                         ),
                         builder.field_id(:description, "hint"),
-                      ].join(" "),
-                      "aria-invalid" => invalid_description,
-                      :autofocus => invalid_description,
-                    } %>
+                       ].join(" "),
+                       "aria-invalid" => invalid_description,
+                     } %>
+
   <% if invalid_description %>
     <%= render "shared/form/field_errors",
     id: builder.field_id(:description, "error"),
     errors: @project.namespace.errors.full_messages_for(:description) %>
   <% end %>
+
   <span id="<%= builder.field_id(:description, "hint") %>" class="field-hint">
     <%= t(:"projects.create.description_help") %>
   </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -722,9 +722,6 @@ en:
     form:
       error_notification: 'Please review the following problems:'
       error_summary:
-        announcement:
-          one: There is 1 field with problems preventing submission
-          other: There are %{count} fields with problems preventing submission
         title:
           one: There is 1 field with problems preventing submission
           other: There are %{count} fields with problems preventing submission

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -723,11 +723,11 @@ en:
       error_notification: 'Please review the following problems:'
       error_summary:
         announcement:
-          one: There is 1 problem with your submission
-          other: There are %{count} problems with your submission
+          one: There is 1 field with problems preventing submission
+          other: There are %{count} fields with problems preventing submission
         title:
-          one: There is 1 problem with your submission
-          other: There are %{count} problems with your submission
+          one: There is 1 field with problems preventing submission
+          other: There are %{count} fields with problems preventing submission
     help: Help
     name: IRIDA Next
     navbar:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -720,7 +720,14 @@ en:
       title: Your work
       workflows: Workflow Executions
     form:
-      error_notification: 'Please review the problems below:'
+      error_notification: 'Please review the following problems:'
+      error_summary:
+        announcement:
+          one: There is 1 problem with your submission
+          other: There are %{count} problems with your submission
+        title:
+          one: There is 1 problem with your submission
+          other: There are %{count} problems with your submission
     help: Help
     name: IRIDA Next
     navbar:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -722,7 +722,14 @@ fr:
       title: Votre travail
       workflows: Exécutions de flux de travail
     form:
-      error_notification: 'Veuillez examiner les problèmes ci-dessous:'
+      error_notification: 'Veuillez examiner les problèmes suivants :'
+      error_summary:
+        announcement:
+          one: Il y a 1 problème avec votre soumission
+          other: Il y a %{count} problèmes avec votre soumission
+        title:
+          one: Il y a 1 problème avec votre soumission
+          other: Il y a %{count} problèmes avec votre soumission
     help: Aide
     name: IRIDA Next
     navbar:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -725,11 +725,11 @@ fr:
       error_notification: 'Veuillez examiner les problèmes suivants :'
       error_summary:
         announcement:
-          one: Il y a 1 problème avec votre soumission
-          other: Il y a %{count} problèmes avec votre soumission
+          one: Il y a 1 champ présentant un problème qui empêche la soumission
+          other: Il y a %{count} champs présentant des problèmes qui empêchent la soumission
         title:
-          one: Il y a 1 problème avec votre soumission
-          other: Il y a %{count} problèmes avec votre soumission
+          one: Il y a 1 champ présentant un problème qui empêche la soumission
+          other: Il y a %{count} champs présentant des problèmes qui empêchent la soumission
     help: Aide
     name: IRIDA Next
     navbar:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -724,9 +724,6 @@ fr:
     form:
       error_notification: 'Veuillez examiner les problèmes suivants :'
       error_summary:
-        announcement:
-          one: Il y a 1 champ présentant un problème qui empêche la soumission
-          other: Il y a %{count} champs présentant des problèmes qui empêchent la soumission
         title:
           one: Il y a 1 champ présentant un problème qui empêche la soumission
           other: Il y a %{count} champs présentant des problèmes qui empêchent la soumission

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -33,6 +33,28 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     assert_selector 'a[href="#user_last_name"]', text: user.errors.full_messages_for(:last_name).first
     assert_selector 'a', text: user.errors.full_messages_for(:email).first, count: 1
     assert_no_text user.errors.full_messages_for(:email).second
+    assert_selector ".alert-component[class*='focus-within:outline-red-600']"
+  end
+
+  test 'component forwards caller-provided system arguments to the alert wrapper' do
+    entries = [
+      FormErrorSummaryEntryBuilder::Entry.new(
+        attribute: :email,
+        message: "Email can't be blank",
+        target_id: 'user_email'
+      )
+    ]
+
+    render_inline(
+      FormErrorSummaryComponent.new(
+        entries:,
+        id: 'custom-summary',
+        data: { testid: 'form-summary' },
+        aria: { label: 'Form error summary' }
+      )
+    )
+
+    assert_selector '.alert-component#custom-summary[data-testid="form-summary"][aria-label="Form error summary"]'
   end
 
   test 'entry builder derives nested builder target ids' do

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -28,9 +28,10 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     email_message = user.errors.full_messages_for(:email).to_sentence
 
     assert_selector '.alert-component', count: 1
-    assert_selector '[data-controller="form-error-summary"]', count: 1
+    assert_selector 'div[data-controller="form-error-summary"]', count: 1
     assert_no_selector '[data-form-error-summary-announcement-value]'
-    assert_selector 'h2', text: I18n.t('general.form.error_summary.title', count: 2)
+    assert_selector 'h2[data-form-error-summary-target="heading"][aria-describedby][tabindex="-1"]',
+                    text: I18n.t('general.form.error_summary.title', count: 2)
     assert_selector 'p', text: I18n.t('general.form.error_notification')
     assert_selector 'a[href="#user_email"]', text: email_message
     assert_selector 'a[href="#user_last_name"]', text: user.errors.full_messages_for(:last_name).first

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -15,7 +15,7 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     assert_empty FormErrorSummaryEntryBuilder.new(builder:).call
   end
 
-  test 'component renders one linked entry per invalid field using the first message' do
+  test 'component renders one linked entry per invalid field using all messages' do
     user = build_user
     user.errors.add(:email, :blank)
     user.errors.add(:email, :invalid)
@@ -25,14 +25,15 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
 
     render_inline(FormErrorSummaryComponent.new(entries:))
 
+    email_message = user.errors.full_messages_for(:email).to_sentence
+
     assert_selector '.alert-component', count: 1
     assert_selector '[data-controller="form-error-summary"]', count: 1
     assert_selector 'h2', text: I18n.t('general.form.error_summary.title', count: 2)
     assert_selector 'p', text: I18n.t('general.form.error_notification')
-    assert_selector 'a[href="#user_email"]', text: user.errors.full_messages_for(:email).first
+    assert_selector 'a[href="#user_email"]', text: email_message
     assert_selector 'a[href="#user_last_name"]', text: user.errors.full_messages_for(:last_name).first
-    assert_selector 'a', text: user.errors.full_messages_for(:email).first, count: 1
-    assert_no_text user.errors.full_messages_for(:email).second
+    assert_selector 'a', text: email_message, count: 1
     assert_selector ".alert-component[class*='focus-within:outline-red-600']"
   end
 

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -28,9 +28,9 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     email_message = user.errors.full_messages_for(:email).to_sentence
 
     assert_selector '.alert-component', count: 1
-    assert_selector 'div[data-controller="form-error-summary"]', count: 1
-    assert_no_selector '[data-form-error-summary-announcement-value]'
-    assert_selector 'h2[data-form-error-summary-target="heading"][aria-describedby][tabindex="-1"]',
+    assert_selector 'div[data-controller="form-error-summary"][tabindex="-1"]', count: 1
+    assert_no_selector '#sr-status'
+    assert_selector 'h2',
                     text: I18n.t('general.form.error_summary.title', count: 2)
     assert_selector 'p', text: I18n.t('general.form.error_notification')
     assert_selector 'a[href="#user_email"]', text: email_message

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -29,6 +29,7 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
 
     assert_selector '.alert-component', count: 1
     assert_selector '[data-controller="form-error-summary"]', count: 1
+    assert_no_selector '[data-form-error-summary-announcement-value]'
     assert_selector 'h2', text: I18n.t('general.form.error_summary.title', count: 2)
     assert_selector 'p', text: I18n.t('general.form.error_notification')
     assert_selector 'a[href="#user_email"]', text: email_message

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'view_component_test_case'
+
+class FormErrorSummaryComponentTest < ViewComponentTestCase
+  test 'component does not render when there are no entries' do
+    render_inline(FormErrorSummaryComponent.new(entries: []))
+
+    assert_no_selector '.alert-component'
+  end
+
+  test 'entry builder returns no entries when the builder has no validation errors' do
+    builder = build_form_builder('user', build_user)
+
+    assert_empty FormErrorSummaryEntryBuilder.new(builder:).call
+  end
+
+  test 'component renders one linked entry per invalid field using the first message' do
+    user = build_user
+    user.errors.add(:email, :blank)
+    user.errors.add(:email, :invalid)
+    user.errors.add(:last_name, :blank)
+
+    entries = FormErrorSummaryEntryBuilder.new(builder: build_form_builder('user', user)).call
+
+    render_inline(FormErrorSummaryComponent.new(entries:))
+
+    assert_selector '.alert-component', count: 1
+    assert_selector '[data-controller="form-error-summary"]', count: 1
+    assert_selector 'h2', text: I18n.t('general.form.error_summary.title', count: 2)
+    assert_selector 'p', text: I18n.t('general.form.error_notification')
+    assert_selector 'a[href="#user_email"]', text: user.errors.full_messages_for(:email).first
+    assert_selector 'a[href="#user_last_name"]', text: user.errors.full_messages_for(:last_name).first
+    assert_selector 'a', text: user.errors.full_messages_for(:email).first, count: 1
+    assert_no_text user.errors.full_messages_for(:email).second
+  end
+
+  test 'entry builder derives nested builder target ids' do
+    namespace = Namespaces::ProjectNamespace.new
+    namespace.errors.add(:path, :taken)
+
+    entry = FormErrorSummaryEntryBuilder.new(
+      builder: build_form_builder('project[namespace_attributes]', namespace)
+    ).call.first
+
+    assert_equal :path, entry.attribute
+    assert_equal 'project_namespace_attributes_path', entry.target_id
+  end
+
+  test 'override path uses validation attributes and raw target ids' do
+    namespace = Namespaces::ProjectNamespace.new
+    namespace.errors.add(:namespace, 'required')
+
+    entries = FormErrorSummaryEntryBuilder.new(
+      builder: build_form_builder('project[namespace_attributes]', namespace),
+      target_overrides: { namespace: 'namespace-select' }
+    ).call
+
+    render_inline(FormErrorSummaryComponent.new(entries:))
+
+    assert_selector 'a[href="#namespace-select"]', text: 'Namespace required'
+  end
+
+  private
+
+  def build_form_builder(object_name, object)
+    template = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
+    ActionView::Helpers::FormBuilder.new(object_name, object, template, {})
+  end
+
+  def build_user
+    User.new(
+      email: 'test@example.com',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      password: 'Password123!',
+      password_confirmation: 'Password123!',
+      locale: I18n.default_locale.to_s
+    )
+  end
+end

--- a/test/components/previews/form_error_summary_component_preview.rb
+++ b/test/components/previews/form_error_summary_component_preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FormErrorSummaryComponentPreview < ViewComponent::Preview
+  def focus_demo
+    render_with_template(locals: {
+                           entries: [
+                             entry(attribute: :email, message: "Email can't be blank", target_id: 'user_email'),
+                             entry(attribute: :namespace,
+                                   message: 'Namespace required',
+                                   target_id: 'namespace-select')
+                           ]
+                         })
+  end
+
+  private
+
+  def entry(attribute:, message:, target_id:)
+    FormErrorSummaryEntryBuilder::Entry.new(
+      attribute:,
+      message:,
+      target_id:
+    )
+  end
+end

--- a/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
+++ b/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
@@ -1,5 +1,4 @@
 <div class="mx-auto max-w-2xl space-y-4 p-4">
-  <%= render LiveRegionComponent.new(id: "sr-status", politeness: :assertive) %>
   <%= render FormErrorSummaryComponent.new(entries:) %>
 
   <div class="form-field">

--- a/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
+++ b/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
@@ -1,0 +1,38 @@
+<div class="mx-auto max-w-2xl space-y-4 p-4">
+  <%= render LiveRegionComponent.new(id: "sr-status", politeness: :assertive) %>
+  <%= render FormErrorSummaryComponent.new(entries:) %>
+
+  <div class="form-field">
+    <label for="user_email">Email</label>
+
+    <input
+      id="user_email"
+      aria-describedby="user_email_error"
+      aria-invalid="true"
+      autocomplete="email"
+      class="block w-full"
+      type="email"
+    >
+
+    <ul id="user_email_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
+      <li><%= viral_help_text(state: :error) { "Email can't be blank" } %></li>
+    </ul>
+  </div>
+
+  <div class="form-field">
+    <label for="namespace-select">Namespace</label>
+
+    <input
+      id="namespace-select"
+      aria-describedby="namespace_error"
+      aria-invalid="true"
+      autocomplete="off"
+      class="block w-full"
+      type="text"
+    >
+
+    <ul id="namespace_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
+      <li><%= viral_help_text(state: :error) { 'Namespace required' } %></li>
+    </ul>
+  </div>
+</div>

--- a/test/components/system/form_error_summary_component_test.rb
+++ b/test/components/system/form_error_summary_component_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module System
+  class FormErrorSummaryComponentTest < ApplicationSystemTestCase
+    test 'focus demo' do
+      visit('rails/view_components/form_error_summary_component/focus_demo')
+
+      assert_selector '[data-controller="form-error-summary"]', focused: true
+      assert_selector '#sr-status',
+                      text: I18n.t('general.form.error_summary.announcement', count: 2),
+                      visible: false
+
+      within '[data-controller="form-error-summary"]' do
+        click_link "Email can't be blank"
+      end
+      assert_selector '#user_email', focused: true
+
+      within '[data-controller="form-error-summary"]' do
+        click_link 'Namespace required'
+      end
+      assert_selector '#namespace-select', focused: true
+
+      assert_accessible
+    end
+  end
+end

--- a/test/components/system/form_error_summary_component_test.rb
+++ b/test/components/system/form_error_summary_component_test.rb
@@ -8,9 +8,7 @@ module System
       visit('rails/view_components/form_error_summary_component/focus_demo')
 
       assert_selector '[data-controller="form-error-summary"]', focused: true
-      assert_selector '#sr-status',
-                      text: I18n.t('general.form.error_summary.announcement', count: 2),
-                      visible: false
+      assert_selector '[data-controller="form-error-summary"][aria-describedby][aria-labelledby][tabindex="-1"]'
 
       within '[data-controller="form-error-summary"]' do
         click_link "Email can't be blank"

--- a/test/components/system/form_error_summary_component_test.rb
+++ b/test/components/system/form_error_summary_component_test.rb
@@ -7,8 +7,8 @@ module System
     test 'focus demo' do
       visit('rails/view_components/form_error_summary_component/focus_demo')
 
-      assert_selector 'h2[data-form-error-summary-target="heading"]', focused: true
-      assert_selector 'h2[data-form-error-summary-target="heading"][aria-describedby][tabindex="-1"]'
+      assert_selector '[data-controller="form-error-summary"]', focused: true
+      assert_selector 'div[data-controller="form-error-summary"][tabindex="-1"]'
 
       within '[data-controller="form-error-summary"]' do
         click_link "Email can't be blank"

--- a/test/components/system/form_error_summary_component_test.rb
+++ b/test/components/system/form_error_summary_component_test.rb
@@ -7,8 +7,8 @@ module System
     test 'focus demo' do
       visit('rails/view_components/form_error_summary_component/focus_demo')
 
-      assert_selector '[data-controller="form-error-summary"]', focused: true
-      assert_selector '[data-controller="form-error-summary"][aria-describedby][aria-labelledby][tabindex="-1"]'
+      assert_selector 'h2[data-form-error-summary-target="heading"]', focused: true
+      assert_selector 'h2[data-form-error-summary-target="heading"][aria-describedby][tabindex="-1"]'
 
       within '[data-controller="form-error-summary"]' do
         click_link "Email can't be blank"

--- a/test/helpers/project_namespace_fields_partial_test.rb
+++ b/test/helpers/project_namespace_fields_partial_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProjectNamespaceFieldsPartialTest < ActionView::TestCase
+  test 'namespace inline error only shows namespace messages' do
+    user = users(:john_doe)
+    @project = Project.new
+    namespace = @project.build_namespace(name: 'a', path: 'new-project', parent_id: user.namespace.id)
+    namespace.errors.add(:namespace, I18n.t('services.projects.create.namespace_required'))
+    namespace.errors.add(:name, 'is too short')
+
+    render partial: 'projects/project_namespace_fields',
+           locals: {
+             builder: build_form_builder('project[namespace_attributes]', namespace),
+             authorized_namespaces: [user.namespace]
+           }
+
+    assert_select '#project_namespace_attributes_namespace_error', text: /Namespace required/
+    assert_select '#project_namespace_attributes_namespace_error', text: /Name is too short/, count: 0
+    assert_select '#project_namespace_attributes_name_error', text: /Name is too short/
+  end
+
+  private
+
+  def build_form_builder(object_name, object)
+    ActionView::Helpers::FormBuilder.new(object_name, object, self, {})
+  end
+
+  def current_user
+    users(:john_doe)
+  end
+
+  def params
+    ActionController::Parameters.new
+  end
+end

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -159,9 +159,6 @@ class ProjectsTest < ApplicationSystemTestCase
     end
 
     assert_selector 'turbo-frame#project_form [data-controller="form-error-summary"]', focused: true
-    assert_selector '#sr-status',
-                    text: I18n.t('general.form.error_summary.announcement', count: 1),
-                    visible: false
     assert_selector '#project_namespace_attributes_namespace_error',
                     text: I18n.t('services.projects.create.namespace_required')
 

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -142,6 +142,39 @@ class ProjectsTest < ApplicationSystemTestCase
     assert_current_path new_project_path
   end
 
+  test 'invalid nested project create focuses the summary and namespace link' do
+    visit new_project_path
+
+    within %(div[data-controller="slugify"][data-controller-connected="true"]) do
+      fill_in 'Name', with: 'New Project'
+      fill_in 'Path', with: 'new-project'
+      page.execute_script <<~JS
+        const namespaceField = document.querySelector('[name="project[namespace_attributes][parent_id]"]');
+        if (namespaceField) {
+          namespaceField.value = "";
+          namespaceField.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+      JS
+      click_on I18n.t(:'projects.new.submit')
+    end
+
+    assert_selector 'turbo-frame#project_form [data-controller="form-error-summary"]', focused: true
+    assert_selector '#sr-status',
+                    text: I18n.t('general.form.error_summary.announcement', count: 1),
+                    visible: false
+    assert_selector '#project_namespace_attributes_namespace_error',
+                    text: I18n.t('services.projects.create.namespace_required')
+
+    within 'turbo-frame#project_form [data-controller="form-error-summary"]' do
+      click_link I18n.t('services.projects.create.namespace_required')
+    end
+
+    assert_selector '#namespace-select', focused: true
+    click_on I18n.t(:'projects.new.submit')
+    assert_selector 'turbo-frame#project_form [data-controller="form-error-summary"]', focused: true
+    assert_accessible
+  end
+
   test 'can update project name and description' do
     project_name = 'New Project'
     project_description = 'New Project Description'

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class RegistrationsTest < ApplicationSystemTestCase
+  setup do
+    @settings = Irida::CurrentSettings.current_application_settings
+    @original_signup_enabled = @settings.signup_enabled
+    @original_password_authentication_enabled = @settings.password_authentication_enabled
+
+    @settings.update(signup_enabled: true, password_authentication_enabled: true)
+  end
+
+  teardown do
+    @settings.update(
+      signup_enabled: @original_signup_enabled,
+      password_authentication_enabled: @original_password_authentication_enabled
+    )
+  end
+
+  test 'invalid sign up focuses the summary and linked control' do
+    visit new_user_registration_path
+
+    click_button I18n.t(:'devise.registrations.new.submit_button')
+
+    assert_selector '[data-controller="form-error-summary"]', focused: true
+    assert_selector '#sr-status',
+                    text: I18n.t('general.form.error_summary.announcement', count: 4),
+                    visible: false
+    assert_selector '#user_email_error', text: "Email can't be blank"
+
+    within '[data-controller="form-error-summary"]' do
+      click_link "Email can't be blank"
+    end
+
+    assert_selector '#user_email', focused: true
+    assert_accessible
+  end
+end

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -24,9 +24,6 @@ class RegistrationsTest < ApplicationSystemTestCase
     click_button I18n.t(:'devise.registrations.new.submit_button')
 
     assert_selector '[data-controller="form-error-summary"]', focused: true
-    assert_selector '#sr-status',
-                    text: I18n.t('general.form.error_summary.announcement', count: 4),
-                    visible: false
     assert_selector '#user_email_error', text: "Email can't be blank"
 
     within '[data-controller="form-error-summary"]' do


### PR DESCRIPTION
## What does this PR do and why?

When a form has validation errors, there's no good way for screen reader users to know what went wrong. This PR adds a form error summary component that shows a list of all the errors at the top of the form. Each error is a link that jumps focus to the field with the problem. When the summary appears, it announces itself to screen readers using an ARIA live region.

The component is now used on the project creation form and the registration form.

## Screenshots or screen recordings

<img width="1825" height="857" alt="image" src="https://github.com/user-attachments/assets/4042e5c3-ac3a-4208-ab7d-47ccfae8c9e1" />

<img width="2021" height="901" alt="image" src="https://github.com/user-attachments/assets/6acad7d0-4b76-4826-a294-5a8498ddd3bc" />

## How to set up and validate locally

1. Start the dev server: `bin/dev`
2. Go to the new project page or the sign up page
3. Submit the form without filling anything in
4. You should see the error summary at the top with links to each field
5. Click a link — it should move focus to that field
6. If you have a screen reader, the summary should be announced when it appears

## PR acceptance checklist

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.