### PR TITLE
feat(data exports): finish queued linelist export with immediate download or saved download

### DIFF
--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -7,6 +7,7 @@
   "linelist-export-save-to-server-url-value": data_exports_url,
   "linelist-export-sample-graphql-id-prefix-value": sample_graphql_id_prefix,
   "linelist-export-minimum-visible-duration-ms-value": 3500,
+  "linelist-export-save-result-visible-duration-ms-value": 6000,
   "linelist-export-no-selection-error-message-value": t("data_exports.new_linelist_export_dialog.no_selection"),
   "linelist-export-selected-count-message-value": t("data_exports.new_linelist_export_dialog.selected_count"),
   "linelist-export-preparing-rows-message-value": t("data_exports.new_linelist_export_dialog.preparing_rows"),
@@ -15,6 +16,7 @@
   "linelist-export-unexpected-error-message-value": t("data_exports.new_linelist_export_dialog.unexpected_error"),
   "linelist-export-download-started-message-value": t("data_exports.new_linelist_export_dialog.download_started"),
   "linelist-export-queueing-save-message-value": t("data_exports.new_linelist_export_dialog.queueing_save"),
+  "linelist-export-view-data-export-message-value": t("data_exports.new_linelist_export_dialog.view_data_export"),
   "linelist-export-created-records-message-value": t("data_exports.new_linelist_export_dialog.created_records"),
   "linelist-export-save-queued-message-value": t("data_exports.new_linelist_export_dialog.save_queued"),
   "linelist-export-save-failed-message-value": t("data_exports.new_linelist_export_dialog.save_failed"),
@@ -265,6 +267,14 @@
             <h4 class="text-sm font-semibold text-slate-900 dark:text-slate-100"><%= t(".exporting_linelist") %></h4>
 
             <p class="mt-0.5 text-xs text-slate-600 dark:text-slate-400" data-linelist-export-progress-message></p>
+
+            <p class="mt-1 hidden text-xs" data-linelist-export-target="progressLinkRow">
+              <a
+                href="/-/data_exports"
+                class="text-primary-700 hover:underline dark:text-primary-300"
+                data-linelist-export-target="progressLink"
+              ></a>
+            </p>
           </div>
 
           <button

--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -106,28 +106,45 @@
 
       <%= form_with(url: "#", method: :get, scope: :data_export, data: { action: "submit->linelist-export#submit" }) do |form| %>
         <div class="grid gap-4">
-          <%= render partial: "data_exports/name_and_email", locals: { form: } %>
-
           <div class="form-field">
-            <label class="inline-flex items-center gap-2">
-              <%= form.check_box :save_to_server,
-                                 {
-                                   checked: false,
-                                   id: "linelist-save-to-server",
-                                   class: "h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500"
-                                 },
-                                 true,
-                                 false %>
+            <fieldset>
+              <legend class="mb-2 text-sm text-slate-900 dark:text-slate-400">
+                <%= t("data_exports.new_linelist_export_dialog.delivery_mode") %>
+              </legend>
 
-              <span class="text-slate-700 dark:text-slate-300">
-                <%= t("data_exports.new_linelist_export_dialog.save_to_server") %>
-              </span>
-            </label>
+              <div class="flex gap-4">
+                <label class="inline-flex items-center gap-1">
+                  <%= radio_button_tag :linelist_delivery_mode,
+                                       "immediate_download",
+                                       true,
+                                       id: "linelist-delivery-download",
+                                       name: "data_export[delivery_mode]",
+                                       data: { action: "change->linelist-export#toggleSaveToServer" } %>
+
+                  <span><%= t("data_exports.new_linelist_export_dialog.immediate_download") %></span>
+                </label>
+
+                <label class="inline-flex items-center gap-1">
+                  <%= radio_button_tag :linelist_delivery_mode,
+                                       "save_to_server",
+                                       false,
+                                       id: "linelist-delivery-save",
+                                       name: "data_export[delivery_mode]",
+                                       data: { action: "change->linelist-export#toggleSaveToServer" } %>
+
+                  <span><%= t("data_exports.new_linelist_export_dialog.save_to_server") %></span>
+                </label>
+              </div>
+            </fieldset>
 
             <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
-              <%= t("data_exports.new_linelist_export_dialog.save_to_server_help") %>
+              <%= t("data_exports.new_linelist_export_dialog.delivery_mode_help") %>
             </p>
           </div>
+
+          <fieldset class="grid gap-4 disabled:opacity-60" data-linelist-export-target="saveDetailsFieldset" disabled>
+            <%= render partial: "data_exports/name_and_email", locals: { form: } %>
+          </fieldset>
 
           <%= form.hidden_field :namespace_id, value: @namespace_id, name: "data_export[export_parameters][namespace_id]" %>
 

--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -1,7 +1,10 @@
+<% metadata_fields = @namespace&.metadata_fields || [] %>
+
 <% linelist_data = {
   controller: "linelist-export",
   "linelist-export-worker-url-value": asset_path("workers/linelist_export_worker.js"),
   "linelist-export-graphql-url-value": graphql_url,
+  "linelist-export-save-to-server-url-value": data_exports_url,
   "linelist-export-sample-graphql-id-prefix-value": sample_graphql_id_prefix,
   "linelist-export-minimum-visible-duration-ms-value": 3500,
   "linelist-export-no-selection-error-message-value": t("data_exports.new_linelist_export_dialog.no_selection"),
@@ -9,11 +12,19 @@
   "linelist-export-preparing-rows-message-value": t("data_exports.new_linelist_export_dialog.preparing_rows"),
   "linelist-export-preparing-export-message-value": t("data_exports.new_linelist_export_dialog.preparing_export"),
   "linelist-export-start-error-message-value": t("data_exports.new_linelist_export_dialog.start_error"),
-  "linelist-export-xlsx-unsupported-message-value": t("data_exports.new_linelist_export_dialog.xlsx_unsupported"),
   "linelist-export-unexpected-error-message-value": t("data_exports.new_linelist_export_dialog.unexpected_error"),
   "linelist-export-download-started-message-value": t("data_exports.new_linelist_export_dialog.download_started"),
   "linelist-export-created-records-message-value": t("data_exports.new_linelist_export_dialog.created_records"),
+  "linelist-export-save-queued-message-value": t("data_exports.new_linelist_export_dialog.save_queued"),
+  "linelist-export-save-failed-message-value": t("data_exports.new_linelist_export_dialog.save_failed"),
 } %>
+
+<% if metadata_fields.any? %>
+  <% linelist_data[:controller] = "linelist-export sortable-lists--v1--two-lists-selection" %>
+  <% linelist_data["sortable-lists--v1--two-lists-selection-selected-list-value"] = "selected-list" %>
+  <% linelist_data["sortable-lists--v1--two-lists-selection-available-list-value"] = "available-list" %>
+  <% linelist_data["sortable-lists--v1--two-lists-selection-field-name-value"] = "data_export[export_parameters][metadata_fields][]" %>
+<% end %>
 
 <%= viral_dialog(open: @open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("data_exports.new_linelist_export_dialog.title")) %>
@@ -39,60 +50,99 @@
 
             <label class="inline-flex items-center gap-1">
               <%= radio_button_tag :linelist_format,
-                                   "xlsx",
-                                   false,
-                                   id: "linelist-format-xlsx",
-                                   disabled: true,
-                                   name: "data_export[export_parameters][linelist_format]" %>
+                                    "xlsx",
+                                    false,
+                                    id: "linelist-format-xlsx",
+                                    name: "data_export[export_parameters][linelist_format]" %>
 
               <span><%= t("data_exports.new_linelist_export_dialog.xlsx") %></span>
             </label>
           </div>
         </fieldset>
+      </div>
 
-        <p class="mt-2 text-xs text-slate-600 dark:text-slate-400">
-          <%= t("data_exports.new_linelist_export_dialog.xlsx_unsupported") %>
+      <% if metadata_fields.any? %>
+        <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100">
+          <%= t("data_exports.new_linelist_export_dialog.metadata") %>
+        </h2>
+        <%= render Viral::SortableListsGuidanceComponent.new(
+          title: t("data_exports.new_linelist_export_dialog.fields_instructions_title"),
+          instructions: t("data_exports.new_linelist_export_dialog.fields_instructions"),
+          keyboard_help: t("data_exports.new_linelist_export_dialog.keyboard_help"),
+          available: {
+            title: t("data_exports.new_linelist_export_dialog.available_list_title"),
+            description: t("data_exports.new_linelist_export_dialog.available_description"),
+          },
+          selected: {
+            title: t("data_exports.new_linelist_export_dialog.selected_list_title"),
+            description: t("data_exports.new_linelist_export_dialog.selected_description"),
+          },
+        ) %>
+        <%= render SortableListsComponent.new(
+          templates: @templates,
+          template_label: t("data_exports.new.template_select_label")
+        ) do |sortable_lists| %>
+          <%= sortable_lists.with_list(
+            id: "available-list",
+            title: t("data_exports.new_linelist_export_dialog.available"),
+            list_items: metadata_fields,
+            group: "metadata_selection",
+          ) %>
+
+          <%= sortable_lists.with_list(
+            id: "selected-list",
+            title: t("data_exports.new_linelist_export_dialog.selected"),
+            group: "metadata_selection",
+          ) %>
+        <% end %>
+        <template id="sortable-list-item-template" data-sortable-lists--v1--two-lists-selection-target="itemTemplate">
+          <%= render SortableLists::V1::ListItemComponent.new(list_item: "NAME_HERE") %>
+        </template>
+      <% else %>
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          <%= t("data_exports.new_linelist_export_dialog.selected") %>
         </p>
-      </div>
+      <% end %>
 
-      <div class="form-field">
-        <fieldset>
-          <legend class="mb-1 text-sm text-slate-900 dark:text-slate-400">
-            <%= t("data_exports.new_linelist_export_dialog.metadata") %>
-          </legend>
+      <%= form_with(url: "#", method: :get, scope: :data_export, data: { action: "submit->linelist-export#submit" }) do |form| %>
+        <div class="grid gap-4">
+          <%= render partial: "data_exports/name_and_email", locals: { form: } %>
 
