### PR TITLE
A11Y: select-page accessibility state in workflow executions

### DIFF
--- a/app/components/samples/table/v1/component.rb
+++ b/app/components/samples/table/v1/component.rb
@@ -72,10 +72,8 @@ module Samples
           args[:data][:'selection-total-value'] = @pagy.count
           args[:data][:'selection-action-button-outlet'] = '.action-button'
           # i18n-tasks-use t('components.samples.table_component.counts.status')
-          args[:data][:'selection-count-message-one-value'] =
-            I18n.t('components.samples.table_component.counts.status.one')
-          args[:data][:'selection-count-message-other-value'] =
-            I18n.t('components.samples.table_component.counts.status.other')
+          args[:data][:'selection-count-message-value'] =
+            I18n.t('components.samples.table_component.counts.status')
         end
 
         def wrapper_arguments

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -2,6 +2,11 @@
   <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
     <%= render Viral::BaseComponent.new(**system_arguments) do %>
       <%= render LiveRegionComponent.new(controller: "selection") %>
+      <span
+        id="select-page-status"
+        class="sr-only"
+        data-selection-target="selectPageStatus"
+      ></span>
 
       <table
         class="w-full text-left text-sm whitespace-nowrap text-slate-500 rtl:text-right dark:text-slate-400"
