### PR TITLE
Use form error summary on project and sample forms

### DIFF
--- a/app/components/form_error_summary_component.rb
+++ b/app/components/form_error_summary_component.rb
@@ -2,10 +2,10 @@
 
 # Renders an accessible validation summary with linked field errors.
 class FormErrorSummaryComponent < Component
-  attr_reader :entries
-
-  def initialize(entries:, **system_arguments)
-    @entries = Array(entries)
+  def initialize(entries:, include: nil, **system_arguments)
+    @entries_all = Array(entries)
+    @include_attributes =
+      Array(include).compact_blank.map { |a| a.to_s.delete_suffix('_id') }.uniq
     @system_arguments = system_arguments
   end
 
@@ -13,9 +13,17 @@ class FormErrorSummaryComponent < Component
     entries.any?
   end
 
+  def entries
+    return entries_all if include_attributes.blank?
+
+    entries_all.select do |entry|
+      include_attributes.include?(entry.attribute.to_s.delete_suffix('_id'))
+    end
+  end
+
   private
 
-  attr_reader :system_arguments
+  attr_reader :entries_all, :include_attributes, :system_arguments
 
   def heading_id
     @heading_id ||= "form-error-summary-heading-#{object_id}"

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -4,6 +4,7 @@
     <%= form_with(model: @project, url: namespace_project_path, method: :patch, html: {novalidate: true}) do |form| %>
       <%= form.fields_for :namespace, include_id: false do |builder| %>
         <div class="grid gap-4">
+          <%= form_error_summary(builder) %>
           <p class="text-slate-600 dark:text-slate-400">
             <%= t(:"projects.edit.advanced.path.description") %>
           </p>
@@ -39,17 +40,16 @@
                                      pattern: Irida::PathRegex::PATH_REGEX_STR,
                                      required: true,
                                      title: @project.path,
-                                     class:
-                                       "text-ellipsis overflow-hidden border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
-                                     aria: {
-                                       describedby: [
-                                         invalid_path ? form.field_id(:path, "error") : nil,
-                                         form.field_id(:path, "hint"),
-                                       ].join(" "),
-                                       invalid: invalid_path,
-                                       required: true,
-                                     },
-                                     autofocus: invalid_path %>
+                                      class:
+                                        "text-ellipsis overflow-hidden border-slate-300 text-slate-800 sm:text-sm rounded-r-lg @md:!rounded-l-none",
+                                      aria: {
+                                        describedby: [
+                                          invalid_path ? builder.field_id(:path, "error") : nil,
+                                          builder.field_id(:path, "hint"),
+                                        ].join(" "),
+                                        invalid: invalid_path,
+                                        required: true,
+                                      } %>
 
                 </div>
               </div>
@@ -58,7 +58,7 @@
                 id: builder.field_id(:path, "error"),
                 errors: @project.namespace.errors.full_messages_for(:path) %>
               <% end %>
-              <span id="<%= form.field_id(:path, "hint") %>" class="field-hint">
+              <span id="<%= builder.field_id(:path, "hint") %>" class="field-hint">
                 <%== t(:"projects.edit.advanced.path.help") %>
               </span>
             </div>

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -5,7 +5,7 @@
     <%= form_with(model: @project, url: namespace_project_path, method: :patch, html: {novalidate: true}) do |form| %>
       <%= form.fields_for :namespace, include_id: false do |builder| %>
         <div class="grid gap-4">
-          <%= form_error_summary(builder) %>
+          <%= form_error_summary(builder, include: %i[path]) %>
 
           <p class="text-slate-600 dark:text-slate-400">
             <%= t(:"projects.edit.advanced.path.description") %>

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -1,13 +1,16 @@
 <%= viral_card do |card| %>
   <% card.with_header(title: t(:"projects.edit.advanced.path.title")) %>
+
   <% card.with_section do %>
     <%= form_with(model: @project, url: namespace_project_path, method: :patch, html: {novalidate: true}) do |form| %>
       <%= form.fields_for :namespace, include_id: false do |builder| %>
         <div class="grid gap-4">
           <%= form_error_summary(builder) %>
+
           <p class="text-slate-600 dark:text-slate-400">
             <%= t(:"projects.edit.advanced.path.description") %>
           </p>
+
           <%= render partial: "shared/form/required_field_legend" %>
 
           <% invalid_path = @project.namespace.errors.include?(:path) %>
@@ -15,26 +18,24 @@
           <div class="form-field <%= 'invalid' if invalid_path %>">
             <div class="@container">
               <%= builder.label :path, data: { required: true } %>
+
               <div class="flex flex-row @max-md:flex-col">
                 <div
                   class="
