### PR TITLE
Accessibility: add aria-label and focus-visible to activity links

### DIFF
--- a/app/components/activities/base_activity_component.rb
+++ b/app/components/activities/base_activity_component.rb
@@ -18,7 +18,9 @@ module Activities
     end
 
     def active_link_classes
-      'text-slate-800 dark:text-slate-300 font-medium underline hover:decoration-2'
+      'text-slate-800 dark:text-slate-300 font-medium underline hover:decoration-2 ' \
+        'focus-visible:outline-3! focus-visible:outline-offset-2! focus-visible:outline-black! ' \
+        'dark:focus-visible:outline-white! focus-visible:outline-solid!'
     end
 
     def more_details_button_classes

--- a/app/components/activities/groups/metadata_template_activity_component.rb
+++ b/app/components/activities/groups/metadata_template_activity_component.rb
@@ -21,6 +21,8 @@ module Activities
                    group_metadata_templates_path(@activity[:group]),
                    class: active_link_classes,
                    title:
+                     t('components.activity.metadata_templates.group.link_descriptive_text'),
+                   'aria-label' =>
                      t('components.activity.metadata_templates.group.link_descriptive_text')
                  )
                else

--- a/app/components/activities/groups/projects/crud_activity_component.rb
+++ b/app/components/activities/groups/projects/crud_activity_component.rb
@@ -11,13 +11,18 @@ module Activities
           !@activity[:project].deleted?
         end
 
-        def activity_message
+        def activity_message # rubocop:disable Metrics/MethodLength
           href = if project_exists?
                    link_to(
                      @activity[:project_puid],
                      namespace_project_path(@activity[:group], @activity[:project].project),
                      class: active_link_classes,
                      title:
+                       t(
+                         'components.activity.groups.projects.link_descriptive_text',
+                         project_puid: @activity[:project_puid]
+                       ),
+                     'aria-label' =>
                        t(
                          'components.activity.groups.projects.link_descriptive_text',
                          project_puid: @activity[:project_puid]

--- a/app/components/activities/groups/projects/transfer_activity_component.rb
+++ b/app/components/activities/groups/projects/transfer_activity_component.rb
@@ -24,6 +24,11 @@ module Activities
                        t(
                          'components.activity.groups.projects.link_descriptive_text',
                          project_puid: @activity[:project_puid]
+                       ),
+                     'aria-label' =>
+                       t(
+                         'components.activity.groups.projects.link_descriptive_text',
+                         project_puid: @activity[:project_puid]
                        )
                    )
                  else

--- a/app/components/activities/groups/subgroup_activity_component.rb
+++ b/app/components/activities/groups/subgroup_activity_component.rb
@@ -26,6 +26,11 @@ module Activities
                      t(
                        'components.activity.subgroups.link_descriptive_text',
                        subgroup_puid: @activity[:created_group_puid]
+                     ),
+                   'aria-label' =>
+                     t(
+                       'components.activity.subgroups.link_descriptive_text',
+                       subgroup_puid: @activity[:created_group_puid]
                      )
                  )
                else

--- a/app/components/activities/groups/transfer_in_activity_component.rb
+++ b/app/components/activities/groups/transfer_in_activity_component.rb
@@ -24,6 +24,11 @@ module Activities
                      t(
                        'components.activity.subgroups.link_descriptive_text',
                        subgroup_puid: @activity[:transferred_group_puid]
+                     ),
+                   'aria-label' =>
+                     t(
+                       'components.activity.subgroups.link_descriptive_text',
+                       subgroup_puid: @activity[:transferred_group_puid]
                      )
                  )
                else

--- a/app/components/activities/member_activity_component.rb
+++ b/app/components/activities/member_activity_component.rb
@@ -20,13 +20,18 @@ module Activities
       !@activity[:member].deleted?
     end
 