@@ -32,6 +37,7 @@
                       id: "select-page",
                       aria: {
                         label: t(:".select_page"),
+                        describedby: "select-page-status",
                       },
                       data: {
                         table: true,

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -4,6 +4,9 @@
       <%= render LiveRegionComponent.new(controller: "selection") %>
       <span
         id="select-page-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
         class="sr-only"
         data-selection-target="selectPageStatus"
       ></span>

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -34,7 +34,6 @@
                       id: "select-page",
                       aria: {
                         label: t(:".select_page"),
-                        describedby: "select-page-status",
                       },
                       data: {
                         table: true,

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -3,14 +3,7 @@
     <%= render Viral::BaseComponent.new(**system_arguments) do %>
       <%= render LiveRegionComponent.new(controller: "selection") %>
 
-      <span
-        id="select-page-status"
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        class="sr-only"
-        data-selection-target="selectPageStatus"
-      ></span>
+      <span id="select-page-status" class="sr-only" data-selection-target="selectPageStatus"></span>
 
       <table
         class="w-full text-left text-sm whitespace-nowrap text-slate-500 rtl:text-right dark:text-slate-400"

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -2,6 +2,7 @@
   <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
     <%= render Viral::BaseComponent.new(**system_arguments) do %>
       <%= render LiveRegionComponent.new(controller: "selection") %>
+
       <span
         id="select-page-status"
         role="status"

--- a/app/components/workflow_executions/table_component.rb
+++ b/app/components/workflow_executions/table_component.rb
@@ -87,20 +87,25 @@ module WorkflowExecutions
     private
 
     def add_selection_data_attributes(args)
-      args[:data] ||= {}
-      args[:data][:controller] = 'selection'
-      args[:data][:'selection-total-value'] = @pagy.count
-      args[:data][:'selection-action-button-outlet'] = '.action-button'
-      args[:data][:'selection-count-message-one-value'] =
-        I18n.t('components.workflow_executions.table_component.counts.one')
-      args[:data][:'selection-count-message-other-value'] =
-        I18n.t('components.workflow_executions.table_component.counts.other')
-      args[:data][:'selection-select-page-none-value'] =
-        I18n.t('components.workflow_executions.table_component.select_page_state.none')
-      args[:data][:'selection-select-page-some-value'] =
-        I18n.t('components.workflow_executions.table_component.select_page_state.some')
-      args[:data][:'selection-select-page-all-value'] =
-        I18n.t('components.workflow_executions.table_component.select_page_state.all')
+      args[:data] = (args[:data] || {}).merge(selection_data_attributes)
+    end
+
+    def selection_data_attributes
+      {
+        controller: 'selection',
+        'selection-total-value': @pagy.count,
+        'selection-action-button-outlet': '.action-button',
+        'selection-count-message-one-value':
+          I18n.t('components.workflow_executions.table_component.counts.one'),
+        'selection-count-message-other-value':
+          I18n.t('components.workflow_executions.table_component.counts.other'),
+        'selection-select-page-none-value':
+          I18n.t('components.workflow_executions.table_component.select_page_state.none'),
+        'selection-select-page-some-value':
+          I18n.t('components.workflow_executions.table_component.select_page_state.some'),
+        'selection-select-page-all-value':
+          I18n.t('components.workflow_executions.table_component.select_page_state.all')
+      }
     end
 
     def columns

--- a/app/components/workflow_executions/table_component.rb
+++ b/app/components/workflow_executions/table_component.rb
@@ -95,10 +95,8 @@ module WorkflowExecutions
         controller: 'selection',
         'selection-total-value': @pagy.count,
         'selection-action-button-outlet': '.action-button',
-        'selection-count-message-one-value':
-          I18n.t('components.workflow_executions.table_component.counts.one'),
-        'selection-count-message-other-value':
-          I18n.t('components.workflow_executions.table_component.counts.other'),
+        'selection-count-message-value':
+          I18n.t('components.workflow_executions.table_component.counts.status'),
         'selection-select-page-none-value':
           I18n.t('components.workflow_executions.table_component.select_page_state.none'),
         'selection-select-page-some-value':

--- a/app/components/workflow_executions/table_component.rb
+++ b/app/components/workflow_executions/table_component.rb
@@ -95,6 +95,12 @@ module WorkflowExecutions
         I18n.t('components.workflow_executions.table_component.counts.one')
       args[:data][:'selection-count-message-other-value'] =
         I18n.t('components.workflow_executions.table_component.counts.other')
+      args[:data][:'selection-select-page-none-value'] =
+        I18n.t('components.workflow_executions.table_component.select_page_state.none')
+      args[:data][:'selection-select-page-some-value'] =
+        I18n.t('components.workflow_executions.table_component.select_page_state.some')
+      args[:data][:'selection-select-page-all-value'] =
+        I18n.t('components.workflow_executions.table_component.select_page_state.all')
     end
 
     def columns

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -56,7 +56,9 @@ export default class extends Controller {
    */
   togglePage(event) {
     const valuesToToggle = this.rowSelectionTargets.map((row) => row.value);
-    this.#modifySelection(event.target.checked, valuesToToggle);
+    this.#modifySelection(event.target.checked, valuesToToggle, {
+      announceSelectPageStatus: false,
+    });
   }
 
   /**
@@ -116,14 +118,14 @@ export default class extends Controller {
     this.update([]);
   }
 
-  update(ids, announce = true) {
+  update(ids, announce = true, options = {}) {
     if (!Array.isArray(ids)) {
       console.warn("SelectionController: ids must be an array");
       return;
     }
     // Persist selection and reflect changes in the UI
     sessionStorage.setItem(this.#getStorageKey(), JSON.stringify(ids));
-    this.#updateUI(ids, announce);
+    this.#updateUI(ids, announce, options);
   }
 
   getOrCreateStoredItems() {
@@ -154,7 +156,7 @@ export default class extends Controller {
    * @param {Array<string>} values - array of ids to add or remove
    * @private
    */
-  #modifySelection(add, values) {
+  #modifySelection(add, values, options = {}) {
     let newStorageValue = this.getOrCreateStoredItems();
     if (add) {
       // Use a Set to deduplicate values
@@ -164,7 +166,7 @@ export default class extends Controller {
         (value) => !values.includes(value),
       );
     }
-    this.update(newStorageValue);
+    this.update(newStorageValue, true, options);
   }
 
   /**
@@ -175,7 +177,7 @@ export default class extends Controller {
    * @param {boolean} announce - whether to announce via aria-live region
    * @private
    */