-                    text-ellipsis overflow-hidden px-4 py-2 text-sm font-medium text-slate-700
-                    bg-slate-100 border @md:border-r-0 border-slate-300 rounded-l-lg rounded-r-lg
-                    @md:!rounded-r-none dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600
-                    whitespace-nowrap max-w-md
+                    max-w-md overflow-hidden rounded-l-lg rounded-r-lg border border-slate-300 bg-slate-100 px-4
+                    py-2 text-sm font-medium text-ellipsis whitespace-nowrap text-slate-700 @md:!rounded-r-none
+                    @md:border-r-0 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300
                   "
                   title="<%= "#{root_url}#{@project&.parent&.full_path}" %>"
                 >
-
                   <% if @project.parent %>
                     <%= root_url %>
-                    <span class="font-bold">
-                      <%= @project.parent.full_path + "/" %>
-                    </span>
+                    <span class="font-bold"><%= @project.parent.full_path + "/" %></span>
                   <% else %>
                     <%= root_url %>
                   <% end %>
                 </div>
+
                 <div class="grow">
                   <%= builder.text_field :path,
                                      pattern: Irida::PathRegex::PATH_REGEX_STR,
@@ -50,14 +51,15 @@
                                         invalid: invalid_path,
                                         required: true,
                                       } %>
-
                 </div>
               </div>
+
               <% if invalid_path %>
                 <%= render "shared/form/field_errors",
                 id: builder.field_id(:path, "error"),
                 errors: @project.namespace.errors.full_messages_for(:path) %>
               <% end %>
+
               <span id="<%= builder.field_id(:path, "hint") %>" class="field-hint">
                 <%== t(:"projects.edit.advanced.path.help") %>
               </span>

--- a/app/views/projects/_edit_name_and_description_form.html.erb
+++ b/app/views/projects/_edit_name_and_description_form.html.erb
@@ -1,6 +1,7 @@
 <%= form_with(model: project, url: namespace_project_path, method: :patch, html: { novalidate: true }, class: "grid gap-4") do |form| %>
   <%= render partial: "shared/form/required_field_legend" %>
   <%= form.fields_for :namespace, include_id: false do |builder| %>
+    <%= form_error_summary(builder) %>
     <% invalid_name = project.namespace.errors.include?(:name) %>
     <div class="form-field <%= 'invalid' if invalid_name %>">
       <%= builder.label :name, data: { required: true } %>
@@ -12,8 +13,7 @@
                              invalid_name ? builder.field_id(:name, "error") : nil,
                            invalid: invalid_name,
                            required: true,
-                         },
-                         autofocus: invalid_name ? true : false %>
+                         } %>
       <% if invalid_name %>
         <%= render "shared/form/field_errors",
         id: builder.field_id(:name, "error"),
@@ -26,7 +26,6 @@
       <%= builder.text_area :description,
                         {
                           :class => "form-control",
-                          :autofocus => invalid_description ? true : false,
                           "aria-label" => t(:"projects.new.description"),
                           "aria-describedby" =>
                             (

--- a/app/views/projects/_edit_name_and_description_form.html.erb
+++ b/app/views/projects/_edit_name_and_description_form.html.erb
@@ -1,10 +1,13 @@
 <%= form_with(model: project, url: namespace_project_path, method: :patch, html: { novalidate: true }, class: "grid gap-4") do |form| %>
   <%= render partial: "shared/form/required_field_legend" %>
+
   <%= form.fields_for :namespace, include_id: false do |builder| %>
     <%= form_error_summary(builder) %>
     <% invalid_name = project.namespace.errors.include?(:name) %>
+
     <div class="form-field <%= 'invalid' if invalid_name %>">
       <%= builder.label :name, data: { required: true } %>
+
       <%= builder.text_field :name,
                          required: true,
                          placeholder: t(:"projects.new.placeholder"),
@@ -14,15 +17,19 @@
                            invalid: invalid_name,
                            required: true,
                          } %>
+
       <% if invalid_name %>
         <%= render "shared/form/field_errors",
         id: builder.field_id(:name, "error"),
         errors: project.namespace.errors.full_messages_for(:name) %>
       <% end %>
     </div>
+
     <% invalid_description = project.namespace.errors.include?(:description) %>
+
     <div class="form-field <%= 'invalid' if invalid_description %>">
       <%= builder.label :description %>
+
       <%= builder.text_area :description,
                         {
                           :class => "form-control",
@@ -36,12 +43,14 @@
                               end
                             ),
                         } %>
+
       <% if invalid_description %>
         <%= render "shared/form/field_errors",
         id: builder.field_id(:description, "error"),
         errors: project.namespace.errors.full_messages_for(:description) %>
       <% end %>
     </div>
