### PR TITLE
Removing Dropdown, Select2, and Prefixed Select2 from Viral Helper

### DIFF
--- a/app/components/layout/breadcrumb_component.html.erb
+++ b/app/components/layout/breadcrumb_component.html.erb
@@ -3,19 +3,17 @@
   class="h-14 w-full min-w-0 overflow-hidden"
   data-controller="breadcrumb"
 >
-  <ol
-    class="flex items-center h-full w-full min-w-0"
-    data-breadcrumb-target="list"
-  >
+  <ol class="flex h-full w-full min-w-0 items-center" data-breadcrumb-target="list">
     <!-- Overflow dropdown -->
-    <li class="shrink-0 invisible absolute" data-breadcrumb-target="dropdownMenu">
-      <%= viral_dropdown(
+    <li class="invisible absolute shrink-0" data-breadcrumb-target="dropdownMenu">
+      <%= render DropdownComponent.new(
         icon: :dots_three_vertical,
         aria: { label: I18n.t(:'components.breadcrumb.dropdown.aria_label') },
         styles: { button: "p-3 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg text-slate-500 cursor-pointer transition" }
       ) do |dropdown| %>
         <% @links.each_with_index do |link, index| %>
           <% next if index == @links.length - 1 %>
+
           <%= dropdown.with_item(
             label: link[:name],
             url: URI.join(root_url, link[:path]).to_s,
@@ -26,13 +24,14 @@
         <% end %>
       <% end %>
     </li>
+
     <!-- Dynamic breadcrumb items -->
     <% @links.each_with_index do |link, index| %>
-      <li class="whitespace-nowrap p-2" data-breadcrumb-target="crumb">
+      <li class="p-2 whitespace-nowrap" data-breadcrumb-target="crumb">
         <% if index == @links.length - 1 %>
           <!-- Current page (last item) -->
           <span
-            class="text-sm text-slate-900 dark:text-white font-medium py-3"
+            class="py-3 text-sm font-medium text-slate-900 dark:text-white"
             aria-current="page"
             title="<%= link[:name] %>"
           >

--- a/app/components/layout/sidebar_component.html.erb
+++ b/app/components/layout/sidebar_component.html.erb
@@ -58,7 +58,7 @@
           </div>
 
           <!-- Add new items -->
-          <%= viral_dropdown(
+          <%= render DropdownComponent.new(
             icon: :plus,
             trigger_id: "sidebar-new-dropdown-trigger",
             tooltip: t("general.navbar.new_dropdown.label"),
@@ -84,7 +84,7 @@
           <% end %>
 
           <!-- Profile menu -->
-          <%= viral_dropdown(
+          <%= render DropdownComponent.new(
             icon: User.icon,
             trigger_id: "sidebar-account-dropdown-trigger",
             tooltip: t(:"general.navbar.account_dropdown.label"),

--- a/app/components/ransack/sort_dropdown_component.html.erb
+++ b/app/components/ransack/sort_dropdown_component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dropdown(label: t("components.ransack.sort_dropdown_component.sorting.#{@ransack_obj.sorts[0].name}_#{@ransack_obj.sorts[0].dir}"),
+<%= render DropdownComponent.new(label: t("components.ransack.sort_dropdown_component.sorting.#{@ransack_obj.sorts[0].name}_#{@ransack_obj.sorts[0].dir}"),
                    caret: true, prefix: t("components.ransack.sort_dropdown_component.prefix")) do |dropdown| %>
   <% @sort_options.each do |sort| %>
     <%= helpers.sorting_item(

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -10,7 +10,6 @@ module ViewHelper
     dialog: 'Viral::DialogComponent',
     empty: 'Viral::EmptyStateComponent',
     data_table: 'Viral::DataTableComponent',
-    dropdown: 'DropdownComponent',
     file_input: 'Viral::Form::FileInputComponent',
     flash: 'Viral::FlashComponent',
     help_text: 'Viral::Form::HelpTextComponent',
@@ -18,10 +17,8 @@ module ViewHelper
     pageheader: 'Viral::PageHeaderComponent',
     prefixed_boolean: 'Viral::Form::Prefixed::BooleanComponent',
     prefixed_select: 'Viral::Form::Prefixed::SelectComponent',
-    prefixed_select2: 'Prefixed::Select2Component',
     prefixed_text_input: 'Viral::Form::Prefixed::TextInputComponent',
     pill: 'Viral::PillComponent',
-    select2: 'Select2Component',
     select: 'Viral::Form::SelectComponent',
     text_input: 'Viral::Form::TextInputComponent',
     tooltip: 'Viral::TooltipComponent'

--- a/app/views/groups/_edit_advanced_transfer_form.html.erb
+++ b/app/views/groups/_edit_advanced_transfer_form.html.erb
@@ -31,7 +31,7 @@ if Flipper.enabled?(:v2_select2, Current.user)
         autocomplete="off"
       >
     <% else %>
-      <%= viral_select2(form:, name: :new_namespace_id, id: form_id, placeholder: t(:"groups.edit.advanced.transfer.select_group")) do |select| %>
+      <%= render Select2Component.new(form:, name: :new_namespace_id, id: form_id, placeholder: t(:"groups.edit.advanced.transfer.select_group")) do |select| %>
         <% @authorized_namespaces.each do |namespace| %>
           <% select.with_option(
                       value: namespace.id,

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,8 +1,10 @@
 <%= render partial: "shared/form/required_field_legend" %>
 
 <% invalid_name = group.errors.include?(:name) %>
+
 <div class="form-field <%= 'invalid' if invalid_name %>">
   <%= form.label :name, data: { required: true } %>
+
   <%= form.text_field :name,
                   data: {
                     "slugify-target": "name",
@@ -28,52 +30,59 @@
     id: form.field_id(:name, "error"),
     errors: group.errors.full_messages_for(:name) %>
   <% end %>
-  <span id="<%= form.field_id(:name, "hint") %>" class="field-hint">
-    <%== t(:"groups.create.name_help") %>
-  </span>
+
+  <span id="<%= form.field_id(:name, "hint") %>" class="field-hint"><%== t(:"groups.create.name_help") %></span>
 </div>
 
 <% if group.new_record? %>
   <% if group.parent_id.present? %>
-    <div class="grid @xs:grid-cols-1 @5xl:grid-cols-2 gap-4">
+    <div class="grid gap-4 @xs:grid-cols-1 @5xl:grid-cols-2">
       <div class="form-field">
         <% form_id = "namespace-select" %>
+
         <%= form.label :parent_id,
                    t("activerecord.attributes.group.parent_id"),
                    for: form_id,
                    class:
                      "mb-1 block text-sm font-medium text-slate-900 dark:text-white" %>
+
         <div>
-          <%= viral_prefixed_select2(form:, name: :parent_id, id: form_id, selected_value: group.parent_id, placeholder: t(:"groups.new_subgroup.select_group")) do |select| %>
+          <%= render Prefixed::Select2Component.new(form:, name: :parent_id, id: form_id, selected_value: group.parent_id, placeholder: t(:"groups.new_subgroup.select_group")) do |select| %>
             <% authorized_namespaces.each do |namespace| %>
               <% select.with_option(
                       value: namespace.id,
                       label: namespace.full_path,
                     ) do %>
-                <div class="flex items-center justify-between gap-3 pointer-events-none">
+                <div class="pointer-events-none flex items-center justify-between gap-3">
                   <div class="min-w-0">
-                    <div class="text-slate-900 dark:text-slate-200 font-semibold truncate">
+                    <div class="truncate font-semibold text-slate-900 dark:text-slate-200">
                       <%= namespace.name %>
                     </div>
-                    <div class="text-slate-600 dark:text-slate-400 text-sm truncate">
+
+                    <div class="truncate text-sm text-slate-600 dark:text-slate-400">
                       <%= namespace.full_path %>
                     </div>
                   </div>
+
                   <div class="shrink-0">
                     <%= render PuidComponent.new(puid: namespace.puid, show_clipboard: false) %>
                   </div>
                 </div>
               <% end %>
             <% end %>
+
             <%= select.with_empty_state do %>
               <%= t(:"groups.new_subgroup.empty_state") %>
             <% end %>
           <% end %>
         </div>
       </div>
+
       <% invalid_path = group.errors.include?(:path) %>
+
       <div class="form-field <%= 'invalid' if invalid_path %>">
         <%= form.label :path, data: { required: true } %>
+
         <%= form.text_field :path,
                         data: {
                           "slugify-target": "path",
@@ -97,15 +106,15 @@
           id: form.field_id(:path, "error"),
           errors: group.errors.full_messages_for(:path) %>
         <% end %>
-        <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
-          <%= t(:"groups.create.path_help") %>
-        </span>
+
+        <span id="<%= form.field_id(:path, "hint") %>" class="field-hint"><%= t(:"groups.create.path_help") %></span>
       </div>
     </div>
   <% else %>
     <% invalid_path = group.errors.include?(:path) %>
     <div class="form-field <%= 'invalid' if invalid_path %>">
       <%= form.label :path, data: { required: true } %>
+
       <%= form.text_field :path,
                       data: {
                         "slugify-target": "path",
@@ -127,16 +136,17 @@
         id: form.field_id(:path, "error"),
         errors: group.errors.full_messages_for(:path) %>
       <% end %>
-      <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
-        <%= t(:"groups.create.path_help") %>
-      </span>
+
+      <span id="<%= form.field_id(:path, "hint") %>" class="field-hint"><%= t(:"groups.create.path_help") %></span>
     </div>
   <% end %>
 <% end %>
 
 <% invalid_description = group.errors.include?(:description) %>
+
 <div class="form-field <%= 'invalid' if invalid_description %>">
   <%= form.label :description %>
+
   <%= form.text_area :description,
                  {
                    :class => "form-control",
@@ -153,11 +163,13 @@
                    "aria-invalid" => invalid_description,
                    :autofocus => invalid_description,
                  } %>
+
   <% if invalid_description %>
     <%= render "shared/form/field_errors",
     id: form.field_id(:description, "error"),
     errors: group.errors.full_messages_for(:description) %>
   <% end %>
+
   <span id="<%= form.field_id(:description, "hint") %>" class="field-hint">
     <%= t(:"groups.create.description_help") %>
   </span>

--- a/app/views/groups/group_links/_form.html.erb
+++ b/app/views/groups/group_links/_form.html.erb
@@ -35,7 +35,7 @@ if Flipper.enabled?(:v2_select2, Current.user)
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
                      data: { required: true } %>
 
-      <%= viral_select2(form:, name: :group_id, id: form_id, selected_value: new_group_link.group_id, aria_invalid: invalid_group_id, field_hint: true) do |select| %>
+      <%= render Select2Component.new(form:, name: :group_id, id: form_id, selected_value: new_group_link.group_id, aria_invalid: invalid_group_id, field_hint: true) do |select| %>
         <% @namespace_linkable_groups.each do |group| %>
           <% select.with_option(
                       value: group.id,

--- a/app/views/groups/members/_form.html.erb
+++ b/app/views/groups/members/_form.html.erb
@@ -30,7 +30,7 @@
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
                      data: { required: true } %>
 
-      <%= viral_select2(form:, name: :user_id, id: form_id, selected_value: @new_member.user_id, aria_invalid: invalid_user_id, field_hint: true) do |select| %>
+      <%= render Select2Component.new(form:, name: :user_id, id: form_id, selected_value: @new_member.user_id, aria_invalid: invalid_user_id, field_hint: true) do |select| %>
         <% @available_users.each do |user| %>
           <% select.with_option(
                       value: user.id,

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -18,7 +18,7 @@
       <% end %>
 
       <% if @group_project_ids.count.positive? && @render_sample_actions %>
-        <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, styles: { button: "button button-default w-full" }) do |dropdown| %>
+        <%= render DropdownComponent.new(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, styles: { button: "button button-default w-full" }) do |dropdown| %>
           <% if @allowed_to[:clone_sample] %>
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.clone"),

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+
 <html class="light" lang="<%= locale %>">
   <% content_for :head do %>
     <style>
@@ -8,21 +9,22 @@
       }
     </style>
   <% end %>
+
   <%= render "layouts/partials/head" %>
+
   <body class="bg-slate-50 dark:bg-slate-900">
     <main class="grid h-screen place-items-center" data-turbo="false">
       <div class="flex flex-col space-y-2">
-
         <section
           class="
-            w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:w-lg xl:p-0
-            dark:bg-slate-800 dark:border-slate-700
+            w-full rounded-lg bg-white shadow sm:w-lg md:mt-0 xl:p-0 dark:border dark:border-slate-700
+            dark:bg-slate-800
           "
         >
-          <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
+          <div class="space-y-4 p-6 sm:p-8 md:space-y-6">
             <div class="relative">
               <div class="absolute right-0">
-                <%= viral_dropdown(icon: :translate, label: t(:"locales.#{locale}", locale: locale), aria: { label: I18n.t(:'layouts.application.language_selection.aria_label')}) do |dropdown| %>
+                <%= render DropdownComponent.new(icon: :translate, label: t(:"locales.#{locale}", locale: locale), aria: { label: I18n.t(:'layouts.application.language_selection.aria_label')}) do |dropdown| %>
                   <%- I18n.available_locales.each do |locale| %>
                     <%= dropdown.with_item(
                       label: t(:"locales.#{locale}", locale: locale),
@@ -40,17 +42,21 @@
                 name: "beaker",
                 classes: "w-20 h-20 text-green-500 rotate-12",
               ) %>
+
               <h1
                 class="
-                  text-xl font-bold leading-tight tracking-tight text-center text-slate-900
-                  md:text-2xl dark:text-white
+                  text-center text-xl leading-tight font-bold tracking-tight text-slate-900 md:text-2xl
+                  dark:text-white
                 "
-              ><%= t("devise.layout.title") %></h1>
+              >
+                <%= t("devise.layout.title") %>
+              </h1>
             </div>
 
             <% flash.each do |type, msg| %>
               <%= viral_alert(type: type, message: msg) %>
             <% end %>
+
             <%= yield %>
           </div>
         </section>

--- a/app/views/projects/_project_namespace_fields.html.erb
+++ b/app/views/projects/_project_namespace_fields.html.erb
@@ -60,7 +60,7 @@
           builder.object.parent_id.presence || current_user.namespace.id
         end %>
 
-      <%= viral_prefixed_select2(form: builder, name: :parent_id, id: form_id, selected_value: selected_value, placeholder: t(:"projects.new.select_namespace"), required: true, aria: { invalid: invalid_namespace,
+      <%= render Prefixed::Select2Component.new(form: builder, name: :parent_id, id: form_id, selected_value: selected_value, placeholder: t(:"projects.new.select_namespace"), required: true, aria: { invalid: invalid_namespace,
       describedby: [invalid_namespace ? builder.field_id(:namespace, "error") : nil, builder.field_id(:namespace, "hint")].join(" ") } ) do |select| %>
         <% authorized_namespaces.each do |namespace| %>
           <% select.with_option(

--- a/app/views/projects/_transfer_form.html.erb
+++ b/app/views/projects/_transfer_form.html.erb
@@ -27,7 +27,7 @@
         autocomplete="off"
       >
     <% else %>
-      <%= viral_select2(form:, name: :new_namespace_id, id: form_id, placeholder: t(:"projects.edit.advanced.transfer.select_namespace")) do |select| %>
+      <%= render Select2Component.new(form:, name: :new_namespace_id, id: form_id, placeholder: t(:"projects.edit.advanced.transfer.select_namespace")) do |select| %>
         <% @authorized_namespaces.each do |namespace| %>
           <% select.with_option(
                       value: namespace.id,

--- a/app/views/projects/group_links/_form.html.erb
+++ b/app/views/projects/group_links/_form.html.erb
@@ -35,7 +35,7 @@ if Flipper.enabled?(:v2_select2, Current.user)
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
                      data: { required: true } %>
 
-      <%= viral_select2(form:, name: :group_id, id: form_id, selected_value: new_group_link.group_id, aria_invalid: invalid_group_id, field_hint: true) do |select| %>
+      <%= render Select2Component.new(form:, name: :group_id, id: form_id, selected_value: new_group_link.group_id, aria_invalid: invalid_group_id, field_hint: true) do |select| %>
         <% @namespace_linkable_groups.each do |group| %>
           <% select.with_option(
                       value: group.id,

--- a/app/views/projects/members/_form.html.erb
+++ b/app/views/projects/members/_form.html.erb
@@ -30,7 +30,7 @@
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
                      data: { required: true } %>
 
-      <%= viral_select2(form:, name: :user_id, id: form_id, selected_value: @new_member.user_id, aria_invalid: invalid_user_id, field_hint: true) do |select| %>
+      <%= render Select2Component.new(form:, name: :user_id, id: form_id, selected_value: @new_member.user_id, aria_invalid: invalid_user_id, field_hint: true) do |select| %>
         <% @available_users.each do |user| %>
           <% select.with_option(
                       value: user.id,

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -18,7 +18,7 @@
       <% end %>
 
       <% if @render_sample_actions %>
-        <%= viral_dropdown(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
+        <%= render DropdownComponent.new(label: t("shared.samples.actions_dropdown.label"), aria: { label: t('shared.samples.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
           <% if @allowed_to[:create_sample] %>
             <% dropdown.with_item(
               label: t("shared.samples.actions_dropdown.new_sample"),

--- a/app/views/projects/workflow_executions/index.html.erb
+++ b/app/views/projects/workflow_executions/index.html.erb
@@ -12,7 +12,7 @@
 ) do |component| %>
   <%= component.with_buttons do %>
     <% if @has_workflow_executions && @render_workflow_actions %>
-      <%= viral_dropdown(label: t("shared.workflow_executions.actions_dropdown.label"), aria: { label: t('shared.workflow_executions.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
+      <%= render DropdownComponent.new(label: t("shared.workflow_executions.actions_dropdown.label"), aria: { label: t('shared.workflow_executions.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
         <% if allowed_to?(:cancel_workflow_executions?, @project.namespace) && Flipper.enabled?(:cancel_multiple_workflows, current_user) %>
           <% dropdown.with_item(
             label:

--- a/app/views/samples/clones/_dialog.html.erb
+++ b/app/views/samples/clones/_dialog.html.erb
@@ -79,7 +79,7 @@
                   autocomplete="off"
                 >
               <% else %>
-                <%= viral_select2(form:, name: :new_project_id, required: true, id: form_id, placeholder: t("samples.clones.dialog.select_project")) do |select| %>
+                <%= render Select2Component.new(form:, name: :new_project_id, required: true, id: form_id, placeholder: t("samples.clones.dialog.select_project")) do |select| %>
                   <% @projects.each do |project| %>
                     <% select.with_option(
                       value: project.id,

--- a/app/views/samples/transfers/_dialog.html.erb
+++ b/app/views/samples/transfers/_dialog.html.erb
@@ -80,7 +80,7 @@
                   autocomplete="off"
                 >
               <% else %>
-                <%= viral_select2(form:, name: :new_project_id, required: true, id: form_id, placeholder: t("samples.transfers.dialog.select_project")) do |select| %>
+                <%= render Select2Component.new(form:, name: :new_project_id, required: true, id: form_id, placeholder: t("samples.transfers.dialog.select_project")) do |select| %>
                   <% @projects.each do |project| %>
                     <% select.with_option(
                       value: project.id,

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -188,7 +188,7 @@
                   <%= t("shared.samples.spreadsheet_imports.dialog.static_project_description") %>
                 </p>
 
-                <%= viral_select2(form:, name: :static_project_id, id: form_id, placeholder: t("shared.samples.spreadsheet_imports.dialog.select_static_project"), required: false) do |select| %>
+                <%= render Select2Component.new(form:, name: :static_project_id, id: form_id, placeholder: t("shared.samples.spreadsheet_imports.dialog.select_static_project"), required: false) do |select| %>
                   <% @group_projects.each do |project| %>
                     <% select.with_option(
                         value: project.id,

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -9,7 +9,7 @@
 <%= render Viral::PageHeaderComponent.new(title: t("shared.workflow_executions.index.title")) do |component| %>
   <%= component.with_buttons do %>
     <% if @has_workflow_executions %>
-      <%= viral_dropdown(label: t("shared.workflow_executions.actions_dropdown.label"), aria: { label: t('shared.workflow_executions.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
+      <%= render DropdownComponent.new(label: t("shared.workflow_executions.actions_dropdown.label"), aria: { label: t('shared.workflow_executions.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
         <% if Flipper.enabled?(:cancel_multiple_workflows, current_user) %>
           <% dropdown.with_item(
             label:

--- a/test/components/previews/prefixed_select2_component_preview/default.html.erb
+++ b/test/components/previews/prefixed_select2_component_preview/default.html.erb
@@ -6,7 +6,7 @@ if Flipper.enabled?(:v2_prefixed_select2, Current.user)
   end) do |form| %>
   <label for="unique_id">Select User</label>
 
-  <%= viral_prefixed_select2(form:, name: :user, id: "unique_id", selected_value: 1, placeholder: 'Select User') do |select| %>
+  <%= render Prefixed::Select2Component.new(form:, name: :user, id: "unique_id", selected_value: 1, placeholder: 'Select User') do |select| %>
     <% (1..50).each do |num| %>
       <% select.with_option(
                       value: num,

--- a/test/components/previews/select2_component_preview/default.html.erb
+++ b/test/components/previews/select2_component_preview/default.html.erb
@@ -6,7 +6,7 @@ if Flipper.enabled?(:v2_select2, Current.user)
   end) do |form| %>
   <label for="unique_id">Select User</label>
 
-  <%= viral_select2(form:, name: :user, id: "unique_id") do |select| %>
+  <%= render Select2Component.new(form:, name: :user, id: "unique_id") do |select| %>
     <% (1..50).each do |num| %>
       <% select.with_option(
                       value: num,


### PR DESCRIPTION
## What does this PR do and why?
This PR removes dropdown, select2, and prefixed_select2 from viral_helper as these components have been moved out of viral.

## Screenshots or screen recordings
N/A

## How to set up and validate locally
Verify tests pass. 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