-          <div class="grid max-h-48 gap-1 overflow-y-auto rounded-lg border border-slate-200 p-2 dark:border-slate-700">
-            <% metadata_fields = @namespace&.metadata_fields || [] %>
+          <div class="form-field">
+            <label class="inline-flex items-center gap-2">
+              <%= form.check_box :save_to_server,
+                                 {
+                                   checked: false,
+                                   id: "linelist-save-to-server",
+                                   class: "h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+                                 },
+                                 true,
+                                 false %>
 
-            <% if metadata_fields.any? %>
-              <% metadata_fields.each_with_index do |field, index| %>
-                <% field_id = "metadata-field-#{index}-#{field.to_s.parameterize}" %>
+              <span class="text-slate-700 dark:text-slate-300">
+                <%= t("data_exports.new_linelist_export_dialog.save_to_server") %>
+              </span>
+            </label>
 
-                <div class="flex items-center gap-2">
-                  <%= check_box_tag(
-                        "metadata_fields[]",
-                        field,
-                        false,
-                        id: field_id,
-                        name: "data_export[export_parameters][metadata_fields][]",
-                        class: "h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500"
-                      ) %>
-
-                  <%= label_tag field_id, field, class: "text-slate-700 dark:text-slate-300" %>
-                </div>
-              <% end %>
-            <% else %>
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                <%= t("data_exports.new_linelist_export_dialog.selected") %>
-              </p>
-            <% end %>
+            <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+              <%= t("data_exports.new_linelist_export_dialog.save_to_server_help") %>
+            </p>
           </div>
-        </fieldset>
-      </div>
 
-      <%= form_with(url: "#", method: :get, data: { action: "submit->linelist-export#submit" }) do |form| %>
-        <%= form.hidden_field :namespace_id, value: @namespace_id, name: "data_export[export_parameters][namespace_id]" %>
-        <%= form.submit t("data_exports.new.submit_button"), class: "button button-primary" %>
+          <%= form.hidden_field :namespace_id, value: @namespace_id, name: "data_export[export_parameters][namespace_id]" %>
+
+          <% if metadata_fields.any? %>
+            <div class="hidden" data-sortable-lists--v1--two-lists-selection-target="field"></div>
+            <% submit_data = {
+              action: "click->sortable-lists--v1--two-lists-selection#constructParams",
+              "sortable-lists--v1--two-lists-selection-target": "submitBtn",
+            } %>
+          <% else %>
+            <% submit_data = {} %>
+          <% end %>
+
+          <%= form.submit t("data_exports.new.submit_button"), data: submit_data, class: "button button-primary" %>
+        </div>
       <% end %>
 
       <p

--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -14,6 +14,7 @@
   "linelist-export-start-error-message-value": t("data_exports.new_linelist_export_dialog.start_error"),
   "linelist-export-unexpected-error-message-value": t("data_exports.new_linelist_export_dialog.unexpected_error"),
   "linelist-export-download-started-message-value": t("data_exports.new_linelist_export_dialog.download_started"),
+  "linelist-export-queueing-save-message-value": t("data_exports.new_linelist_export_dialog.queueing_save"),
   "linelist-export-created-records-message-value": t("data_exports.new_linelist_export_dialog.created_records"),
   "linelist-export-save-queued-message-value": t("data_exports.new_linelist_export_dialog.save_queued"),
   "linelist-export-save-failed-message-value": t("data_exports.new_linelist_export_dialog.save_failed"),
@@ -65,22 +66,103 @@
         <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100">
           <%= t("data_exports.new_linelist_export_dialog.metadata") %>
         </h2>
-        <%= render Viral::SortableListsGuidanceComponent.new(
-          title: t("data_exports.new_linelist_export_dialog.fields_instructions_title"),
-          instructions: t("data_exports.new_linelist_export_dialog.fields_instructions"),
-          keyboard_help: t("data_exports.new_linelist_export_dialog.keyboard_help"),
-          available: {
-            title: t("data_exports.new_linelist_export_dialog.available_list_title"),
-            description: t("data_exports.new_linelist_export_dialog.available_description"),
-          },
-          selected: {
-            title: t("data_exports.new_linelist_export_dialog.selected_list_title"),
-            description: t("data_exports.new_linelist_export_dialog.selected_description"),
-          },
-        ) %>
+        <section
+          class="
+            rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700 dark:border-slate-700
+            dark:bg-slate-800/60 dark:text-slate-300
+          "
+        >
+          <h3 class="font-semibold text-slate-900 dark:text-slate-100">
+            <%= t("data_exports.new_linelist_export_dialog.fields_instructions_title") %>
+          </h3>
+
+          <p class="mt-1">
+            <%= t("data_exports.new_linelist_export_dialog.fields_instructions") %>
+          </p>
+
+          <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+            <%= t("data_exports.new_linelist_export_dialog.keyboard_help") %>
+          </p>
+
+          <div class="mt-2 flex flex-wrap gap-2 text-xs">
+            <span
+              class="
+                inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-2 py-1 text-slate-700
+                dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200
+              "
+            >
+              <span class="font-medium"><%= t("components.sortable_lists.v1.list_component.add") %>:</span>
+
+              <kbd
+                class="
+                  rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5 font-mono text-[11px]
+                  dark:border-slate-500 dark:bg-slate-800
+                "
+              >
+                <%= t("components.sortable_lists.v1.list_component.keyboard_shortcuts.add") %>
+              </kbd>
+            </span>
+
+            <span
+              class="
+                inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-2 py-1 text-slate-700
+                dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200
+              "
+            >
+              <span class="font-medium"><%= t("common.actions.remove") %>:</span>
+
+              <kbd
+                class="
+                  rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5 font-mono text-[11px]
+                  dark:border-slate-500 dark:bg-slate-800
+                "
+              >
+                <%= t("components.sortable_lists.v1.list_component.keyboard_shortcuts.remove") %>
+              </kbd>
+            </span>
+
+            <span
+              class="
+                inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-2 py-1 text-slate-700
+                dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200
+              "
+            >
+              <span class="font-medium"><%= t("components.sortable_lists.v1.list_component.up") %>:</span>
+
+              <kbd
+                class="
+                  rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5 font-mono text-[11px]
+                  dark:border-slate-500 dark:bg-slate-800
+                "
+              >
+                <%= t("components.sortable_lists.v1.list_component.keyboard_shortcuts.up") %>
+              </kbd>
+            </span>
+
+            <span
+              class="
+                inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-2 py-1 text-slate-700
+                dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200
+              "
+            >
+              <span class="font-medium"><%= t("components.sortable_lists.v1.list_component.down") %>:</span>
+
+              <kbd
+                class="
+                  rounded border border-slate-300 bg-slate-100 px-1.5 py-0.5 font-mono text-[11px]
+                  dark:border-slate-500 dark:bg-slate-800
+                "
+              >
+                <%= t("components.sortable_lists.v1.list_component.keyboard_shortcuts.down") %>
+              </kbd>
+            </span>
+          </div>
+        </section>
         <%= render SortableListsComponent.new(
           templates: @templates,
-          template_label: t("data_exports.new.template_select_label")
+          template_label: t("data_exports.new.template_select_label"),
+          grouped_controls: true,
+          selected_empty_state: t("data_exports.new_linelist_export_dialog.selected_empty_state")
         ) do |sortable_lists| %>
           <%= sortable_lists.with_list(
             id: "available-list",
@@ -136,13 +218,13 @@
                 </label>
               </div>
             </fieldset>
-
-            <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
-              <%= t("data_exports.new_linelist_export_dialog.delivery_mode_help") %>
-            </p>
           </div>
 
-          <fieldset class="grid gap-4 disabled:opacity-60" data-linelist-export-target="saveDetailsFieldset" disabled>
+          <fieldset
+            class="grid hidden gap-4 disabled:opacity-60"
+            data-linelist-export-target="saveDetailsFieldset"
+            disabled
+          >
             <%= render partial: "data_exports/name_and_email", locals: { form: } %>
           </fieldset>
 
@@ -158,16 +240,22 @@
             <% submit_data = {} %>
           <% end %>
 
-          <%= form.submit t("data_exports.new.submit_button"), data: submit_data, class: "button button-primary" %>
+          <p
+            class="text-sm text-slate-600 dark:text-slate-300"
+            data-linelist-export-target="sampleStatus"
+            role="status"
+            aria-live="polite"
+          ></p>
+
+          <div class="flex items-center justify-between gap-3">
+            <button type="button" class="button button-default" data-action="click->linelist-export#closeDialog">
+              <%= t("common.actions.cancel") %>
+            </button>
+
+            <%= form.submit t("data_exports.new_linelist_export_dialog.export_data_button"), data: submit_data, class: "button button-primary" %>
+          </div>
         </div>
       <% end %>
-
-      <p
-        class="text-sm text-slate-600 dark:text-slate-300"
-        data-linelist-export-target="sampleStatus"
-        role="status"
-        aria-live="polite"
-      ></p>
     </div>
 
     <template data-linelist-export-target="progressTemplate">

--- a/app/components/data_exports/linelist_export_dialog/v2/component.rb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.rb
@@ -17,6 +17,10 @@ module DataExports
           helpers.api_graphql_path
         end
 
+        def data_exports_url
+          helpers.data_exports_path
+        end
+
         def sample_graphql_id_prefix
           "gid://#{GlobalID.app}/Sample/"
         end

--- a/app/components/sortable_lists/v1/component.html.erb
+++ b/app/components/sortable_lists/v1/component.html.erb
@@ -34,11 +34,69 @@
   </div>
 <% end %>
 
-<div class="grid gap-2 max-sm:grid-cols-1 sm:grid-cols-2">
-  <% lists.each do |list| %>
-    <%= list %>
-  <% end %>
-</div>
+<% if grouped_controls && lists.size == 2 %>
+  <% available_list = lists.first %>
+  <% selected_list = lists.second %>
+  <div class="grid gap-3 max-sm:grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto] sm:items-start">
+    <%= available_list %>
+
+    <div class="flex sm:items-center sm:self-stretch">
+      <div class="flex gap-2 sm:mt-6 sm:flex-col" role="group" aria-label="<%= t('common.labels.actions') %>">
+        <button
+          type="button"
+          class="button button-default whitespace-nowrap"
+          data-action="click->sortable-lists--v1--two-lists-selection#addSelectionByAddButton"
+          data-sortable-lists--v1--two-lists-selection-target="addButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.add') %>"
+        >
+          <%= t('components.sortable_lists.v1.list_component.add') %>
+        </button>
+
+        <button
+          type="button"
+          class="button button-default whitespace-nowrap"
+          data-action="click->sortable-lists--v1--two-lists-selection#removeSelectionByRemoveButton"
+          data-sortable-lists--v1--two-lists-selection-target="removeButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.remove') %>"
+        >
+          <%= t('common.actions.remove') %>
+        </button>
+      </div>
+    </div>
+
+    <%= selected_list %>
+
+    <div class="flex sm:items-start sm:self-stretch">
+      <div class="flex gap-2 sm:mt-6 sm:flex-col" role="group" aria-label="<%= t('common.labels.actions') %>">
+        <button
+          type="button"
+          class="button button-default whitespace-nowrap"
+          data-action="click->sortable-lists--v1--two-lists-selection#moveSelection"
+          data-sortable-lists--v1--two-lists-selection-target="upButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.up') %>"
+        >
+          <%= t('components.sortable_lists.v1.list_component.up') %>
+        </button>
+
+        <button
+          type="button"
+          class="button button-default whitespace-nowrap"
+          data-action="click->sortable-lists--v1--two-lists-selection#moveSelection"
+          data-sortable-lists--v1--two-lists-selection-target="downButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.down') %>"
+        >
+          <%= t('components.sortable_lists.v1.list_component.down') %>
+        </button>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <div class="grid gap-2 max-sm:grid-cols-1 sm:grid-cols-2">
+    <% lists.each do |list| %>
+      <%= list %>
+    <% end %>
+  </div>
+<% end %>
 
 <div
   class="sr-only"

--- a/app/components/sortable_lists/v1/component.rb
+++ b/app/components/sortable_lists/v1/component.rb
@@ -5,20 +5,34 @@ module SortableLists
     # This component creates the sortable_lists.
     class Component < ::Component
       attr_reader :title, :description, :templates, :template_label,
-                  :required, :aria_live_translations
+                  :required, :aria_live_translations, :grouped_controls
 
       renders_many :lists, lambda { |id:, group:, title:, **system_arguments|
-        SortableLists::V1::ListComponent.new(id:, group:, title:, required: @required, **system_arguments)
+        empty_state_message = id.to_s.include?('selected') ? @selected_empty_state : nil
+        SortableLists::V1::ListComponent.new(
+          id:,
+          group:,
+          title:,
+          required: @required,
+          show_actions: !@grouped_controls,
+          empty_state_message:,
+          **system_arguments
+        )
       }
 
-      def initialize(title: nil, description: nil, templates: [], template_label: nil, required: false)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(title: nil, description: nil, templates: [], template_label: nil, required: false,
+                     grouped_controls: false, selected_empty_state: nil)
         @title = title
         @description = description
         @templates = templates
         @template_label = template_label
         @required = required
+        @grouped_controls = grouped_controls
+        @selected_empty_state = selected_empty_state
         @aria_live_translations = load_translations
       end
+      # rubocop:enable Metrics/ParameterLists
 
       private
 

--- a/app/components/sortable_lists/v1/list_component.html.erb
+++ b/app/components/sortable_lists/v1/list_component.html.erb
@@ -9,69 +9,82 @@
     <% end %>
   </p>
 
-  <ul
-    id="<%= id %>"
-    data-sortable-lists--v1--list-group-name-value="<%= group %>"
-    class="<%= @system_arguments[:list_classes] %>"
-    tabindex="0"
-    role="listbox"
-    aria-labelledby="<%= id %>-list-label"
-    aria-roledescription="<%= t('components.sortable_lists.v1.list_component.aria_role_description', list: title) %>"
-    aria-required="<%= required %>"
-    aria-multiselectable="true"
-  >
-    <%= render SortableLists::V1::ListItemComponent.with_collection(list_items) %>
-  </ul>
+  <div class="relative">
+    <ul
+      id="<%= id %>"
+      data-sortable-lists--v1--list-group-name-value="<%= group %>"
+      class="<%= @system_arguments[:list_classes] %>"
+      tabindex="0"
+      role="listbox"
+      aria-labelledby="<%= id %>-list-label"
+      aria-roledescription="<%= t('components.sortable_lists.v1.list_component.aria_role_description', list: title) %>"
+      aria-required="<%= required %>"
+      aria-multiselectable="true"
+    >
+      <%= render SortableLists::V1::ListItemComponent.with_collection(list_items) %>
+    </ul>
 
-  <div class="mt-1" role="group" aria-label="<%= t('common.labels.actions') %>">
-    <% if available_list %>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="
-          click->sortable-lists--v1--two-lists-selection#addSelectionByAddButton
-        "
-        data-sortable-lists--v1--two-lists-selection-target="addButton"
-        aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.add') %>"
+    <% if empty_state_message.present? %>
+      <p
+        class="<%= class_names('pointer-events-none absolute inset-3 flex items-center justify-center text-center text-xs text-slate-500 dark:text-slate-400', { 'hidden': list_items.any? }) %>"
+        data-sortable-lists--v1--two-lists-selection-target="selectedEmptyState"
       >
-        <%= t("components.sortable_lists.v1.list_component.add") %>
-      </button>
-    <% end %>
-
-    <% if selected_list %>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="
-          click->sortable-lists--v1--two-lists-selection#removeSelectionByRemoveButton
-        "
-        data-sortable-lists--v1--two-lists-selection-target="removeButton"
-        aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.remove') %>"
-      >
-        <%= t('common.actions.remove') %>
-      </button>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="
-          click->sortable-lists--v1--two-lists-selection#moveSelection
-        "
-        data-sortable-lists--v1--two-lists-selection-target="upButton"
-        aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.up') %>"
-      >
-        <%= t("components.sortable_lists.v1.list_component.up") %>
-      </button>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="
-          click->sortable-lists--v1--two-lists-selection#moveSelection
-        "
-        data-sortable-lists--v1--two-lists-selection-target="downButton"
-        aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.down') %>"
-      >
-        <%= t("components.sortable_lists.v1.list_component.down") %>
-      </button>
+        <%= empty_state_message %>
+      </p>
     <% end %>
   </div>
+
+  <% if show_actions %>
+    <div class="mt-1" role="group" aria-label="<%= t('common.labels.actions') %>">
+      <% if available_list %>
+        <button
+          type="button"
+          class="button button-default"
+          data-action="
+            click->sortable-lists--v1--two-lists-selection#addSelectionByAddButton
+          "
+          data-sortable-lists--v1--two-lists-selection-target="addButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.add') %>"
+        >
+          <%= t("components.sortable_lists.v1.list_component.add") %>
+        </button>
+      <% end %>
+
+      <% if selected_list %>
+        <button
+          type="button"
+          class="button button-default"
+          data-action="
+            click->sortable-lists--v1--two-lists-selection#removeSelectionByRemoveButton
+          "
+          data-sortable-lists--v1--two-lists-selection-target="removeButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.remove') %>"
+        >
+          <%= t('common.actions.remove') %>
+        </button>
+        <button
+          type="button"
+          class="button button-default"
+          data-action="
+            click->sortable-lists--v1--two-lists-selection#moveSelection
+          "
+          data-sortable-lists--v1--two-lists-selection-target="upButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.up') %>"
+        >
+          <%= t("components.sortable_lists.v1.list_component.up") %>
+        </button>
+        <button
+          type="button"
+          class="button button-default"
+          data-action="
+            click->sortable-lists--v1--two-lists-selection#moveSelection
+          "
+          data-sortable-lists--v1--two-lists-selection-target="downButton"
+          aria-keyshortcuts="<%= t('components.sortable_lists.v1.list_component.keyboard_shortcuts.down') %>"
+        >
+          <%= t("components.sortable_lists.v1.list_component.down") %>
+        </button>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/components/sortable_lists/v1/list_component.rb
+++ b/app/components/sortable_lists/v1/list_component.rb
@@ -4,21 +4,25 @@ module SortableLists
   module V1
     # This component creates the individual lists for the sortable_lists component.
     class ListComponent < ::Component
-      attr_reader :id, :group, :title, :list_items, :required, :available_list, :selected_list
+      attr_reader :id, :group, :title, :list_items, :required, :available_list, :selected_list,
+                  :show_actions, :empty_state_message
 
       # rubocop:disable Metrics/ParameterLists
 
       # If creating multiple lists to utilize the same list values, assign them the same group.
-      def initialize(id: nil, group: nil, title: nil, list_items: [], required: false, **system_arguments)
+      def initialize(id: nil, group: nil, title: nil, list_items: [], required: false,
+                     show_actions: true, empty_state_message: nil, **system_arguments)
         @id = id
         @group = group
         @title = title
         @list_items = list_items
         @required = required
+        @show_actions = show_actions
+        @empty_state_message = empty_state_message
         @system_arguments = system_arguments
         @system_arguments[:list_classes] =
           class_names('border border-slate-300 rounded-lg block dark:bg-slate-800 dark:border-slate-600 max-h-[225px]
-          min-h-[225px] overflow-y-auto')
+          min-h-[225px] overflow-y-auto relative')
         @system_arguments[:container_classes] =
           class_names('text-slate-900 dark:text-white grow block mb-1 text-sm font-medium')
         @available_list = id.include?('available')

--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -94,7 +94,7 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
       end
 
       format.any do
-        flash[:success] = t('.success', name: @data_export.name || @data_export.id)
+        flash[:success] = t('data_exports.create.success', name: @data_export.name || @data_export.id)
         redirect_to data_export_path(@data_export), status: :see_other
       end
     end

--- a/app/controllers/data_exports_controller.rb
+++ b/app/controllers/data_exports_controller.rb
@@ -38,14 +38,7 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
   def create
     @data_export = DataExports::CreateService.new(current_user, data_export_params).execute
 
-    if @data_export.errors.any?
-      render status: :unprocessable_content,
-             locals: { type: 'alert', message: error_message(@data_export),
-                       export_type: data_export_params['export_type'] }
-    else
-      flash[:success] = t('.success', name: @data_export.name || @data_export.id)
-      redirect_to data_export_path(@data_export), status: :see_other
-    end
+    @data_export.errors.any? ? render_create_error_response : render_create_success_response
   end
 
   def redirect
@@ -75,6 +68,37 @@ class DataExportsController < ApplicationController # rubocop:disable Metrics/Cl
   end
 
   private
+
+  def render_create_error_response
+    respond_to do |format|
+      format.json do
+        render json: { errors: @data_export.errors.full_messages }, status: :unprocessable_content
+      end
+
+      format.any do
+        render status: :unprocessable_content,
+               locals: { type: 'alert', message: error_message(@data_export),
+                         export_type: data_export_params['export_type'] }
+      end
+    end
+  end
+
+  def render_create_success_response
+    respond_to do |format|
+      format.json do
+        render json: {
+          id: @data_export.id,
+          status: @data_export.status,
+          export_type: @data_export.export_type
+        }, status: :accepted
+      end
+
+      format.any do
+        flash[:success] = t('.success', name: @data_export.name || @data_export.id)
+        redirect_to data_export_path(@data_export), status: :see_other
+      end
+    end
+  end
 
   def export_dialog_render_method
     return :render_analysis_single_workflow_export_dialog if analysis_single_workflow_export_dialog?

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -198,11 +198,12 @@ export default class extends Controller {
         }),
         100,
       );
-      this.scheduleProgressWindowDismiss();
       const saveRequest = this._pendingSaveRequest;
       this._pendingSaveRequest = null;
       if (saveRequest?.saveToServer) {
         void this.saveToServer(saveRequest);
+      } else {
+        this.scheduleProgressWindowDismiss();
       }
       this.terminateWorker();
       return;
@@ -415,23 +416,25 @@ export default class extends Controller {
         throw new Error(detail);
       }
 
-      if (this.hasSampleStatusTarget) {
-        this.sampleStatusTarget.textContent = this.t(
-          this.saveQueuedMessageValue,
-          {
-            id: payload.id,
-          },
-        );
-      }
-    } catch (error) {
-      if (!this.hasSampleStatusTarget) return;
+      const message = this.t(this.saveQueuedMessageValue, {
+        id: payload.id,
+      });
 
-      this.sampleStatusTarget.textContent = this.t(
-        this.saveFailedMessageValue,
-        {
-          message: error?.message || "unknown error",
-        },
-      );
+      if (this.hasSampleStatusTarget) {
+        this.sampleStatusTarget.textContent = message;
+      }
+      this.updateProgress(message, 100);
+      this.scheduleProgressWindowDismiss();
+    } catch (error) {
+      const message = this.t(this.saveFailedMessageValue, {
+        message: error?.message || "unknown error",
+      });
+
+      if (this.hasSampleStatusTarget) {
+        this.sampleStatusTarget.textContent = message;
+      }
+      this.updateProgress(message, 100, true);
+      this.scheduleProgressWindowDismiss();
     }
   }
 

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -2,7 +2,13 @@ import { Controller } from "@hotwired/stimulus";
 import * as XLSX from "xlsx";
 
 export default class extends Controller {
-  static targets = ["sampleStatus", "progressTemplate", "saveDetailsFieldset"];
+  static targets = [
+    "sampleStatus",
+    "progressTemplate",
+    "saveDetailsFieldset",
+    "progressLink",
+    "progressLinkRow",
+  ];
   static values = {
     workerUrl: String,
     graphqlUrl: String,
@@ -11,6 +17,10 @@ export default class extends Controller {
     minimumVisibleDurationMs: {
       type: Number,
       default: 3500,
+    },
+    saveResultVisibleDurationMs: {
+      type: Number,
+      default: 6000,
     },
     noSelectionErrorMessage: {
       type: String,
@@ -40,6 +50,10 @@ export default class extends Controller {
     queueingSaveMessage: {
       type: String,
       default: "Queueing save to Data Exports...",
+    },
+    viewDataExportMessage: {
+      type: String,
+      default: "View in Data Exports",
     },
     createdRecordsMessage: {
       type: String,
@@ -445,16 +459,21 @@ export default class extends Controller {
       const message = this.t(this.saveQueuedMessageValue, {
         id: payload.id,
       });
+      this.setProgressLink(this.dataExportShowUrl(payload.id));
 
       if (this.hasSampleStatusTarget) {
         this.sampleStatusTarget.textContent = message;
       }
       this.updateProgress(message, 100);
-      this.scheduleProgressWindowDismiss();
+      this.scheduleProgressWindowDismiss(
+        this.saveResultVisibleDurationMsValue,
+        true,
+      );
     } catch (error) {
       const message = this.t(this.saveFailedMessageValue, {
         message: error?.message || "unknown error",
       });
+      this.clearProgressLink();
 
       if (this.hasSampleStatusTarget) {
         this.sampleStatusTarget.textContent = message;
@@ -517,6 +536,8 @@ export default class extends Controller {
     this._progressMsgEl = null;
     this._progressBarEl = null;
     this._progressPctEl = null;
+    this._progressLinkEl = null;
+    this._progressLinkRowEl = null;
   }
 
   ensureExportCard() {
@@ -537,6 +558,12 @@ export default class extends Controller {
       );
       this._progressPctEl = card.querySelector(
         "[data-linelist-export-progress-percent]",
+      );
+      this._progressLinkEl = card.querySelector(
+        "[data-linelist-export-target='progressLink']",
+      );
+      this._progressLinkRowEl = card.querySelector(
+        "[data-linelist-export-target='progressLinkRow']",
       );
     }
 
@@ -574,6 +601,12 @@ export default class extends Controller {
       this._progressPctEl = clone.querySelector(
         "[data-linelist-export-progress-percent]",
       );
+      this._progressLinkEl = clone.querySelector(
+        "[data-linelist-export-target='progressLink']",
+      );
+      this._progressLinkRowEl = clone.querySelector(
+        "[data-linelist-export-target='progressLinkRow']",
+      );
       card.appendChild(clone);
     }
 
@@ -585,20 +618,24 @@ export default class extends Controller {
     if (!this._progressWindowOpenedAt) {
       this._progressWindowOpenedAt = Date.now();
     }
+    this.clearProgressLink();
     this.updateProgress(message, 0);
   }
 
-  scheduleProgressWindowDismiss() {
+  scheduleProgressWindowDismiss(
+    minimumVisibleDurationMs = this.minimumVisibleDurationMsValue,
+    restartWindowTimer = false,
+  ) {
     if (this.progressWindowDismissed) return;
 
     this.clearProgressWindowDismissTimeout();
+    if (restartWindowTimer) {
+      this._progressWindowOpenedAt = Date.now();
+    }
 
     const openedAt = this._progressWindowOpenedAt || Date.now();
     const elapsedMs = Date.now() - openedAt;
-    const remainingMs = Math.max(
-      this.minimumVisibleDurationMsValue - elapsedMs,
-      0,
-    );
+    const remainingMs = Math.max(minimumVisibleDurationMs - elapsedMs, 0);
 
     this._dismissProgressWindowTimeout = setTimeout(() => {
       this.dismissProgressWindow();
@@ -610,6 +647,37 @@ export default class extends Controller {
 
     clearTimeout(this._dismissProgressWindowTimeout);
     this._dismissProgressWindowTimeout = null;
+  }
+
+  setProgressLink(url) {
+    if (!url) {
+      this.clearProgressLink();
+      return;
+    }
+
+    this.ensureExportCard();
+    if (!this._progressLinkEl || !this._progressLinkRowEl) return;
+
+    this._progressLinkEl.href = url;
+    this._progressLinkEl.textContent = this.t(this.viewDataExportMessageValue);
+    this._progressLinkRowEl.classList.remove("hidden");
+  }
+
+  clearProgressLink() {
+    if (this._progressLinkEl) {
+      this._progressLinkEl.removeAttribute("href");
+      this._progressLinkEl.textContent = "";
+    }
+    if (this._progressLinkRowEl) {
+      this._progressLinkRowEl.classList.add("hidden");
+    }
+  }
+
+  dataExportShowUrl(exportId) {
+    const saveUrl = this.saveToServerUrl();
+    if (!saveUrl || !exportId) return "";
+
+    return `${saveUrl.replace(/\/$/, "")}/${encodeURIComponent(exportId)}`;
   }
 
   workerSourceUrl() {

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus";
 import * as XLSX from "xlsx";
 
 export default class extends Controller {
-  static targets = ["sampleStatus", "progressTemplate"];
+  static targets = ["sampleStatus", "progressTemplate", "saveDetailsFieldset"];
   static values = {
     workerUrl: String,
     graphqlUrl: String,
@@ -59,6 +59,7 @@ export default class extends Controller {
     this._pendingSaveRequest = null;
     this.progressWindowDismissed = false;
     this.updateSelectedCount();
+    this.updateSaveToServerFields();
   }
 
   disconnect() {
@@ -77,7 +78,7 @@ export default class extends Controller {
     const sampleIds = this.selectedSampleIds();
     const metadataFields = this.selectedMetadataFields();
     const format = this.selectedFormat();
-    const saveToServer = this.saveToServerSelected();
+    const saveToServer = this.saveModeSelected();
     const exportName = this.selectedExportName();
     const emailNotification = this.selectedEmailNotification();
     const namespaceId = this.selectedNamespaceId();
@@ -114,22 +115,31 @@ export default class extends Controller {
     }
 
     try {
-      this.showProgressWindow(
-        this.t(this.preparingRowsMessageValue, { count: totalCount }),
-      );
-      this.spawnWorker();
+      if (saveToServer) {
+        this.showProgressWindow(
+          this.t(this.preparingExportMessageValue, { count: totalCount }),
+        );
+        const saveRequest = this._pendingSaveRequest;
+        this._pendingSaveRequest = null;
+        void this.saveToServer(saveRequest);
+      } else {
+        this.showProgressWindow(
+          this.t(this.preparingRowsMessageValue, { count: totalCount }),
+        );
+        this.spawnWorker();
 
-      this.worker.postMessage({
-        sample_ids: sampleIds,
-        metadata_fields: metadataFields,
-        namespace_id: namespaceId,
-        graphql_url: graphqlUrl,
-        csrf_token: this.csrfToken(),
-        sample_graphql_id_prefix: sampleGraphqlIdPrefix,
-        format,
-        filename,
-        total_count: totalCount,
-      });
+        this.worker.postMessage({
+          sample_ids: sampleIds,
+          metadata_fields: metadataFields,
+          namespace_id: namespaceId,
+          graphql_url: graphqlUrl,
+          csrf_token: this.csrfToken(),
+          sample_graphql_id_prefix: sampleGraphqlIdPrefix,
+          format,
+          filename,
+          total_count: totalCount,
+        });
+      }
     } catch (error) {
       this.updateProgress(
         this.t(this.startErrorMessageValue, {
@@ -337,11 +347,19 @@ export default class extends Controller {
     return Boolean(emailCheckbox?.checked);
   }
 
-  saveToServerSelected() {
-    const checkbox = this.element.querySelector(
-      "input[name='data_export[save_to_server]']",
+  selectedDeliveryMode() {
+    const selected = this.element.querySelector(
+      "input[name='data_export[delivery_mode]']:checked",
     );
-    return Boolean(checkbox?.checked);
+    return selected?.value || "immediate_download";
+  }
+
+  saveModeSelected() {
+    return this.selectedDeliveryMode() === "save_to_server";
+  }
+
+  toggleSaveToServer() {
+    this.updateSaveToServerFields();
   }
 
   selectedSampleIds() {
@@ -450,6 +468,17 @@ export default class extends Controller {
         { count: selected },
       );
     }
+  }
+
+  updateSaveToServerFields() {
+    if (!this.hasSaveDetailsFieldsetTarget) return;
+
+    const enabled = this.saveModeSelected();
+    this.saveDetailsFieldsetTarget.disabled = !enabled;
+    this.saveDetailsFieldsetTarget.setAttribute(
+      "aria-disabled",
+      String(!enabled),
+    );
   }
 
   handleProgressWindowClick(event) {

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -1,10 +1,12 @@
 import { Controller } from "@hotwired/stimulus";
+import * as XLSX from "xlsx";
 
 export default class extends Controller {
   static targets = ["sampleStatus", "progressTemplate"];
   static values = {
     workerUrl: String,
     graphqlUrl: String,
+    saveToServerUrl: String,
     sampleGraphqlIdPrefix: String,
     minimumVisibleDurationMs: {
       type: Number,
@@ -27,10 +29,6 @@ export default class extends Controller {
       type: String,
       default: "Unable to start export: %{message}",
     },
-    xlsxUnsupportedMessage: {
-      type: String,
-      default: "XLSX export is not supported in this client-side flow yet.",
-    },
     unexpectedErrorMessage: {
       type: String,
       default: "Unexpected error while generating export: %{message}",
@@ -43,6 +41,14 @@ export default class extends Controller {
       type: String,
       default: "Created %{current} of %{total} records",
     },
+    saveQueuedMessage: {
+      type: String,
+      default: "Saved to Data Exports (ID: %{id})",
+    },
+    saveFailedMessage: {
+      type: String,
+      default: "Download completed, but saving to server failed: %{message}",
+    },
   };
 
   connect() {
@@ -50,6 +56,7 @@ export default class extends Controller {
     this._exportId = null;
     this._progressWindowOpenedAt = null;
     this._dismissProgressWindowTimeout = null;
+    this._pendingSaveRequest = null;
     this.progressWindowDismissed = false;
     this.updateSelectedCount();
   }
@@ -70,6 +77,9 @@ export default class extends Controller {
     const sampleIds = this.selectedSampleIds();
     const metadataFields = this.selectedMetadataFields();
     const format = this.selectedFormat();
+    const saveToServer = this.saveToServerSelected();
+    const exportName = this.selectedExportName();
+    const emailNotification = this.selectedEmailNotification();
     const namespaceId = this.selectedNamespaceId();
     const graphqlUrl = this.graphqlUrl();
     const sampleGraphqlIdPrefix = this.sampleGraphqlIdPrefix();
@@ -80,21 +90,21 @@ export default class extends Controller {
       return;
     }
 
-    if (format !== "csv") {
-      this.updateProgress(
-        this.t(this.xlsxUnsupportedMessageValue, { format }),
-        100,
-        true,
-      );
-      return;
-    }
-
     const filename = `linelist-${new Date().toISOString().replace(/[:.]/g, "-")}.${format}`;
     const totalCount = selectedCount;
     this.clearProgressWindowDismissTimeout();
     this._exportId = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
     this._progressWindowOpenedAt = null;
     this.progressWindowDismissed = false;
+    this._pendingSaveRequest = {
+      saveToServer,
+      sampleIds,
+      metadataFields,
+      namespaceId,
+      format,
+      exportName,
+      emailNotification,
+    };
 
     if (this.hasSampleStatusTarget) {
       this.sampleStatusTarget.textContent = this.t(
@@ -128,6 +138,7 @@ export default class extends Controller {
         100,
         true,
       );
+      this._pendingSaveRequest = null;
       this.terminateWorker();
     }
   }
@@ -180,7 +191,7 @@ export default class extends Controller {
     }
 
     if (payload.type === "done") {
-      this.download(payload.filename, payload.content);
+      this.download(payload);
       this.updateProgress(
         this.t(this.downloadStartedMessageValue, {
           filename: payload.filename,
@@ -188,12 +199,18 @@ export default class extends Controller {
         100,
       );
       this.scheduleProgressWindowDismiss();
+      const saveRequest = this._pendingSaveRequest;
+      this._pendingSaveRequest = null;
+      if (saveRequest?.saveToServer) {
+        void this.saveToServer(saveRequest);
+      }
       this.terminateWorker();
       return;
     }
 
     if (payload.type === "error") {
       this.updateProgress(payload.message, 100, true);
+      this._pendingSaveRequest = null;
       this.terminateWorker();
     }
   }
@@ -228,8 +245,16 @@ export default class extends Controller {
     }
   }
 
-  download(filename, csvContent) {
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  download(payload) {
+    const filename = payload?.filename || "linelist-export.csv";
+    const format = payload?.format === "xlsx" ? "xlsx" : "csv";
+    const blob =
+      format === "xlsx"
+        ? this.xlsxBlobFromRows(payload?.rows)
+        : new Blob([payload?.content || ""], {
+            type: "text/csv;charset=utf-8;",
+          });
+
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");
     anchor.href = url;
@@ -238,6 +263,16 @@ export default class extends Controller {
     anchor.click();
     anchor.remove();
     URL.revokeObjectURL(url);
+  }
+
+  xlsxBlobFromRows(rows) {
+    const workbook = XLSX.utils.book_new();
+    const sheet = XLSX.utils.aoa_to_sheet(Array.isArray(rows) ? rows : []);
+    XLSX.utils.book_append_sheet(workbook, sheet, "Linelist");
+    const content = XLSX.write(workbook, { bookType: "xlsx", type: "array" });
+    return new Blob([content], {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
   }
 
   closeDialog() {
@@ -268,9 +303,9 @@ export default class extends Controller {
   selectedMetadataFields() {
     return Array.from(
       this.element.querySelectorAll(
-        "input[name='data_export[export_parameters][metadata_fields][]']:checked",
+        "input[name='data_export[export_parameters][metadata_fields][]']",
       ),
-    ).map((checkbox) => checkbox.value);
+    ).map((input) => input.value);
   }
 
   selectedFormat() {
@@ -285,6 +320,27 @@ export default class extends Controller {
       "input[name='data_export[export_parameters][namespace_id]']",
     );
     return namespaceInput?.value || "";
+  }
+
+  selectedExportName() {
+    const nameInput = this.element.querySelector(
+      "input[name='data_export[name]']",
+    );
+    return nameInput?.value?.trim() || "";
+  }
+
+  selectedEmailNotification() {
+    const emailCheckbox = this.element.querySelector(
+      "input[name='data_export[email_notification]']",
+    );
+    return Boolean(emailCheckbox?.checked);
+  }
+
+  saveToServerSelected() {
+    const checkbox = this.element.querySelector(
+      "input[name='data_export[save_to_server]']",
+    );
+    return Boolean(checkbox?.checked);
   }
 
   selectedSampleIds() {
@@ -311,6 +367,72 @@ export default class extends Controller {
 
   sampleGraphqlIdPrefix() {
     return this.sampleGraphqlIdPrefixValue;
+  }
+
+  saveToServerUrl() {
+    return this.saveToServerUrlValue;
+  }
+
+  async saveToServer(request) {
+    const saveUrl = this.saveToServerUrl();
+    if (!saveUrl) return;
+
+    try {
+      const response = await fetch(saveUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-CSRF-Token": this.csrfToken(),
+        },
+        body: JSON.stringify({
+          data_export: {
+            ...(request.exportName ? { name: request.exportName } : {}),
+            email_notification: request.emailNotification,
+            export_type: "linelist",
+            export_parameters: {
+              ids: request.sampleIds,
+              namespace_id: request.namespaceId,
+              linelist_format: request.format,
+              metadata_fields: request.metadataFields,
+            },
+          },
+        }),
+      });
+
+      let payload = {};
+      try {
+        payload = await response.json();
+      } catch {
+        payload = {};
+      }
+
+      if (!response.ok) {
+        const detail = Array.isArray(payload?.errors)
+          ? payload.errors.join(", ")
+          : `Request failed (${response.status})`;
+        throw new Error(detail);
+      }
+
+      if (this.hasSampleStatusTarget) {
+        this.sampleStatusTarget.textContent = this.t(
+          this.saveQueuedMessageValue,
+          {
+            id: payload.id,
+          },
+        );
+      }
+    } catch (error) {
+      if (!this.hasSampleStatusTarget) return;
+
+      this.sampleStatusTarget.textContent = this.t(
+        this.saveFailedMessageValue,
+        {
+          message: error?.message || "unknown error",
+        },
+      );
+    }
   }
 
   selectionStorageKey() {

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -37,6 +37,10 @@ export default class extends Controller {
       type: String,
       default: "Download started: %{filename}",
     },
+    queueingSaveMessage: {
+      type: String,
+      default: "Queueing save to Data Exports...",
+    },
     createdRecordsMessage: {
       type: String,
       default: "Created %{current} of %{total} records",
@@ -47,7 +51,7 @@ export default class extends Controller {
     },
     saveFailedMessage: {
       type: String,
-      default: "Download completed, but saving to server failed: %{message}",
+      default: "Saving to server failed: %{message}",
     },
   };
 
@@ -116,9 +120,12 @@ export default class extends Controller {
 
     try {
       if (saveToServer) {
-        this.showProgressWindow(
-          this.t(this.preparingExportMessageValue, { count: totalCount }),
-        );
+        const queueingMessage = this.t(this.queueingSaveMessageValue);
+        this.showProgressWindow(queueingMessage);
+        this.updateProgress(queueingMessage, 75);
+        if (this.hasSampleStatusTarget) {
+          this.sampleStatusTarget.textContent = queueingMessage;
+        }
         const saveRequest = this._pendingSaveRequest;
         this._pendingSaveRequest = null;
         void this.saveToServer(saveRequest);
@@ -202,12 +209,13 @@ export default class extends Controller {
 
     if (payload.type === "done") {
       this.download(payload);
-      this.updateProgress(
-        this.t(this.downloadStartedMessageValue, {
-          filename: payload.filename,
-        }),
-        100,
-      );
+      const downloadMessage = this.t(this.downloadStartedMessageValue, {
+        filename: payload.filename,
+      });
+      this.updateProgress(downloadMessage, 100);
+      if (this.hasSampleStatusTarget) {
+        this.sampleStatusTarget.textContent = downloadMessage;
+      }
       const saveRequest = this._pendingSaveRequest;
       this._pendingSaveRequest = null;
       if (saveRequest?.saveToServer) {
@@ -475,6 +483,7 @@ export default class extends Controller {
 
     const enabled = this.saveModeSelected();
     this.saveDetailsFieldsetTarget.disabled = !enabled;
+    this.saveDetailsFieldsetTarget.classList.toggle("hidden", !enabled);
     this.saveDetailsFieldsetTarget.setAttribute(
       "aria-disabled",
       String(!enabled),

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
     "removeButton",
     "upButton",
     "downButton",
+    "selectedEmptyState",
     "templateSelector",
     "itemTemplate",
     "checkmarkTemplate",
@@ -291,6 +292,14 @@ export default class extends Controller {
     });
 
     this.templateSelectorTarget.value = matchingTemplate?.value ?? "none";
+  }
+
+  #checkSelectedEmptyState() {
+    if (!this.hasSelectedEmptyStateTarget) return;
+
+    const hasSelectedItems =
+      this.selectedList.querySelectorAll("li").length > 0;
+    this.selectedEmptyStateTarget.classList.toggle("hidden", hasSelectedItems);
   }
 
   #setSubmitButtonDisableState(disableState) {
@@ -944,6 +953,7 @@ export default class extends Controller {
   #checkStates() {
     this.#saveListStates();
     this.#checkButtonStates();
+    this.#checkSelectedEmptyState();
     if (this.hasTemplateSelectorTarget) {
       this.#checkTemplateSelectorState();
       this.#cleanupAvailableList();

--- a/app/javascript/workers/linelist_export_worker.js
+++ b/app/javascript/workers/linelist_export_worker.js
@@ -104,6 +104,7 @@ self.onmessage = async (event) => {
     format,
   } = event.data || {};
 
+  const exportFormat = format === "xlsx" ? "xlsx" : "csv";
   const fields = Array.isArray(metadataFields) ? metadataFields : [];
   const ids = Array.isArray(sampleIds) ? sampleIds : [];
   const rows = ids.length;
@@ -116,7 +117,7 @@ self.onmessage = async (event) => {
     return;
   }
 
-  if (format != null && format !== "csv") {
+  if (format != null && !["csv", "xlsx"].includes(format)) {
     self.postMessage({
       type: "error",
       message: "Unsupported linelist format for this flow.",
@@ -177,7 +178,7 @@ self.onmessage = async (event) => {
       "PROJECT PUID",
       ...fields.map((field) => String(field).toUpperCase()),
     ];
-    const lines = [header.join(",")];
+    const exportRows = [header];
 
     sampleGraphqlIds.forEach((sampleGraphqlId) => {
       const sample = sampleById.get(sampleGraphqlId);
@@ -191,23 +192,37 @@ self.onmessage = async (event) => {
       const metadata = sample.metadata || {};
 
       const row = [
-        escapeCsv(sample.puid),
-        escapeCsv(sample.name),
-        escapeCsv(sample.project?.puid),
+        String(sample.puid ?? ""),
+        String(sample.name ?? ""),
+        String(sample.project?.puid ?? ""),
       ];
 
       fields.forEach((field) => {
-        row.push(escapeCsv(metadata[field]));
+        row.push(String(metadata[field] ?? ""));
       });
 
-      lines.push(row.join(","));
+      exportRows.push(row);
     });
 
-    self.postMessage({
-      type: "done",
-      filename,
-      content: lines.join("\n"),
-    });
+    if (exportFormat === "xlsx") {
+      self.postMessage({
+        type: "done",
+        filename,
+        format: exportFormat,
+        rows: exportRows,
+      });
+    } else {
+      const content = exportRows
+        .map((row) => row.map((value) => escapeCsv(value)).join(","))
+        .join("\n");
+
+      self.postMessage({
+        type: "done",
+        filename,
+        format: exportFormat,
+        content,
+      });
+    }
   } catch (error) {
     self.postMessage({
       type: "error",

--- a/app/jobs/data_exports/create_job.rb
+++ b/app/jobs/data_exports/create_job.rb
@@ -284,60 +284,34 @@ module DataExports
 
     # Linelist export specific functions---------------------------------------------------------------------
     def create_linelist_spreadsheet(data_export, temp_export_file)
-      samples = Sample.includes(project: :namespace).where(id: data_export.export_parameters['ids'])
+      rows = DataExports::LinelistRowsService.call(
+        sample_ids: data_export.export_parameters['ids'],
+        metadata_fields: data_export.export_parameters['metadata_fields'],
+        current_user: data_export.user
+      )
+
       if data_export.export_parameters['linelist_format'] == 'csv'
-        write_csv_export(data_export, samples, temp_export_file)
+        write_csv_export(rows, temp_export_file)
       else
-        write_xlsx_export(data_export, samples, temp_export_file)
+        write_xlsx_export(rows, temp_export_file)
       end
     end
 
-    def write_csv_export(data_export, samples, temp_export_file)
+    def write_csv_export(rows, temp_export_file)
       temp_export_file.tap do |tempfile|
         CSV.open(tempfile, 'wb') do |csv|
-          csv << write_spreadsheet_header(data_export.export_parameters['metadata_fields'])
-          samples.each do |sample|
-            csv << write_spreadsheet_row(sample, data_export)
-          end
+          rows.each { |row| csv << row }
         end
       end
     end
 
-    def write_xlsx_export(data_export, samples, temp_export_file)
+    def write_xlsx_export(rows, temp_export_file)
       temp_export_file.tap do |tempfile|
         Axlsx::Package.new do |workbook|
           workbook.workbook.add_worksheet(name: 'linelist') do |sheet|
-            sheet.add_row write_spreadsheet_header(data_export.export_parameters['metadata_fields'])
-            samples.each do |sample|
-              sheet.add_row write_spreadsheet_row(sample, data_export)
-            end
+            rows.each { |row| sheet.add_row row }
           end
           workbook.serialize(tempfile.path)
-        end
-      end
-    end
-
-    def write_spreadsheet_header(metadata_fields)
-      header = ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID']
-      header += metadata_fields.map(&:upcase) unless metadata_fields.nil?
-      header
-    end
-
-    def write_spreadsheet_row(sample, data_export)
-      row = [sample.puid, sample.name, sample.project.puid]
-      unless data_export.export_parameters['metadata_fields'].nil?
-        row += map_metadata_fields(data_export.export_parameters['metadata_fields'],
-                                   sample.metadata)
-      end
-      row
-    end
-
-    def map_metadata_fields(metadata_fields, sample_metadata)
-      metadata_fields.map do |metadata_field|
-        if sample_metadata.key?(metadata_field)
-          sample_metadata[metadata_field]
-        else
-          ''
         end
       end
     end

--- a/app/services/data_exports/linelist_rows_service.rb
+++ b/app/services/data_exports/linelist_rows_service.rb
@@ -82,9 +82,10 @@ module DataExports
     end
 
     def to_global_id(id)
-      return id.to_s if id.to_s.start_with?('gid://')
+      value = id.to_s
+      return value if value.start_with?('gid://')
 
-      Sample.find(id).to_global_id.to_s
+      "gid://#{GlobalID.app}/Sample/#{value}"
     end
 
     def build_header

--- a/app/services/data_exports/linelist_rows_service.rb
+++ b/app/services/data_exports/linelist_rows_service.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module DataExports
+  # Builds linelist spreadsheet rows using the same GraphQL-shaped sample field
+  # contract as the client-side linelist export worker (PR #1636).
+  #
+  # Returns an Array of Arrays: the first element is the header row, followed by
+  # one data row per sample in the order of +sample_ids+.
+  #
+  # Fields per row: SAMPLE PUID, SAMPLE NAME, PROJECT PUID, then one column per
+  # requested metadata field (uppercased), with blank strings for absent keys.
+  class LinelistRowsService
+    LINELIST_SAMPLES_QUERY = <<~GRAPHQL
+      query LinelistSamples($ids: [ID!]!, $metadataKeys: [String!]) {
+        nodes(ids: $ids) {
+          id
+          __typename
+          ... on Sample {
+            puid
+            name
+            project {
+              puid
+            }
+            metadata(keys: $metadataKeys)
+          }
+        }
+      }
+    GRAPHQL
+
+    CHUNK_SIZE = 100
+
+    def self.call(sample_ids:, metadata_fields:, current_user:)
+      new(sample_ids:, metadata_fields:, current_user:).call
+    end
+
+    def initialize(sample_ids:, metadata_fields:, current_user:)
+      @sample_ids = Array(sample_ids)
+      @metadata_fields = Array(metadata_fields)
+      @current_user = current_user
+    end
+
+    def call
+      samples_by_gid = fetch_samples_by_gid
+      rows = [build_header]
+
+      @sample_ids.each do |id|
+        gid = to_global_id(id)
+        sample = samples_by_gid[gid]
+        rows << build_row(sample)
+      end
+
+      rows
+    end
+
+    private
+
+    def fetch_samples_by_gid
+      gids = @sample_ids.map { |id| to_global_id(id) }
+      result = {}
+
+      gids.each_slice(CHUNK_SIZE) do |chunk|
+        nodes = execute_query(chunk)
+        nodes.each do |node|
+          next unless node['__typename'] == 'Sample' && node['id']
+
+          result[node['id']] = node
+        end
+      end
+
+      result
+    end
+
+    def execute_query(gid_chunk)
+      response = IridaSchema.execute(
+        LINELIST_SAMPLES_QUERY,
+        context: { current_user: @current_user },
+        variables: { ids: gid_chunk, metadataKeys: @metadata_fields.presence }
+      )
+
+      response.dig('data', 'nodes') || []
+    end
+
+    def to_global_id(id)
+      return id.to_s if id.to_s.start_with?('gid://')
+
+      Sample.find(id).to_global_id.to_s
+    end
+
+    def build_header
+      fixed = ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID']
+      fixed + @metadata_fields.map { |f| f.to_s.upcase }
+    end
+
+    def build_row(sample)
+      [
+        sample_value(sample, 'puid'),
+        sample_value(sample, 'name'),
+        project_puid(sample),
+        *metadata_values(sample)
+      ]
+    end
+
+    def sample_value(sample, key)
+      sample&.dig(key) || ''
+    end
+
+    def project_puid(sample)
+      sample&.dig('project', 'puid') || ''
+    end
+
+    def metadata_values(sample)
+      metadata = sample&.dig('metadata') || {}
+      @metadata_fields.map { |field| metadata[field.to_s] || '' }
+    end
+  end
+end

--- a/app/services/data_exports/linelist_rows_service.rb
+++ b/app/services/data_exports/linelist_rows_service.rb
@@ -61,6 +61,7 @@ module DataExports
       gids.each_slice(CHUNK_SIZE) do |chunk|
         nodes = execute_query(chunk)
         nodes.each do |node|
+          next unless node.is_a?(Hash)
           next unless node['__typename'] == 'Sample' && node['id']
 
           result[node['id']] = node

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -378,10 +378,10 @@ fr:
           aria_role_description: Glisser-déposer dans la liste %{list}
           down: Bas
           keyboard_shortcuts:
-            add: Enter
-            down: Alt+ArrowDown
-            remove: Delete
-            up: Alt+ArrowUp
+            add: Entrée
+            down: Alt+FlècheBas
+            remove: Suppr
+            up: Alt+FlècheHaut
           up: Haut
     token:
       copied: Copié!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -544,7 +544,6 @@ en:
       title: Linelist Export
       unexpected_error: 'Unexpected error while generating export: %{message}'
       xlsx: ".xlsx"
-      xlsx_unsupported: XLSX export is not supported in this client-side flow yet.
     new_sample_export_dialog:
       available: Available
       available_description: File formats not included in this export. By default, all formats are included.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -532,6 +532,10 @@ en:
       no_selection: Please select at least 1 sample before exporting.
       preparing_export: Preparing linelist export for %{count} rows...
       preparing_rows: Preparing %{count} rows
+      save_failed: 'Download completed, but saving to server failed: %{message}'
+      save_queued: 'Saved to Data Exports (ID: %{id})'
+      save_to_server: Save to Data Exports
+      save_to_server_help: Optionally keep a server-side copy in your Data Exports history.
       selected: Selected
       selected_count: 'Selected samples: %{count}'
       selected_description: Metadata fields included in the export. Reorder this list to control column order.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -522,10 +522,11 @@ en:
       available_list_title: Not in export
       close_progress: Close export progress
       created_records: Created %{current} of %{total} records
-      csv: ".csv"
+      csv: CSV
       delivery_mode: Delivery Mode
       delivery_mode_help: Choose one delivery option.
       download_started: 'Download started: %{filename}'
+      export_data_button: Export Data
       fields_instructions: Select one or more metadata fields, then use the action buttons to move fields between lists. The ordering of the selected list determines export column order.
       fields_instructions_title: How the lists work
       format: Format
@@ -541,11 +542,12 @@ en:
       selected: Selected
       selected_count: 'Selected samples: %{count}'
       selected_description: Metadata fields included in the export. Reorder this list to control column order.
+      selected_empty_state: No fields selected. Select fields from the left to include them.
       selected_list_title: In export
       start_error: 'Unable to start export: %{message}'
       title: Linelist Export
       unexpected_error: 'Unexpected error while generating export: %{message}'
-      xlsx: ".xlsx"
+      xlsx: Excel (.xlsx)
     new_sample_export_dialog:
       available: Available
       available_description: File formats not included in this export. By default, all formats are included.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -548,6 +548,7 @@ en:
       start_error: 'Unable to start export: %{message}'
       title: Linelist Export
       unexpected_error: 'Unexpected error while generating export: %{message}'
+      view_data_export: View in Data Exports
       xlsx: Excel (.xlsx)
     new_sample_export_dialog:
       available: Available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,19 +523,21 @@ en:
       close_progress: Close export progress
       created_records: Created %{current} of %{total} records
       csv: ".csv"
+      delivery_mode: Delivery Mode
+      delivery_mode_help: Choose one delivery option.
       download_started: 'Download started: %{filename}'
       fields_instructions: Select one or more metadata fields, then use the action buttons to move fields between lists. The ordering of the selected list determines export column order.
       fields_instructions_title: How the lists work
       format: Format
+      immediate_download: Immediate Download
       keyboard_help: Keyboard shortcuts are available on the list action buttons.
       metadata: Metadata
       no_selection: Please select at least 1 sample before exporting.
       preparing_export: Preparing linelist export for %{count} rows...
       preparing_rows: Preparing %{count} rows
-      save_failed: 'Download completed, but saving to server failed: %{message}'
+      save_failed: 'Saving to server failed: %{message}'
       save_queued: 'Saved to Data Exports (ID: %{id})'
       save_to_server: Save to Data Exports
-      save_to_server_help: Optionally keep a server-side copy in your Data Exports history.
       selected: Selected
       selected_count: 'Selected samples: %{count}'
       selected_description: Metadata fields included in the export. Reorder this list to control column order.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -536,6 +536,7 @@ en:
       no_selection: Please select at least 1 sample before exporting.
       preparing_export: Preparing linelist export for %{count} rows...
       preparing_rows: Preparing %{count} rows
+      queueing_save: Queueing save to Data Exports...
       save_failed: 'Saving to server failed: %{message}'
       save_queued: 'Saved to Data Exports (ID: %{id})'
       save_to_server: Save to Data Exports

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -536,6 +536,7 @@ fr:
       no_selection: Veuillez sélectionner au moins 1 échantillon avant d'exporter.
       preparing_export: Préparation de l’exportation pour %{count} lignes...
       preparing_rows: Préparation de %{count} lignes
+      queueing_save: Mise en file d’attente de l’enregistrement dans les exportations de données...
       save_failed: 'La sauvegarde sur le serveur a échoué : %{message}'
       save_queued: 'Enregistré dans les exportations de données (ID : %{id})'
       save_to_server: Enregistrer dans les exportations de données

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -532,6 +532,10 @@ fr:
       no_selection: Veuillez sélectionner au moins 1 échantillon avant d'exporter.
       preparing_export: Préparation de l’exportation pour %{count} lignes...
       preparing_rows: Préparation de %{count} lignes
+      save_failed: 'Téléchargement terminé, mais la sauvegarde sur le serveur a échoué : %{message}'
+      save_queued: 'Enregistré dans les exportations de données (ID : %{id})'
+      save_to_server: Enregistrer dans les exportations de données
+      save_to_server_help: Conservez éventuellement une copie côté serveur dans votre historique d'exportations de données.
       selected: Sélectionné
       selected_count: 'Échantillons sélectionnés : %{count}'
       selected_description: Champs de métadonnées inclus dans l’exportation. Réorganisez cette liste pour contrôler l’ordre des colonnes.
@@ -540,7 +544,6 @@ fr:
       title: Exportation de liste détaillée
       unexpected_error: 'Erreur inattendue lors de la génération de l’exportation : %{message}'
       xlsx: ".xlsx"
-      xlsx_unsupported: L’exportation XLSX n’est pas encore prise en charge dans ce flux côté client.
     new_sample_export_dialog:
       available: Disponible
       available_description: Formats de fichiers non inclus dans cette exportation. Par défaut, tous les formats sont inclus.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -548,6 +548,7 @@ fr:
       start_error: 'Impossible de démarrer l’exportation : %{message}'
       title: Exportation de liste détaillée
       unexpected_error: 'Erreur inattendue lors de la génération de l’exportation : %{message}'
+      view_data_export: Voir dans les exportations de données
       xlsx: Excel (.xlsx)
     new_sample_export_dialog:
       available: Disponible

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -522,10 +522,11 @@ fr:
       available_list_title: Non inclus dans l’exportation
       close_progress: Fermer la progression de l’exportation
       created_records: Créé %{current} sur %{total} enregistrements
-      csv: ".csv"
+      csv: CSV
       delivery_mode: Mode de livraison
       delivery_mode_help: Choisissez une seule option de livraison.
       download_started: 'Téléchargement démarré : %{filename}'
+      export_data_button: Exporter les données
       fields_instructions: Sélectionnez un ou plusieurs champs de métadonnées, puis utilisez les boutons d’action pour déplacer les champs entre les listes. L’ordre de la liste sélectionnée détermine l’ordre des colonnes de l’exportation.
       fields_instructions_title: Fonctionnement des listes
       format: Format
@@ -541,11 +542,12 @@ fr:
       selected: Sélectionné
       selected_count: 'Échantillons sélectionnés : %{count}'
       selected_description: Champs de métadonnées inclus dans l’exportation. Réorganisez cette liste pour contrôler l’ordre des colonnes.
+      selected_empty_state: Aucun champ sélectionné. Sélectionnez des champs à gauche pour les inclure.
       selected_list_title: Inclus dans l’exportation
       start_error: 'Impossible de démarrer l’exportation : %{message}'
       title: Exportation de liste détaillée
       unexpected_error: 'Erreur inattendue lors de la génération de l’exportation : %{message}'
-      xlsx: ".xlsx"
+      xlsx: Excel (.xlsx)
     new_sample_export_dialog:
       available: Disponible
       available_description: Formats de fichiers non inclus dans cette exportation. Par défaut, tous les formats sont inclus.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -523,19 +523,21 @@ fr:
       close_progress: Fermer la progression de l’exportation
       created_records: Créé %{current} sur %{total} enregistrements
       csv: ".csv"
+      delivery_mode: Mode de livraison
+      delivery_mode_help: Choisissez une seule option de livraison.
       download_started: 'Téléchargement démarré : %{filename}'
       fields_instructions: Sélectionnez un ou plusieurs champs de métadonnées, puis utilisez les boutons d’action pour déplacer les champs entre les listes. L’ordre de la liste sélectionnée détermine l’ordre des colonnes de l’exportation.
       fields_instructions_title: Fonctionnement des listes
       format: Format
+      immediate_download: Téléchargement immédiat
       keyboard_help: Des raccourcis clavier sont disponibles sur les boutons d’action des listes.
       metadata: Métadonnées
       no_selection: Veuillez sélectionner au moins 1 échantillon avant d'exporter.
       preparing_export: Préparation de l’exportation pour %{count} lignes...
       preparing_rows: Préparation de %{count} lignes
-      save_failed: 'Téléchargement terminé, mais la sauvegarde sur le serveur a échoué : %{message}'
+      save_failed: 'La sauvegarde sur le serveur a échoué : %{message}'
       save_queued: 'Enregistré dans les exportations de données (ID : %{id})'
       save_to_server: Enregistrer dans les exportations de données
-      save_to_server_help: Conservez éventuellement une copie côté serveur dans votre historique d'exportations de données.
       selected: Sélectionné
       selected_count: 'Échantillons sélectionnés : %{count}'
       selected_description: Champs de métadonnées inclus dans l’exportation. Réorganisez cette liste pour contrôler l’ordre des colonnes.

--- a/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
+++ b/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
@@ -25,6 +25,7 @@ module DataExports
           assert_selector "[data-linelist-export-graphql-url-value='#{graphql_path}']"
           assert_selector "[data-linelist-export-save-to-server-url-value='#{data_exports_path}']"
           assert_selector "[data-linelist-export-sample-graphql-id-prefix-value='gid://#{GlobalID.app}/Sample/']"
+          assert_selector "[data-linelist-export-save-result-visible-duration-ms-value='6000']"
           assert_selector 'input#linelist-format-xlsx:not([disabled])'
           assert_selector "input#linelist-delivery-download[type='radio'][checked]"
           assert_no_selector "input#linelist-delivery-save[type='radio'][checked]"

--- a/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
+++ b/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
@@ -26,8 +26,9 @@ module DataExports
           assert_selector "[data-linelist-export-save-to-server-url-value='#{data_exports_path}']"
           assert_selector "[data-linelist-export-sample-graphql-id-prefix-value='gid://#{GlobalID.app}/Sample/']"
           assert_selector 'input#linelist-format-xlsx:not([disabled])'
-          assert_selector "input#linelist-save-to-server[type='checkbox']"
-          assert_no_selector 'input#linelist-save-to-server[checked]'
+          assert_selector "input#linelist-delivery-download[type='radio'][checked]"
+          assert_no_selector "input#linelist-delivery-save[type='radio'][checked]"
+          assert_selector "fieldset[data-linelist-export-target='saveDetailsFieldset'][disabled]"
           assert_selector "input[name='data_export[name]']"
           assert_selector "input[name='data_export[email_notification]']"
           assert_selector 'ul#available-list'

--- a/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
+++ b/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
@@ -19,10 +19,19 @@ module DataExports
           )
 
           graphql_path = Rails.application.routes.url_helpers.api_graphql_path
+          data_exports_path = Rails.application.routes.url_helpers.data_exports_path
 
-          assert_selector "[data-controller='linelist-export']"
+          assert_selector "[data-controller*='linelist-export']"
           assert_selector "[data-linelist-export-graphql-url-value='#{graphql_path}']"
+          assert_selector "[data-linelist-export-save-to-server-url-value='#{data_exports_path}']"
           assert_selector "[data-linelist-export-sample-graphql-id-prefix-value='gid://#{GlobalID.app}/Sample/']"
+          assert_selector 'input#linelist-format-xlsx:not([disabled])'
+          assert_selector "input#linelist-save-to-server[type='checkbox']"
+          assert_no_selector 'input#linelist-save-to-server[checked]'
+          assert_selector "input[name='data_export[name]']"
+          assert_selector "input[name='data_export[email_notification]']"
+          assert_selector 'ul#available-list'
+          assert_selector 'ul#selected-list'
         end
       end
     end

--- a/test/controllers/data_exports_controller_test.rb
+++ b/test/controllers/data_exports_controller_test.rb
@@ -122,6 +122,29 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test 'should create new linelist csv export with viable params as json without redirect' do
+    params = {
+      'data_export' => {
+        'export_type' => 'linelist',
+        'export_parameters' => {
+          'ids' => [@sample1.id],
+          'namespace_id' => @project1.namespace.id,
+          'linelist_format' => 'csv',
+          'metadata_fields' => ['metadatafield1']
+        }
+      }
+    }
+
+    assert_difference('DataExport.count', 1) do
+      post data_exports_path, params:, as: :json
+    end
+
+    assert_response :accepted
+    payload = response.parsed_body
+    assert_equal('processing', payload['status'])
+    assert payload['id'].present?
+  end
+
   test 'should delete export through destroy action' do
     assert_difference('DataExport.count', -1) do
       delete data_export_path(@data_export1),
@@ -304,6 +327,28 @@ class DataExportsControllerTest < ActionDispatch::IntegrationTest
            }
          }
     assert_response :unprocessable_content
+  end
+
+  test 'should return json errors for invalid linelist json create request' do
+    params = {
+      'data_export' => {
+        'export_type' => 'linelist',
+        'export_parameters' => {
+          'ids' => [@sample1.id],
+          'namespace_id' => @project1.namespace.id,
+          'metadata_fields' => ['metadatafield1']
+        }
+      }
+    }
+
+    assert_no_difference('DataExport.count') do
+      post data_exports_path, params:, as: :json
+    end
+
+    assert_response :unprocessable_content
+    payload = response.parsed_body
+    assert_kind_of(Array, payload['errors'])
+    assert payload['errors'].any?
   end
 
   test 'should not create sample export without attachment_formats param' do

--- a/test/fixtures/data_exports.yml
+++ b/test/fixtures/data_exports.yml
@@ -163,6 +163,20 @@ data_export_twelve:
   expires_at: <%= 5.days.from_now %>
   manifest: '{"type":"Analysis Export","date":"2024-01-01","children":[{"name":"<%= ActiveRecord::FixtureSet.identify(:workflow_execution_completed_shared2, :uuid) %>", "type":"folder","irida-next-type":"workflow_execution","irida-next-name":"<%= ActiveRecord::FixtureSet.identify(:workflow_execution_completed_shared2, :uuid) %>","children":[{"name":"summary.txt.gz","type":"file"},{"name":"INXT_SAM_AAAAAAAABW","type":"folder","irida-next-type":"sample","irida-next-name":"Sample 47","children":[{"name":"INXT_SAM_AAAAAAAABW.assembly.fa.gz","type":"file"}]}]}]}'
 
+data_export_linelist_processing:
+  name: Data Export Linelist Processing
+  export_type: linelist
+  status: processing
+  export_parameters: {
+    ids: [<%= ActiveRecord::FixtureSet.identify(:sample32, :uuid) %>],
+    linelist_format: 'csv',
+    namespace_id: <%= ActiveRecord::FixtureSet.identify(:project29_namespace, :uuid) %>,
+    metadata_fields: ['metadatafield1', 'metadatafield2']
+  }
+  created_at: <%= 1.week.ago %>
+  updated_at: <%= 1.day.ago %>
+  user_id: <%= ActiveRecord::FixtureSet.identify(:jeff_doe, :uuid) %>
+
 data_export_thirteen:
   name: Data Export 13
   export_type: analysis

--- a/test/jobs/data_exports/cleanup_job_test.rb
+++ b/test/jobs/data_exports/cleanup_job_test.rb
@@ -25,5 +25,19 @@ module DataExports
 
       assert_raises(ActiveRecord::RecordNotFound) { @data_export.reload }
     end
+
+    test 'cleanup expired linelist export attachment' do
+      linelist_export = data_exports(:data_export_eight)
+      assert linelist_export.file.valid?
+
+      linelist_export.update!(expires_at: 1.day.ago)
+
+      assert_difference -> { ActiveStorage::Attachment.count } => -1,
+                        -> { DataExport.count } => -1 do
+        DataExports::CleanupJob.perform_now
+      end
+
+      assert_raises(ActiveRecord::RecordNotFound) { linelist_export.reload }
+    end
   end
 end

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -620,23 +620,20 @@ module DataExports
     end
 
     test 'linelist csv export stays processing until CreateJob attaches file and marks ready' do
-      # This test documents the queue lifecycle contract for linelist exports:
-      # the DataExport starts in processing and must not be ready until the job completes.
-      data_export8 = data_exports(:data_export_eight)
-      # Override status to processing to simulate enqueued state
-      data_export8.status = 'processing'
-      data_export8.save!(validate: false)
+      # Documents the queue lifecycle contract: DataExport starts in processing
+      # and is only marked ready once CreateJob attaches the generated file.
+      data_export = data_exports(:data_export_linelist_processing)
 
-      assert_equal 'processing', data_export8.status
-      assert_not data_export8.file.valid?
+      assert_equal 'processing', data_export.status
+      assert_not data_export.file.valid?
 
       assert_difference -> { ActiveStorage::Attachment.count } => +1 do
-        DataExports::CreateJob.perform_now(data_export8)
+        DataExports::CreateJob.perform_now(data_export)
       end
 
-      assert_equal 'ready', data_export8.reload.status
-      assert data_export8.file.valid?
-      assert_equal "#{data_export8.id}.csv", data_export8.file.filename.to_s
+      assert_equal 'ready', data_export.reload.status
+      assert data_export.file.valid?
+      assert_equal "#{data_export.id}.csv", data_export.file.filename.to_s
     end
   end
 end

--- a/test/jobs/data_exports/create_job_test.rb
+++ b/test/jobs/data_exports/create_job_test.rb
@@ -597,5 +597,46 @@ module DataExports
 
       assert_match I18n.t('data_exports.create.error'), error.message
     end
+
+    test 'linelist export delegates row hydration to LinelistRowsService' do
+      data_export8 = data_exports(:data_export_eight)
+
+      rows_called = false
+      rows_result = [
+        ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID', 'METADATAFIELD1', 'METADATAFIELD2'],
+        ['INXT_SAM_AAAAAAAABC', 'Sample 32', 'INXT_PRJ_AAAAAAAAAD', 'value1', 'value2']
+      ]
+
+      DataExports::LinelistRowsService.stub :call, lambda { |**_kwargs|
+        rows_called = true
+        rows_result
+      } do
+        DataExports::CreateJob.perform_now(data_export8)
+      end
+
+      assert rows_called, 'Expected LinelistRowsService.call to be invoked during linelist export'
+      assert_equal 'ready', data_export8.status
+      assert data_export8.file.valid?
+    end
+
+    test 'linelist csv export stays processing until CreateJob attaches file and marks ready' do
+      # This test documents the queue lifecycle contract for linelist exports:
+      # the DataExport starts in processing and must not be ready until the job completes.
+      data_export8 = data_exports(:data_export_eight)
+      # Override status to processing to simulate enqueued state
+      data_export8.status = 'processing'
+      data_export8.save!(validate: false)
+
+      assert_equal 'processing', data_export8.status
+      assert_not data_export8.file.valid?
+
+      assert_difference -> { ActiveStorage::Attachment.count } => +1 do
+        DataExports::CreateJob.perform_now(data_export8)
+      end
+
+      assert_equal 'ready', data_export8.reload.status
+      assert data_export8.file.valid?
+      assert_equal "#{data_export8.id}.csv", data_export8.file.filename.to_s
+    end
   end
 end

--- a/test/services/data_exports/linelist_rows_service_test.rb
+++ b/test/services/data_exports/linelist_rows_service_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DataExports
+  class LinelistRowsServiceTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:john_doe)
+      @sample32 = samples(:sample32)
+      @sample33 = samples(:sample33)
+      @sample34 = samples(:sample34)
+    end
+
+    # Header shape ----------------------------------------------------------
+
+    test 'call returns header row as first element' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: %w[metadatafield1 metadatafield2],
+        current_user: @user
+      )
+
+      assert_equal ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID', 'METADATAFIELD1', 'METADATAFIELD2'],
+                   result.first
+    end
+
+    test 'header is uppercased from metadata_fields input' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: ['metadatafield1'],
+        current_user: @user
+      )
+
+      assert_equal ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID', 'METADATAFIELD1'], result.first
+    end
+
+    test 'header has no metadata columns when metadata_fields is empty' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: [],
+        current_user: @user
+      )
+
+      assert_equal ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID'], result.first
+    end
+
+    # Row shape -------------------------------------------------------------
+
+    test 'call returns puid, name and project puid for each sample' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: [],
+        current_user: @user
+      )
+
+      # row 0 is the header; row 1 is the first sample
+      data_row = result[1]
+      assert_equal @sample32.puid, data_row[0]
+      assert_equal @sample32.name, data_row[1]
+      assert_equal @sample32.project.puid, data_row[2]
+    end
+
+    test 'call returns metadata values in requested field order' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: %w[metadatafield2 metadatafield1],
+        current_user: @user
+      )
+
+      data_row = result[1]
+      # metadatafield2 first because that is the order requested
+      assert_equal @sample32.metadata['metadatafield2'], data_row[3]
+      assert_equal @sample32.metadata['metadatafield1'], data_row[4]
+    end
+
+    # Missing metadata ------------------------------------------------------
+
+    test 'blank string for metadata key not present on sample' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: %w[metadatafield1 non_existent_field],
+        current_user: @user
+      )
+
+      data_row = result[1]
+      assert_equal @sample32.metadata['metadatafield1'], data_row[3]
+      assert_equal '', data_row[4]
+    end
+
+    test 'all metadata columns are blank when sample has no metadata' do
+      # sample33 has metadata; use a sample fixture with no metadata if available,
+      # or just assert the contract for a field that is missing
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: %w[non_existent_a non_existent_b],
+        current_user: @user
+      )
+
+      data_row = result[1]
+      assert_equal '', data_row[3]
+      assert_equal '', data_row[4]
+    end
+
+    # Multiple samples ------------------------------------------------------
+
+    test 'returns one row per sample plus header' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id, @sample33.id, @sample34.id],
+        metadata_fields: %w[metadatafield1],
+        current_user: @user
+      )
+
+      assert_equal 4, result.length # 1 header + 3 data rows
+    end
+
+    test 'row order matches sample_ids order' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample34.id, @sample32.id],
+        metadata_fields: [],
+        current_user: @user
+      )
+
+      assert_equal @sample34.puid, result[1][0]
+      assert_equal @sample32.puid, result[2][0]
+    end
+
+    # nil metadata_fields ---------------------------------------------------
+
+    test 'nil metadata_fields produces header with no metadata columns' do
+      result = DataExports::LinelistRowsService.call(
+        sample_ids: [@sample32.id],
+        metadata_fields: nil,
+        current_user: @user
+      )
+
+      assert_equal ['SAMPLE PUID', 'SAMPLE NAME', 'PROJECT PUID'], result.first
+      assert_equal 3, result[1].length
+    end
+  end
+end

--- a/test/services/data_exports/linelist_rows_service_test.rb
+++ b/test/services/data_exports/linelist_rows_service_test.rb
@@ -124,6 +124,40 @@ module DataExports
       assert_equal @sample32.puid, result[2][0]
     end
 
+    test 'ignores nil nodes returned from graphql nodes query' do
+      node_payload = {
+        'data' => { 'nodes' => [
+          nil,
+          {
+            'id' => @sample32.to_global_id.to_s,
+            '__typename' => 'Sample',
+            'puid' => @sample32.puid,
+            'name' => @sample32.name,
+            'project' => { 'puid' => @sample32.project.puid },
+            'metadata' => { 'metadatafield1' => @sample32.metadata['metadatafield1'] }
+          }
+        ] }
+      }
+
+      schema_singleton = IridaSchema.singleton_class
+      schema_singleton.alias_method :__execute_for_test, :execute
+      schema_singleton.define_method(:execute) { |_query, **_kwargs| node_payload }
+
+      begin
+        result = DataExports::LinelistRowsService.call(
+          sample_ids: [@sample32.id],
+          metadata_fields: ['metadatafield1'],
+          current_user: @user
+        )
+
+        assert_equal @sample32.puid, result[1][0]
+        assert_equal @sample32.metadata['metadatafield1'], result[1][3]
+      ensure
+        schema_singleton.alias_method :execute, :__execute_for_test
+        schema_singleton.remove_method :__execute_for_test
+      end
+    end
+
     # nil metadata_fields ---------------------------------------------------
 
     test 'nil metadata_fields produces header with no metadata columns' do

--- a/test/services/data_exports/linelist_rows_service_test.rb
+++ b/test/services/data_exports/linelist_rows_service_test.rb
@@ -158,6 +158,41 @@ module DataExports
       end
     end
 
+    test 'does not raise when sample_ids includes missing records' do
+      node_payload = {
+        'data' => { 'nodes' => [
+          {
+            'id' => @sample32.to_global_id.to_s,
+            '__typename' => 'Sample',
+            'puid' => @sample32.puid,
+            'name' => @sample32.name,
+            'project' => { 'puid' => @sample32.project.puid },
+            'metadata' => { 'metadatafield1' => @sample32.metadata['metadatafield1'] }
+          },
+          nil
+        ] }
+      }
+
+      schema_singleton = IridaSchema.singleton_class
+      schema_singleton.alias_method :__execute_for_test, :execute
+      schema_singleton.define_method(:execute) { |_query, **_kwargs| node_payload }
+
+      begin
+        missing_id = SecureRandom.uuid
+        result = DataExports::LinelistRowsService.call(
+          sample_ids: [@sample32.id, missing_id],
+          metadata_fields: ['metadatafield1'],
+          current_user: @user
+        )
+
+        assert_equal @sample32.puid, result[1][0]
+        assert_equal ['', '', '', ''], result[2]
+      ensure
+        schema_singleton.alias_method :execute, :__execute_for_test
+        schema_singleton.remove_method :__execute_for_test
+      end
+    end
+
     # nil metadata_fields ---------------------------------------------------
 
     test 'nil metadata_fields produces header with no metadata columns' do

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -1012,7 +1012,10 @@ class DataExportsTest < ApplicationSystemTestCase
     within 'dialog[open].dialog--size-lg' do
       assert_selector "[data-controller*='linelist-export']"
       assert_selector 'input#linelist-format-xlsx:not([disabled])'
-      assert_field 'data_export[save_to_server]', checked: false
+      assert_selector "input#linelist-delivery-download[type='radio']:checked"
+      assert_selector "input#linelist-delivery-save[type='radio']:not(:checked)"
+      assert_field 'data_export[name]', disabled: true
+      assert_field 'data_export[email_notification]', disabled: true
       assert_text I18n.t('data_exports.new.name_label')
       assert_text I18n.t('data_exports.new.email_label')
       assert_selector 'ul#available-list'
@@ -1029,7 +1032,6 @@ class DataExportsTest < ApplicationSystemTestCase
     within 'dialog[open].dialog--size-lg' do
       find('li', exact_text: 'metadatafield1').click
       click_button I18n.t('components.sortable_lists.v1.list_component.add')
-      fill_in 'data_export_name', with: 'v2 unchecked save export'
       click_button I18n.t('data_exports.new.submit_button')
     end
 
@@ -1045,15 +1047,18 @@ class DataExportsTest < ApplicationSystemTestCase
     within 'dialog[open].dialog--size-lg' do
       find('li', exact_text: 'metadatafield1').click
       click_button I18n.t('components.sortable_lists.v1.list_component.add')
+      find("input[type='radio'][id='linelist-delivery-save']").click
+      assert_field 'data_export[name]', disabled: false
+      assert_field 'data_export[email_notification]', disabled: false
       fill_in 'data_export_name', with: 'v2 checked save export'
       find("input[type='checkbox'][id='data_export_email_notification']").click
-      find("input[type='checkbox'][id='linelist-save-to-server']").click
       click_button I18n.t('data_exports.new.submit_button')
     end
 
     assert_selector '#linelist-export-progress-window',
                     text: I18n.t('data_exports.new_linelist_export_dialog.save_queued', id: 'stub-export-id'),
                     wait: 5
+    assert_no_text 'Download started:'
     assert_equal 1, evaluate_script('window.__linelistSaveRequests.length')
 
     payload = evaluate_script('JSON.parse(window.__linelistSaveRequests[0].body)')

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -1051,9 +1051,9 @@ class DataExportsTest < ApplicationSystemTestCase
       click_button I18n.t('data_exports.new.submit_button')
     end
 
-    assert_text :all,
-                I18n.t('data_exports.new_linelist_export_dialog.save_queued', id: 'stub-export-id'),
-                wait: 5
+    assert_selector '#linelist-export-progress-window',
+                    text: I18n.t('data_exports.new_linelist_export_dialog.save_queued', id: 'stub-export-id'),
+                    wait: 5
     assert_equal 1, evaluate_script('window.__linelistSaveRequests.length')
 
     payload = evaluate_script('JSON.parse(window.__linelistSaveRequests[0].body)')

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -1014,10 +1014,12 @@ class DataExportsTest < ApplicationSystemTestCase
       assert_selector 'input#linelist-format-xlsx:not([disabled])'
       assert_selector "input#linelist-delivery-download[type='radio']:checked"
       assert_selector "input#linelist-delivery-save[type='radio']:not(:checked)"
-      assert_field 'data_export[name]', disabled: true
-      assert_field 'data_export[email_notification]', disabled: true
-      assert_text I18n.t('data_exports.new.name_label')
-      assert_text I18n.t('data_exports.new.email_label')
+      assert_text I18n.t('data_exports.new_linelist_export_dialog.fields_instructions_title')
+      assert_text I18n.t('data_exports.new_linelist_export_dialog.fields_instructions')
+      assert_no_field 'data_export[name]'
+      assert_no_field 'data_export[email_notification]'
+      assert_text I18n.t('common.actions.cancel')
+      assert_button I18n.t('data_exports.new_linelist_export_dialog.export_data_button')
       assert_selector 'ul#available-list'
       assert_selector 'ul#selected-list'
     end
@@ -1032,7 +1034,7 @@ class DataExportsTest < ApplicationSystemTestCase
     within 'dialog[open].dialog--size-lg' do
       find('li', exact_text: 'metadatafield1').click
       click_button I18n.t('components.sortable_lists.v1.list_component.add')
-      click_button I18n.t('data_exports.new.submit_button')
+      click_button I18n.t('data_exports.new_linelist_export_dialog.export_data_button')
     end
 
     assert_text 'Download started:'
@@ -1052,7 +1054,7 @@ class DataExportsTest < ApplicationSystemTestCase
       assert_field 'data_export[email_notification]', disabled: false
       fill_in 'data_export_name', with: 'v2 checked save export'
       find("input[type='checkbox'][id='data_export_email_notification']").click
-      click_button I18n.t('data_exports.new.submit_button')
+      click_button I18n.t('data_exports.new_linelist_export_dialog.export_data_button')
     end
 
     assert_selector '#linelist-export-progress-window',

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -1060,6 +1060,8 @@ class DataExportsTest < ApplicationSystemTestCase
     assert_selector '#linelist-export-progress-window',
                     text: I18n.t('data_exports.new_linelist_export_dialog.save_queued', id: 'stub-export-id'),
                     wait: 5
+    assert_selector "#linelist-export-progress-window a[href$='/-/data_exports/stub-export-id']",
+                    text: I18n.t('data_exports.new_linelist_export_dialog.view_data_export')
     assert_no_text 'Download started:'
     assert_equal 1, evaluate_script('window.__linelistSaveRequests.length')
 

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -992,6 +992,77 @@ class DataExportsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'v2 linelist export dialog enables xlsx and defaults save-to-server unchecked' do
+    Flipper.enable(:client_linelist_exports_v1, @user)
+
+    visit namespace_project_samples_url(@group1, @project1)
+    click_button I18n.t('shared.samples.actions_dropdown.label')
+    assert_selector 'button[disabled]',
+                    text: I18n.t('shared.samples.actions_dropdown.linelist_export')
+
+    within %(#samples-table) do
+      find("input[type='checkbox'][value='#{@sample30.id}']").click
+    end
+
+    assert_no_selector 'button[disabled]',
+                       text: I18n.t('shared.samples.actions_dropdown.linelist_export')
+    click_button I18n.t('shared.samples.actions_dropdown.label')
+    click_button I18n.t('shared.samples.actions_dropdown.linelist_export')
+
+    within 'dialog[open].dialog--size-lg' do
+      assert_selector "[data-controller*='linelist-export']"
+      assert_selector 'input#linelist-format-xlsx:not([disabled])'
+      assert_field 'data_export[save_to_server]', checked: false
+      assert_text I18n.t('data_exports.new.name_label')
+      assert_text I18n.t('data_exports.new.email_label')
+      assert_selector 'ul#available-list'
+      assert_selector 'ul#selected-list'
+    end
+  end
+
+  test 'v2 linelist submit downloads without background save when save-to-server is unchecked' do
+    open_v2_linelist_dialog
+    install_v2_linelist_export_stubs
+
+    current_path = page.current_path
+
+    within 'dialog[open].dialog--size-lg' do
+      find('li', exact_text: 'metadatafield1').click
+      click_button I18n.t('components.sortable_lists.v1.list_component.add')
+      fill_in 'data_export_name', with: 'v2 unchecked save export'
+      click_button I18n.t('data_exports.new.submit_button')
+    end
+
+    assert_text 'Download started:'
+    assert_equal 0, evaluate_script('window.__linelistSaveRequests.length')
+    assert_equal current_path, page.current_path
+  end
+
+  test 'v2 linelist submit triggers background save when save-to-server is checked' do
+    open_v2_linelist_dialog
+    install_v2_linelist_export_stubs
+
+    within 'dialog[open].dialog--size-lg' do
+      find('li', exact_text: 'metadatafield1').click
+      click_button I18n.t('components.sortable_lists.v1.list_component.add')
+      fill_in 'data_export_name', with: 'v2 checked save export'
+      find("input[type='checkbox'][id='data_export_email_notification']").click
+      find("input[type='checkbox'][id='linelist-save-to-server']").click
+      click_button I18n.t('data_exports.new.submit_button')
+    end
+
+    assert_text :all,
+                I18n.t('data_exports.new_linelist_export_dialog.save_queued', id: 'stub-export-id'),
+                wait: 5
+    assert_equal 1, evaluate_script('window.__linelistSaveRequests.length')
+
+    payload = evaluate_script('JSON.parse(window.__linelistSaveRequests[0].body)')
+    assert_equal 'linelist', payload['data_export']['export_type']
+    assert_equal 'v2 checked save export', payload['data_export']['name']
+    assert_equal true, payload['data_export']['email_notification']
+    assert_equal ['metadatafield1'], payload['data_export']['export_parameters']['metadata_fields']
+  end
+
   test 'sortable list buttons in new linelist export dialog' do
     visit namespace_project_samples_url(@group1, @project1)
     click_button I18n.t('shared.samples.actions_dropdown.label')
@@ -1780,5 +1851,79 @@ class DataExportsTest < ApplicationSystemTestCase
       assert_text I18n.t('components.viral.pagy.empty_state.title')
       assert_text I18n.t('components.viral.pagy.empty_state.description')
     end
+  end
+
+  def open_v2_linelist_dialog
+    Flipper.enable(:client_linelist_exports_v1, @user)
+
+    visit namespace_project_samples_url(@group1, @project1)
+    click_button I18n.t('shared.samples.actions_dropdown.label')
+    assert_selector 'button[disabled]',
+                    text: I18n.t('shared.samples.actions_dropdown.linelist_export')
+
+    within %(#samples-table) do
+      find("input[type='checkbox'][value='#{@sample30.id}']").click
+    end
+
+    assert_no_selector 'button[disabled]',
+                       text: I18n.t('shared.samples.actions_dropdown.linelist_export')
+    click_button I18n.t('shared.samples.actions_dropdown.label')
+    click_button I18n.t('shared.samples.actions_dropdown.linelist_export')
+  end
+
+  LINELIST_EXPORT_STUBS_SCRIPT = <<~JS
+    window.__linelistSaveRequests = [];
+    window.__linelistOriginalFetch ||= window.fetch.bind(window);
+
+    window.fetch = async (input, init = {}) => {
+      const url = typeof input === "string" ? input : input?.url;
+      const method = (init?.method || "GET").toUpperCase();
+
+      if (url && url.includes("/-/data_exports") && method === "POST") {
+        window.__linelistSaveRequests.push({ url, body: init.body });
+        return new Response(
+          JSON.stringify({
+            id: "stub-export-id",
+            status: "processing",
+            export_type: "linelist",
+          }),
+          {
+            status: 202,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return window.__linelistOriginalFetch(input, init);
+    };
+
+    window.Worker = class {
+      postMessage(payload) {
+        const donePayload =
+          payload.format === "xlsx"
+            ? {
+                type: "done",
+                filename: payload.filename,
+                format: "xlsx",
+                rows: [["SAMPLE PUID"], ["INXT_SAM_STUB"]],
+              }
+            : {
+                type: "done",
+                filename: payload.filename,
+                format: "csv",
+                content: "SAMPLE PUID\\\\nINXT_SAM_STUB",
+              };
+
+        setTimeout(() => {
+          if (this.onmessage) this.onmessage({ data: donePayload });
+        }, 10);
+      }
+
+      terminate() {}
+    };
+  JS
+
+  def install_v2_linelist_export_stubs
+    execute_script LINELIST_EXPORT_STUBS_SCRIPT
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR finishes the queued linelist export flow end-to-end so users can choose how exports are delivered and track save progress clearly.

- Linelist export backend
  - Adds `LinelistRowsService` to build export rows from GraphQL sample data
  - Updates create job flow to use the new row builder for linelist exports
  - Handles nil GraphQL nodes safely so sparse data does not break export generation

- Linelist export UX (V2 dialog + progress)
  - Adds delivery mode options for linelist exports (download + optional server save, or save-only)
  - Improves dialog interaction and list selection behavior for field selection
  - Shows save/queueing status in progress UI with a direct link to the created data export when available

- Supporting updates
  - Adds/updates EN + FR locale strings used by the new flow
  - Cleans up stale translation keys touched by this feature work

Why:
- Supports save-first and queued workflows for larger linelist exports
- Makes export state clearer to users while background processing is running
- Keeps linelist export generation aligned with GraphQL-backed sample data

## Screenshots or screen recordings
UI changes in this PR:
- Linelist export dialog (V2) with delivery mode selection
- Progress state showing queue/save status and data export link

## How to set up and validate locally
1. Start the app (`bin/dev`) and open a project with sample data.
2. Start a linelist export from the dialog and verify:
   - delivery mode options render correctly
   - save-only and save+download paths both run successfully
3. Confirm progress messaging updates through queueing/processing/ready states.
4. If save is selected, confirm the progress view shows a working link to the created data export.
5. Run targeted tests:
   - `PARALLEL_WORKERS=4 bin/rails test test/services/data_exports/linelist_rows_service_test.rb`
   - `PARALLEL_WORKERS=4 bin/rails test test/jobs/data_exports/create_job_test.rb`
   - `PARALLEL_WORKERS=4 bin/rails test test/controllers/data_exports_controller_test.rb`
   - `PARALLEL_WORKERS=4 bin/rails test test/components/data_exports/linelist_export_dialog/v2/component_test.rb`
   - `PARALLEL_WORKERS=4 bin/rails test test/system/data_exports_test.rb`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