-  #updateUI(ids, announce) {
+  #updateUI(ids, announce, options = {}) {
     try {
       // Set checkbox checked states based on whether their value is included
       this.rowSelectionTargets.forEach((row) => {
@@ -184,7 +186,9 @@ export default class extends Controller {
 
       this.#updateActionButtons(ids.length);
       this.#updateCounts(ids.length, announce);
-      this.#setSelectPageCheckboxValue(announce);
+      this.#setSelectPageCheckboxValue(
+        options.announceSelectPageStatus ?? announce,
+      );
     } catch (error) {
       console.error("selectionController: Failed to update UI", error);
     }
@@ -201,7 +205,7 @@ export default class extends Controller {
     });
   }
 
-  #setSelectPageCheckboxValue(announce) {
+  #setSelectPageCheckboxValue(shouldAnnounce) {
     if (this.hasSelectPageTarget) {
       const totalOnPage = this.rowSelectionTargets.length;
       const selectedOnPage = this.rowSelectionTargets.filter(
@@ -217,6 +221,7 @@ export default class extends Controller {
       // screen readers announce it as "half checked", which is misleading
       // when an arbitrary subset (e.g. 1 of 8) is selected.
       this.selectPageTarget.indeterminate = false;
+      this.#updateSelectPageDescription(mixed);
 
       this.#updateSelectPageStatusText(
         {
@@ -224,29 +229,34 @@ export default class extends Controller {
           totalOnPage,
           state: mixed ? "some" : allChecked ? "all" : "none",
         },
-        announce,
+        shouldAnnounce,
       );
     }
   }
 
-  #updateSelectPageStatusText(
-    { selectedOnPage, totalOnPage, state },
-    announce,
-  ) {
+  #updateSelectPageStatusText({ selectedOnPage, totalOnPage, state }) {
     if (!this.hasSelectPageStatusTarget) return;
 
-    const template =
-      state === "all"
-        ? this.selectPageAllValue
-        : state === "none"
-          ? this.selectPageNoneValue
-          : this.selectPageSomeValue;
+    const template = state === "some" ? this.selectPageSomeValue : "";
 
     const text = template
       .replace("%{selected}", String(selectedOnPage))
       .replace("%{total}", String(totalOnPage));
 
     this.selectPageStatusTarget.textContent = text;
+  }
+
+  #updateSelectPageDescription(mixed) {
+    if (!this.hasSelectPageTarget || !this.hasSelectPageStatusTarget) return;
+
+    if (mixed) {
+      this.selectPageTarget.setAttribute(
+        "aria-describedby",
+        this.selectPageStatusTarget.id,
+      );
+    } else {
+      this.selectPageTarget.removeAttribute("aria-describedby");
+    }
   }
 
   #updateCounts(selected, announce) {

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -214,15 +214,10 @@ export default class extends Controller {
       const mixed = !allChecked && !noneChecked;
 
       this.selectPageTarget.checked = allChecked;
-      this.selectPageTarget.indeterminate = mixed;
-
-      // Ensure screen readers announce meaningful state rather than just
-      // "checked"/"not checked" or an ambiguous "half checked".
-      // Use ARIA checkbox tri-state: true | false | mixed.
-      this.selectPageTarget.setAttribute(
-        "aria-checked",
-        mixed ? "mixed" : allChecked ? "true" : "false",
-      );
+      // Do not expose an indeterminate checkbox state here because many
+      // screen readers announce it as "half checked", which is misleading
+      // when an arbitrary subset (e.g. 1 of 8) is selected.
+      this.selectPageTarget.indeterminate = false;
 
       this.#updateSelectPageStatusText({
         selectedOnPage,
@@ -246,7 +241,7 @@ export default class extends Controller {
       .replace("%{selected}", String(selectedOnPage))
       .replace("%{total}", String(totalOnPage));
 
-    this.selectPageStatusTarget.textContent = text;
+    announce(text, { element: this.selectPageStatusTarget });
   }
 
   #updateCounts(selected, announce) {

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -2,7 +2,13 @@ import { Controller } from "@hotwired/stimulus";
 import { announce } from "utilities/live_region";
 
 export default class extends Controller {
-  static targets = ["rowSelection", "selectPage", "selected", "status"];
+  static targets = [
+    "rowSelection",
+    "selectPage",
+    "selectPageStatus",
+    "selected",
+    "status",
+  ];
   static outlets = ["action-button"];
 
   static values = {
@@ -12,6 +18,9 @@ export default class extends Controller {
     total: Number,
     countMessageOne: String,
     countMessageOther: String,
+    selectPageNone: String,
+    selectPageSome: String,
+    selectPageAll: String,
   };
 
   #lastActiveCheckbox;
@@ -195,15 +204,49 @@ export default class extends Controller {
 
   #setSelectPageCheckboxValue() {
     if (this.hasSelectPageTarget) {
-      const uncheckedBoxes = this.rowSelectionTargets.filter(
-        (row) => !row.checked,
+      const totalOnPage = this.rowSelectionTargets.length;
+      const selectedOnPage = this.rowSelectionTargets.filter(
+        (row) => row.checked,
+      ).length;
+
+      const allChecked = totalOnPage > 0 && selectedOnPage === totalOnPage;
+      const noneChecked = selectedOnPage === 0;
+      const mixed = !allChecked && !noneChecked;
+
+      this.selectPageTarget.checked = allChecked;
+      this.selectPageTarget.indeterminate = mixed;
+
+      // Ensure screen readers announce meaningful state rather than just
+      // "checked"/"not checked" or an ambiguous "half checked".
+      // Use ARIA checkbox tri-state: true | false | mixed.
+      this.selectPageTarget.setAttribute(
+        "aria-checked",
+        mixed ? "mixed" : allChecked ? "true" : "false",
       );
-      this.selectPageTarget.checked = uncheckedBoxes.length === 0;
-      this.selectPageTarget.indeterminate = !(
-        uncheckedBoxes.length === 0 ||
-        uncheckedBoxes.length === this.rowSelectionTargets.length
-      );
+
+      this.#updateSelectPageStatusText({
+        selectedOnPage,
+        totalOnPage,
+        state: mixed ? "some" : allChecked ? "all" : "none",
+      });
     }
+  }
+
+  #updateSelectPageStatusText({ selectedOnPage, totalOnPage, state }) {
+    if (!this.hasSelectPageStatusTarget) return;
+
+    const template =
+      state === "all"
+        ? this.selectPageAllValue
+        : state === "none"
+          ? this.selectPageNoneValue
+          : this.selectPageSomeValue;
+
+    const text = template
+      .replace("%{selected}", String(selectedOnPage))
+      .replace("%{total}", String(totalOnPage));
+
+    this.selectPageStatusTarget.textContent = text;
   }
 
   #updateCounts(selected, announce) {

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -93,7 +93,6 @@ export default class extends Controller {
           valuesToToggle = indices.map(
             (i) => this.rowSelectionTargets[i].value,
           );
-          this.#lastActiveCheckbox;
         } else {
           valuesToToggle = [];
         }
@@ -185,7 +184,7 @@ export default class extends Controller {
 
       this.#updateActionButtons(ids.length);
       this.#updateCounts(ids.length, announce);
-      this.#setSelectPageCheckboxValue();
+      this.#setSelectPageCheckboxValue(announce);
     } catch (error) {
       console.error("selectionController: Failed to update UI", error);
     }
@@ -202,7 +201,7 @@ export default class extends Controller {
     });
   }
 
