### PR TITLE
Enhance metadata selection with sortable lists in linelist export dialog

### DIFF
--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -55,40 +55,56 @@
         </p>
       </div>
 
-      <div class="form-field">
-        <fieldset>
-          <legend class="mb-1 text-sm text-slate-900 dark:text-slate-400">
+      <% metadata_fields = @namespace&.metadata_fields || [] %>
+
+      <% if metadata_fields.any? %>
+        <div
+          data-controller="sortable-lists--v1--two-lists-selection"
+          data-sortable-lists--v1--two-lists-selection-selected-list-value="selected-list"
+          data-sortable-lists--v1--two-lists-selection-available-list-value="available-list"
+          data-sortable-lists--v1--two-lists-selection-field-name-value="data_export[export_parameters][metadata_fields][]"
+        >
+          <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100">
             <%= t("data_exports.new_linelist_export_dialog.metadata") %>
-          </legend>
+          </h2>
 
-          <div class="grid max-h-48 gap-1 overflow-y-auto rounded-lg border border-slate-200 p-2 dark:border-slate-700">
-            <% metadata_fields = @namespace&.metadata_fields || [] %>
+          <%= render Viral::SortableListsGuidanceComponent.new(
+            title: t("data_exports.new_linelist_export_dialog.fields_instructions_title"),
+            instructions: t("data_exports.new_linelist_export_dialog.fields_instructions"),
+            keyboard_help: t("data_exports.new_linelist_export_dialog.keyboard_help"),
+            available: {
+              title: t("data_exports.new_linelist_export_dialog.available_list_title"),
+              description: t("data_exports.new_linelist_export_dialog.available_description"),
+            },
+            selected: {
+              title: t("data_exports.new_linelist_export_dialog.selected_list_title"),
+              description: t("data_exports.new_linelist_export_dialog.selected_description"),
+            },
+          ) %>
 
-            <% if metadata_fields.any? %>
-              <% metadata_fields.each_with_index do |field, index| %>
-                <% field_id = "metadata-field-#{index}-#{field.to_s.parameterize}" %>
+          <%= render SortableListsComponent.new(
+            templates: @templates,
+            template_label: t("data_exports.new.template_select_label")
+          ) do |sortable_lists| %>
+            <%= sortable_lists.with_list(
+              id: "available-list",
+              title: t("data_exports.new_linelist_export_dialog.available"),
+              list_items: metadata_fields,
+              group: "metadata_selection",
+            ) %>
 
-                <div class="flex items-center gap-2">
-                  <%= check_box_tag(
-                        "metadata_fields[]",
-                        field,
-                        false,
-                        id: field_id,
-                        name: "data_export[export_parameters][metadata_fields][]",
-                        class: "h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500"
-                      ) %>
+            <%= sortable_lists.with_list(
+              id: "selected-list",
+              title: t("data_exports.new_linelist_export_dialog.selected"),
+              group: "metadata_selection",
+            ) %>
+          <% end %>
 
-                  <%= label_tag field_id, field, class: "text-slate-700 dark:text-slate-300" %>
-                </div>
-              <% end %>
-            <% else %>
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                <%= t("data_exports.new_linelist_export_dialog.selected") %>
-              </p>
-            <% end %>
-          </div>
-        </fieldset>
-      </div>
+          <template id="sortable-list-item-template" data-sortable-lists--v1--two-lists-selection-target="itemTemplate">
+            <%= render SortableLists::V1::ListItemComponent.new(list_item: "NAME_HERE") %>
+          </template>
+        </div>
+      <% end %>
 
       <%= form_with(url: "#", method: :get, data: { action: "submit->linelist-export#submit" }) do |form| %>
         <%= form.hidden_field :namespace_id, value: @namespace_id, name: "data_export[export_parameters][namespace_id]" %>

--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -82,23 +82,25 @@
             },
           ) %>
 
