### PR TITLE
Global Groups: Database and group policy updates

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -53,7 +53,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
       end
     end
 
-    def effective_access_level(namespace, user, include_group_links = true) # rubocop:disable Metrics/CyclomaticComplexity,Style/OptionalBooleanParameter,Metrics/PerceivedComplexity
+    def effective_access_level(namespace, user, include_group_links = true) # rubocop:disable Metrics/CyclomaticComplexity,Style/OptionalBooleanParameter,Metrics/PerceivedComplexity,Metrics/AbcSize
       return AccessLevel::OWNER if namespace.parent&.user_namespace? && namespace.parent.owner == user
 
       access_level = Member.for_namespace_and_ancestors(namespace).not_expired
@@ -61,7 +61,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
       access_level = access_level_in_namespace_group_links(user, namespace) if include_group_links && access_level.nil?
 
-      return AccessLevel::GUEST if access_level.zero? && namespace.public?
+      return AccessLevel::GUEST if (access_level.zero? || access_level.nil?) && namespace.public?
 
       access_level.nil? ? AccessLevel::NO_ACCESS : access_level
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -53,13 +53,15 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
       end
     end
 
-    def effective_access_level(namespace, user, include_group_links = true) # rubocop:disable Metrics/CyclomaticComplexity,Style/OptionalBooleanParameter
+    def effective_access_level(namespace, user, include_group_links = true) # rubocop:disable Metrics/CyclomaticComplexity,Style/OptionalBooleanParameter,Metrics/PerceivedComplexity
       return AccessLevel::OWNER if namespace.parent&.user_namespace? && namespace.parent.owner == user
 
       access_level = Member.for_namespace_and_ancestors(namespace).not_expired
                            .where(user:).order(access_level: :desc).select(:access_level).first&.access_level
 
       access_level = access_level_in_namespace_group_links(user, namespace) if include_group_links && access_level.nil?
+
+      return AccessLevel::GUEST if access_level.zero? && namespace.public?
 
       access_level.nil? ? AccessLevel::NO_ACCESS : access_level
     end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -338,16 +338,19 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
 
   scope_for :relation do |relation|
     relation.with(
-      user_groups: relation.where(id: user.members.not_expired.select(:namespace_id)).self_and_descendant_ids,
+      user_groups: relation.where(id: user.members.not_expired.select(:namespace_id),
+                                  public: false).self_and_descendant_ids,
       linked_groups: relation.where(id: NamespaceGroupLink.not_expired
                                         .where(
                                           Arel.sql('namespace_group_links.group_id in (select * from user_groups)')
                                         ).select(:namespace_id))
-                     .self_and_descendant_ids
+                     .self_and_descendant_ids,
+      public_groups: relation.where(public: true).self_and_descendant_ids
     ).where(
       Arel.sql(
         'namespaces.id in (select * from user_groups)
-        or namespaces.id in (select * from linked_groups)'
+        or namespaces.id in (select * from linked_groups)
+        or namespaces.id in (select * from public_groups)'
       )
     )
   end