-  #setSelectPageCheckboxValue() {
+  #setSelectPageCheckboxValue(announce) {
     if (this.hasSelectPageTarget) {
       const totalOnPage = this.rowSelectionTargets.length;
       const selectedOnPage = this.rowSelectionTargets.filter(
@@ -219,15 +218,21 @@ export default class extends Controller {
       // when an arbitrary subset (e.g. 1 of 8) is selected.
       this.selectPageTarget.indeterminate = false;
 
-      this.#updateSelectPageStatusText({
-        selectedOnPage,
-        totalOnPage,
-        state: mixed ? "some" : allChecked ? "all" : "none",
-      });
+      this.#updateSelectPageStatusText(
+        {
+          selectedOnPage,
+          totalOnPage,
+          state: mixed ? "some" : allChecked ? "all" : "none",
+        },
+        announce,
+      );
     }
   }
 
-  #updateSelectPageStatusText({ selectedOnPage, totalOnPage, state }) {
+  #updateSelectPageStatusText(
+    { selectedOnPage, totalOnPage, state },
+    announce,
+  ) {
     if (!this.hasSelectPageStatusTarget) return;
 
     const template =
@@ -241,7 +246,11 @@ export default class extends Controller {
       .replace("%{selected}", String(selectedOnPage))
       .replace("%{total}", String(totalOnPage));
 
-    announce(text, { element: this.selectPageStatusTarget });
+    this.selectPageStatusTarget.textContent = text;
+
+    if (announce) {
+      announce(text);
+    }
   }
 
   #updateCounts(selected, announce) {

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -16,8 +16,7 @@ export default class extends Controller {
       type: String,
     },
     total: Number,
-    countMessageOne: String,
-    countMessageOther: String,
+    countMessage: String,
     selectPageNone: String,
     selectPageSome: String,
     selectPageAll: String,
@@ -271,17 +270,18 @@ export default class extends Controller {
   /**
    * 🔊 Announce current selection status to an aria-live region.
    *
-   * - 🧮 Builds a localized message using one/other templates: "X of Y selected".
-   * - 🧩 Reads values from data attributes (`countMessageOneValue`, `countMessageOtherValue`).
+   * - 🧮 Builds a localized message using a single template: "X of Y selected".
+   * - 🧩 Reads value from the data attribute (`countMessageValue`).
    * - ♿ Updates the component's hidden polite live region, falling back to `#sr-status` if absent.
    *
    * @param {number} selected - Current number of selected items.
    * @private
    */
   #announceSelectionStatus(selected) {
-    // 🧮 Choose the correct i18n template based on count
-    const messageTemplate =
-      selected === 1 ? this.countMessageOneValue : this.countMessageOtherValue;
+    const messageTemplate = this.countMessageValue;
+
+    // Skip announcement if this selection context is not configured with a count template.
+    if (!messageTemplate) return;
 
     // 🔁 Interpolate counts into the template
     const message = messageTemplate

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -247,10 +247,6 @@ export default class extends Controller {
       .replace("%{total}", String(totalOnPage));
 
     this.selectPageStatusTarget.textContent = text;
-
-    if (announce) {
-      announce(text);
-    }
   }
 
   #updateCounts(selected, announce) {

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -395,3 +395,7 @@ en:
         counts:
           one: 1 workflow execution selected
           other: "%{selected} of %{total} workflow executions selected"
+        select_page_state:
+          none: None selected
+          some: "%{selected} of %{total} selected"
+          all: All selected

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -312,9 +312,7 @@ en:
     samples:
       table_component:
         counts:
-          status:
-            one: 1 sample selected
-            other: "%{selected} of %{total} samples selected"
+          status: "%{selected} of %{total} samples selected"
         create_template_link: create a metadata template with those fields
         metadata_fields_size_warning: The number of metadata fields has been limited to %{calculated_limit} for %{sample_count} samples (maximum %{target_max_cells} cells).
         metadata_fields_size_warning_with_link_html: The number of metadata fields has been limited to %{calculated_limit} for %{sample_count} samples (maximum %{target_max_cells} cells). If there are fields you need, %{create_template_link}.
@@ -393,8 +391,7 @@ en:
     workflow_executions:
       table_component:
         counts:
-          one: 1 workflow execution selected
-          other: "%{selected} of %{total} workflow executions selected"
+          status: "%{selected} of %{total} workflow executions selected"
         select_page_state:
           all: All checked
           none: None checked

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -396,6 +396,6 @@ en:
           one: 1 workflow execution selected
           other: "%{selected} of %{total} workflow executions selected"
         select_page_state:
-          none: None selected
-          some: "%{selected} of %{total} selected"
-          all: All selected
+          none: None checked
+          some: "%{selected} of %{total} checked"
+          all: All checked

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -396,6 +396,6 @@ en:
           one: 1 workflow execution selected
           other: "%{selected} of %{total} workflow executions selected"
         select_page_state:
+          all: All checked
           none: None checked
           some: "%{selected} of %{total} checked"
-          all: All checked

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -350,9 +350,7 @@ fr:
     samples:
       table_component:
         counts:
-          status:
-            one: 1 échantillon sélectionné
-            other: "%{selected} sur %{total} échantillons sélectionnés"
+          status: "%{selected} sur %{total} échantillons sélectionnés"
         create_template_link: créez un modèle de métadonnées avec ces champs
         metadata_fields_size_warning: Le nombre de champs de métadonnées a été limité à %{calculated_limit} pour %{sample_count} échantillons (maximum %{target_max_cells} cellules).
         metadata_fields_size_warning_with_link_html: Le nombre de champs de métadonnées a été limité à %{calculated_limit} pour %{sample_count} échantillons (maximum %{target_max_cells} cellules). Si vous avez besoin de champs, %{create_template_link}.
@@ -431,8 +429,7 @@ fr:
     workflow_executions:
       table_component:
         counts:
-          one: 1 exécution de flux de travail sélectionnée
-          other: "%{selected} sur %{total} exécutions de flux de travail sélectionnées"
+          status: "%{selected} sur %{total} exécutions de flux de travail sélectionnées"
         select_page_state:
           all: Toutes les cases cochées
           none: Aucune case cochée

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -434,6 +434,6 @@ fr:
           one: 1 exécution de flux de travail sélectionnée
           other: "%{selected} sur %{total} exécutions de flux de travail sélectionnées"
         select_page_state:
-          none: Aucune sélection
-          some: "%{selected} sur %{total} sélectionnées"
-          all: Toutes sélectionnées
+          none: Aucune case cochée
+          some: "%{selected} sur %{total} cases cochées"
+          all: Toutes les cases cochées

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -433,3 +433,7 @@ fr:
         counts:
           one: 1 exécution de flux de travail sélectionnée
           other: "%{selected} sur %{total} exécutions de flux de travail sélectionnées"
+        select_page_state:
+          none: Aucune sélection
+          some: "%{selected} sur %{total} sélectionnées"
+          all: Toutes sélectionnées

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -434,6 +434,6 @@ fr:
           one: 1 exécution de flux de travail sélectionnée
           other: "%{selected} sur %{total} exécutions de flux de travail sélectionnées"
         select_page_state:
+          all: Toutes les cases cochées
           none: Aucune case cochée
           some: "%{selected} sur %{total} cases cochées"
-          all: Toutes les cases cochées

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -1169,27 +1169,56 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_text I18n.t('concerns.workflow_execution_actions.cancel_multiple.success')
   end
 
-  test 'select page checkbox exposes accurate aria-checked state' do
+  test 'select page checkbox exposes accurate state and status text' do
     visit workflow_executions_path
 
-    select_page = find("input#select-page", visible: :all)
-    assert_equal 'false', select_page['aria-checked']
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none'),
-                visible: :all
+    select_page = find('input#select-page', visible: :all)
+    assert_not select_page.checked?
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none')
 
     first_row_checkbox =
-      find("input[name='workflow_execution_ids[]']", match: :first, visible: :all)
+      find('input[name=\'workflow_execution_ids[]\']', match: :first, visible: :all)
     first_row_checkbox.click
 
-    select_page = find("input#select-page", visible: :all)
-    assert_equal 'mixed', select_page['aria-checked']
+    select_page = find('input#select-page', visible: :all)
+    assert_not select_page.checked?
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
+                       selected: 1,
+                       total: PAGE_SIZE)
 
     select_page.click
 
-    select_page = find("input#select-page", visible: :all)
-    assert_equal 'true', select_page['aria-checked']
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all'),
-                visible: :all
+    select_page = find('input#select-page', visible: :all)
+    assert select_page.checked?
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all')
+  end
+
+  test 'select page status text is localized in french' do
+    visit workflow_executions_path
+
+    find('#language-selection-dd-trigger').click
+    within find('#language-selection-dd-menu') do
+      click_button I18n.t(:'locales.fr', locale: :fr)
+    end
+
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none', locale: :fr)
+
+    first_row_checkbox =
+      find('input[name=\'workflow_execution_ids[]\']', match: :first, visible: :all)
+    first_row_checkbox.click
+
+    select_page = find('input#select-page', visible: :all)
+    assert_not select_page.checked?
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
+                       selected: 1,
+                       total: PAGE_SIZE,
+                       locale: :fr)
+
+    select_page.click
+
+    select_page = find('input#select-page', visible: :all)
+    assert select_page.checked?
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all', locale: :fr)
   end
 
   test 'can partially cancel multiple workflows at once' do

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -1169,6 +1169,29 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_text I18n.t('concerns.workflow_execution_actions.cancel_multiple.success')
   end
 
