### PR TITLE
BugFix: SampleCleanupJob 

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,13 +48,15 @@ class Project < ApplicationRecord
   end
 
   def broadcast_refresh_later_to_samples_table
-    broadcast_refresh_later_to self, :samples
+    broadcast_refresh_later_to self, :samples unless self && !deleted?
 
     return unless Flipper.enabled?(:samples_refresh_notice, Current.user)
 
     # Broadcast to all ancestor groups since they display samples from child projects/groups.
     # This ensures group sample views are notified of changes in nested projects.
     namespace.self_and_ancestors_of_type(Group.sti_name).each do |namespace|
+      next unless namespace && !namespace.deleted?
+
       broadcast_refresh_later_to namespace, :samples
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,14 +48,14 @@ class Project < ApplicationRecord
   end
 
   def broadcast_refresh_later_to_samples_table
-    broadcast_refresh_later_to self, :samples unless self && !deleted?
+    broadcast_refresh_later_to self, :samples if self && !deleted?
 
     return unless Flipper.enabled?(:samples_refresh_notice, Current.user)
 
     # Broadcast to all ancestor groups since they display samples from child projects/groups.
     # This ensures group sample views are notified of changes in nested projects.
     namespace.self_and_ancestors_of_type(Group.sti_name).each do |namespace|
-      next unless namespace && !namespace.deleted?
+      next if namespace&.deleted?
 
       broadcast_refresh_later_to namespace, :samples
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -22,7 +22,7 @@ class Sample < ApplicationRecord
   scope :sort_by_attachments_updated_at_nulls_last_desc,
         -> { order('attachments_updated_at DESC NULLS LAST') }
 
-  has_many :samples_workflow_executions, dependent: :nullify
+  has_many :samples_workflow_executions, -> { with_deleted }, dependent: :nullify # rubocop:disable Rails/InverseOf
   has_many :workflow_executions, through: :samples_workflow_executions
 
   validates :name, presence: true, length: { minimum: 3, maximum: 255 }
@@ -71,14 +71,19 @@ class Sample < ApplicationRecord
 
   private
 
-  def broadcast_refresh_later_to_samples_table
+  def broadcast_refresh_later_to_samples_table # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     return if Sample.suppressed_turbo_broadcasts
 
-    projects = [project]
+    projects = project && !project.deleted? ? [project] : []
+
     if previous_changes['project_id'] && !previous_changes['project_id'][0].nil?
       projects << Project.find(previous_changes['project_id'][0])
     end
 
-    projects.each(&:broadcast_refresh_later_to_samples_table)
+    projects.each do |proj|
+      next unless proj&.deleted?
+
+      proj.broadcast_refresh_later_to_samples_table
+    end
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -81,7 +81,7 @@ class Sample < ApplicationRecord
     end
 
     projects.each do |proj|
-      next unless proj&.deleted?
+      next if proj&.deleted?
 
       proj.broadcast_refresh_later_to_samples_table
     end

--- a/app/services/base_sample_service.rb
+++ b/app/services/base_sample_service.rb
@@ -80,7 +80,7 @@ class BaseSampleService < BaseService
     Turbo::StreamsChannel.broadcast_refresh_later_to old_project, :samples if old_project && !old_project.deleted?
 
     old_namespaces.each do |old_namespace|
-      next unless old_namespace && !old_namespace.deleted?
+      next if old_namespace&.deleted?
 
       Turbo::StreamsChannel.broadcast_refresh_later_to old_namespace, :samples
     end
@@ -88,7 +88,7 @@ class BaseSampleService < BaseService
     Turbo::StreamsChannel.broadcast_refresh_later_to new_project, :samples if new_project && !new_project.deleted?
 
     new_namespaces.each do |new_namespace|
-      next unless new_namespace && !new_namespace.deleted?
+      next if new_namespace&.deleted?
 
       Turbo::StreamsChannel.broadcast_refresh_later_to new_namespace, :samples
     end

--- a/app/services/base_sample_service.rb
+++ b/app/services/base_sample_service.rb
@@ -74,18 +74,22 @@ class BaseSampleService < BaseService
   end
 
   # Broadcast all turbo broadcasts for sample services where the broadcasts were suppressed
-  def broadcast_refresh_later_to_samples_table(old_namespaces, new_namespaces, old_project, new_project)
+  def broadcast_refresh_later_to_samples_table(old_namespaces, new_namespaces, old_project, new_project) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     return unless Flipper.enabled?(:samples_refresh_notice, current_user)
 
-    Turbo::StreamsChannel.broadcast_refresh_later_to old_project, :samples
+    Turbo::StreamsChannel.broadcast_refresh_later_to old_project, :samples if old_project && !old_project.deleted?
 
     old_namespaces.each do |old_namespace|
