### PR TITLE
Fix: Samplesheet file_cell and fastq_cell autopopulation

### DIFF
--- a/lib/irida/nextflow/samplesheet/properties.rb
+++ b/lib/irida/nextflow/samplesheet/properties.rb
@@ -63,7 +63,7 @@ module Irida
           end)
         end
 
-        def identify_autopopulated_file_properties(properties)
+        def identify_autopopulated_file_properties(properties) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
           file_properties = properties.select { |_property, entry| FILE_CELL_TYPES.include?(entry['cell_type']) }
           required_file_properties = file_properties.select { |_property, entry| entry['required'] }
 
@@ -74,6 +74,12 @@ module Irida
 
             properties[property]['autopopulate'] = true
           end
+
+          # If fastq_1 is required and marked for autopopulation, and fastq_2 has a pattern defined,
+          # mark fastq_2 for autopopulation as well
+          return unless properties.dig('fastq_1', 'autopopulate') && properties.dig('fastq_2', 'pattern').present?
+
+          properties['fastq_2']['autopopulate'] = true
         end
       end
     end

--- a/lib/irida/nextflow/samplesheet/sample_attributes.rb
+++ b/lib/irida/nextflow/samplesheet/sample_attributes.rb
@@ -27,23 +27,21 @@ module Irida
 
         private
 
-        def file_cells
-          properties.select do |name, entry|
-            entry['cell_type'] == 'file_cell' || (%w[fastq_1
-                                                     fastq_2].include?(name) && entry['cell_type'] == 'fastq_cell')
+        def autopopulated_file_cells
+          @autopopulated_file_cells ||= properties.select do |_name, entry|
+            Properties::FILE_CELL_TYPES.include?(entry['cell_type']) &&
+              entry['autopopulate'] == true &&
+              entry['pattern'].present?
           end
         end
 
         def samples_attachments(samples) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
           attachments = {}
-          file_cells.each do |property, entry|
-            expected_pattern = entry['pattern']
-            next unless expected_pattern
-
+          autopopulated_file_cells.each do |property, entry|
             # fastq_2 files are queried in relation to fastq_1 files, so we can skip querying them here
             next if property == 'fastq_2'
 
-            attachments[property] = Attachment.matching_filename(expected_pattern)
+            attachments[property] = Attachment.matching_filename(entry['pattern'])
                                               .where(attachable_type: 'Sample', attachable_id: samples.pluck(:id))
 
             if property == 'fastq_1'
@@ -51,7 +49,7 @@ module Irida
                 'DISTINCT ON (attachable_id) attachments.*, active_storage_blobs.filename as filename'
               ).order(:attachable_id).prefer_associated_attachment.recent.index_by(&:attachable_id)
 
-              if file_cells.key?('fastq_2')
+              if autopopulated_file_cells.key?('fastq_2')
                 attachments['fastq_2'] = Attachment.joins(:file_blob)
                                                    .where(id: attachments[property].map do |_, att|
                                                                 att.metadata['associated_attachment_id']
@@ -84,10 +82,10 @@ module Irida
             when 'sample_name_cell'
               [name, sample.name]
             when 'file_cell'
-              [name, file_samplesheet_values(attachments[name][sample.id], sample.id, name)]
+              [name, file_samplesheet_values(attachments.dig(name, sample.id), sample.id, name)]
             when 'fastq_cell'
               if %w[fastq_1 fastq_2].include?(name)
-                [name, file_samplesheet_values(attachments[name][sample.id], sample.id, name)]
+                [name, file_samplesheet_values(attachments.dig(name, sample.id), sample.id, name)]
               else
                 [name, '']
               end

--- a/test/lib/irida/nextflow/samplesheet/properties_test.rb
+++ b/test/lib/irida/nextflow/samplesheet/properties_test.rb
@@ -36,6 +36,26 @@ module Irida
         assert_equal true, properties['fastq_1']['autopopulate']
         assert_equal true, properties['fastq_2']['autopopulate']
       end
+
+      test 'autopopulates fastq_2 when no file_cells are required and fastq_2 has pattern' do
+        schema = {
+          'items' => {
+            'required' => %w[sample],
+            'properties' => {
+              'sample' => { 'type' => 'string' },
+              'fastq_1' => { 'type' => 'string', 'pattern' => '*_R1*.fastq' },
+              'fastq_2' => { 'type' => 'string', 'pattern' => '*_R2*.fastq' }
+            }
+          }
+        }
+
+        properties = Irida::Nextflow::Samplesheet::Properties.new(schema).properties
+
+        # fastq_1 should be autopopulated because no file cells are required (default behavior)
+        assert_equal true, properties['fastq_1']['autopopulate']
+        # fastq_2 should be autopopulated because fastq_1 is autopopulated and fastq_2 has a pattern
+        assert_equal true, properties['fastq_2']['autopopulate']
+      end
     end
   end
 end

--- a/test/lib/irida/nextflow/samplesheet/sample_attributes_test.rb
+++ b/test/lib/irida/nextflow/samplesheet/sample_attributes_test.rb
@@ -119,6 +119,95 @@ module Irida
             builder.file_attributes
           )
         end