+
     <div>
       <%= form.submit t("projects.edit.general.submit"), class: "button button-default" %>
     </div>

--- a/app/views/projects/_edit_name_and_description_form.html.erb
+++ b/app/views/projects/_edit_name_and_description_form.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "shared/form/required_field_legend" %>
 
   <%= form.fields_for :namespace, include_id: false do |builder| %>
-    <%= form_error_summary(builder) %>
+    <%= form_error_summary(builder, include: %i[name description]) %>
     <% invalid_name = project.namespace.errors.include?(:name) %>
 
     <div class="form-field <%= 'invalid' if invalid_name %>">

--- a/app/views/projects/samples/_form_fields.html.erb
+++ b/app/views/projects/samples/_form_fields.html.erb
@@ -1,12 +1,4 @@
-<%= if @sample.errors.any?
-  viral_alert(
-    type: "alert",
-    message: I18n.t(:"general.form.error_notification"),
-    aria: {
-      live: "assertive",
-    },
-  )
-end %>
+<%= form_error_summary(form) %>
 
 <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/projects/samples/_form_fields.html.erb
+++ b/app/views/projects/samples/_form_fields.html.erb
@@ -3,8 +3,10 @@
 <%= render partial: "shared/form/required_field_legend" %>
 
 <% invalid_name = sample.errors.include?(:name) %>
+
 <div class="form-field <%= 'invalid' if invalid_name %>">
   <%= form.label :name, data: { required: true } %>
+
   <%= form.text_field :name,
                   required: true,
                   minlength: 3,
@@ -24,8 +26,10 @@
 </div>
 
 <% invalid_description = sample.errors.include?(:description) %>
+
 <div class="form-field <%= 'invalid' if invalid_description %>">
   <%= form.label :description %>
+
   <%= form.text_area :description,
                  rows: 4,
                  aria: {
@@ -40,6 +44,7 @@
                    invalid: invalid_description,
                    required: true,
                  } %>
+
   <% if invalid_description %>
     <%= render "shared/form/field_errors",
     id: form.field_id(:description, "error"),

--- a/app/views/projects/samples/metadata/_update_form.html.erb
+++ b/app/views/projects/samples/metadata/_update_form.html.erb
@@ -1,18 +1,8 @@
-<%= if @sample.errors.any?
-  viral_alert(
-    type: "alert",
-    classes: "mb-2",
-    message: I18n.t(:"general.form.error_notification"),
-    aria: {
-      live: "assertive",
-    },
-  )
-end %>
-
 <%= form_with(model: @sample, url: sample_metadata_path(@sample), method: :patch, html: { novalidate: true } )do |form| %>
   <% if @sample.errors[:base].any? %>
     <%= turbo_frame_tag "update-alert" %>
   <% end %>
+  <%= form_error_summary(form, target_overrides: { key: "sample_update_field_key_input", value: "sample_update_field_value_input" }, classes: "mb-2") %>
   <div class="grid gap-4">
     <%= render partial: "shared/form/required_field_legend" %>
     <%= form.fields_for :update_field do |field| %>
@@ -32,14 +22,13 @@ end %>
             <% key_aria_attributes[:describedby] = form.field_id(:key, "error") %>
           <% end %>
 
-          <%= metadata_key.text_field key,
-                                  id: "sample_update_field_key_input",
-                                  value: key,
-                                  required: true,
-                                  aria: key_aria_attributes,
-                                  autofocus: invalid_key,
-                                  class:
-                                    "block w-full mb-2 text-xs text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400" %>
+           <%= metadata_key.text_field key,
+                                   id: "sample_update_field_key_input",
+                                   value: key,
+                                   required: true,
+                                   aria: key_aria_attributes,
+                                   class:
+                                     "block w-full mb-2 text-xs text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400" %>
 
           <%= if invalid_key
             render "shared/form/field_errors",
@@ -63,14 +52,13 @@ end %>
           <% if invalid_value %>
             <% value_aria_attributes[:describedby] = form.field_id(:value, "error") %>
           <% end %>
-          <%= metadata_value.text_field value,
-                                    id: "sample_update_field_value_input",
-                                    value: value,
-                                    required: true,
-                                    aria: value_aria_attributes,
-                                    autofocus: invalid_value,
-                                    class:
-                                      "block w-full mb-2 text-xs text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400" %>
+           <%= metadata_value.text_field value,
+                                     id: "sample_update_field_value_input",
+                                     value: value,
+                                     required: true,
+                                     aria: value_aria_attributes,
+                                     class:
+                                       "block w-full mb-2 text-xs text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400" %>
 
           <%= if invalid_value
             render "shared/form/field_errors",

