### PR TITLE
Adopt form error summary on group forms

### DIFF
--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -3,6 +3,7 @@
   <% card.with_section do %>
     <%= form_with(model: @group, url: group_path, method: :patch, html: { novalidate: true }) do |form| %>
       <div class="grid gap-4">
+        <%= form_error_summary(form) %>
         <p class="text-slate-600 dark:text-slate-400">
           <%= t(:"groups.edit.advanced.path.description") %>
         </p>
@@ -38,15 +39,14 @@
                                 title: @group.path,
                                 class:
                                   "text-ellipsis overflow-hidden border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
-                                aria: {
-                                  describedby: [
-                                    invalid_path ? form.field_id(:path, "error") : nil,
-                                    form.field_id(:path, "hint"),
-                                  ].join(" "),
-                                  invalid: invalid_path,
-                                  required: true,
-                                },
-                                autofocus: invalid_path %>
+                                 aria: {
+                                   describedby: [
+                                     invalid_path ? form.field_id(:path, "error") : nil,
+                                     form.field_id(:path, "hint"),
+                                   ].join(" "),
+                                   invalid: invalid_path,
+                                   required: true,
+                                 } %>
               </div>
             </div>
             <% if invalid_path %>

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -1,37 +1,40 @@
 <%= viral_card do |card| %>
   <% card.with_header(title: t(:"groups.edit.advanced.path.title")) %>
+
   <% card.with_section do %>
     <%= form_with(model: @group, url: group_path, method: :patch, html: { novalidate: true }) do |form| %>
       <div class="grid gap-4">
         <%= form_error_summary(form) %>
+
         <p class="text-slate-600 dark:text-slate-400">
           <%= t(:"groups.edit.advanced.path.description") %>
         </p>
+
         <%= render partial: "shared/form/required_field_legend" %>
+
         <% invalid_path = @group.errors.include?(:path) %>
+
         <div class="form-field <%= 'invalid' if invalid_path %>">
           <div class="@container">
             <%= form.label :path, data: { required: true } %>
+
             <div class="flex flex-row @max-md:flex-col">
               <div
                 class="
-                  text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
-                  bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
-                  @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
-                  whitespace-nowrap max-w-md
+                  max-w-md overflow-hidden rounded-l-lg rounded-r-lg border border-slate-300 bg-slate-100 px-4 py-2
+                  text-sm font-medium text-ellipsis whitespace-nowrap text-slate-700 @md:!rounded-r-none
+                  @md:border-r-0 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300
                 "
                 title="<%= "#{root_url}#{@group&.parent&.full_path}" %>"
               >
-
                 <% if @group.parent %>
                   <%= root_url %>
-                  <span class="font-bold">
-                    <%= @group.parent.full_path + "/" %>
-                  </span>
+                  <span class="font-bold"><%= @group.parent.full_path + "/" %></span>
                 <% else %>
                   <%= root_url %>
                 <% end %>
               </div>
+
               <div class="grow">
                 <%= form.text_field :path,
                                 pattern: Irida::PathRegex::PATH_REGEX_STR,
@@ -49,16 +52,19 @@
                                  } %>
               </div>
             </div>
+
             <% if invalid_path %>
               <%= render "shared/form/field_errors",
               id: form.field_id(:path, "error"),
               errors: @group.errors.full_messages_for(:path) %>
             <% end %>
+
             <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
               <%== t(:"groups.create.path_help") %>
             </span>
           </div>
         </div>
+
         <div>
           <%= form.submit t(:"groups.edit.advanced.path.submit"),
                       data: {

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= form_error_summary(form, target_overrides: { parent_id: "namespace-select" }) %>
+
 <%= render partial: "shared/form/required_field_legend" %>
 
 <% invalid_name = group.errors.include?(:name) %>
@@ -15,15 +17,14 @@
                   pattern: "[a-zA-Z0-9_\\-\\.\\s\\p{Emoji}]+",
                   placeholder: t(:"groups.create.name_placeholder"),
                   required: true,
-                  aria: {
-                    describedby: [
-                      invalid_name ? form.field_id(:name, "error") : nil,
-                      form.field_id(:name, "hint"),
-                    ].join(" "),
-                    invalid: invalid_name,
-                    required: true,
-                  },
-                  autofocus: invalid_name %>
+                   aria: {
+                     describedby: [
+                       invalid_name ? form.field_id(:name, "error") : nil,
+                       form.field_id(:name, "hint"),
+                     ].join(" "),
+                     invalid: invalid_name,
+                     required: true,
+                   } %>
 
   <% if invalid_name %>
     <%= render "shared/form/field_errors",
@@ -91,15 +92,14 @@
                         maxlength: 255,
                         pattern: Irida::PathRegex::PATH_REGEX_STR,
                         required: true,
-                        aria: {
-                          describedby: [
-                            invalid_path ? form.field_id(:path, "error") : nil,
-                            form.field_id(:path, "hint"),
-                          ].join(" "),
-                          invalid: invalid_path,
-                          required: true,
-                        },
-                        autofocus: invalid_path %>
+                         aria: {
+                           describedby: [
+                             invalid_path ? form.field_id(:path, "error") : nil,
+                             form.field_id(:path, "hint"),
+                           ].join(" "),
+                           invalid: invalid_path,
+                           required: true,
+                         } %>
 
         <% if invalid_path %>
           <%= render "shared/form/field_errors",
@@ -121,15 +121,14 @@
                       },
                       pattern: Irida::PathRegex::PATH_REGEX_STR,
                       required: true,