-    def activity_message # rubocop:disable Metrics/MethodLength
+    def activity_message # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       href = if member_exists?
                link_to(
                  @activity[:member_email],
                  members_page,
                  class: active_link_classes,
                  title:
+                   t(
+                     'components.activity.members.link_descriptive_text',
+                     namespace_type: @activity[:member].namespace.type.downcase
+                   ),
+                 'aria-label' =>
                    t(
                      'components.activity.members.link_descriptive_text',
                      namespace_type: @activity[:member].namespace.type.downcase

--- a/app/components/activities/namespace_group_link_activity_component.rb
+++ b/app/components/activities/namespace_group_link_activity_component.rb
@@ -38,11 +38,10 @@ module Activities
           @activity[:namespace_puid],
           group_path(@activity[:group_link].namespace),
           class: active_link_classes,
-          title =>
-            t(
-              'components.activity.groups.link_descriptive_text',
-              group_puid: @activity[:namespace_puid]
-            ),
+          title: t(
+            'components.activity.groups.link_descriptive_text',
+            group_puid: @activity[:namespace_puid]
+          ),
           'aria-label' =>
             t(
               'components.activity.groups.link_descriptive_text',

--- a/app/components/activities/namespace_group_link_activity_component.rb
+++ b/app/components/activities/namespace_group_link_activity_component.rb
@@ -32,13 +32,18 @@ module Activities
 
     private
 
-    def active_links # rubocop:disable Metrics/MethodLength
+    def active_links # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       if link_to_shared_group?
         link_to(
           @activity[:namespace_puid],
           group_path(@activity[:group_link].namespace),
           class: active_link_classes,
-          title:
+          title =>
+            t(
+              'components.activity.groups.link_descriptive_text',
+              group_puid: @activity[:namespace_puid]
+            ),
+          'aria-label' =>
             t(
               'components.activity.groups.link_descriptive_text',
               group_puid: @activity[:namespace_puid]
@@ -49,7 +54,11 @@ module Activities
           @activity[:group_puid],
           group_path(@activity[:group_link].group),
           class: active_link_classes,
-          title:
+          title: t(
+            'components.activity.groups.link_descriptive_text',
+            group_puid: @activity[:group_puid]
+          ),
+          'aria-label' =>
             t(
               'components.activity.groups.link_descriptive_text',
               group_puid: @activity[:group_puid]

--- a/app/components/activities/projects/metadata_template_activity_component.rb
+++ b/app/components/activities/projects/metadata_template_activity_component.rb
@@ -14,7 +14,7 @@ module Activities
         !@activity[:template].deleted?
       end
 
-      def activity_message
+      def activity_message # rubocop:disable Metrics/MethodLength
         href = if template_exists?
 
                  link_to(
@@ -25,6 +25,8 @@ module Activities
                    ),
                    class: active_link_classes,
                    title:
+                     t('components.activity.metadata_templates.project.link_descriptive_text'),
+                   'aria-label' =>
                      t('components.activity.metadata_templates.project.link_descriptive_text')
                  )
                else

--- a/app/components/activities/projects/sample_activity_component.rb
+++ b/app/components/activities/projects/sample_activity_component.rb
@@ -52,6 +52,11 @@ module Activities
                 t(
                   'components.activity.samples.link_descriptive_text',
                   sample_puid: @activity[:sample_puid]
+                ),
+              'aria-label' =>
+                t(
+                  'components.activity.samples.link_descriptive_text',
+                  sample_puid: @activity[:sample_puid]
                 )
             )
 

--- a/app/components/activities/projects/sample_clone_activity_component.rb
+++ b/app/components/activities/projects/sample_clone_activity_component.rb
@@ -32,6 +32,11 @@ module Activities
                      t(
                        'components.activity.samples.clone.link_descriptive_text',
                        project_puid: namespace_puid(namespace)
+                     ),
+                   'aria-label' =>
+                     t(
+                       'components.activity.samples.clone.link_descriptive_text',
+                       project_puid: namespace_puid(namespace)
                      )
                  )
                else

--- a/app/components/activities/projects/sample_transfer_activity_component.rb
+++ b/app/components/activities/projects/sample_transfer_activity_component.rb
@@ -32,6 +32,11 @@ module Activities
                      t(
                        'components.activity.samples.transfer.link_descriptive_text',
                        project_puid: namespace_puid(namespace)
+                     ),
+                   'aria-label' =>
+                     t(
+                       'components.activity.samples.transfer.link_descriptive_text',
+                       project_puid: namespace_puid(namespace)
                      )
                  )
                else

--- a/app/components/activities/workflow_execution_activity_component.rb
+++ b/app/components/activities/workflow_execution_activity_component.rb
@@ -36,7 +36,7 @@ module Activities
       end
     end
 
-    def automated_workflow_execution_activity
+    def automated_workflow_execution_activity # rubocop:disable Metrics/MethodLength
       href = if workflow_execution_exists?
                link_to(
                  @activity[:workflow_id],
@@ -46,6 +46,8 @@ module Activities
                  ),
                  class: active_link_classes,
                  title:
+                   t('components.activity.workflow_executions.index.link_descriptive_text'),
+                 'aria-label' =>
                    t('components.activity.workflow_executions.index.link_descriptive_text')
                )
              else
@@ -68,6 +70,11 @@ module Activities
           t(
             'components.activity.workflow_executions.show.link_descriptive_text',
             workflow_id: @activity[:workflow_id]
+          ),
+        'aria-label' =>
+          t(
+            'components.activity.workflow_executions.show.link_descriptive_text',
+            workflow_id: @activity[:workflow_id]
           )
       )
 
