### PR TITLE
Versioned Metadata Template Dropdown Component

### DIFF
--- a/app/components/metadata_templates/dropdown/v1/component.html.erb
+++ b/app/components/metadata_templates/dropdown/v1/component.html.erb
@@ -7,7 +7,7 @@
   distance: 10,
   styles: {
     button: "button w-full button-default",
-    dropdown: "w-48 divide-y divide-slate-100 dark:divide-slate-600 z-30",
+    dropdown: "divide-y divide-slate-100 dark:divide-slate-600",
   },
 ) do |dropdown| %>
   <% dropdown.with_custom_item do %>

--- a/app/components/metadata_templates/dropdown/v1/component.html.erb
+++ b/app/components/metadata_templates/dropdown/v1/component.html.erb
@@ -1,30 +1,20 @@
-<div
-  class="flex max-sm:grow"
-  data-controller="dropdown--v1"
-  data-dropdown--v1-skidding-value="0"
-  data-dropdown--v1-distance-value="10"
->
-  <button
-    data-dropdown--v1-target="trigger"
-    title="<%= t("shared.samples.metadata_templates.tooltip") %>"
-    id="metadata-template-dd-trigger"
-    class="button w-full button-default"
-    type="button"
-    aria-haspopup="true"
-    aria-expanded="false"
-    aria-controls="metadata-template-dd-menu"
-  >
-    <span id="metadata-template-dd-label"><%= t("shared.samples.metadata_templates.label") %></span>
-    <%= icon(:sliders_horizontal, size: :sm, class: "ml-2 flex-none") %>
-  </button>
-
-  <!-- Dropdown menu -->
-  <%= helpers.turbo_frame_tag "metadata-template-dd-menu", class: "
-      w-48 bg-white divide-y divide-slate-100 rounded-lg shadow-sm
-      dark:bg-slate-700 dark:divide-slate-600 z-30
-    ", "data-dropdown--v1-target": "menu", src: url, refresh: "morph", loading: :lazy, hidden: true do %>
-    <%= render SpinnerComponent.new(
-      message: t("shared.samples.metadata_templates.loading"),
-    ) %>
+<%= viral_dropdown(
+  label: t("shared.samples.metadata_templates.label"),
+  icon: :sliders_horizontal,
+  title: t("shared.samples.metadata_templates.tooltip"),
+  trigger_id: "metadata-template-dd-trigger",
+  skidding: 0,
+  distance: 10,
+  styles: {
+    button: "button w-full button-default",
+    dropdown: "w-48 divide-y divide-slate-100 dark:divide-slate-600 z-30",
+  },
+) do |dropdown| %>
+  <% dropdown.with_custom_item do %>
+    <%= helpers.turbo_frame_tag "metadata-template-dd-menu", src: url, refresh: "morph", loading: :lazy do %>
+      <%= render SpinnerComponent.new(
+        message: t("shared.samples.metadata_templates.loading"),
+      ) %>
+    <% end %>
   <% end %>
-</div>
+<% end %>

