### PR TITLE
Fix advanced search layout overflow and combobox indicator behavior

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -668,11 +668,7 @@ a.pill-focus-reset:focus-visible {
   @apply relative text-slate-900 dark:text-white;
 
   input {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' aria-hidden='true' viewBox='0 0 10 6'%3E%3Cpath stroke='%236B7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m1 1 4 4 4-4'/%3E%3C/svg%3E");
-    background-position: right 0.75rem center;
-    background-repeat: no-repeat;
-    background-size: 0.75em 0.75em;
-    @apply relative m-0 box-border w-full cursor-pointer rounded-lg border border-slate-300 px-3 py-2 align-bottom outline-none focus-visible:shadow-none focus-visible:outline dark:border-slate-600 dark:bg-slate-800;
+    @apply relative m-0 box-border w-full cursor-pointer rounded-lg border border-slate-300 px-3 py-2 pr-20 align-bottom outline-none focus-visible:shadow-none focus-visible:outline dark:border-slate-600 dark:bg-slate-800;
   }
 
   input[aria-invalid="true"] {

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -5,8 +5,8 @@
   data-advanced-search--v1-legend-template="<%= t("components.advanced_search_component.v1.condition", index: "__INDEX__") %>"
   data-advanced-search-selected-field="<%= selected_field %>"
   class="
-    flex items-end space-x-2 rounded-lg border border-slate-300 p-4 text-sm text-slate-500 @max-xl:flex-col
-    @max-xl:space-y-2 dark:border-slate-600 dark:text-slate-400
+    relative flex flex-col space-y-3 rounded-lg border border-slate-300 p-4 pr-14 text-sm text-slate-500
+    dark:border-slate-600 dark:text-slate-400
   "
 >
   <legend><%= t("components.advanced_search_component.v1.condition", index: @condition_number) %></legend>
@@ -14,7 +14,7 @@
   <%= @groups_form.fields_for :conditions, @condition, child_index: @condition_index do |conditions_form| %>
     <% invalid_field = @condition.errors.include?(:field) %>
 
-    <div class="form-field min-w-[200px] flex-1 @max-xl:w-full <%= 'invalid' if invalid_field %>">
+    <div class="form-field w-full <%= 'invalid' if invalid_field %>">
       <% options = options_for_select(field_options, @condition.field).concat(
         grouped_options_for_select(grouped_field_options, @condition.field),
       ) %>
@@ -57,7 +57,7 @@
 
     <% invalid_operator = @condition.errors.include?(:operator) %>
 
-    <div class="form-field min-w-[180px] flex-1 @max-xl:w-full <%= 'invalid' if invalid_operator %>">
+    <div class="form-field w-full max-w-xs <%= 'invalid' if invalid_operator %>">
       <%= conditions_form.label :operator, data: { required: true } %>
 
       <%= conditions_form.select :operator,
@@ -92,7 +92,7 @@
   <button
     type="button"
     class="
-      mb-1 inline-flex h-8 w-8 flex-shrink-0 cursor-pointer items-center justify-center rounded-lg p-1.5
+      absolute right-2 top-2 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-lg
       text-slate-400 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-500 dark:hover:bg-slate-700
       dark:hover:text-white
     "

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -92,7 +92,7 @@
   <button
     type="button"
     class="
-      absolute right-2 top-2 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-lg
+      absolute right-2 -top-4 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-lg
       text-slate-400 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-500 dark:hover:bg-slate-700
       dark:hover:text-white
     "

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -92,7 +92,7 @@
   <button
     type="button"
     class="
-      absolute right-2 -top-4 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-lg
+      absolute -top-4 right-2 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-lg
       text-slate-400 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-500 dark:hover:bg-slate-700
       dark:hover:text-white
     "

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -57,7 +57,7 @@
 
     <% invalid_operator = @condition.errors.include?(:operator) %>
 
-    <div class="form-field w-full max-w-xs <%= 'invalid' if invalid_operator %>">
+    <div class="form-field w-full sm:max-w-xs <%= 'invalid' if invalid_operator %>">
       <%= conditions_form.label :operator, data: { required: true } %>
 
       <%= conditions_form.select :operator,

--- a/app/components/advanced_search/v1/value_component.html.erb
+++ b/app/components/advanced_search/v1/value_component.html.erb
@@ -6,7 +6,7 @@
 
 <div
   class="
-    value form-field w-5/12 @max-xl:w-full <%= 'invalid' if invalid_value %>
+    value form-field w-full <%= 'invalid' if invalid_value %>
     <%= 'invisible @max-xl:hidden' if operator_exists %>
   "
 >

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -23,7 +23,7 @@
       type="button"
       class="
         <%= selection_present? ? 'flex' : 'hidden' %>
-        h-full w-8 items-center justify-center text-slate-500
+        h-full w-8 items-center justify-center text-slate-500 cursor-pointer
         transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
       "
       data-combobox--v1-target="indicatorClearButton"
@@ -37,7 +37,7 @@
     <button
       type="button"
       class="
-        flex h-full w-10 items-center justify-center rounded-r-lg text-slate-500
+        flex h-full w-10 items-center justify-center rounded-r-lg text-slate-500 cursor-pointer
         transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
       "
       data-combobox--v1-target="indicatorButton"

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -1,7 +1,9 @@
 <%= tag.div(
   data: {
     controller: "combobox--v1",
+    "combobox--v1-clear-selection-label-value": t("combobox_component.clear_selection"),
     "combobox--v1-no-results-text-value": t("combobox_component.no_results_text"),
+    "combobox--v1-show-options-label-value": t("combobox_component.show_options"),
     "combobox--v1-single-result-text-value": t("combobox_component.single_result_text"),
     "combobox--v1-multiple-results-text-value": t("combobox_component.multiple_results_text"),
   },
@@ -15,6 +17,37 @@
                      } %>
 
   <%= render Viral::BaseComponent.new(**combobox_arguments) %>
+
+  <div class="absolute inset-y-0 right-0 z-10 flex items-center">
+    <button
+      type="button"
+      class="
+        <%= selection_present? ? 'flex' : 'hidden' %>
+        h-full w-8 items-center justify-center text-slate-500
+        transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
+      "
+      data-combobox--v1-target="indicatorClearButton"
+      data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onClearClick"
+      aria-label="<%= t('combobox_component.clear_selection') %>"
+      title="<%= t('combobox_component.clear_selection') %>"
+    >
+      <%= icon(:x, size: :sm, color: :subdued) %>
+    </button>
+
+    <button
+      type="button"
+      class="
+        flex h-full w-10 items-center justify-center rounded-r-lg text-slate-500
+        transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
+      "
+      data-combobox--v1-target="indicatorButton"
+      data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onIndicatorClick"
+      aria-label="<%= t('combobox_component.show_options') %>"
+      title="<%= t('combobox_component.show_options') %>"
+    >
+      <%= icon(:caret_down, size: :sm, color: :subdued) %>
+    </button>
+  </div>
 
   <%= tag.div(
     id: @listbox_id,

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -22,9 +22,8 @@
     <button
       type="button"
       class="
+        h-full w-8 cursor-pointer items-center justify-center text-slate-500 transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
         <%= selection_present? ? 'flex' : 'hidden' %>
-        h-full w-8 items-center justify-center text-slate-500 cursor-pointer
-        transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
       "
       data-combobox--v1-target="indicatorClearButton"
       data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onClearClick"
@@ -37,8 +36,8 @@
     <button
       type="button"
       class="
-        flex h-full w-10 items-center justify-center rounded-r-lg text-slate-500 cursor-pointer
-        transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
+        flex h-full w-10 cursor-pointer items-center justify-center rounded-r-lg text-slate-500 transition-colors
+        hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
       "
       data-combobox--v1-target="indicatorButton"
       data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onIndicatorClick"

--- a/app/components/combobox/v1/component.rb
+++ b/app/components/combobox/v1/component.rb
@@ -32,6 +32,10 @@ module Combobox
         end
       end
 
+      def selection_present?
+        @selected_option[:value].present?
+      end
+
       def selected_option(options)
         fragment = Nokogiri::HTML.fragment(options)
         fragment.search('option').each do |option|

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -17,9 +17,18 @@ import FloatingDropdown from "utilities/floating_dropdown";
  * - Dropdown positioning and focus management
  */
 export default class extends Controller {
-  static targets = ["combobox", "listbox", "hidden", "ariaLiveUpdate"];
+  static targets = [
+    "combobox",
+    "listbox",
+    "hidden",
+    "ariaLiveUpdate",
+    "indicatorButton",
+    "indicatorClearButton",
+  ];
   static values = {
+    clearSelectionLabel: String,
     noResultsText: String,
+    showOptionsLabel: String,
     singleResultText: String,
     multipleResultsText: String,
   };
@@ -83,6 +92,8 @@ export default class extends Controller {
       this.#setOption(option);
       this.#setValue(option);
     }
+
+    this.#updateIndicatorState();
   }
 
   disconnect() {
@@ -240,6 +251,7 @@ export default class extends Controller {
     );
     this.hiddenTarget.dispatchEvent(new Event("change", { bubbles: true }));
     this.comboboxTarget.dispatchEvent(new Event("change", { bubbles: true }));
+    this.#updateIndicatorState();
   }
 
   #setOption(option) {
@@ -276,6 +288,42 @@ export default class extends Controller {
 
   #hasOptions() {
     return this.#filteredOptions.length;
+  }
+
+  #hasSelection() {
+    return this.hiddenTarget.value.length > 0;
+  }
+
+  #updateIndicatorState() {
+    if (this.hasIndicatorButtonTarget) {
+      this.indicatorButtonTarget.setAttribute(
+        "aria-label",
+        this.showOptionsLabelValue,
+      );
+      this.indicatorButtonTarget.setAttribute("title", this.showOptionsLabelValue);
+    }
+
+    if (!this.hasIndicatorClearButtonTarget) return;
+
+    const hasSelection = this.#hasSelection();
+    this.indicatorClearButtonTarget.classList.toggle("hidden", !hasSelection);
+    this.indicatorClearButtonTarget.classList.toggle("flex", hasSelection);
+    this.indicatorClearButtonTarget.setAttribute(
+      "aria-label",
+      this.clearSelectionLabelValue,
+    );
+    this.indicatorClearButtonTarget.setAttribute(
+      "title",
+      this.clearSelectionLabelValue,
+    );
+  }
+
+  #clearSelection() {
+    this.#setValue();
+    this.#setOption(null);
+    this.#filterOptions();
+    this.#floatingDropdown.hide();
+    this.comboboxTarget.focus();
   }
 
   #onShow() {