+  test 'select page checkbox exposes accurate aria-checked state' do
+    visit workflow_executions_path
+
+    select_page = find("input#select-page", visible: :all)
+    assert_equal 'false', select_page['aria-checked']
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none'),
+                visible: :all
+
+    first_row_checkbox =
+      find("input[name='workflow_execution_ids[]']", match: :first, visible: :all)
+    first_row_checkbox.click
+
+    select_page = find("input#select-page", visible: :all)
+    assert_equal 'mixed', select_page['aria-checked']
+
+    select_page.click
+
+    select_page = find("input#select-page", visible: :all)
+    assert_equal 'true', select_page['aria-checked']
+    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all'),
+                visible: :all
+  end
+
   test 'can partially cancel multiple workflows at once' do
     # attempt to cancel cancellable and non-cancellable workflows
     visit workflow_executions_path

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -1173,8 +1173,12 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     visit workflow_executions_path
 
     select_page = find('input#select-page', visible: :all)
+    assert_equal 'select-page-status', select_page['aria-describedby']
     assert_not select_page.checked?
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none')
+
+    within '#select-page-status' do
+      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none')
+    end
 
     first_row_checkbox =
       find('input[name=\'workflow_execution_ids[]\']', match: :first, visible: :all)
@@ -1182,15 +1186,22 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     select_page = find('input#select-page', visible: :all)
     assert_not select_page.checked?
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
-                       selected: 1,
-                       total: PAGE_SIZE)
+    assert_equal false, page.evaluate_script("document.querySelector('#select-page').indeterminate")
+
+    within '#select-page-status' do
+      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
+                         selected: 1,
+                         total: PAGE_SIZE)
+    end
 
     select_page.click
 
     select_page = find('input#select-page', visible: :all)
     assert select_page.checked?
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all')
+
+    within '#select-page-status' do
+      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all')
+    end
   end
 
   test 'select page status text is localized in french' do