@@ -80,6 +87,11 @@ module Activities
         ),
         class: active_link_classes,
         title:
+          t(
+            'components.activity.samples.link_descriptive_text',
+            sample_puid: @activity[:sample_puid]
+          ),
+        'aria-label' =>
           t(
             'components.activity.samples.link_descriptive_text',
             sample_puid: @activity[:sample_puid]
@@ -103,6 +115,11 @@ module Activities
           t(
             'components.activity.workflow_executions.show.link_descriptive_text',
             workflow_id: @activity[:workflow_id]
+          ),
+        'aria-label' =>
+          t(
+            'components.activity.workflow_executions.show.link_descriptive_text',
+            workflow_id: @activity[:workflow_id]
           )
       )
 
@@ -123,6 +140,11 @@ module Activities
         ),
         class: active_link_classes,
         title:
+          t(
+            'components.activity.samples.link_descriptive_text',
+            sample_puid: @activity[:sample_puid]
+          ),
+        'aria-label' =>
           t(
             'components.activity.samples.link_descriptive_text',
             sample_puid: @activity[:sample_puid]


### PR DESCRIPTION
## What does this PR do and why?

Activity links (e.g. group links, sample links, workflow execution links) now have:

- **`aria-label`** so screen readers announce a descriptive name instead of just the PUID text
- **`title`** so mouse users see a tooltip on hover with the same descriptive text
- **`focus-visible` styles** on the shared `active_link_classes` so keyboard users see a visible focus ring when tabbing to these links

Previously, some links only had `title` (which screen readers mostly ignore) and none had focus indicators due to inline `outline: none` styles overriding the global focus ring.

### Files changed

- `base_activity_component.rb` — added focus-visible utilities to `active_link_classes`
- All 12 activity components — added both `title:` and `aria-label` with the same i18n descriptive text to every `link_to` call

## Screenshots or screen recordings

_N/A — no visual layout changes. Focus ring now appears on keyboard Tab; tooltip appears on hover._

<img width="1272" height="890" alt="image" src="https://github.com/user-attachments/assets/0778e1ee-bb4b-4b41-85ba-c724fe20e0aa" />

## How to set up and validate locally

1. Start the dev server with `bin/dev`
2. Navigate to a project or group page that shows recent activity
3. **Keyboard test**: Press Tab until you reach an activity link — a black outline ring should appear
4. **Screen reader test**: Use NVDA or VoiceOver to navigate to a link — it should announce the descriptive text (e.g. "View group page for group with persistent unique identifier INXT_GRP_...")
5. **Hover test**: Mouse over an activity link — a tooltip with the same descriptive text should appear

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.