-          <%= render SortableListsComponent.new(
+          <div class="mt-4">
+            <%= render SortableListsComponent.new(
             templates: @templates,
             template_label: t("data_exports.new.template_select_label")
           ) do |sortable_lists| %>
-            <%= sortable_lists.with_list(
+              <%= sortable_lists.with_list(
               id: "available-list",
               title: t("data_exports.new_linelist_export_dialog.available"),
               list_items: metadata_fields,
               group: "metadata_selection",
             ) %>
 
-            <%= sortable_lists.with_list(
+              <%= sortable_lists.with_list(
               id: "selected-list",
               title: t("data_exports.new_linelist_export_dialog.selected"),
               group: "metadata_selection",
             ) %>
-          <% end %>
+            <% end %>
+          </div>
 
           <template id="sortable-list-item-template" data-sortable-lists--v1--two-lists-selection-target="itemTemplate">
             <%= render SortableLists::V1::ListItemComponent.new(list_item: "NAME_HERE") %>

--- a/app/components/sortable_lists/v1/component.html.erb
+++ b/app/components/sortable_lists/v1/component.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <% unless templates.empty? %>
-  <div>
+  <div class="mb-4">
     <label for="template-selector" class="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
       <%= template_label %>
     </label>

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -266,22 +266,6 @@ export default class extends Controller {
   }
 
   selectedMetadataFields() {
-    const metadataFieldSelector =
-      "input[name='data_export[export_parameters][metadata_fields][]']";
-    const metadataInputs = Array.from(
-      this.element.querySelectorAll(metadataFieldSelector),
-    );
-
-    if (metadataInputs.some((input) => input.type === "checkbox")) {
-      return metadataInputs
-        .filter((input) => input.checked)
-        .map((input) => input.value);
-    }
-
-    if (metadataInputs.length > 0) {
-      return metadataInputs.map((input) => input.value);
-    }
-
     return Array.from(
       this.element.querySelectorAll("#selected-list li"),
       (item) => item.lastElementChild?.textContent?.trim() || "",

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -266,11 +266,26 @@ export default class extends Controller {
   }
 
   selectedMetadataFields() {
+    const metadataFieldSelector =
+      "input[name='data_export[export_parameters][metadata_fields][]']";
+    const metadataInputs = Array.from(
+      this.element.querySelectorAll(metadataFieldSelector),
+    );
+
+    if (metadataInputs.some((input) => input.type === "checkbox")) {
+      return metadataInputs
+        .filter((input) => input.checked)
+        .map((input) => input.value);
+    }
+
+    if (metadataInputs.length > 0) {
+      return metadataInputs.map((input) => input.value);
+    }
+
     return Array.from(
-      this.element.querySelectorAll(
-        "input[name='data_export[export_parameters][metadata_fields][]']:checked",
-      ),
-    ).map((checkbox) => checkbox.value);
+      this.element.querySelectorAll("#selected-list li"),
+      (item) => item.lastElementChild?.textContent?.trim() || "",
+    ).filter((value) => value.length > 0);
   }
 
   selectedFormat() {

--- a/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
+++ b/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
@@ -24,6 +24,25 @@ module DataExports
           assert_selector "[data-linelist-export-graphql-url-value='#{graphql_path}']"
           assert_selector "[data-linelist-export-sample-graphql-id-prefix-value='gid://#{GlobalID.app}/Sample/']"
         end
+
+        test 'renders metadata sortable lists' do
+          project = projects(:project1)
+
+          render_inline(
+            Component.new(
+              open: true,
+              namespace_id: project.namespace.id,
+              namespace: project.namespace,
+              templates: []
+            )
+          )
+
+          assert_selector "[data-controller='sortable-lists--v1--two-lists-selection']"
+          assert_selector 'ul#available-list li', text: 'metadatafield1'
+          assert_selector 'ul#available-list li', text: 'metadatafield2'
+          assert_selector 'ul#selected-list'
+          assert_no_selector "input[type='checkbox'][name='data_export[export_parameters][metadata_fields][]']"
+        end
       end
     end
   end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Added sortable list to new linelist export dialog

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2246" height="903" alt="image" src="https://github.com/user-attachments/assets/a833114d-c53e-4d2d-b0ab-6002acb23782" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Enable flipper flag for `client_linelist_exports_v1`
2. Try exporting from a groups or project samples page.
3. Metadata field selection with sort should be available

**Note:**  _The rest of the modal is still in development.  It only works right now with csv and saved to your machine._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