-                      aria: {
-                        describedby: [
-                          invalid_path ? form.field_id(:path, "error") : nil,
-                          form.field_id(:path, "hint"),
-                        ].join(" "),
-                        invalid: invalid_path,
-                        required: true,
-                      },
-                      autofocus: invalid_path %>
+                       aria: {
+                         describedby: [
+                           invalid_path ? form.field_id(:path, "error") : nil,
+                           form.field_id(:path, "hint"),
+                         ].join(" "),
+                         invalid: invalid_path,
+                         required: true,
+                       } %>
 
       <% if invalid_path %>
         <%= render "shared/form/field_errors",
@@ -159,10 +158,9 @@
                        end
                      ),
                      form.field_id(:description, "hint"),
-                   ].join(" "),
-                   "aria-invalid" => invalid_description,
-                   :autofocus => invalid_description,
-                 } %>
+                    ].join(" "),
+                    "aria-invalid" => invalid_description,
+                  } %>
 
   <% if invalid_description %>
     <%= render "shared/form/field_errors",

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -2,6 +2,7 @@
   title: t(:"groups.create.title"),
   subtitle: t(:"groups.create.subtitle"),
 ) %>
+
 <div data-controller="slugify" class="@xl:container">
   <%= form_with(model: @new_group, url: groups_path, method: :post, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
@@ -17,6 +18,5 @@
         <%= link_to t('common.actions.cancel'), groups_path, class: "button button-default" %>
       </div>
     </div>
-
   <% end %>
 </div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -5,17 +5,6 @@
 <div data-controller="slugify" class="@xl:container">
   <%= form_with(model: @new_group, url: groups_path, method: :post, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
-
-      <%= if @new_group.errors.any?
-        viral_alert(
-          type: "alert",
-          message: I18n.t(:"general.form.error_notification"),
-          aria: {
-            live: "assertive",
-          },
-        )
-      end %>
-
       <%= render partial: "form_fields",
       locals: {
         form: form,

--- a/app/views/groups/new_subgroup.html.erb
+++ b/app/views/groups/new_subgroup.html.erb
@@ -11,16 +11,6 @@
     { controller: "select2--v1" }
   end, html: { novalidate: true }) do |form| %>
     <div class="grid gap-4">
-      <%= if @new_group.errors.any?
-        viral_alert(
-          type: "alert",
-          message: I18n.t(:"general.form.error_notification"),
-          aria: {
-            live: "assertive",
-          },
-        )
-      end %>
-
       <%= render partial: "form_fields",
       locals: {
         form: form,

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -44,10 +44,14 @@ class GroupsTest < ApplicationSystemTestCase
     end
 
     assert_text I18n.t(:'general.form.error_notification')
+    assert_text 'Group name is too short'
+    assert_selector '[data-controller="form-error-summary"]', focused: true
+
+    within '[data-controller="form-error-summary"]' do
+      click_link 'Group name is too short'
+    end
 
     assert_selector '#group_name', focused: true
-
-    assert_text 'Group name is too short'
     assert_current_path '/-/groups/new'
   end
 
@@ -61,10 +65,14 @@ class GroupsTest < ApplicationSystemTestCase
     end
 
     assert_text I18n.t(:'general.form.error_notification')
+    assert_text 'Group name has already been taken'
+    assert_selector '[data-controller="form-error-summary"]', focused: true
+
+    within '[data-controller="form-error-summary"]' do
+      click_link 'Group name has already been taken'
+    end
 
     assert_selector '#group_name', focused: true
-
-    assert_text 'Group name has already been taken'
     assert_current_path '/-/groups/new'
   end
 
@@ -78,10 +86,14 @@ class GroupsTest < ApplicationSystemTestCase
     end
 
     assert_text I18n.t(:'general.form.error_notification')
+    assert_text 'Description is too long'
+    assert_selector '[data-controller="form-error-summary"]', focused: true
+
+    within '[data-controller="form-error-summary"]' do
+      click_link 'Description is too long'
+    end
 
     assert_selector '#group_description', focused: true
-
-    assert_text 'Description is too long'
     assert_current_path '/-/groups/new'
   end
 
@@ -96,10 +108,14 @@ class GroupsTest < ApplicationSystemTestCase
     end
 
     assert_text I18n.t(:'general.form.error_notification')
+    assert_text 'Path has already been taken'
+    assert_selector '[data-controller="form-error-summary"]', focused: true
+
+    within '[data-controller="form-error-summary"]' do
+      click_link 'Path has already been taken'
+    end
 
     assert_selector '#group_path', focused: true
-
-    assert_text 'Path has already been taken'
     assert_current_path '/-/groups/new'
   end
 


### PR DESCRIPTION
## What does this PR do and why?
This updates the group create and edit forms to use the shared form error summary and removes conflicting autofocus behavior. We need this so users always land on one clear error summary first and can jump to the right field by clicking each error.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2073" height="923" alt="image" src="https://github.com/user-attachments/assets/40d0a817-c6c6-41f0-9808-cae7059e24ee" />

## How to set up and validate locally
1. Start the app with `bin/dev`.
2. Sign in and open `/-/groups/new`, then submit invalid values (for example: short name, duplicate name, duplicate path, and overlong description).
3. Confirm the error summary appears at the top and receives focus, and confirm focus is not auto-placed in a field before interaction.
4. Click each error link in the summary and confirm focus moves to the matching field.
5. Open the new subgroup form and repeat invalid submissions; confirm the same summary and focus behavior.
6. Open an existing group, go to the advanced path edit form, submit an invalid path, and confirm the summary appears and links to the path field.
7. Run `bin/rails test test/system/groups_test.rb` and confirm it passes.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