+      next unless old_namespace && !old_namespace.deleted?
+
       Turbo::StreamsChannel.broadcast_refresh_later_to old_namespace, :samples
     end
 
-    Turbo::StreamsChannel.broadcast_refresh_later_to new_project, :samples
+    Turbo::StreamsChannel.broadcast_refresh_later_to new_project, :samples if new_project && !new_project.deleted?
 
     new_namespaces.each do |new_namespace|
+      next unless new_namespace && !new_namespace.deleted?
+
       Turbo::StreamsChannel.broadcast_refresh_later_to new_namespace, :samples
     end
   end

--- a/test/jobs/samples_cleanup_job_test.rb
+++ b/test/jobs/samples_cleanup_job_test.rb
@@ -58,4 +58,63 @@ class SamplesCleanupJobTest < ActiveJob::TestCase
       SamplesCleanupJob.perform_now(days_old: 4)
     end
   end
+
+  test 'deleting a sample also nullifies associated samples_workflow_executions' do
+    workflow_execution = workflow_executions(:workflow_execution_valid)
+    sample_workflow_execution = samples_workflow_executions(:samples_workflow_executions_valid)
+
+    # Ensure the association exists before deletion
+    assert_includes workflow_execution.samples_workflow_executions, sample_workflow_execution
+
+    # Delete the workflow execution
+    workflow_execution.destroy
+
+    @sample1.update(deleted_at: 12.days.ago)
+
+    SamplesCleanupJob.perform_now
+
+    # Reload the sample_workflow_execution and check if it has been deleted
+    sample_id = sample_workflow_execution.reload.sample_id
+    assert_nil sample_id, 'Associated SamplesWorkflowExecution should be deleted when WorkflowExecution is destroyed'
+  end
+
+  test 'no turbo stream broadcasts to project if project is deleted' do
+    project = projects(:project1)
+    sample = samples(:sample1)
+
+    assert_not project.deleted?
+    assert_not sample.project.deleted?
+
+    assert_no_enqueued_jobs(only: Turbo::Streams::BroadcastStreamJob) do
+      project.destroy!
+      perform_enqueued_jobs
+    end
+
+    SamplesCleanupJob.perform_now
+
+    assert_no_enqueued_jobs(only: Turbo::Streams::BroadcastStreamJob) do
+      perform_enqueued_jobs
+    end
+  end
+
+  test 'no turbo stream broadcasts to a project namespace parent if parent is deleted' do
+    group = groups(:group_one)
+    project = projects(:project1)
+    sample = samples(:sample1)
+
+    assert_not project.deleted?
+    assert_not sample.project.deleted?
+
+    assert_no_enqueued_jobs(only: Turbo::Streams::BroadcastStreamJob) do
+      project.destroy!
+      group.destroy!
+      perform_enqueued_jobs
+    end
+
+    SamplesCleanupJob.perform_now
+
+    assert_no_enqueued_jobs(only: Turbo::Streams::BroadcastStreamJob) do
+      perform_enqueued_jobs
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes multiple bugs when running the SamplesCleanupJob

1) Foreign key constraint error when a workflow execution was deleted which would delete the samples_workflow_execution objects (soft delete), and then a sample deleted. When the clean up job would run the error would be raised as the samples_workflow_execution objects in soft deleted state did not have the sample column nullified

2) Broadcasting turbostream job would throw a nil error if a sample was soft deleted and it's project was deleted before the cleanup job ran  

Foreign key constraint error has been fixed so samples_workflow_executions objects in soft deleted state have the sample column nullified if the sample is deleted

Broadcasting turbostreams nil error has been fixed by only queuing a job if the project and/or namespace are not deleted before the cleanup job is ran

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

**Foreign key constraint error and fix:**

1. On the main branch
2.  From a project, select a sample with files, and run a pipeline
3. Once completed, in rails console, get the `samples_workflow_execution` object used in the workflow execution and verify that the `sample_id` has a value
4. Now delete the workflow execution
5. Delete the sample used for the workflow execution
6. In the rails console, update the `deleted_at` for this sample to `10.days.ago `
7. Run `SamplesCleanupJob.perform_now`
8. Verify that you get an error (PG::ForeignKeyViolation: ERROR)
9. Reload the `samples_workflow_execution` object  from above
10. Verify that the sample_id column has not been nullified
11. Switch over to this branch and repeat step 2 through 8. This time verify that the `sample_id` column has been nullified


Turbostream Broadcast error and fix

1. On the main branch 
2. Create a new project add a few samples
3. Now delete the samples in the project and from rails console update the `deleted_at` to `10.days.ago`
4. Now from the UI delete the project
5. Run `SamplesCleanupJob.perform_now` in the rails console
6. Verify you get a nil error ( undefined method 'broadcast_refresh_later_to_samples_table' for nil)
7.  Switch to this branch and repeat steps 2 through 5
8. Verify that there is no error 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