@@ -1201,7 +1212,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       click_button I18n.t(:'locales.fr', locale: :fr)
     end
 
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none', locale: :fr)
+    within '#select-page-status' do
+      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none', locale: :fr)
+    end
 
     first_row_checkbox =
       find('input[name=\'workflow_execution_ids[]\']', match: :first, visible: :all)
@@ -1209,16 +1222,22 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     select_page = find('input#select-page', visible: :all)
     assert_not select_page.checked?
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
-                       selected: 1,
-                       total: PAGE_SIZE,
-                       locale: :fr)
+
+    within '#select-page-status' do
+      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
+                         selected: 1,
+                         total: PAGE_SIZE,
+                         locale: :fr)
+    end
 
     select_page.click
 
     select_page = find('input#select-page', visible: :all)
     assert select_page.checked?
-    assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all', locale: :fr)
+
+    within '#select-page-status' do
+      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all', locale: :fr)
+    end
   end
 
   test 'can partially cancel multiple workflows at once' do

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -1173,7 +1173,6 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     visit workflow_executions_path
 
     select_page = find('input#select-page', visible: :all)
-    assert_equal 'select-page-status', select_page['aria-describedby']
     assert_not select_page.checked?
 
     within '#select-page-status' do
@@ -1193,6 +1192,10 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
                          selected: 1,
                          total: PAGE_SIZE)
     end
