### PR TITLE
Add user opt-in features to application settings

### DIFF
--- a/app/helpers/application_settings_helper.rb
+++ b/app/helpers/application_settings_helper.rb
@@ -4,5 +4,6 @@
 module ApplicationSettingsHelper
   delegate :allow_signup?,
            :password_authentication_enabled?,
+           :user_opt_in_features,
            to: :'Irida::CurrentSettings.current_application_settings'
 end

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -3,7 +3,11 @@
 # database table for application settings. Only one row should be allowed in this table, and it should be created on
 # application initialization.
 class ApplicationSetting < ApplicationRecord
+  USER_OPT_IN_FEATURES_JSON_SCHEMA = Rails.root.join('config/schemas/user_opt_in_features.json')
+
   validate :only_one_instance, on: :create
+  validates :user_opt_in_features,
+            json: { message: ->(errors) { errors }, schema: USER_OPT_IN_FEATURES_JSON_SCHEMA }
 
   def self.current
     first

--- a/config/schemas/user_opt_in_features.json
+++ b/config/schemas/user_opt_in_features.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "patternProperties": {
+    "^[a-z0-9_]+$": {
+      "type": "object",
+      "required": ["allowlist", "name", "description"],
+      "properties": {
+        "allowlist": {
+          "oneOf": [
+            { "type": "string", "enum": ["all"] },
+            {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          ]
+        },
+        "name": {
+          "type": "object",
+          "required": ["en"],
+          "properties": {
+            "en": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": { "type": "string" }
+        },
+        "description": {
+          "type": "object",
+          "required": ["en"],
+          "properties": {
+            "en": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/db/migrate/20260424121251_add_user_opt_in_features_to_application_settings.rb
+++ b/db/migrate/20260424121251_add_user_opt_in_features_to_application_settings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Moves user opt-in feature configuration from config/user_opt_in_features.yml
+# into a jsonb column on application_settings so it can be edited at runtime.
+class AddUserOptInFeaturesToApplicationSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :application_settings, :user_opt_in_features, :jsonb, default: {}, null: false
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -914,4 +914,23 @@ if Rails.env.development?
   DataExport.suppressing_turbo_broadcasts do
     seed_exports
   end
+
+  # Seed default user opt-in features into ApplicationSetting
+  app_setting = ApplicationSetting.current || ApplicationSetting.create_from_defaults
+  default_opt_in_features = {
+    'data_grid_samples_table' => {
+      'allowlist' => 'all',
+      'name' => {
+        'en' => 'Data Grid Samples Table',
+        'fr' => 'Tableau de données des échantillons'
+      },
+      'description' => {
+        'en' => 'Enable the new data grid for the samples table.',
+        'fr' => "Activer la nouvelle grille de données pour le tableau d'échantillons."
+      }
+    }
+  }
+  app_setting.update!(
+    user_opt_in_features: default_opt_in_features.merge(app_setting.user_opt_in_features)
+  )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -928,6 +928,17 @@ if Rails.env.development?
         'en' => 'Enable the new data grid for the samples table.',
         'fr' => "Activer la nouvelle grille de données pour le tableau d'échantillons."
       }
+    },
+    'client_linelist_exports' => {
+      'allowlist' => ['user1@email.com'],
+      'name' => {
+        'en' => 'Client Linelist Exports',
+        'fr' => 'Exports de listes de clients'
+      },
+      'description' => {
+        'en' => 'Enable the new client linelist exports feature.',
+        'fr' => "Activer la nouvelle fonctionnalité d'exports de listes de clients."
+      }
     }
   }
   app_setting.update!(

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -926,7 +926,7 @@ CREATE TABLE public.site_banners (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT site_banners_singleton_guard_check CHECK (((singleton_guard)::text = 'global'::text)),
-    CONSTRAINT site_banners_style_check CHECK (((style)::text = ANY (ARRAY[('info'::character varying)::text, ('warning'::character varying)::text, ('danger'::character varying)::text, ('success'::character varying)::text])))
+    CONSTRAINT site_banners_style_check CHECK (((style)::text = ANY ((ARRAY['info'::character varying, 'warning'::character varying, 'danger'::character varying, 'success'::character varying])::text[])))
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -520,7 +520,8 @@ CREATE TABLE public.application_settings (
     password_authentication_enabled boolean DEFAULT true NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    cleanup_inactive_access_tokens_after_days integer DEFAULT 30 NOT NULL
+    cleanup_inactive_access_tokens_after_days integer DEFAULT 30 NOT NULL,
+    user_opt_in_features jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -2142,6 +2143,7 @@ ALTER TABLE ONLY public.workflow_executions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260424121251'),
 ('20260416173126'),
 ('20260410170502'),
 ('20260306153207'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1363,10 +1363,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2777,12 +2773,6 @@ snapshots:
       resolve: 1.22.12
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.12:
     dependencies:

--- a/test/models/application_setting_test.rb
+++ b/test/models/application_setting_test.rb
@@ -72,4 +72,69 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     settings.update(cleanup_inactive_access_tokens_after_days: 60)
     assert_equal 60, settings.cleanup_inactive_access_tokens_after_days
   end
+
+  test 'user_opt_in_features accepts valid feature configuration' do
+    settings = ApplicationSetting.build_from_defaults(
+      user_opt_in_features: {
+        'data_grid_samples_table' => {
+          'allowlist' => ['john_doe@email.com'],
+          'name' => { 'en' => 'Data Grid Samples Table' },
+          'description' => { 'en' => 'Enable the new data grid for the samples table.' }
+        }
+      }
+    )
+
+    assert settings.valid?
+  end
+
+  test 'user_opt_in_features rejects invalid feature key format' do
+    settings = ApplicationSetting.build_from_defaults(
+      user_opt_in_features: {
+        'InvalidKey' => {
+          'allowlist' => 'all',
+          'name' => { 'en' => 'Feature' },
+          'description' => { 'en' => 'Description' }
+        }
+      }
+    )
+
+    assert_not settings.valid?
+    assert settings.errors[:user_opt_in_features].any?
+  end
+
+  test 'user_opt_in_features rejects invalid allowlist format' do
+    settings = ApplicationSetting.build_from_defaults(
+      user_opt_in_features: {
+        'data_grid_samples_table' => {
+          'allowlist' => '',
+          'name' => { 'en' => 'Data Grid Samples Table' },
+          'description' => { 'en' => 'Enable the new data grid for the samples table.' }
+        }
+      }
+    )
+
+    assert_not settings.valid?
+    assert_includes settings.errors[:user_opt_in_features],
+                    'value at `/data_grid_samples_table/allowlist` is not one of: ["all"]'
+    assert_includes settings.errors[:user_opt_in_features],
+                    'value at `/data_grid_samples_table/allowlist` is not an array'
+  end
+
+  test 'user_opt_in_features requires english fallback translations' do
+    settings = ApplicationSetting.build_from_defaults(
+      user_opt_in_features: {
+        'data_grid_samples_table' => {
+          'allowlist' => 'all',
+          'name' => { 'fr' => 'Tableau de donnees des echantillons' },
+          'description' => { 'fr' => 'Activer la nouvelle grille.' }
+        }
+      }
+    )
+
+    assert_not settings.valid?
+    assert_includes settings.errors[:user_opt_in_features],
+                    'object at `/data_grid_samples_table/name` is missing required properties: en'
+    assert_includes settings.errors[:user_opt_in_features],
+                    'object at `/data_grid_samples_table/description` is missing required properties: en'
+  end
 end

--- a/test/models/application_setting_test.rb
+++ b/test/models/application_setting_test.rb
@@ -87,6 +87,20 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     assert settings.valid?
   end
 
+  test 'user_opt_in_features accepts all-user allowlist configuration' do
+    settings = ApplicationSetting.build_from_defaults(
+      user_opt_in_features: {
+        'data_grid_samples_table' => {
+          'allowlist' => 'all',
+          'name' => { 'en' => 'Data Grid Samples Table' },
+          'description' => { 'en' => 'Enable the new data grid for the samples table.' }
+        }
+      }
+    )
+
+    assert settings.valid?
+  end
+
   test 'user_opt_in_features rejects invalid feature key format' do
     settings = ApplicationSetting.build_from_defaults(
       user_opt_in_features: {
@@ -114,10 +128,8 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     )
 
     assert_not settings.valid?
-    assert_includes settings.errors[:user_opt_in_features],
-                    'value at `/data_grid_samples_table/allowlist` is not one of: ["all"]'
-    assert_includes settings.errors[:user_opt_in_features],
-                    'value at `/data_grid_samples_table/allowlist` is not an array'
+    error_text = settings.errors[:user_opt_in_features].join(' ')
+    assert_includes error_text, '/data_grid_samples_table/allowlist'
   end
 
   test 'user_opt_in_features requires english fallback translations' do
@@ -132,9 +144,9 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     )
 
     assert_not settings.valid?
-    assert_includes settings.errors[:user_opt_in_features],
-                    'object at `/data_grid_samples_table/name` is missing required properties: en'
-    assert_includes settings.errors[:user_opt_in_features],
-                    'object at `/data_grid_samples_table/description` is missing required properties: en'
+    error_text = settings.errors[:user_opt_in_features].join(' ')
+    assert_includes error_text, '/data_grid_samples_table/name'
+    assert_includes error_text, '/data_grid_samples_table/description'
+    assert_includes error_text, 'en'
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This stores user opt-in feature settings on ApplicationSetting in a new jsonb column and validates the structure with a JSON schema. We need this so opt-in features can be changed at runtime instead of only through a static config file.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Run `bin/rails db:migrate` to add the new `application_settings.user_opt_in_features` column.
2. Run `bin/rails db:seed` in development, then open `bin/rails console` and run `ApplicationSetting.current.user_opt_in_features`; confirm it includes `data_grid_samples_table` with `allowlist`, `name`, and `description`.
3. Run `bin/rails test test/models/application_setting_test.rb`; confirm the new user opt-in feature validation tests pass, including allowlist values of both `"all"` and an email array.
4. In `bin/rails console`, try an invalid update such as `ApplicationSetting.current.update(user_opt_in_features: { "BadKey" => { "allowlist" => "all", "name" => { "fr" => "Nom" }, "description" => { "fr" => "Desc" } } })`; confirm it does not save and returns schema validation errors.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