--- a/db/migrate/20260421182359_add_public_to_namespace.rb
+++ b/db/migrate/20260421182359_add_public_to_namespace.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Migration to add public column to namespace table.
+class AddPublicToNamespace < ActiveRecord::Migration[8.1]
+  def change
+    add_column :namespaces, :public, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -929,7 +929,7 @@ CREATE TABLE public.site_banners (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT site_banners_singleton_guard_check CHECK (((singleton_guard)::text = 'global'::text)),
-    CONSTRAINT site_banners_style_check CHECK (((style)::text = ANY ((ARRAY['info'::character varying, 'warning'::character varying, 'danger'::character varying, 'success'::character varying])::text[])))
+    CONSTRAINT site_banners_style_check CHECK (((style)::text = ANY (ARRAY[('info'::character varying)::text, ('warning'::character varying)::text, ('danger'::character varying)::text, ('success'::character varying)::text])))
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -779,7 +779,8 @@ CREATE TABLE public.namespaces (
     parent_id uuid,
     puid character varying NOT NULL,
     attachments_updated_at timestamp(6) without time zone,
-    samples_count integer DEFAULT 0
+    samples_count integer DEFAULT 0,
+    public boolean DEFAULT false NOT NULL
 );
 
 
@@ -2146,6 +2147,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260424121251'),
+('20260421182359'),
 ('20260416173126'),
 ('20260410170502'),
 ('20260327212553'),

--- a/test/controllers/dashboard/groups_controller_test.rb
+++ b/test/controllers/dashboard/groups_controller_test.rb
@@ -36,7 +36,7 @@ module Dashboard
 
       assert_response :success
       assert_active_sort('q', 'name desc')
-      assert_includes first_treegrid_row_text, groups(:group_z).name
+      assert_includes first_treegrid_row_text, groups(:public_group10).name
     end
 
     test 'should sort groups by name ascending' do

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -628,4 +628,5 @@ public_group<%= (n) %>:
   description: <%= "Public Group #{n} description" %>
   puid: <%= "INXT_GRP_AXATAA#{((n/26).round+66).chr}AA#{((n%26)+65).chr}" %>
   samples_count: 0
+  updated_at: <%= (n + 1).days.ago %>
 <% end %>

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -617,3 +617,15 @@ shared_group_sample_actions_guest:
   puid: INXT_GRP_AAAAAAAACW
   metadata_summary: { "metadatafield1": 1, "metadatafield2": 1 }
   samples_count: 1
+
+
+<% (1..10).each do |n| %>
+public_group<%= (n) %>:
+  <<: *DEFAULTS
+  name: <%= "Public Group #{n}" %>
+  public: true
+  path: <%= "public-group-#{n}" %>
+  description: <%= "Public Group #{n} description" %>
+  puid: <%= "INXT_GRP_AXATAA#{((n/26).round+66).chr}AA#{((n%26)+65).chr}" %>
+  samples_count: 0
+<% end %>

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -712,3 +712,9 @@ project_chunked_samples_member_chunked_samples_doe:
   created_by_id: <%= ActiveRecord::FixtureSet.identify(:chunked_samples_doe, :uuid) %>
   namespace_id: <%= ActiveRecord::FixtureSet.identify(:project_chunked_samples_namespace, :uuid) %>
   access_level: <%= Member::AccessLevel::OWNER %>
+
+public_group_one_member_john_doe:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  created_by_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  namespace_id: <%= ActiveRecord::FixtureSet.identify(:public_group1, :uuid) %>
+  access_level: <%= Member::AccessLevel::OWNER %>

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -803,3 +803,11 @@ project_chunked_samples_namespace_route:
   name: chunked_samples_doe@localhost / Project Chunked Samples
   path: chunked-samples-doe-at-localhost/project-chunked-samples
   source: project_chunked_samples_namespace (Namespace)
+
+
+<% (1..10).each do |n| %>
+public_group_<%= n %>_route:
+  name: Public Group <%= n %>
+  path: public-group-<%= n %>
+  source: public_group<%= n %> (Namespace)
+<% end %>

--- a/test/graphql/groups_query_test.rb
+++ b/test/graphql/groups_query_test.rb
@@ -71,8 +71,10 @@ class GroupsQueryTest < ActiveSupport::TestCase
                                                        .not_expired.select(:namespace_id))
 
     groups = @user.groups.self_and_descendants.or(groups_via_namespace_group_links)
+    public_groups_without_membership = Group.where(public: true)
+                                            .where.not(id: @user.members.not_expired.select(:namespace_id))
 
-    groups_count = groups.count
+    groups_count = groups.count + public_groups_without_membership.count
 
     result = IridaSchema.execute(GROUPS_QUERY, context: { current_user: @user },
                                                variables: { first: 20 })

--- a/test/models/members/group_member_test.rb
+++ b/test/models/members/group_member_test.rb
@@ -133,6 +133,22 @@ class GroupMemberTest < ActiveSupport::TestCase
     end
   end
 
+  test 'effective access level is returned for public group where user is a member' do
+    group = groups(:public_group1)
+    user = users(:john_doe)
+
+    access_level = Member.effective_access_level(group, user)
+    assert_equal Member::AccessLevel::OWNER, access_level
+  end
+
+  test 'access level of GUEST is returned for public group and user is not a member' do
+    group = groups(:public_group1)
+    user = users(:joan_doe)
+
+    access_level = Member.effective_access_level(group, user)
+    assert_equal Member::AccessLevel::GUEST, access_level
+  end
+
   test '#scope for_namespace_and_ancestors returns the correct collection' do
     namespace = groups(:subgroup1)
     members = Member.for_namespace_and_ancestors(namespace)

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -144,16 +144,22 @@ class GroupPolicyTest < ActiveSupport::TestCase
   test 'scope' do
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    # John Doe has access to 28 groups
-    assert_equal 32, scoped_groups.count
+    assert_equal 42, scoped_groups.count
 
     user = users(:david_doe)
     policy = GroupPolicy.new(user:)
     scoped_groups = policy.apply_scope(Group, type: :relation)
-    # David Doe has access to 2 groups
-    assert_equal 11, scoped_groups.count
+    assert_equal 21, scoped_groups.count
   end
 