--- a/app/components/metadata_templates/dropdown/v1/component.html.erb
+++ b/app/components/metadata_templates/dropdown/v1/component.html.erb
@@ -1,6 +1,7 @@
 <%= render DropdownComponent.new(
   label: t("shared.samples.metadata_templates.label"),
   icon: :sliders_horizontal,
+  icon_size: :sm,
   title: t("shared.samples.metadata_templates.tooltip"),
   trigger_id: "metadata-template-dd-trigger",
   skidding: 0,

--- a/app/components/metadata_templates/dropdown/v1/component.html.erb
+++ b/app/components/metadata_templates/dropdown/v1/component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dropdown(
+<%= render DropdownComponent.new(
   label: t("shared.samples.metadata_templates.label"),
   icon: :sliders_horizontal,
   title: t("shared.samples.metadata_templates.tooltip"),

--- a/app/components/metadata_templates/dropdown/v1/component.html.erb
+++ b/app/components/metadata_templates/dropdown/v1/component.html.erb
@@ -11,10 +11,12 @@
   },
 ) do |dropdown| %>
   <% dropdown.with_custom_item do %>
-    <%= helpers.turbo_frame_tag "metadata-template-dd-menu", src: url, refresh: "morph", loading: :lazy do %>
-      <%= render SpinnerComponent.new(
+    <li>
+      <%= helpers.turbo_frame_tag "metadata-template-dd-menu", src: url, refresh: "morph", loading: :lazy do %>
+        <%= render SpinnerComponent.new(
         message: t("shared.samples.metadata_templates.loading"),
       ) %>
-    <% end %>
+      <% end %>
+    </li>
   <% end %>
 <% end %>

--- a/app/components/metadata_templates/dropdown/v1/component.html.erb
+++ b/app/components/metadata_templates/dropdown/v1/component.html.erb
@@ -19,10 +19,10 @@
   </button>
 
   <!-- Dropdown menu -->
-  <%= turbo_frame_tag "metadata-template-dd-menu", class: "
-      hidden w-48 bg-white divide-y divide-slate-100 rounded-lg shadow-sm
+  <%= helpers.turbo_frame_tag "metadata-template-dd-menu", class: "
+      w-48 bg-white divide-y divide-slate-100 rounded-lg shadow-sm
       dark:bg-slate-700 dark:divide-slate-600 z-30
-    ", "data-dropdown--v1-target": "menu", src: url, refresh: "morph", loading: :lazy do %>
+    ", "data-dropdown--v1-target": "menu", src: url, refresh: "morph", loading: :lazy, hidden: true do %>
     <%= render SpinnerComponent.new(
       message: t("shared.samples.metadata_templates.loading"),
     ) %>

--- a/app/components/metadata_templates/dropdown/v1/component.rb
+++ b/app/components/metadata_templates/dropdown/v1/component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module MetadataTemplates
+  module Dropdown
+    module V1
+      # Dropdown component for metadata templates
+      class Component < ::Component
+        attr_reader :url
+
+        def initialize(url:)
+          @url = url
+        end
+      end
+    end
+  end
+end

--- a/app/components/metadata_templates/dropdown_component.rb
+++ b/app/components/metadata_templates/dropdown_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module MetadataTemplates
+  # Stable entrypoint for rendering a metadata templates drop down across UI versions.
+  class DropdownComponent < Versioning::VersionedComponent
+    IMPLEMENTATIONS = {
+      v1: MetadataTemplates::Dropdown::V1::Component
+    }.freeze
+
+    VERSION_RESOLVER = -> { :v1 }
+  end
+end

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -196,18 +196,15 @@
 
       <div id="table-filter" role="presentation" class="contents"><%= render partial: "table_filter" %></div>
 
-      <%= render partial: "shared/samples/metadata_template_dropdown",
-      locals: {
-        url:
-          list_group_metadata_templates_url(
-            @group,
-            metadata_template: @metadata_template[:id],
-            limit: @pagy&.limit,
-            page: @pagy&.page,
-          ),
-        metadata_template: @metadata_template,
-        pagy: @pagy,
-      } %>
+      <%= render MetadataTemplates::DropdownComponent.new(
+      url:
+        list_group_metadata_templates_url(
+          @group,
+          metadata_template: @metadata_template[:id],
+          limit: @pagy&.limit,
+          page: @pagy&.page,
+        )
+      ) %>
     </div>
   <% end %>
 

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -209,19 +209,13 @@
 
       <div id="table-filter" role="presentation" class="contents"><%= render partial: "table_filter" %></div>
 
-      <%= render partial: "shared/samples/metadata_template_dropdown",
-      locals: {
-        url:
-          list_namespace_project_metadata_templates_url(
-            @project.namespace.parent,
-            @project,
-            metadata_template: @metadata_template[:id],
-            limit: @pagy&.limit,
-            page: @pagy&.page,
-          ),
-        metadata_template: @metadata_template,
-        pagy: @pagy,
-      } %>
+      <%= render MetadataTemplates::DropdownComponent.new(
+      url:
+        list_namespace_project_metadata_templates_url(
+          @project.namespace.parent, @project, metadata_template: @metadata_template[:id],
+          limit: @pagy&.limit, page: @pagy&.page
+        )
+      ) %>
     </div>
   <% end %>
 

--- a/test/components/metadata_templates/dropdown/component_test.rb
+++ b/test/components/metadata_templates/dropdown/component_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MetadataTemplates
+  module Dropdown
+    class ComponentTest < ViewComponent::TestCase
+      setup do
+        @group = groups(:group_one)
+        @metadata_template = metadata_templates(:valid_group_metadata_template)
+        @pagy = Pagy::Offset.new(count: 10, page: 1, limit: 10)
+      end
+
+      test 'renders metadata template turbo frame with lazy loading and spinner' do
+        url = Rails.application.routes.url_helpers.list_group_metadata_templates_url(
+          @group,
+          metadata_template: @metadata_template[:id],
+          limit: @pagy&.limit,
+          page: @pagy&.page
+        )
+
+        render_inline MetadataTemplates::DropdownComponent.new(url: url)
+
+        assert_selector "turbo-frame#metadata-template-dd-menu[src='#{url}'][loading='lazy'][refresh='morph']",
+                        visible: :all
+        assert_text I18n.t('shared.samples.metadata_templates.loading')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
This PR introduces a **component versioning system for the Metadata Template Dropdown component**, enabling the application to support multiple implementations that can be switched via a feature flag.

#### Key Changes

- The single versioned implementation:
  - **V1 (Current/Stable)**: Uses the `DropdownComponent` helper for dropdown rendering
- Refactored `MetadataTemplates::DropdownComponent` to act as a versioned component entry point 
 
## Screenshots or screen recordings
N/A

## How to set up and validate locally
#### Enable Feature Flag
1. Start the server: 
```bash
bin/setup
```
2. Open Rails console: 
```bash
bin/rails console
```
3. Enable the flag: 
```bash
Flipper.enable(:v2_dropdown)
```

#### Manual Tests
1. Verify metadata template dropdown appears/disappears correctly
1. Verify metadata template dropdown positions correctly (no overflow issues)
1. Verify metadata template dropdown remains accessible
2. Repeat with feature flag turned off.

#### Automated Tests

Run the new component versioning tests:
```bash
rails test test/components/metadata_templates/dropdown/component_test.rb
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.