+
+    # Ensure select-page state text is not announced via the global live region.
+    # Selection announcements should be count-only via the local selection live region.
+    assert_no_selector '#sr-status', visible: false
 
     select_page.click
 
@@ -1215,6 +1218,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     within '#select-page-status' do
       assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none', locale: :fr)
     end
+
+    # Ensure select-page state text is not announced via the global live region.
+    assert_no_selector '#sr-status', visible: false
 
     first_row_checkbox =
       find('input[name=\'workflow_execution_ids[]\']', match: :first, visible: :all)

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -1212,9 +1212,10 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
   test 'select page status text is localized in french' do
     visit workflow_executions_path
+    Capybara.execute_script 'sessionStorage.clear()'
 
     find('#language-selection-dd-trigger').click
-    within find('#language-selection-dd-menu') do
+    within find('#language-selection-dd-trigger-menu') do
       click_button I18n.t(:'locales.fr', locale: :fr)
     end
 

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -1174,9 +1174,10 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     select_page = find('input#select-page', visible: :all)
     assert_not select_page.checked?
+    assert_nil select_page[:'aria-describedby']
 
     within '#select-page-status' do
-      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none')
+      assert_no_text I18n.t('components.workflow_executions.table_component.select_page_state.none')
     end
 
     first_row_checkbox =