@@ -435,12 +483,34 @@ export default class extends Controller {
   #onBackgroundMouseDown(event) {
     if (
       !this.comboboxTarget.contains(event.target) &&
-      !this.listboxTarget.contains(event.target)
+      !this.listboxTarget.contains(event.target) &&
+      !this.indicatorButtonTarget.contains(event.target) &&
+      (!this.hasIndicatorClearButtonTarget ||
+        !this.indicatorClearButtonTarget.contains(event.target))
     ) {
       this.debouncedFilterAndUpdate.flush();
       this.#setValue(this.#option);
       this.#floatingDropdown.hide();
     }
+  }
+
+  onIndicatorMouseDown(event) {
+    event.preventDefault();
+  }
+
+  onIndicatorClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.comboboxTarget.focus();
+    this.#floatingDropdown.toggle();
+  }
+
+  onClearClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.#clearSelection();
   }
 
   // Listbox Option events

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -40,6 +40,7 @@ export default class extends Controller {
   #option;
   #firstOption;
   #lastOption;
+  #clearShouldKeepOpen;
 
   connect() {
     this.#filter = this.comboboxTarget.value;
@@ -48,6 +49,7 @@ export default class extends Controller {
     this.#option = null;
     this.#firstOption = null;
     this.#lastOption = null;
+    this.#clearShouldKeepOpen = false;
 
     this.boundOnBackgroundMouseDown = this.#onBackgroundMouseDown.bind(this);
     this.boundOnComboboxKeyDown = this.#onComboboxKeyDown.bind(this);
@@ -318,11 +320,17 @@ export default class extends Controller {
     );
   }
 
-  #clearSelection() {
+  #clearSelection({ keepOpen = false } = {}) {
     this.#setValue();
     this.#setOption(null);
     this.#filterOptions();
-    this.#floatingDropdown.hide();
+
+    if (keepOpen) {
+      this.#floatingDropdown.show();
+    } else {
+      this.#floatingDropdown.hide();
+    }
+
     this.comboboxTarget.focus();
   }
 
@@ -496,6 +504,7 @@ export default class extends Controller {
 
   onIndicatorMouseDown(event) {
     event.preventDefault();
+    this.#clearShouldKeepOpen = this.#floatingDropdown.isVisible();
   }
 
   onIndicatorClick(event) {
@@ -510,7 +519,8 @@ export default class extends Controller {
     event.preventDefault();
     event.stopPropagation();
 
-    this.#clearSelection();
+    this.#clearSelection({ keepOpen: this.#clearShouldKeepOpen });
+    this.#clearShouldKeepOpen = false;
   }
 
   // Listbox Option events

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -360,6 +360,7 @@ export default class extends Controller {
       case "Enter": {
         this.debouncedFilterAndUpdate.flush();
         this.#setValue(this.#option);
+        this.#setOption(this.#filterOptions());
         this.#floatingDropdown.hide();
         flag = true;
         break;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,8 +352,10 @@ en:
         inactive_tokens_aria_label: 'View %{count} inactive personal access tokens for bot account: %{name}'
         never: Never
   combobox_component:
+    clear_selection: Clear selection
     multiple_results_text: "%{num} results found"
     no_results_text: No results found
+    show_options: Show options
     single_result_text: 1 result found
   concerns:
     attachment_actions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -352,8 +352,10 @@ fr:
         inactive_tokens_aria_label: 'Afficher %{count} jetons d''accès personnel inactifs pour le compte de bot : %{name}'
         never: Jamais
   combobox_component:
+    clear_selection: Effacer la sélection
     multiple_results_text: "%{num} résultats trouvés"
     no_results_text: Aucun résultat trouvé
+    show_options: Afficher les options
     single_result_text: 1 résultat trouvé
   concerns:
     attachment_actions:

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -54,7 +54,7 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
 
         within all("fieldset[data-advanced-search--v1-target='groupsContainer']")[0] do
           within all("fieldset[data-advanced-search--v1-target='conditionsContainer']")[0] do
-            find('button').click
+            find("button[data-action='advanced-search--v1#removeCondition']").click
           end
           assert_selector "fieldset[data-advanced-search--v1-target='conditionsContainer']", count: 2
         end
@@ -264,7 +264,7 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
                           visible: :all
 
           within all("fieldset[data-advanced-search--v1-target='conditionsContainer']").first do
-            find('button').click
+            find("button[data-action='advanced-search--v1#removeCondition']").click
           end
 
           assert_selector :xpath,

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -47,6 +47,9 @@ module Combobox
           assert_equal 'patient_age', combobox.value
           hidden = find("input[type='hidden']", visible: false)
           assert_equal 'metadata.patient_age', hidden.value
+          combobox.click
+          assert_selector "div[role='listbox']", visible: true
+          assert_selector "div[role='option'][data-value='metadata.patient_age']", count: 1
         end
       end
 

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -116,55 +116,6 @@ module Combobox
           assert_empty hidden.value
         end
       end
-
-      def test_clear_button_does_not_replace_dropdown_caret
-        visit('/rails/view_components/combobox_component/default')
-        within "div[data-controller='combobox--v1']" do
-          combobox = find("input[role='combobox']")
-          clear_button_selector = "button[data-combobox--v1-target='indicatorClearButton']"
-          caret_button_selector = "button[data-combobox--v1-target='indicatorButton'][aria-label='#{I18n.t('combobox_component.show_options')}']"
-
-          assert_selector clear_button_selector, visible: true
-          assert_selector caret_button_selector, visible: true
-
-          find(clear_button_selector).click
-
-          assert_empty combobox.value
-          hidden = find("input[type='hidden']", visible: false)
-          assert_empty hidden.value
-
-          clear_button = find(clear_button_selector, visible: :all)
-          assert_not clear_button.visible?
-          assert_selector caret_button_selector, visible: true
-
-          find(caret_button_selector).click
-          assert_selector "div[role='listbox']", visible: true
-        end
-      end
-      def test_clear_click_keeps_dropdown_open_and_restores_all_options
-        visit('/rails/view_components/combobox_component/default')
-        within "div[data-controller='combobox--v1']" do
-          combobox = find("input[role='combobox']")
-          clear_button_selector = "button[data-combobox--v1-target='indicatorClearButton']"
-
-          combobox.send_keys(%i[alt down])
-          assert_selector "div[role='listbox']", visible: true
-
-          options_before_clear = all("div[role='option']", minimum: 1).count
-          assert_operator options_before_clear, :<, 16
-
-          find(clear_button_selector).click
-
-          assert_selector "div[role='listbox']", visible: true
-          assert_empty combobox.value
-          hidden = find("input[type='hidden']", visible: false)
-          assert_empty hidden.value
-
-          options_after_clear = all("div[role='option']", minimum: 1).count
-          assert_equal 16, options_after_clear
-        end
-      end
-
     end
   end
 end

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -113,6 +113,31 @@ module Combobox
           assert_empty hidden.value
         end
       end
+
+      def test_clear_button_does_not_replace_dropdown_caret
+        visit('/rails/view_components/combobox_component/default')
+        within "div[data-controller='combobox--v1']" do
+          combobox = find("input[role='combobox']")
+          clear_button_selector = "button[data-combobox--v1-target='indicatorClearButton']"
+          caret_button_selector = "button[data-combobox--v1-target='indicatorButton'][aria-label='#{I18n.t('combobox_component.show_options')}']"
+
+          assert_selector clear_button_selector, visible: true
+          assert_selector caret_button_selector, visible: true
+
+          find(clear_button_selector).click
+
+          assert_empty combobox.value
+          hidden = find("input[type='hidden']", visible: false)
+          assert_empty hidden.value
+
+          clear_button = find(clear_button_selector, visible: :all)
+          assert_not clear_button.visible?
+          assert_selector caret_button_selector, visible: true
+
+          find(caret_button_selector).click
+          assert_selector "div[role='listbox']", visible: true
+        end
+      end
     end
   end
 end

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -138,6 +138,30 @@ module Combobox
           assert_selector "div[role='listbox']", visible: true
         end
       end
+      def test_clear_click_keeps_dropdown_open_and_restores_all_options
+        visit('/rails/view_components/combobox_component/default')
+        within "div[data-controller='combobox--v1']" do
+          combobox = find("input[role='combobox']")
+          clear_button_selector = "button[data-combobox--v1-target='indicatorClearButton']"
+
+          combobox.send_keys(%i[alt down])
+          assert_selector "div[role='listbox']", visible: true
+
+          options_before_clear = all("div[role='option']", minimum: 1).count
+          assert_operator options_before_clear, :<, 16
+
+          find(clear_button_selector).click
+
+          assert_selector "div[role='listbox']", visible: true
+          assert_empty combobox.value
+          hidden = find("input[type='hidden']", visible: false)
+          assert_empty hidden.value
+
+          options_after_clear = all("div[role='option']", minimum: 1).count
+          assert_equal 16, options_after_clear
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes two UX issues in advanced search v1:
1. Condition row layout could overflow and crowd controls on smaller screens.
2. Added clear button to combobox.

Changes in this branch:
- advanced search condition rows now stack vertically with full-width field/value controls
- operator control is full width on mobile and constrained on larger screens
- remove-condition button is repositioned and uses a larger tap target
- clear button visibility follows selection state, caret remains visible, and clear/open interactions are handled explicitly in the Stimulus controller
- added i18n strings for clear/show-options labels in English and French
- expanded component tests for:
  - clear button and caret visible together
  - clearing keeps dropdown open when the list was already open
  - clearing restores the full option list
  - enter-key flow keeps dropdown option state consistent

## Screenshots or screen recordings

<img width="1087" height="829" alt="image" src="https://github.com/user-attachments/assets/43a70a7d-9b03-46df-a874-cb7e08d1c94a" />

## How to set up and validate locally
1. Start the app and open component previews.
2. Visit /rails/view_components/advanced_search_component/default and confirm each condition row stacks cleanly without overflow, with the remove button accessible at the top-right.
3. Visit /rails/view_components/combobox_component/default.
4. Confirm both indicator buttons work:
   - caret button opens and closes options
   - clear button clears the value but does not remove the caret
   - if the list is open, clearing keeps it open and restores all options
5. Run PARALLEL_WORKERS=4 bundle exec rails test test/components/combobox/v1/component_test.rb

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
