### PR TITLE
Enable client-side xlsx linelist export V2

### DIFF
--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -9,7 +9,6 @@
   "linelist-export-preparing-rows-message-value": t("data_exports.new_linelist_export_dialog.preparing_rows"),
   "linelist-export-preparing-export-message-value": t("data_exports.new_linelist_export_dialog.preparing_export"),
   "linelist-export-start-error-message-value": t("data_exports.new_linelist_export_dialog.start_error"),
-  "linelist-export-xlsx-unsupported-message-value": t("data_exports.new_linelist_export_dialog.xlsx_unsupported"),
   "linelist-export-unexpected-error-message-value": t("data_exports.new_linelist_export_dialog.unexpected_error"),
   "linelist-export-download-started-message-value": t("data_exports.new_linelist_export_dialog.download_started"),
   "linelist-export-created-records-message-value": t("data_exports.new_linelist_export_dialog.created_records"),
@@ -42,17 +41,12 @@
                                    "xlsx",
                                    false,
                                    id: "linelist-format-xlsx",
-                                   disabled: true,
                                    name: "data_export[export_parameters][linelist_format]" %>
 
               <span><%= t("data_exports.new_linelist_export_dialog.xlsx") %></span>
             </label>
           </div>
         </fieldset>
-
-        <p class="mt-2 text-xs text-slate-600 dark:text-slate-400">
-          <%= t("data_exports.new_linelist_export_dialog.xlsx_unsupported") %>
-        </p>
       </div>
 
       <% metadata_fields = @namespace&.metadata_fields || [] %>

--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -9,6 +9,7 @@
   "linelist-export-preparing-rows-message-value": t("data_exports.new_linelist_export_dialog.preparing_rows"),
   "linelist-export-preparing-export-message-value": t("data_exports.new_linelist_export_dialog.preparing_export"),
   "linelist-export-start-error-message-value": t("data_exports.new_linelist_export_dialog.start_error"),
+  "linelist-export-xlsx-load-error-message-value": t("data_exports.new_linelist_export_dialog.xlsx_load_error"),
   "linelist-export-unexpected-error-message-value": t("data_exports.new_linelist_export_dialog.unexpected_error"),
   "linelist-export-download-started-message-value": t("data_exports.new_linelist_export_dialog.download_started"),
   "linelist-export-created-records-message-value": t("data_exports.new_linelist_export_dialog.created_records"),