+  test 'scoped groups with public groups' do
+    user = users(:david_doe)
+    policy = GroupPolicy.new(user:)
+    public_group = groups(:public_group1)
+    scoped_groups = policy.apply_scope(Group, type: :relation)
+    assert_includes scoped_groups, public_group
+    assert_equal 21, scoped_groups.count
+  end
   test 'scope with expired group member' do
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date
@@ -161,7 +167,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    assert_equal 30, scoped_groups.count
+    assert_equal 40, scoped_groups.count
     scoped_groups_names = scoped_groups.pluck(:name)
     assert_not scoped_groups_names.include?(groups(:group_one).name)
     assert_not scoped_groups_names.include?(groups(:david_doe_group_four).name)
@@ -172,7 +178,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    assert_equal 29, scoped_groups.count
+    assert_equal 39, scoped_groups.count
     scoped_groups_names = scoped_groups.pluck(:name)
     assert_not scoped_groups_names.include?(groups(:namespace_group_link_group_one).name)
   end

--- a/test/policies/namespace_policy_test.rb
+++ b/test/policies/namespace_policy_test.rb
@@ -70,9 +70,9 @@ class NamespacePolicyTest < ActiveSupport::TestCase
     policy = NamespacePolicy.new(user:)
     scoped_namespaces = policy.apply_scope(Namespace, type: :relation, name: :manageable)
 
-    # John Doe has manageable access to 29 namespaces
-    # (1 user namespace and 27 group namespaces)
-    assert_equal 32, scoped_namespaces.count
+    # John Doe has manageable access to 33 namespaces
+    # (1 user namespace and 32 group namespaces)
+    assert_equal 33, scoped_namespaces.count
 
     assert_not scoped_namespaces.include?(namespace_group_link.namespace)
 
@@ -85,9 +85,9 @@ class NamespacePolicyTest < ActiveSupport::TestCase
     scoped_namespaces = policy.apply_scope(Namespace, type: :relation, name: :manageable)
 
     # John Doe has manageable access to 30 namespaces (1 user namespace,
-    # 29 group namespaces, and 1 group namespace via a namespace
+    # 32 group namespaces, and 1 group namespace via a namespace
     # group link)
-    assert_equal 33, scoped_namespaces.count
+    assert_equal 34, scoped_namespaces.count
 
     assert scoped_namespaces.include?(namespace_group_link.namespace)
   end

--- a/test/system/dashboard/groups_test.rb
+++ b/test/system/dashboard/groups_test.rb
@@ -50,6 +50,9 @@ module Dashboard
       subgroup1 = groups(:subgroup1)
       visit dashboard_groups_url
 
+      click_on I18n.t(:'dashboard.groups.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.groups.index.sorting.name_asc'), match: :first
+
       within('div.treegrid-container') do
         assert_text group1.name
         assert_no_text subgroup1.name
@@ -108,6 +111,9 @@ module Dashboard
       group3 = groups(:group_three)
       login_as users(:john_doe)
       visit dashboard_groups_url
+
+      click_on I18n.t(:'dashboard.groups.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.groups.index.sorting.name_asc'), match: :first
 
       within('#groups_tree') do
         within("##{dom_id(group1)}") do

--- a/test/system/dashboard/groups_test.rb
+++ b/test/system/dashboard/groups_test.rb
@@ -28,7 +28,7 @@ module Dashboard
       assert_selector 'nav.pagy ul li a[aria-current="page"]', text: '2'
       assert_text I18n.t(:'components.viral.pagy.pagination_component.previous')
       within 'div.treegrid-container' do
-        assert_selector 'div.treegrid-row', count: 6
+        assert_selector 'div.treegrid-row', count: 16
         [*('f'..'a')].each do |letter|
           assert_text groups(:"group_#{letter}").name
         end
@@ -137,6 +137,9 @@ module Dashboard
       group = groups(:group_three)
 
       assert_selector 'h1', text: I18n.t(:'dashboard.groups.index.title')
+
+      click_on I18n.t(:'dashboard.groups.index.sorting.created_at_desc')
+      click_on I18n.t(:'dashboard.groups.index.sorting.created_at_asc'), match: :first
 
       assert_equal 4, group.aggregated_samples_count
 

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -379,7 +379,7 @@ class GroupsTest < ApplicationSystemTestCase
 
     assert_text I18n.t('groups.destroy.success', group_name: group2.name)
     assert_selector 'h1', text: I18n.t('dashboard.groups.index.title')
-    assert_no_text group2.name
+    assert_no_text group2.name, exact: true
   end
 
   test 'can transfer a group' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in the `public` column to the `namespaces` table, updates the group policy scope to return public groups, and updates the `effective_access_level` method to return a role of GUEST if the namespace is public and the user is not a member of the group or any groups the group was shared with

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Login as any user and create a group
2. In rails console, update the group to (public: true)
3. Logout from IRIDA Next and login as a different user
4. Verify they can see the group (only top level currently) with GUEST access

**Note: Will be updated in the next PR to set group projects and subgroups as `public` where the parent group in public**

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