+
+        test 'only autopopulates file_cells with autopopulate true' do
+          sample = FakeSample.new(
+            id: 3,
+            puid: 'PUID-3',
+            name: 'Sample 3',
+            metadata: {}
+          )
+
+          properties = {
+            'sample_cell' => { 'cell_type' => 'sample_cell' },
+            'file_cell_autopopulate' => { 'cell_type' => 'file_cell', 'autopopulate' => true, 'pattern' => '*.fastq' },
+            'file_cell_no_autopopulate' => { 'cell_type' => 'file_cell', 'pattern' => '*.bam' }
+          }
+
+          builder = Irida::Nextflow::Samplesheet::SampleAttributes.new(
+            samples: [sample],
+            properties: properties
+          )
+
+          # Mock the attachments - only autopopulated file cells should be queried
+          fake_autopopulate_attachment = FakeAttachment.new(id: 61, filename: 'auto.fastq', global_id: 'gid://auto')
+          builder.stubs(:samples_attachments)
+                 .returns({
+                            'file_cell_autopopulate' => { 3 => fake_autopopulate_attachment }
+                          })
+
+          result = builder.samples_workflow_executions_attributes[3]
+
+          # Autopopulated file_cell should have the attachment value
+          assert_equal 'gid://auto', result['samplesheet_params']['file_cell_autopopulate']
+          # Non-autopopulated file_cell should be empty
+          assert_equal '', result['samplesheet_params']['file_cell_no_autopopulate']
+
+          # file_attributes should only include the autopopulated cell
+          assert_equal(
+            {
+              3 => {
+                'file_cell_autopopulate' => { filename: 'auto.fastq', attachment_id: 61 },
+                'file_cell_no_autopopulate' => { filename: 'No selected file', attachment_id: '' }
+              }
+            },
+            builder.file_attributes
+          )
+        end
+
+        test 'autopopulates fastq_2 when fastq_1 has autopopulate true and fastq_2 has pattern' do
+          sample = FakeSample.new(
+            id: 4,
+            puid: 'PUID-4',
+            name: 'Sample 4',
+            metadata: {}
+          )
+
+          properties = {
+            'fastq_1' => { 'cell_type' => 'fastq_cell', 'autopopulate' => true, 'pattern' => '*_R1*.fastq' },
+            'fastq_2' => { 'cell_type' => 'fastq_cell', 'pattern' => '*_R2*.fastq' }
+          }
+
+          builder = Irida::Nextflow::Samplesheet::SampleAttributes.new(
+            samples: [sample],
+            properties: properties
+          )
+
+          # Mock the attachments - fastq_2 should be autopopulated along with fastq_1
+          fake_fwd_attachment = FakeAttachment.new(id: 71, filename: 'sample_R1.fastq', global_id: 'gid://fwd')
+          fake_rev_attachment = FakeAttachment.new(id: 72, filename: 'sample_R2.fastq', global_id: 'gid://rev')
+          builder.stubs(:samples_attachments).returns({
+                                                        'fastq_1' => { 4 => fake_fwd_attachment },
+                                                        'fastq_2' => { 4 => fake_rev_attachment }
+                                                      })
+
+          result = builder.samples_workflow_executions_attributes[4]
+
+          # Both fastq_1 and fastq_2 should be autopopulated
+          assert_equal 'gid://fwd', result['samplesheet_params']['fastq_1']
+          assert_equal 'gid://rev', result['samplesheet_params']['fastq_2']
+
+          # Both should be in file_attributes
+          assert_equal(
+            {
+              4 => {
+                'fastq_1' => { filename: 'sample_R1.fastq', attachment_id: 71 },
+                'fastq_2' => { filename: 'sample_R2.fastq', attachment_id: 72 }
+              }
+            },
+            builder.file_attributes
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes an issue with samplesheet autopopulation where file_cell and fastq_cell were autopopulated without checking `autopopulate` option.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

Add the following pipeline entry to your `config/pipelines/development.json`:
```json
"phac-nml/mikrokondo": {
    "url": "https://github.com/phac-nml/mikrokondo",
    "name": {
      "en": "Mikrokondo",
      "fr": "Mikrokondo"
    },
    "description": {
      "en": "High Cost - Primary assembly and typing of WGS reads",
      "fr": "Coût élevé – Assemblage primaire et typage des SGE"
    },
    "versions": [
      {
        "name": "0.10.2",
        "executable": true,
        "automatable": true,
        "overrides": {
          "definitions": {
            "input_output_options": {
              "title": {
                "en": "Input/output options",
                "fr": "Options de saisie et de résultat"
              },
              "description": {
                "en": "Define where the pipeline should find input data and save output data.",
                "fr": "Définir où le pipeline doit trouver les données d’entrée et sauvegarder les données de sortie."
              },
              "properties": {
                "platform": {
                  "description": {
                    "en": "Sequencing platform used",
                    "fr": "Plateforme de séquençage utilisée"
                  }
                },
                "max_samples": {
                  "enum": [
                    100
                  ],
                  "description": {
                    "en": "Mikrokondo Sample limit: Contact IRIDA Next admin for increased sample limit",
                    "fr": "Limite d’échantillons de Mikrokondo : communiquez avec l’administrateur d’IRIDA Next pour augmenter la limite d’échantillons."
                  },
                  "hidden": false
                },
                "long_read_opt": {
                  "description": {
                    "en": "Specify which longread platform your data is from (nanopore or pacbio). This option must be specified if performing a hybrid assembly.",
                    "fr": "Préciser la plateforme de lecture longue (nanopore ou pacbio) dont sont tirées les données. Cette option doit être précisée si un assemblage hybride est réalisé."
                  }
                },
                "metagenomic_run": {
                  "description": {
                    "en": "Label all samples as metagenomic (Skip autodetection)",
                    "fr": "Marquer tous les échantillons comme étant métagénomiques (sauter l’autodétection)"
                  }
                }
              }
            },
            "databases_and_pre_computed_files": {
              "title": {
                "en": "Databases and Pre-Computed Files",
                "fr": "Bases de données et fichiers précalculés"
              },
              "description": {
                "en": "The location of databases used by Mikrokondo",
                "fr": "L’emplacement des bases de données utilisées par Mikrokondo"
              },
              "properties": {
                "dehosting_idx": {
                  "description": {
                    "en": "Minimap2 index for dehosting and kitome removal",
                    "fr": "Indice Minimap2 pour le retrait des séquences de l’hôte et du kitome"
                  },
                  "type": "string",
                  "enum": [
                    [
                      "PhiPacHum",
                      "az://databases/mikrokondo/PhiPacHum_m2.idx"
                    ]
                  ]
                },
                "mash_sketch": {
                  "description": {
                    "en": "Mash sketch used for contamination detection and speciation (Sketch comments must be a taxonomic string similar to what Kraken2 outputs)",
                    "fr": "Mash Sketch utilisé pour la détection de la contamination et l’identification de l’espèce (les commentaires dans Sketch doivent être une chaîne taxinomique semblable à ce que produit Kraken2)"
                  },
                  "type": "string",
                  "enum": [
                    [
                      "GTDB+Shigella_20231003",
                      "az://databases/mikrokondo/EnteroRef_GTDBSketch_20231003_V2.msh"
                    ],
                    [
                      "GTDBSketch_20231003",
                      "az://databases/mikrokondo/GTDBSketch_20231003.msh"
                    ]
                  ]
                },
                "kraken2_db": {
                  "description": {
                    "en": "Kraken2 database",
                    "fr": "Base de données Kraken2"
                  },
                  "type": "string",
                  "enum": [
                    [
                      "Standard (Refeq archaea, bacteria, viral, plasmid, human, UniVec_Core) (Version: k2_standard_20230605)",
                      "az://databases/kraken2/standard-2023-06-05/"
                    ]
                  ]
                },
                "checkm2_db": {
                  "description": {
                    "en": "CheckM2 database",
                    "fr": "Base de données CheckM2"
                  },
                  "type": "string",
                  "enum": [
                    [
                      "CheckM2 v.1.1.0 database.",
                      "az://databases/CheckM2/v.1.1.0/uniref100.KO.1.dmnd"
                    ]
                  ]
                }
              }
            },
            "allele_schema_options": {
              "title": {
                "en": "Allele Schema Options",
                "fr": "Options de schéma d’allèle"
              },
              "description": {
                "en": "Specify an allele calling schema.",
                "fr": "Préciser un schéma d’appel d’allèle."
              },
              "properties": {
                "lx_allele_database": {
                  "description": {
                    "en": "The path to a folder containing a collection of locidex databases to allow for automatic allele database selection. The folder should contain a 'manifest.json' file created by locidex. If you wish to force a certain allele scheme to be used you can specify an option for the `override_allele_scheme` argument which will perform allele calling with the specified scheme.",
                    "fr": "Chemin d’accès vers un dossier contenant une collection de bases de données locidex pour permettre la sélection automatique de la base de données d’allèles. Le dossier doit contenir un fichier « manifest.json » créé par locidex. Si l’on souhaite obliger l’utilisation d’un certain schéma d’allèles, on peut préciser une option pour l’argument « override_allele_scheme », qui effectuera l’identification d’allèles présentant le schéma précisé."
                  },
                  "enum": [
                    [
                      "pnc-2025-09-11",
                      "az://databases/locidex/pnc-2025-09-11/"
                    ],
                    [
                      "pnc-2024-09-05",
                      "az://databases/locidex/pnc-2024-09-05/"
                    ]
                  ]
                },
                "override_allele_scheme": {
                  "description": {
                    "en": "Specify the path to an allele calling schema to be used. This schema will be used for allele calling of all samples.",
                    "fr": "Préciser le chemin vers un schéma d’identification d’allèle à utiliser. Ce schéma sera utilisé pour l’identification des allèles de tous les échantillons."
                  },
                  "enum": [
                    [
                      "Automated selection from allele database",
                      ""
                    ],
                    [
                      "wgmlst_listeria-pnc-2025-09-11",
                      "az://databases/locidex/pnc-2025-09-11/wgmlst_listeria/"
                    ],
                    [
                      "wgmlst_salmonella-pnc-2025-09-11",
                      "az://databases/locidex/pnc-2025-09-11/wgmlst_salmonella/"
                    ],
                    [
                      "wgmlst_escherichia_shigella-pnc-2025-09-11",
                      "az://databases/locidex/pnc-2025-09-11/wgmlst_escherichia_shigella/"
                    ],
                    [
                      "wgmlst_listeria-pnc-2024-09-05",
                      "az://databases/locidex/pnc-2024-09-05/wgmlst_listeria/"
                    ],
                    [
                      "wgmlst_salmonella-pnc-2024-09-05",
                      "az://databases/locidex/pnc-2024-09-05/wgmlst_salmonella/"
                    ],
                    [
                      "wgmlst_escherichia_shigella-pnc-2024-09-05",
                      "az://databases/locidex/pnc-2024-09-05/wgmlst_escherichia_shigella/"
                    ]
                  ]
                }
              }
            },
            "control_flow_options": {
              "title": {
                "en": "Control flow options",
                "fr": "Options de flux de commande"
              },
              "description": {
                "en": "Options to alter control flow of the pipeline",
                "fr": "Options pour modifier le débit de contrôle du pipeline"
              },
              "properties": {
                "run_kraken": {
                  "description": {
                    "en": "Use Kraken2 instead of Mash for sample speciation (Useful if you have Eukaryotic data or Archae)",
                    "fr": "Utiliser Kraken2 plutôt que Mash pour l’identification de l’espèce de l’échantillon (utile si les données proviennent d’eucaryotes ou d’archées)"
                  }
                },
                "hybrid_unicycler": {
                  "description": {
                    "en": "Use unicycler for hybrid assembly.",
                    "fr": "Utiliser unicycler pour l’assemblage hybride."
                  }
                },
                "skip_report": {
                  "description": {
                    "en": "Skip summary report generation",
                    "fr": "Sauter la génération du rapport sommaire"
                  }
                },
                "skip_raw_read_metrics": {
                  "description": {
                    "en": "Skip generating raw-read metrics. e.g. when data first enters the pipeline",
                    "fr": "Sauter la génération des paramètres de lectures brutes, p. ex. lorsque les données entrent dans le pipeline pour la première fois"
                  }
                },
                "skip_version_gathering": {
                  "description": {
                    "en": "Skip creating a report of the final versions of tools used in mikrokondo",
                    "fr": "Sauter la création d’un rapport sur les versions finales des outils utilisés dans mikrokondo"
                  }
                },
                "skip_subtyping": {
                  "description": {
                    "en": "Do not enter the subtyping workflow, e.g. ECTyper, SISTR etc will not be ran.",
                    "fr": "Ne pas entrer dans le flux de travail de sous-typage, p. ex. ECTyper, SISTR etc. ne sera pas exécuté."
                  }
                },
                "skip_abricate": {
                  "description": {
                    "en": "Skip running abricate for annotation",
                    "fr": "Sauter l’exécution d’abricate pour l’annotation"
                  }
                },
                "skip_checkm": {
                  "description": {
                    "en": "Skip running CheckM2",
                    "fr": "Sauter l’exécution de CheckM2"
                  }
                },
                "skip_depth_sampling": {
                  "description": {
                    "en": "Skip down sampling of data to a target depth. This is not supported for metagenomic samples or hybrid assemblies.",
                    "fr": "Sauter l’échantillonnage des données à une profondeur cible. Cela n’est pas pris en charge pour les échantillons métagénomiques ou les assemblages hybrides."
                  }
                },
                "skip_ont_header_cleaning": {
                  "description": {
                    "en": "Make nanopore headers unique. Only turn this on if you are worried about duplicate id's e.g. from errors in running sequencing",
                    "fr": "Utiliser des en-têtes de nanopore uniques. Activer cette fonction seulement en cas de crainte d’identifiants en double, p. ex. à cause d’erreurs dans le séquençage"
                  }
                },
                "skip_polishing": {
                  "description": {
                    "en": "Skip polishing of assemblies, useful in case of errors or for metagenomic samples that fail.",
                    "fr": "Sauter le polissage des assemblages; utile en cas d’erreurs ou pour les échantillons métagénomiques qui échouent."
                  }
                },
                "skip_species_classification": {
                  "description": {
                    "en": "Skip determining what your species is (with Kraken2 or Mash)",
                    "fr": "Sauter la détermination de l’identité de l’espèce (par Kraken2 ou Mash)"
                  }
                },
                "skip_mlst": {
                  "description": {
                    "en": "Skip classic 7 gene MLST (Uses Torsten Seemann's mlst)",
                    "fr": "Sauter le typage MLST classique à 7 gènes (utiliser le typage mlst de Torsten Seeman)"
                  }
                },
                "skip_mobrecon": {
                  "description": {
                    "en": "Skip running mob recon for plasmid identification.",
                    "fr": "Sauter l’exécution de mob recon pour l’identification de plasmides."
                  }
                },
                "skip_metagenomic_detection": {
                  "description": {
                    "en": "Skip metagenomic detection. (Forces samples to be analyzed as if they were isolates)",
                    "fr": "Sauter la détection métagénomique. (Oblige l’analyse des échantillons comme s’il s’agissait d’isolats)"
                  }
                },
                "skip_staramr": {
                  "description": {
                    "en": "Skip running StarAMR",
                    "fr": "Sauter l’exécution de StarAMR"
                  }
                },
                "skip_allele_calling": {
                  "description": {
                    "en": "Skip allele calling with Locidex",
                    "fr": "Sauter l’identification d’allèle par Locidex"
                  }
                },
                "skip_length_filtering_contigs": {
                  "description": {
                    "en": "Skip filtering contigs by length.",
                    "fr": "Sauter le filtrage des contigs selon la longueur."
                  }
                },
                "fail_on_metagenomic": {
                  "description": {
                    "en": "Samples which are determined to be metagenomic will not be assembled.",
                    "fr": "Les échantillons qui ont été désignés comme étant métagénomiques ne seront pas assemblés."
                  }
                }
              }
            },
            "ectyper": {
              "title": {
                "en": "ECTyper",
                "fr": "ECTyper"
              },
              "description": {
                "en": "Options for ECTyper (E.coli serotyping)",
                "fr": "Options pour ECTyper (E.coli serotyping)"
              },
              "properties": {
                "ec_opid": {
                  "description": {
                    "en": "Minimum percent identity to determine O antigens presence",
                    "fr": "Pourcentage minimal d’identité pour la détermination de la présence d’antigènes O"
                  }
                },
                "ec_opcov": {
                  "description": {
                    "en": "Minimum percent coverage of O antigen",
                    "fr": "Pourcentage minimal de couverture de l’antigène O"
                  }
                },
                "ec_hpid": {
                  "description": {
                    "en": "Miniumum percent identity to determine H antigens presence",
                    "fr": "Pourcentage minimal d’identité pour la détermination de la présence d’antigènes H"
                  }
                },
                "ec_hpcov": {
                  "description": {
                    "en": "Minimum percent coverage of H antigen",
                    "fr": "Pourcentage minimal de couverture de l’antigène H"
                  }
                },
                "ec_enable_verification": {
                  "description": {
                    "en": "Enable species verification in ECTyper",
                    "fr": "Activer la vérification des espèces dans ECTyper"
                  }
                },
                "ec_pathpid": {
                  "description": {
                    "en": "Minimum percent identity threshold for pathotype and shiga toxin subtyping results filtering.",
                    "fr": "Seuil minimal de pourcentage d’identité pour le filtrage des résultats de sous-typage du pathotype et des shigatoxines."
                  }
                },
                "ec_pathcov": {
                  "description": {
                    "en": "Minimum percent coverage threshold for pathotype and shiga toxin subtyping results filtering.",
                    "fr": "Seuil minimal de pourcentage de couverture pour le filtrage des résultats de sous-typage du pathotype et de la shigatoxine."
                  }
                }
              }
            },
            "sistr": {
              "title": {
                "en": "SISTR",
                "fr": "SISTR"
              },
              "description": {
                "en": "Options for SISTR (Salmonella serotyping)",
                "fr": "Options pour SISTR (Salmonella serotyping)"
              },
              "properties": {
                "sr_full_cgmlst": {
                  "description": {
                    "en": "Run SISTR using the full set of cgMLST alleles which can include highly similar alleles.",
                    "fr": "Exécuter SISTR en utilisant l’ensemble complet d’allèles cgMLST qui peut comprendre des allèles très semblables."
                  }
                }
              }
            },
            "fastp_options": {
              "title": {
                "en": "Fastp options",
                "fr": "Options de Fastp"
              },
              "description": {
                "en": "Options to pass to FastP for read quality assurance",
                "fr": "Options de transmission au FastP pour l’assurance de la qualité de la lecture"
              },
              "properties": {
                "fp_average_quality": {
                  "description": {
                    "en": "Average quality of a read to be included (read pair is discarded if it is below this value)",
                    "fr": "Qualité moyenne d’une lecture à inclure (la paire de lectures est éliminée si elle est inférieure à cette valeur)"
                  }
                },
                "fp_cut_tail_mean_quality": {
                  "description": {
                    "en": "The mean quality requirement option shared by cut_front, cut_tail or cut_sliding",
                    "fr": "Option d’exigence moyenne de qualité partagée par cut_front, cut_tail ou cut_sliding"
                  }
                },
                "fp_cut_tail_window_size": {
                  "description": {
                    "en": "The window size option shared by cut_front, cut_tail or cut_sliding.",
                    "fr": "Option de taille de fenêtre partagée par cut_front, cut_tail ou cut_sliding."
                  }
                },
                "fp_complexity_threshold": {
                  "description": {
                    "en": "The threshold for low complexity filter",
                    "fr": "Seuil pour le filtre de faible complexité"
                  }
                },
                "fp_qualified_phred": {
                  "description": {
                    "en": "The quality value that a base is qualified.",
                    "fr": "Valeur de qualité à laquelle une base est qualifiée."
                  }
                },
                "fp_unqualified_percent_limit": {
                  "description": {
                    "en": "The percentage of bases that are allowed to be unqualified",
                    "fr": "Pourcentage de bases qui peuvent être non qualifiées"
                  }
                },
                "fp_polyg_min_len": {
                  "description": {
                    "en": "The minimum length to detect polyG in the read tail",
                    "fr": "Longueur minimale pour détecter le polyG dans la queue de la lecture"
                  }
                },
                "fp_polyx_min_len": {
                  "description": {
                    "en": "The minimum length to detect polyX in the read tail",
                    "fr": "Longueur minimale pour détecter le polyX dans la queue de la lecture"
                  }
                },
                "fp_illumina_length_min": {
                  "description": {
                    "en": "Reads shorter than length_required will be discarded",
                    "fr": "Les lectures plus courtes que la longueur requise (length_required) seront rejetées"
                  }
                },
                "fp_illumina_length_max": {
                  "description": {
                    "en": "Reads longer than length_limit will be discarded, 0 means no limitation.",
                    "fr": "Les lectures dépassant la longueur maximale (length_limit) seront rejetées, 0 signifie qu’il n’y a aucune limite."
                  }
                },
                "fp_single_end_length_min": {
                  "description": {
                    "en": "Same as fp_illumina_length_min but for single-end data. reads shorter than length_required will be discarded",
                    "fr": "Identique à fp_illumina_length_min, mais pour les données à une seule extrémité. Les lectures plus courtes que la longueur requise (length_required) seront rejetées."
                  }
                },
                "fp_dedup_reads": {
                  "description": {
                    "en": "Enable deduplication to drop the duplicated reads/pairs",
                    "fr": "Activer la déduplication pour supprimer les lectures/paires dupliquées"
                  }
                }
              }
            },
            "locidex": {
              "title": {
                "en": "Locidex",
                "fr": "Locidex"
              },
              "description": {
                "en": "Options for allele calling with locidex.",
                "fr": "Options d’identification d’allèle avec locidex."
              },
              "properties": {
                "lx_min_evalue": {
                  "description": {
                    "en": "Minimum e-value required for match.",
                    "fr": "Valeur e minimale requise pour une correspondance."
                  }
                },
                "lx_min_dna_len": {
                  "description": {
                    "en": "Global minimum query length of DNA strand.",
                    "fr": "Longueur de requête minimale globale de la chaîne d’ADN."
                  }
                },
                "lx_min_aa_len": {
                  "description": {
                    "en": "Global minimum query length of an Amino Acid strand.",
                    "fr": "Longueur de requête minimale globale de la chaîne d’acides aminés."
                  }
                },
                "lx_max_dna_len": {
                  "description": {
                    "en": "Global maximum query length of DNA strand.",
                    "fr": "Longueur de requête maximale globale de la chaîne d’ADN."
                  }
                },
                "lx_max_aa_len": {
                  "description": {
                    "en": "Global maximum query length of Amino Acid strand.",
                    "fr": "Longueur de requête maximale globale de la chaîne d’acides aminés."
                  }
                },
                "lx_min_dna_ident": {
                  "description": {
                    "en": "Global minimum DNA percent identity required for match.",
                    "fr": "Pourcentage global minimal d’identité d’ADN requis pour une correspondance."
                  }
                },
                "lx_min_aa_ident": {
                  "description": {
                    "en": "Global minimum Amino Acid percent identiy required for match.",
                    "fr": "Pourcentage global minimal d’identité d’acides aminés requis pour une correspondance."
                  }
                },
                "lx_min_dna_match_cov": {
                  "description": {
                    "en": "Global minimum DNA percent hit coverage identity required for match.",
                    "fr": "Pourcentage global minimal d’identité de couverture d’occurrence d’ADN requis pour une correspondance."
                  }
                },
                "lx_min_aa_match_cov": {
                  "description": {
                    "en": "Global minimum Amino Acid hit coverage identity required for match.",
                    "fr": "Identité globale minimale de couverture d’occurrence d’acides aminés requise pour une correspondance."
                  }
                },
                "lx_max_target_seqs": {
                  "description": {
                    "en": "Maximum number of sequence hits per query",
                    "fr": "Nombre maximal d’occurrences de séquence par requête"
                  }
                },
                "lx_extraction_mode": {
                  "description": {
                    "en": "Different ways to run locidex.",
                    "fr": "Différentes façons d’exécuter locidex."
                  }
                },
                "lx_report_mode": {
                  "description": {
                    "en": "Allele profile assignment.",
                    "fr": "Attribution du profil d’allèle."
                  }
                },
                "lx_report_prop": {
                  "description": {
                    "en": "Metadata label to use for aggregation. Only alphanumeric characters, underscores and dashes are allowed in names.",
                    "fr": "Étiquette de métadonnées à utiliser pour l’agrégation. Seuls les caractères alphanumériques, les traits de soulignement et les tirets sont autorisés dans les noms."
                  }
                },
                "lx_report_max_ambig": {
                  "description": {
                    "en": "Maximum number of ambiguous characters allowed in a sequence.",
                    "fr": "Nombre maximal de caractères ambigus permis dans une séquence."
                  }
                },
                "lx_report_max_stop": {
                  "description": {
                    "en": "Maximum number of internal stop codons allowed in a sequence.",
                    "fr": "Nombre maximal de codons d’arrêt internes permis dans une séquence."
                  }
                }
              }
            },
            "data_processing_thresholds": {
              "title": {
                "en": "Data processing thresholds",
                "fr": "Seuils de traitement des données"
              },
              "description": {
                "en": "Thresholds for processing or quality assurance of data",
                "fr": "Seuils de traitement ou d’assurance de la qualité des données"
              },
              "properties": {
                "target_depth": {
                  "description": {
                    "en": "Target depth to sub-sample reads to",
                    "fr": "Profondeur cible de lecture à laquelle un sous-échantillonnage doit être effectué"
                  }
                },
                "min_reads": {
                  "description": {
                    "en": "Minimum number of reads a sample requires to move forward for assembly",
                    "fr": "Nombre minimal de lectures requises pour qu’un échantillon soit transféré à l’assemblage"
                  }
                },
                "ba_min_contig_length": {
                  "description": {
                    "en": "Minimum contig length for processing in Bakta",
                    "fr": "Longueur minimale de contig pour le traitement dans Bakta"
                  }
                },
                "qt_min_contig_length": {
                  "description": {
                    "en": "Minimum contig length for quast",
                    "fr": "Longueur minimale de contig pour quast"
                  }
                },
                "mh_min_kmer": {
                  "description": {
                    "en": "Minimum Kmer count needed for a unique kmer to be used in genome size estimation",
                    "fr": "Nombre minimal de k-mères requis pour qu’un k-mère unique soit utilisé dans l’estimation de la taille du génome"
                  }
                }
              }
            },
            "other": {
              "title": {
                "en": "Other",
                "fr": "Autre"
              },
              "description": {
                "en": "Other parameters",
                "fr": "Autres paramètres"
              },
              "properties": {
                "nanopore_chemistry": {
                  "description": {
                    "en": "The guppy base calling model. See the docs for a link of valid options",
                    "fr": "Modèle d’identification de base guppy. Consulter les documents pour obtenir un lien vers les options valides"
                  }
                },
                "flye_read_type": {
                  "description": {
                    "en": "Read type for flye to use. hq corresponds to hifi for Pacbio data.",
                    "fr": "Type de lecture que flye doit utiliser. hq correspond à hifi pour les données de Pacbio."
                  }
                }
              }
            }
          }
        }
      }
    ]
  }
```

1. Start server with `bin/dev`
2. Login as user of choice
3. Navigate to Project samples page of your own choice
4. Select a single sample
5. Launch Mikrokondo pipeline
6. Confirm in samplesheet that `LONG_READS` is not populated for the sample

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
