### PR TITLE
Bug: Empty Access Level form field with inherited member access

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -120,7 +120,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def higher_access_level_than_group
-    return unless highest_group_member && highest_group_member.access_level > access_level
+    return unless highest_group_member && access_level.present? && highest_group_member.access_level > access_level
 
     errors.add(:access_level, I18n.t('activerecord.errors.models.member.attributes.access_level.invalid',
                                      user: user.email,


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where if a user had access to a project through some other way other than direct invite (eg: access from the parent group), and the user was then invited to the group but `access level` was left blank, the proper error handling did not trigger, causing a crash.

## Screenshots or screen recordings
Without fix:

[Screencast from 2026-04-24 11-45-08.webm](https://github.com/user-attachments/assets/9782c89e-ff38-4e2e-8a3f-7bd7fae98910)

With fix:

[Screencast from 2026-04-24 11-48-02.webm](https://github.com/user-attachments/assets/627f71bc-517f-40b3-ac45-5a5bbe7acc82)



## How to set up and validate locally
1. Recreate the bug on `main`
- Create a group with a project
- In the group, invite a member
- Now in the project, try to invite the same user, but leave the `access level` field blank.
- A crash should occur

2. Checkout this branch and now try to invite the user to the project. The application should not crash, and the proper error fields should now be appended to the `access level` for field.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