--- a/app/javascript/controllers/linelist_export/downloader.js
+++ b/app/javascript/controllers/linelist_export/downloader.js
@@ -1,0 +1,32 @@
+export async function downloadExport(filename, content, format = "csv") {
+  if (format === "xlsx") {
+    await downloadXlsx(filename, content);
+    return;
+  }
+
+  downloadCsv(filename, content);
+}
+
+function downloadCsv(filename, csvContent) {
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function downloadXlsx(filename, rows) {
+  if (!Array.isArray(rows)) {
+    throw new Error("Invalid spreadsheet data received from export worker.");
+  }
+
+  const XLSX = await import("xlsx");
+  const workbook = XLSX.utils.book_new();
+  const worksheet = XLSX.utils.aoa_to_sheet(rows);
+  XLSX.utils.book_append_sheet(workbook, worksheet, "linelist");
+  XLSX.writeFile(workbook, filename);
+}

--- a/app/javascript/controllers/linelist_export/downloader.js
+++ b/app/javascript/controllers/linelist_export/downloader.js
@@ -1,3 +1,10 @@
+export class XlsxLibraryLoadError extends Error {
+  constructor() {
+    super("Failed to load XLSX export library.");
+    this.name = "XlsxLibraryLoadError";
+  }
+}
+
 export async function downloadExport(filename, content, format = "csv") {
   if (format === "xlsx") {
     await downloadXlsx(filename, content);
@@ -24,7 +31,14 @@ async function downloadXlsx(filename, rows) {
     throw new Error("Invalid spreadsheet data received from export worker.");
   }
 
-  const XLSX = await import("xlsx");
+  let XLSX;
+
+  try {
+    XLSX = await import("xlsx");
+  } catch {
+    throw new XlsxLibraryLoadError();
+  }
+
   const workbook = XLSX.utils.book_new();
   const worksheet = XLSX.utils.aoa_to_sheet(rows);
   XLSX.utils.book_append_sheet(workbook, worksheet, "linelist");

--- a/app/javascript/controllers/linelist_export/progress_window.js
+++ b/app/javascript/controllers/linelist_export/progress_window.js
@@ -1,0 +1,157 @@
+const PROGRESS_WINDOW_ID = "linelist-export-progress-window";
+const DISMISS_SELECTOR = '[data-linelist-export-dismiss="true"]';
+
+export function updateProgressWindow(
+  controller,
+  message,
+  percentage,
+  error = false,
+) {
+  if (controller.progressWindowDismissed) return;
+
+  const percent = Math.min(Math.max(percentage, 0), 100);
+  ensureExportCard(controller);
+
+  if (controller._progressMsgEl) {
+    controller._progressMsgEl.textContent = message;
+    if (error) {
+      controller._progressMsgEl.setAttribute("role", "alert");
+      controller._progressMsgEl.removeAttribute("aria-live");
+    } else {
+      controller._progressMsgEl.setAttribute("aria-live", "polite");
+      controller._progressMsgEl.removeAttribute("role");
+    }
+  }
+
+  if (controller._progressBarEl) {
+    controller._progressBarEl.style.width = `${percent}%`;
+    controller._progressBarEl.setAttribute(
+      "aria-valuenow",
+      Math.round(percent),
+    );
+    controller._progressBarEl.setAttribute("aria-label", message);
+    controller._progressBarEl.classList.toggle("bg-red-600", error);
+    controller._progressBarEl.classList.toggle("bg-primary-600", !error);
+  }
+
+  if (controller._progressPctEl) {
+    controller._progressPctEl.textContent = `${Math.round(percent)}%`;
+  }
+}
+
+export function showProgressWindow(controller, message) {
+  if (!controller._progressWindowOpenedAt) {
+    controller._progressWindowOpenedAt = Date.now();
+  }
+
+  updateProgressWindow(controller, message, 0);
+}
+
+export function scheduleProgressWindowDismiss(controller) {
+  if (controller.progressWindowDismissed) return;
+
+  clearProgressWindowDismissTimeout(controller);
+
+  const openedAt = controller._progressWindowOpenedAt || Date.now();
+  const elapsedMs = Date.now() - openedAt;
+  const remainingMs = Math.max(
+    controller.minimumVisibleDurationMsValue - elapsedMs,
+    0,
+  );
+
+  controller._dismissProgressWindowTimeout = setTimeout(() => {
+    dismissProgressWindow(controller);
+  }, remainingMs);
+}
+
+export function clearProgressWindowDismissTimeout(controller) {
+  if (!controller._dismissProgressWindowTimeout) return;
+
+  clearTimeout(controller._dismissProgressWindowTimeout);
+  controller._dismissProgressWindowTimeout = null;
+}
+
+export function dismissProgressWindow(controller) {
+  clearProgressWindowDismissTimeout(controller);
+
+  if (controller._exportId) {
+    const card = document.getElementById(
+      `linelist-export-card-${controller._exportId}`,
+    );
+    if (card) card.remove();
+  }
+
+  const container = document.getElementById(PROGRESS_WINDOW_ID);
+  if (container && container.children.length === 0) container.remove();
+
+  controller.progressWindowDismissed = true;
+  controller._exportId = null;
+  controller._progressWindowOpenedAt = null;
+  controller._progressMsgEl = null;
+  controller._progressBarEl = null;
+  controller._progressPctEl = null;
+}
+
+function ensureExportCard(controller) {
+  if (!controller._exportId) return null;
+
+  const cardId = `linelist-export-card-${controller._exportId}`;
+  let card = document.getElementById(cardId);
+
+  if (!card) {
+    card = createExportCard(controller, cardId);
+  } else if (!controller._progressMsgEl) {
+    // Recover refs after Turbo reconnect
+    controller._progressMsgEl = card.querySelector(
+      "[data-linelist-export-progress-message]",
+    );
+    controller._progressBarEl = card.querySelector(
+      "[data-linelist-export-progress-bar]",
+    );
+    controller._progressPctEl = card.querySelector(
+      "[data-linelist-export-progress-percent]",
+    );
+  }
+
+  return card;
+}
+
+function ensureProgressContainer() {
+  let container = document.getElementById(PROGRESS_WINDOW_ID);
+  if (!container) {
+    container = document.createElement("div");
+    container.id = PROGRESS_WINDOW_ID;
+    container.className = "fixed bottom-5 right-5 z-50 w-80 space-y-2";
+    container.setAttribute("data-turbo-permanent", "");
+    document.body.appendChild(container);
+  }
+
+  return container;
+}
+
+function createExportCard(controller, cardId) {
+  const container = ensureProgressContainer();
+  const card = document.createElement("div");
+  card.id = cardId;
+  card.addEventListener("click", (event) => {
+    if (!event?.target?.closest?.(DISMISS_SELECTOR)) return;
+    dismissProgressWindow(controller);
+  });
+
+  if (controller.hasProgressTemplateTarget) {
+    const clone = controller.progressTemplateTarget.content.cloneNode(true);
+    controller._progressMsgEl = clone.querySelector(
+      "[data-linelist-export-progress-message]",
+    );
+    controller._progressBarEl = clone.querySelector(
+      "[data-linelist-export-progress-bar]",
+    );
+    controller._progressPctEl = clone.querySelector(
+      "[data-linelist-export-progress-percent]",
+    );
+    card.appendChild(clone);
+  }
+
+  container.appendChild(card);
+  return card;
+}

--- a/app/javascript/controllers/linelist_export/selection.js
+++ b/app/javascript/controllers/linelist_export/selection.js
@@ -1,0 +1,43 @@
+export function selectedMetadataFields(rootElement) {
+  return Array.from(
+    rootElement.querySelectorAll("#selected-list li"),
+    (item) => item.lastElementChild?.textContent?.trim() || "",
+  ).filter((value) => value.length > 0);
+}
+
+export function selectedFormat(rootElement) {
+  const selected = rootElement.querySelector(
+    "input[name='data_export[export_parameters][linelist_format]']:checked",
+  );
+
+  return selected?.value || "csv";
+}
+
+export function selectedNamespaceId(rootElement) {
+  const namespaceInput = rootElement.querySelector(
+    "input[name='data_export[export_parameters][namespace_id]']",
+  );
+
+  return namespaceInput?.value || "";
+}
+
+export function selectedSampleIds(storageKey, storage = sessionStorage) {
+  const value = storage.getItem(storageKey);
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function selectionStorageKey(loc = location) {
+  return `${loc.protocol}//${loc.host}${loc.pathname}`;
+}
+
+export function csrfToken(doc = document) {
+  const meta = doc.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute("content") || "";
+}

--- a/app/javascript/controllers/linelist_export/worker_client.js
+++ b/app/javascript/controllers/linelist_export/worker_client.js
@@ -1,0 +1,99 @@
+export class LinelistExportWorkerClient {
+  constructor({
+    resolveWorkerSource,
+    onProgress,
+    onDone,
+    onError,
+    formatUnexpectedError = (detail) => detail,
+  }) {
+    this.resolveWorkerSource = resolveWorkerSource;
+    this.onProgress = onProgress;
+    this.onDone = onDone;
+    this.onError = onError;
+    this.formatUnexpectedError = formatUnexpectedError;
+    this.worker = null;
+  }
+
+  start(payload) {
+    this.stop();
+
+    const workerSource = this.resolveWorkerSource();
+    const worker = this.buildWorker(workerSource);
+    worker.onmessage = (event) => {
+      void this.handleWorkerMessage(event);
+    };
+    worker.onerror = (event) => {
+      const detail = event?.message || event?.error?.message || "";
+      this.onError(this.formatUnexpectedError(detail));
+    };
+    this.worker = worker;
+    worker.postMessage(payload);
+  }
+
+  stop() {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+  }
+
+  buildWorker(workerSource) {
+    try {
+      return new Worker(workerSource, { type: "module" });
+    } catch (error) {
+      console.warn(
+        "[linelist-export] Module worker unavailable, falling back to classic worker:",
+        error,
+      );
+      return new Worker(workerSource);
+    }
+  }
+
+  async handleWorkerMessage(event) {
+    const payload = event.data || {};
+
+    if (payload.type === "progress") {
+      this.onProgress(payload);
+      return;
+    }
+
+    if (payload.type === "done") {
+      await this.onDone(payload);
+      return;
+    }
+
+    if (payload.type === "error") {
+      this.onError(payload.message);
+    }
+  }
+}
+
+export function resolveLinelistExportWorkerSource(
+  { hasWorkerUrlValue, workerUrlValue },
+  doc = document,
+  loc = location,
+) {
+  if (hasWorkerUrlValue && workerUrlValue) {
+    return workerUrlValue;
+  }
+
+  const resolvedFromImportMap = workerSourceFromImportMap(doc);
+  if (resolvedFromImportMap) {
+    return new URL(resolvedFromImportMap, loc.origin).href;
+  }
+
+  return new URL("../../workers/linelist_export_worker.js", import.meta.url)
+    .href;
+}
+
+function workerSourceFromImportMap(doc) {
+  const importMapScript = doc.querySelector("script[type='importmap']");
+  if (!importMapScript?.textContent) return null;
+
+  try {
+    const importMap = JSON.parse(importMapScript.textContent);
+    return importMap?.imports?.["workers/linelist_export_worker"] || null;
+  } catch {
+    return null;
+  }
+}

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -126,10 +126,6 @@ export default class extends Controller {
         this.t(this.preparingRowsMessageValue, { count: totalCount }),
       );
 
-      if (!this.workerClient) {
-        this.workerClient = this.buildWorkerClient();
-      }
-
       this.workerClient.start({
         sample_ids: sampleIds,
         metadata_fields: metadataFields,

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -1,5 +1,8 @@
 import { Controller } from "@hotwired/stimulus";
-import { downloadExport } from "controllers/linelist_export/downloader";
+import {
+  downloadExport,
+  XlsxLibraryLoadError,
+} from "controllers/linelist_export/downloader";
 import {
   clearProgressWindowDismissTimeout as clearProgressWindowDismissTimeoutState,
   dismissProgressWindow as dismissProgressWindowState,
@@ -46,6 +49,11 @@ export default class extends Controller {
     startErrorMessage: {
       type: String,
       default: "Unable to start export: %{message}",
+    },
+    xlsxLoadErrorMessage: {
+      type: String,
+      default:
+        "Unable to load the XLSX export library. Please retry or export as CSV.",
     },
     unexpectedErrorMessage: {
       type: String,
@@ -177,6 +185,11 @@ export default class extends Controller {
     try {
       await this.download(payload.filename, payload.content, payload.format);
     } catch (error) {
+      if (error instanceof XlsxLibraryLoadError) {
+        this.handleWorkerError(this.t(this.xlsxLoadErrorMessageValue));
+        return;
+      }
+
       this.handleWorkerError(this.formatUnexpectedError(error?.message || ""));
       return;
     }

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -27,10 +27,6 @@ export default class extends Controller {
       type: String,
       default: "Unable to start export: %{message}",
     },
-    xlsxUnsupportedMessage: {
-      type: String,
-      default: "XLSX export is not supported in this client-side flow yet.",
-    },
     unexpectedErrorMessage: {
       type: String,
       default: "Unexpected error while generating export: %{message}",
@@ -77,15 +73,6 @@ export default class extends Controller {
 
     if (!selectedCount) {
       this.updateProgress(this.t(this.noSelectionErrorMessageValue), 100, true);
-      return;
-    }
-
-    if (format !== "csv") {
-      this.updateProgress(
-        this.t(this.xlsxUnsupportedMessageValue, { format }),
-        100,
-        true,
-      );
       return;
     }
 
@@ -144,7 +131,9 @@ export default class extends Controller {
 
     const workerSource = this.workerSourceUrl();
     const worker = this.buildWorker(workerSource);
-    worker.onmessage = (event) => this.handleWorkerMessage(event);
+    worker.onmessage = (event) => {
+      void this.handleWorkerMessage(event);
+    };
     worker.onerror = (event) => {
       const detail = event?.message || event?.error?.message || "";
       const message = this.t(this.unexpectedErrorMessageValue, {
@@ -167,7 +156,7 @@ export default class extends Controller {
     }
   }
 
-  handleWorkerMessage(event) {
+  async handleWorkerMessage(event) {
     const payload = event.data || {};
 
     if (payload.type === "progress") {
@@ -180,7 +169,18 @@ export default class extends Controller {
     }
 
     if (payload.type === "done") {
-      this.download(payload.filename, payload.content);
+      try {
+        await this.download(payload.filename, payload.content, payload.format);
+      } catch (error) {
+        const detail = error?.message || "";
+        const message = this.t(this.unexpectedErrorMessageValue, {
+          message: detail,
+        }).replace(/:\s*$/, "");
+        this.updateProgress(message, 100, true);
+        this.terminateWorker();
+        return;
+      }
+
       this.updateProgress(
         this.t(this.downloadStartedMessageValue, {
           filename: payload.filename,
@@ -228,7 +228,16 @@ export default class extends Controller {
     }
   }
 
-  download(filename, csvContent) {
+  async download(filename, content, format = "csv") {
+    if (format === "xlsx") {
+      await this.downloadXlsx(filename, content);
+      return;
+    }
+
+    this.downloadCsv(filename, content);
+  }
+
+  downloadCsv(filename, csvContent) {
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");
@@ -238,6 +247,18 @@ export default class extends Controller {
     anchor.click();
     anchor.remove();
     URL.revokeObjectURL(url);
+  }
+
+  async downloadXlsx(filename, rows) {
+    if (!Array.isArray(rows)) {
+      throw new Error("Invalid spreadsheet data received from export worker.");
+    }
+
+    const XLSX = await import("xlsx");
+    const workbook = XLSX.utils.book_new();
+    const worksheet = XLSX.utils.aoa_to_sheet(rows);
+    XLSX.utils.book_append_sheet(workbook, worksheet, "linelist");
+    XLSX.writeFile(workbook, filename);
   }
 
   closeDialog() {

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -1,4 +1,20 @@
 import { Controller } from "@hotwired/stimulus";
+import { downloadExport } from "controllers/linelist_export/downloader";
+import {
+  clearProgressWindowDismissTimeout as clearProgressWindowDismissTimeoutState,
+  dismissProgressWindow as dismissProgressWindowState,
+  scheduleProgressWindowDismiss as scheduleProgressWindowDismissState,
+  showProgressWindow as showProgressWindowState,
+  updateProgressWindow,
+} from "controllers/linelist_export/progress_window";
+import {
+  csrfToken as csrfTokenFromDocument,
+  selectedFormat as selectedFormatFromForm,
+  selectedMetadataFields as selectedMetadataFieldsFromList,
+  selectedNamespaceId as selectedNamespaceIdFromForm,
+  selectedSampleIds as selectedSampleIdsFromSession,
+  selectionStorageKey as buildSelectionStorageKey,
+} from "controllers/linelist_export/selection";
 
 export default class extends Controller {
   static targets = ["sampleStatus", "progressTemplate"];
@@ -46,6 +62,9 @@ export default class extends Controller {
     this._exportId = null;
     this._progressWindowOpenedAt = null;
     this._dismissProgressWindowTimeout = null;
+    this._progressMsgEl = null;
+    this._progressBarEl = null;
+    this._progressPctEl = null;
     this.progressWindowDismissed = false;
     this.updateSelectedCount();
   }
@@ -199,66 +218,11 @@ export default class extends Controller {
   }
 
   updateProgress(message, percentage, error = false) {
-    if (this.progressWindowDismissed) return;
-
-    const percent = Math.min(Math.max(percentage, 0), 100);
-    this.ensureExportCard();
-
-    if (this._progressMsgEl) {
-      this._progressMsgEl.textContent = message;
-      if (error) {
-        this._progressMsgEl.setAttribute("role", "alert");
-        this._progressMsgEl.removeAttribute("aria-live");
-      } else {
-        this._progressMsgEl.setAttribute("aria-live", "polite");
-        this._progressMsgEl.removeAttribute("role");
-      }
-    }
-
-    if (this._progressBarEl) {
-      this._progressBarEl.style.width = `${percent}%`;
-      this._progressBarEl.setAttribute("aria-valuenow", Math.round(percent));
-      this._progressBarEl.setAttribute("aria-label", message);
-      this._progressBarEl.classList.toggle("bg-red-600", error);
-      this._progressBarEl.classList.toggle("bg-primary-600", !error);
-    }
-
-    if (this._progressPctEl) {
-      this._progressPctEl.textContent = `${Math.round(percent)}%`;
-    }
+    updateProgressWindow(this, message, percentage, error);
   }
 
   async download(filename, content, format = "csv") {
-    if (format === "xlsx") {
-      await this.downloadXlsx(filename, content);
-      return;
-    }
-
-    this.downloadCsv(filename, content);
-  }
-
-  downloadCsv(filename, csvContent) {
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
-  }
-
-  async downloadXlsx(filename, rows) {
-    if (!Array.isArray(rows)) {
-      throw new Error("Invalid spreadsheet data received from export worker.");
-    }
-
-    const XLSX = await import("xlsx");
-    const workbook = XLSX.utils.book_new();
-    const worksheet = XLSX.utils.aoa_to_sheet(rows);
-    XLSX.utils.book_append_sheet(workbook, worksheet, "linelist");
-    XLSX.writeFile(workbook, filename);
+    await downloadExport(filename, content, format);
   }
 
   closeDialog() {
@@ -287,37 +251,19 @@ export default class extends Controller {
   }
 
   selectedMetadataFields() {
-    return Array.from(
-      this.element.querySelectorAll("#selected-list li"),
-      (item) => item.lastElementChild?.textContent?.trim() || "",
-    ).filter((value) => value.length > 0);
+    return selectedMetadataFieldsFromList(this.element);
   }
 
   selectedFormat() {
-    const selected = this.element.querySelector(
-      "input[name='data_export[export_parameters][linelist_format]']:checked",
-    );
-    return selected?.value || "csv";
+    return selectedFormatFromForm(this.element);
   }
 
   selectedNamespaceId() {
-    const namespaceInput = this.element.querySelector(
-      "input[name='data_export[export_parameters][namespace_id]']",
-    );
-    return namespaceInput?.value || "";
+    return selectedNamespaceIdFromForm(this.element);
   }
 
   selectedSampleIds() {
-    const storageKey = this.selectionStorageKey();
-    const value = sessionStorage.getItem(storageKey);
-    if (!value) return [];
-
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
+    return selectedSampleIdsFromSession(this.selectionStorageKey());
   }
 
   graphqlUrl() {
@@ -325,8 +271,7 @@ export default class extends Controller {
   }
 
   csrfToken() {
-    const meta = document.querySelector('meta[name="csrf-token"]');
-    return meta?.getAttribute("content") || "";
+    return csrfTokenFromDocument();
   }
 
   sampleGraphqlIdPrefix() {
@@ -334,7 +279,7 @@ export default class extends Controller {
   }
 
   selectionStorageKey() {
-    return `${location.protocol}//${location.host}${location.pathname}`;
+    return buildSelectionStorageKey();
   }
 
   updateSelectedCount() {
@@ -347,126 +292,20 @@ export default class extends Controller {
     }
   }
 
-  handleProgressWindowClick(event) {
-    if (!event?.target?.closest?.('[data-linelist-export-dismiss="true"]'))
-      return;
-    this.dismissProgressWindow();
-  }
-
   dismissProgressWindow() {
-    this.clearProgressWindowDismissTimeout();
-
-    if (this._exportId) {
-      const card = document.getElementById(
-        `linelist-export-card-${this._exportId}`,
-      );
-      if (card) card.remove();
-    }
-
-    const container = document.getElementById(
-      "linelist-export-progress-window",
-    );
-    if (container && container.children.length === 0) container.remove();
-
-    this.progressWindowDismissed = true;
-    this._exportId = null;
-    this._progressWindowOpenedAt = null;
-    this._progressMsgEl = null;
-    this._progressBarEl = null;
-    this._progressPctEl = null;
-  }
-
-  ensureExportCard() {
-    if (!this._exportId) return null;
-
-    const cardId = `linelist-export-card-${this._exportId}`;
-    let card = document.getElementById(cardId);
-
-    if (!card) {
-      card = this.createExportCard(cardId);
-    } else if (!this._progressMsgEl) {
-      // Recover refs after Turbo reconnect
-      this._progressMsgEl = card.querySelector(
-        "[data-linelist-export-progress-message]",
-      );
-      this._progressBarEl = card.querySelector(
-        "[data-linelist-export-progress-bar]",
-      );
-      this._progressPctEl = card.querySelector(
-        "[data-linelist-export-progress-percent]",
-      );
-    }
-
-    return card;
-  }
-
-  ensureProgressContainer() {
-    let container = document.getElementById("linelist-export-progress-window");
-    if (!container) {
-      container = document.createElement("div");
-      container.id = "linelist-export-progress-window";
-      container.className = "fixed bottom-5 right-5 z-50 w-80 space-y-2";
-      container.setAttribute("data-turbo-permanent", "");
-      document.body.appendChild(container);
-    }
-    return container;
-  }
-
-  createExportCard(cardId) {
-    const container = this.ensureProgressContainer();
-    const card = document.createElement("div");
-    card.id = cardId;
-    card.addEventListener("click", (event) =>
-      this.handleProgressWindowClick(event),
-    );
-
-    if (this.hasProgressTemplateTarget) {
-      const clone = this.progressTemplateTarget.content.cloneNode(true);
-      this._progressMsgEl = clone.querySelector(
-        "[data-linelist-export-progress-message]",
-      );
-      this._progressBarEl = clone.querySelector(
-        "[data-linelist-export-progress-bar]",
-      );
-      this._progressPctEl = clone.querySelector(
-        "[data-linelist-export-progress-percent]",
-      );
-      card.appendChild(clone);
-    }
-
-    container.appendChild(card);
-    return card;
+    dismissProgressWindowState(this);
   }
 
   showProgressWindow(message) {
-    if (!this._progressWindowOpenedAt) {
-      this._progressWindowOpenedAt = Date.now();
-    }
-    this.updateProgress(message, 0);
+    showProgressWindowState(this, message);
   }
 
   scheduleProgressWindowDismiss() {
-    if (this.progressWindowDismissed) return;
-
-    this.clearProgressWindowDismissTimeout();
-
-    const openedAt = this._progressWindowOpenedAt || Date.now();
-    const elapsedMs = Date.now() - openedAt;
-    const remainingMs = Math.max(
-      this.minimumVisibleDurationMsValue - elapsedMs,
-      0,
-    );
-
-    this._dismissProgressWindowTimeout = setTimeout(() => {
-      this.dismissProgressWindow();
-    }, remainingMs);
+    scheduleProgressWindowDismissState(this);
   }
 
   clearProgressWindowDismissTimeout() {
-    if (!this._dismissProgressWindowTimeout) return;
-
-    clearTimeout(this._dismissProgressWindowTimeout);
-    this._dismissProgressWindowTimeout = null;
+    clearProgressWindowDismissTimeoutState(this);
   }
 
   workerSourceUrl() {

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -70,14 +70,15 @@ export default class extends Controller {
   };
 
   connect() {
-    this.workerClient = this.buildWorkerClient();
-    this._exportId = null;
-    this._progressWindowOpenedAt = null;
-    this._dismissProgressWindowTimeout = null;
+    // Preserve in-flight export state if Stimulus reconnects this controller.
+    this.workerClient ||= this.buildWorkerClient();
+    this._exportId ||= null;
+    this._progressWindowOpenedAt ||= null;
+    this._dismissProgressWindowTimeout ||= null;
     this._progressMsgEl = null;
     this._progressBarEl = null;
     this._progressPctEl = null;
-    this.progressWindowDismissed = false;
+    this.progressWindowDismissed ??= false;
     this.updateSelectedCount();
   }
 

--- a/app/javascript/controllers/linelist_export_controller.js
+++ b/app/javascript/controllers/linelist_export_controller.js
@@ -15,6 +15,10 @@ import {
   selectedSampleIds as selectedSampleIdsFromSession,
   selectionStorageKey as buildSelectionStorageKey,
 } from "controllers/linelist_export/selection";
+import {
+  LinelistExportWorkerClient,
+  resolveLinelistExportWorkerSource,
+} from "controllers/linelist_export/worker_client";
 
 export default class extends Controller {
   static targets = ["sampleStatus", "progressTemplate"];
@@ -58,7 +62,7 @@ export default class extends Controller {
   };
 
   connect() {
-    this.worker = null;
+    this.workerClient = this.buildWorkerClient();
     this._exportId = null;
     this._progressWindowOpenedAt = null;
     this._dismissProgressWindowTimeout = null;
@@ -113,9 +117,12 @@ export default class extends Controller {
       this.showProgressWindow(
         this.t(this.preparingRowsMessageValue, { count: totalCount }),
       );
-      this.spawnWorker();
 
-      this.worker.postMessage({
+      if (!this.workerClient) {
+        this.workerClient = this.buildWorkerClient();
+      }
+
+      this.workerClient.start({
         sample_ids: sampleIds,
         metadata_fields: metadataFields,
         namespace_id: namespaceId,
@@ -139,82 +146,60 @@ export default class extends Controller {
   }
 
   terminateWorker() {
-    if (this.worker) {
-      this.worker.terminate();
-      this.worker = null;
-    }
+    this.workerClient?.stop();
   }
 
-  spawnWorker() {
-    this.terminateWorker();
-
-    const workerSource = this.workerSourceUrl();
-    const worker = this.buildWorker(workerSource);
-    worker.onmessage = (event) => {
-      void this.handleWorkerMessage(event);
-    };
-    worker.onerror = (event) => {
-      const detail = event?.message || event?.error?.message || "";
-      const message = this.t(this.unexpectedErrorMessageValue, {
-        message: detail,
-      }).replace(/:\s*$/, "");
-      this.updateProgress(message, 100, true);
-    };
-    this.worker = worker;
+  buildWorkerClient() {
+    return new LinelistExportWorkerClient({
+      resolveWorkerSource: () => resolveLinelistExportWorkerSource(this),
+      onProgress: (payload) => {
+        this.handleWorkerProgress(payload);
+      },
+      onDone: async (payload) => {
+        await this.handleWorkerDone(payload);
+      },
+      onError: (message) => {
+        this.handleWorkerError(message);
+      },
+      formatUnexpectedError: (detail) => this.formatUnexpectedError(detail),
+    });
   }
 
-  buildWorker(workerSource) {
+  handleWorkerProgress(payload) {
+    const message = this.t(this.createdRecordsMessageValue, {
+      current: payload.current,
+      total: payload.total,
+    });
+    this.updateProgress(message, payload.percentage);
+  }
+
+  async handleWorkerDone(payload) {
     try {
-      return new Worker(workerSource, { type: "module" });
+      await this.download(payload.filename, payload.content, payload.format);
     } catch (error) {
-      console.warn(
-        "[linelist-export] Module worker unavailable, falling back to classic worker:",
-        error,
-      );
-      return new Worker(workerSource);
+      this.handleWorkerError(this.formatUnexpectedError(error?.message || ""));
+      return;
     }
+
+    this.updateProgress(
+      this.t(this.downloadStartedMessageValue, {
+        filename: payload.filename,
+      }),
+      100,
+    );
+    this.scheduleProgressWindowDismiss();
+    this.terminateWorker();
   }
 
-  async handleWorkerMessage(event) {
-    const payload = event.data || {};
+  handleWorkerError(message) {
+    this.updateProgress(message, 100, true);
+    this.terminateWorker();
+  }
 
-    if (payload.type === "progress") {
-      const message = this.t(this.createdRecordsMessageValue, {
-        current: payload.current,
-        total: payload.total,
-      });
-      this.updateProgress(message, payload.percentage);
-      return;
-    }
-
-    if (payload.type === "done") {
-      try {
-        await this.download(payload.filename, payload.content, payload.format);
-      } catch (error) {
-        const detail = error?.message || "";
-        const message = this.t(this.unexpectedErrorMessageValue, {
-          message: detail,
-        }).replace(/:\s*$/, "");
-        this.updateProgress(message, 100, true);
-        this.terminateWorker();
-        return;
-      }
-
-      this.updateProgress(
-        this.t(this.downloadStartedMessageValue, {
-          filename: payload.filename,
-        }),
-        100,
-      );
-      this.scheduleProgressWindowDismiss();
-      this.terminateWorker();
-      return;
-    }
-
-    if (payload.type === "error") {
-      this.updateProgress(payload.message, 100, true);
-      this.terminateWorker();
-    }
+  formatUnexpectedError(detail) {
+    return this.t(this.unexpectedErrorMessageValue, {
+      message: detail,
+    }).replace(/:\s*$/, "");
   }
 
   updateProgress(message, percentage, error = false) {
@@ -306,32 +291,6 @@ export default class extends Controller {
 
   clearProgressWindowDismissTimeout() {
     clearProgressWindowDismissTimeoutState(this);
-  }
-
-  workerSourceUrl() {
-    if (this.hasWorkerUrlValue && this.workerUrlValue) {
-      return this.workerUrlValue;
-    }
-
-    const resolvedFromImportMap = this.workerSourceFromImportMap();
-    if (resolvedFromImportMap) {
-      return new URL(resolvedFromImportMap, location.origin).href;
-    }
-
-    return new URL("../workers/linelist_export_worker.js", import.meta.url)
-      .href;
-  }
-
-  workerSourceFromImportMap() {
-    const importMapScript = document.querySelector("script[type='importmap']");
-    if (!importMapScript?.textContent) return null;
-
-    try {
-      const importMap = JSON.parse(importMapScript.textContent);
-      return importMap?.imports?.["workers/linelist_export_worker"] || null;
-    } catch {
-      return null;
-    }
   }
 
   t(template, vars = {}) {

--- a/app/javascript/workers/linelist_export_worker.js
+++ b/app/javascript/workers/linelist_export_worker.js
@@ -1,4 +1,5 @@
 const SAMPLE_CHUNK_SIZE = 100;
+const SUPPORTED_FORMATS = new Set(["csv", "xlsx"]);
 
 const LINELIST_SAMPLES_QUERY = `
   query LinelistSamples($ids: [ID!]!, $metadataKeys: [String!]) {
@@ -25,6 +26,11 @@ const escapeCsv = (value) => {
   }
 
   return text;
+};
+
+const toCellValue = (value) => {
+  if (value == null) return "";
+  return value;
 };
 
 const chunk = (items, size) => {
@@ -107,6 +113,7 @@ self.onmessage = async (event) => {
   const fields = Array.isArray(metadataFields) ? metadataFields : [];
   const ids = Array.isArray(sampleIds) ? sampleIds : [];
   const rows = ids.length;
+  const normalizedFormat = format || "csv";
 
   if (!rows) {
     self.postMessage({
@@ -116,7 +123,7 @@ self.onmessage = async (event) => {
     return;
   }
 
-  if (format != null && format !== "csv") {
+  if (!SUPPORTED_FORMATS.has(normalizedFormat)) {
     self.postMessage({
       type: "error",
       message: "Unsupported linelist format for this flow.",
@@ -177,7 +184,7 @@ self.onmessage = async (event) => {
       "PROJECT PUID",
       ...fields.map((field) => String(field).toUpperCase()),
     ];
-    const lines = [header.join(",")];
+    const tableRows = [header];
 
     sampleGraphqlIds.forEach((sampleGraphqlId) => {
       const sample = sampleById.get(sampleGraphqlId);
@@ -191,22 +198,31 @@ self.onmessage = async (event) => {
       const metadata = sample.metadata || {};
 
       const row = [
-        escapeCsv(sample.puid),
-        escapeCsv(sample.name),
-        escapeCsv(sample.project?.puid),
+        toCellValue(sample.puid),
+        toCellValue(sample.name),
+        toCellValue(sample.project?.puid),
       ];
 
       fields.forEach((field) => {
-        row.push(escapeCsv(metadata[field]));
+        row.push(toCellValue(metadata[field]));
       });
 
-      lines.push(row.join(","));
+      tableRows.push(row);
     });
+
+    let content;
+    if (normalizedFormat === "xlsx") {
+      content = tableRows;
+    } else {
+      const lines = tableRows.map((row) => row.map(escapeCsv).join(","));
+      content = lines.join("\n");
+    }
 
     self.postMessage({
       type: "done",
       filename,
-      content: lines.join("\n"),
+      format: normalizedFormat,
+      content,
     });
   } catch (error) {
     self.postMessage({

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -542,6 +542,7 @@ en:
       title: Linelist Export
       unexpected_error: 'Unexpected error while generating export: %{message}'
       xlsx: ".xlsx"
+      xlsx_load_error: Unable to load the XLSX export library. Please retry or export as CSV.
     new_sample_export_dialog:
       available: Available
       available_description: File formats not included in this export. By default, all formats are included.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -542,7 +542,6 @@ en:
       title: Linelist Export
       unexpected_error: 'Unexpected error while generating export: %{message}'
       xlsx: ".xlsx"
-      xlsx_unsupported: XLSX export is not supported in this client-side flow yet.
     new_sample_export_dialog:
       available: Available
       available_description: File formats not included in this export. By default, all formats are included.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -542,6 +542,7 @@ fr:
       title: Exportation de liste détaillée
       unexpected_error: 'Erreur inattendue lors de la génération de l’exportation : %{message}'
       xlsx: ".xlsx"
+      xlsx_load_error: Impossible de charger la bibliothèque d’exportation XLSX. Veuillez réessayer ou exporter en CSV.
     new_sample_export_dialog:
       available: Disponible
       available_description: Formats de fichiers non inclus dans cette exportation. Par défaut, tous les formats sont inclus.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -542,7 +542,6 @@ fr:
       title: Exportation de liste détaillée
       unexpected_error: 'Erreur inattendue lors de la génération de l’exportation : %{message}'
       xlsx: ".xlsx"
-      xlsx_unsupported: L’exportation XLSX n’est pas encore prise en charge dans ce flux côté client.
     new_sample_export_dialog:
       available: Disponible
       available_description: Formats de fichiers non inclus dans cette exportation. Par défaut, tous les formats sont inclus.

--- a/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
+++ b/test/components/data_exports/linelist_export_dialog/v2/component_test.rb
@@ -43,6 +43,22 @@ module DataExports
           assert_selector 'ul#selected-list'
           assert_no_selector "input[type='checkbox'][name='data_export[export_parameters][metadata_fields][]']"
         end
+
+        test 'renders enabled xlsx format option' do
+          project = projects(:project1)
+
+          render_inline(
+            Component.new(
+              open: true,
+              namespace_id: project.namespace.id,
+              namespace: project.namespace,
+              templates: []
+            )
+          )
+
+          assert_selector "input#linelist-format-xlsx[type='radio'][value='xlsx']"
+          assert_no_selector 'input#linelist-format-xlsx[disabled]'
+        end
       end
     end
   end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds XLSX support to the client-side linelist export in the V2 dialog on project and group samples pages.

Before this, V2 only worked for CSV and the XLSX option was disabled with an unsupported message.

What I changed:
- Enabled the XLSX option in the linelist export dialog.
- Updated the linelist export worker to support both csv and xlsx formats.
- For xlsx, the worker now sends row data and the Stimulus controller creates/downloads the spreadsheet with SheetJS.
- Removed the old xlsx unsupported text from the dialog and locale files.
- Added a component test to make sure the xlsx option is enabled.

Why:
- Users already expect xlsx export for linelist data, and this keeps the V2 flow aligned with that.

## Screenshots or screen recordings

<img width="1882" height="776" alt="image" src="https://github.com/user-attachments/assets/4d106084-e17f-444b-bd58-53b6012043a3" />

## How to set up and validate locally
1. Check out this branch and start the app, ensure Feature flag `client_linelist_exports_v1` is enabled.
2. Go to a project samples page or a group samples page.
3. Select at least one sample.
4. Open Actions and click Linelist Export.
5. Add at least one metadata field.
6. Select .xlsx and submit.
7. Confirm a .xlsx file downloads and opens.
8. Verify columns include SAMPLE PUID, SAMPLE NAME, PROJECT PUID, and selected metadata fields.
9. Repeat with .csv to confirm the CSV flow still works.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