@@ -1186,6 +1187,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     select_page = find('input#select-page', visible: :all)
     assert_not select_page.checked?
     assert_equal false, page.evaluate_script("document.querySelector('#select-page').indeterminate")
+    assert_equal 'select-page-status', select_page[:'aria-describedby']
 
     within '#select-page-status' do
       assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
@@ -1201,9 +1203,10 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     select_page = find('input#select-page', visible: :all)
     assert select_page.checked?
+    assert_nil select_page[:'aria-describedby']
 
     within '#select-page-status' do
-      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all')
+      assert_no_text I18n.t('components.workflow_executions.table_component.select_page_state.all')
     end
   end
 
@@ -1216,7 +1219,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
 
     within '#select-page-status' do
-      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.none', locale: :fr)
+      assert_no_text I18n.t('components.workflow_executions.table_component.select_page_state.none', locale: :fr)
     end
 
     # Ensure select-page state text is not announced via the global live region.
@@ -1228,6 +1231,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     select_page = find('input#select-page', visible: :all)
     assert_not select_page.checked?
+    assert_equal 'select-page-status', select_page[:'aria-describedby']
 
     within '#select-page-status' do
       assert_text I18n.t('components.workflow_executions.table_component.select_page_state.some',
@@ -1240,9 +1244,10 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     select_page = find('input#select-page', visible: :all)
     assert select_page.checked?
+    assert_nil select_page[:'aria-describedby']
 
     within '#select-page-status' do
-      assert_text I18n.t('components.workflow_executions.table_component.select_page_state.all', locale: :fr)
+      assert_no_text I18n.t('components.workflow_executions.table_component.select_page_state.all', locale: :fr)
     end
   end
 


### PR DESCRIPTION
## What does this PR do and why?
This updates the workflow executions select-page checkbox so it only uses checked or not checked and reports partial selection through clear status text. We needed this because screen readers could announce "half checked," which did not match what users actually selected.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Start the app with `bin/dev`, sign in, and open `/workflow_executions`.
2. Run the targeted system tests:
   - `bin/rails test test/system/workflow_executions_test.rb -n "/select page checkbox exposes accurate state and status text|select page status text is localized in french/"`
3. In English, verify the no-selection state:
   - The header checkbox (`#select-page`) starts unchecked.
   - The hidden status area (`#select-page-status`) is empty.
4. Select one row and verify partial selection behavior:
   - The header checkbox stays unchecked.
   - `document.querySelector('#select-page').indeterminate` is `false`.
   - The header checkbox has `aria-describedby="select-page-status"`.
   - The status text shows `1 of <page size> checked`.
   - It should not announce a mixed or half-checked state.
5. Click the header checkbox and verify full-page selection behavior:
   - All rows on the page become selected.
   - The header checkbox becomes checked.
   - `aria-describedby` is removed.
   - `#select-page-status` no longer shows partial-selection text.
6. Switch language to French and repeat the same checks:
   - Partial-selection status text appears in French (`%{selected} sur %{total} cases cochées`).
   - It should still avoid mixed or half-checked announcements.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