--- a/app/views/projects/samples/metadata/_update_form.html.erb
+++ b/app/views/projects/samples/metadata/_update_form.html.erb
@@ -2,13 +2,17 @@
   <% if @sample.errors[:base].any? %>
     <%= turbo_frame_tag "update-alert" %>
   <% end %>
+
   <%= form_error_summary(form, target_overrides: { key: "sample_update_field_key_input", value: "sample_update_field_value_input" }, classes: "mb-2") %>
+
   <div class="grid gap-4">
     <%= render partial: "shared/form/required_field_legend" %>
+
     <%= form.fields_for :update_field do |field| %>
       <%= field.fields_for :key do |metadata_key| %>
         <% invalid_key = @sample.errors.include?(:key) %>
         <% key_aria_attributes = { invalid: invalid_key, required: true } %>
+
         <div class="form-field <%= 'invalid' if invalid_key %>">
           <%= metadata_key.label "input",
                              t("projects.samples.show.metadata.update.key"),
@@ -22,7 +26,7 @@
             <% key_aria_attributes[:describedby] = form.field_id(:key, "error") %>
           <% end %>
 
-           <%= metadata_key.text_field key,
+          <%= metadata_key.text_field key,
                                    id: "sample_update_field_key_input",
                                    value: key,
                                    required: true,
@@ -37,9 +41,11 @@
           end %>
         </div>
       <% end %>
+
       <%= field.fields_for :value do |metadata_value| %>
         <% invalid_value = @sample.errors.include?(:value) %>
         <% value_aria_attributes = { invalid: invalid_value, required: true } %>
+
         <div class="form-field <%= 'invalid' if invalid_value %>">
           <%= metadata_value.label "input",
                                t("projects.samples.show.metadata.update.value"),
@@ -52,7 +58,8 @@
           <% if invalid_value %>
             <% value_aria_attributes[:describedby] = form.field_id(:value, "error") %>
           <% end %>
-           <%= metadata_value.text_field value,
+
+          <%= metadata_value.text_field value,
                                      id: "sample_update_field_value_input",
                                      value: value,
                                      required: true,

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -60,6 +60,28 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     assert_selector '.alert-component#custom-summary[data-testid="form-summary"][aria-label="Form error summary"]'
   end
 
+  test 'component can limit rendered entries with include argument' do
+    entries = [
+      FormErrorSummaryEntryBuilder::Entry.new(
+        attribute: :name,
+        message: "Name can't be blank",
+        target_id: 'project_name'
+      ),
+      FormErrorSummaryEntryBuilder::Entry.new(
+        attribute: :path,
+        message: "Path can't be blank",
+        target_id: 'project_path'
+      )
+    ]
+
+    render_inline(FormErrorSummaryComponent.new(entries:, include: %i[path]))
+
+    assert_selector 'a[href="#project_path"]', text: "Path can't be blank"
+    assert_no_selector 'a[href="#project_name"]'
+    assert_selector 'h2',
+                    text: I18n.t('general.form.error_summary.title', count: 1)
+  end
+
   test 'entry builder derives nested builder target ids' do
     namespace = Namespaces::ProjectNamespace.new
     namespace.errors.add(:path, :taken)


### PR DESCRIPTION
## What does this PR do and why?
This updates the project edit forms and the sample edit forms to use the reusable error summary that was added in the earlier form summary work. We need this so these pages handle validation errors the same way and move focus to one clear summary instead of jumping straight to an invalid field.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2073" height="764" alt="image" src="https://github.com/user-attachments/assets/7be1fd98-4e8b-4a18-b46e-12c5bd35ced6" />

## How to set up and validate locally
1. Check out `feat/form-error-summary-project-pages`, run `bin/dev`, and sign in.
2. Open a project edit page, for example `/-/groups/INXT_GRP_AAAAAAAAAA/projects/project1/edit`, and submit the name/description form with invalid data. Confirm the error summary appears at the top of the form, receives focus, and its links move focus to the matching input.
3. On the same project edit screen, open the advanced path form and submit an invalid path. Confirm the summary appears in that card, receives focus, and keeps the inline field error and hint text in place.
4. Open a sample create or edit page, submit invalid name or description data, and confirm the summary appears above the form instead of focusing the invalid field first.
5. Open a sample metadata edit dialog, clear either the key or value, submit, and confirm the summary appears above the dialog form and the summary links move focus to `sample_update_field_key_input` or `sample_update_field_value_input`.
6. Run `PARALLEL_WORKERS=4 bin/rails test test/system/projects_test.rb test/system/projects/samples/metadata_test.rb` and confirm the relevant project and sample flows stay green.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
