### PR TITLE
Use form error summary in member invite modals

### DIFF
--- a/app/views/groups/members/_form.html.erb
+++ b/app/views/groups/members/_form.html.erb
@@ -9,10 +9,12 @@
     { controller: "select2--v1" }
   end, method: :post, html: { novalidate: true }) do |form| %>
   <% form_id = "group-add-member-select2" %>
+
   <div class="grid gap-4">
     <%= form_error_summary(form, target_overrides: { user: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
+
     <% invalid_user_id = @new_member.errors.include?(:user) %>
 
     <div class="form-field <%= 'invalid' if invalid_user_id %>">

--- a/app/views/groups/members/_form.html.erb
+++ b/app/views/groups/members/_form.html.erb
@@ -9,9 +9,13 @@
     { controller: "select2--v1" }
   end, method: :post, html: { novalidate: true }) do |form| %>
   <% form_id = "group-add-member-select2" %>
+  <% expires_at_input_id = "#{form.field_id(:expires_at)}-input" %>
 
   <div class="grid gap-4">
-    <%= form_error_summary(form, target_overrides: { user: form_id, user_id: form_id }) %>
+    <%= form_error_summary(
+      form,
+      target_overrides: { user: form_id, user_id: form_id, expires_at: expires_at_input_id }
+    ) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/groups/members/_form.html.erb
+++ b/app/views/groups/members/_form.html.erb
@@ -11,11 +11,11 @@
   <% form_id = "group-add-member-select2" %>
 
   <div class="grid gap-4">
-    <%= form_error_summary(form, target_overrides: { user: form_id }) %>
+    <%= form_error_summary(form, target_overrides: { user: form_id, user_id: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
 
-    <% invalid_user_id = @new_member.errors.include?(:user) %>
+    <% invalid_user_id = @new_member.errors.include?(:user) || @new_member.errors.include?(:user_id) %>
 
     <div class="form-field <%= 'invalid' if invalid_user_id %>">
       <%= form.label :user_id, t("groups.members.new.user_select"),

--- a/app/views/groups/members/_form.html.erb
+++ b/app/views/groups/members/_form.html.erb
@@ -8,23 +8,14 @@
   else
     { controller: "select2--v1" }
   end, method: :post, html: { novalidate: true }) do |form| %>
+  <% form_id = "group-add-member-select2" %>
   <div class="grid gap-4">
-    <%= if @new_member.errors.any?
-      viral_alert(
-        type: "alert",
-        message: I18n.t(:"general.form.error_notification"),
-        aria: {
-          live: "assertive",
-        },
-      )
-    end %>
+    <%= form_error_summary(form, target_overrides: { user: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
     <% invalid_user_id = @new_member.errors.include?(:user) %>
 
     <div class="form-field <%= 'invalid' if invalid_user_id %>">
-      <% form_id = "group-add-member-select2" %>
-
       <%= form.label :user_id, t("groups.members.new.user_select"),
                      for: form_id,
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
@@ -82,7 +73,6 @@
                       invalid: invalid_access_level,
                       required: true,
                     },
-                    autofocus: invalid_access_level,
                     value: @new_member.access_level,
                   } %>
 

--- a/app/views/projects/members/_form.html.erb
+++ b/app/views/projects/members/_form.html.erb
@@ -11,11 +11,11 @@
   <% form_id = "add-user-select2" %>
 
   <div class="grid gap-4">
-    <%= form_error_summary(form, target_overrides: { user: form_id }) %>
+    <%= form_error_summary(form, target_overrides: { user: form_id, user_id: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
 
-    <% invalid_user_id = @new_member.errors.include?(:user) %>
+    <% invalid_user_id = @new_member.errors.include?(:user) || @new_member.errors.include?(:user_id) %>
 
     <div class="form-field <%= 'invalid' if invalid_user_id %>">
       <%= form.label :user_id, t("projects.members.new.user_select"),

--- a/app/views/projects/members/_form.html.erb
+++ b/app/views/projects/members/_form.html.erb
@@ -9,9 +9,13 @@
     { controller: "select2--v1" }
   end, method: :post,  html: { novalidate: true }) do |form| %>
   <% form_id = "add-user-select2" %>
+  <% expires_at_input_id = "#{form.field_id(:expires_at)}-input" %>
 
   <div class="grid gap-4">
-    <%= form_error_summary(form, target_overrides: { user: form_id, user_id: form_id }) %>
+    <%= form_error_summary(
+      form,
+      target_overrides: { user: form_id, user_id: form_id, expires_at: expires_at_input_id }
+    ) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/projects/members/_form.html.erb
+++ b/app/views/projects/members/_form.html.erb
@@ -9,10 +9,12 @@
     { controller: "select2--v1" }
   end, method: :post,  html: { novalidate: true }) do |form| %>
   <% form_id = "add-user-select2" %>
+
   <div class="grid gap-4">
     <%= form_error_summary(form, target_overrides: { user: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
+
     <% invalid_user_id = @new_member.errors.include?(:user) %>
 
     <div class="form-field <%= 'invalid' if invalid_user_id %>">

--- a/app/views/projects/members/_form.html.erb
+++ b/app/views/projects/members/_form.html.erb
@@ -8,23 +8,14 @@
   else
     { controller: "select2--v1" }
   end, method: :post,  html: { novalidate: true }) do |form| %>
+  <% form_id = "add-user-select2" %>
   <div class="grid gap-4">
-    <%= if @new_member.errors.any?
-      viral_alert(
-        type: "alert",
-        message: I18n.t(:"general.form.error_notification"),
-        aria: {
-          live: "assertive",
-        },
-      )
-    end %>
+    <%= form_error_summary(form, target_overrides: { user: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
     <% invalid_user_id = @new_member.errors.include?(:user) %>
 
     <div class="form-field <%= 'invalid' if invalid_user_id %>">
-      <% form_id = "add-user-select2" %>
-
       <%= form.label :user_id, t("projects.members.new.user_select"),
                      for: form_id,
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
@@ -82,7 +73,6 @@
                       invalid: invalid_access_level,
                       required: true,
                     },
-                    autofocus: invalid_access_level,
                     value: @new_member.access_level,
                   } %>
 

--- a/test/system/groups/members_test.rb
+++ b/test/system/groups/members_test.rb
@@ -126,6 +126,31 @@ module Groups
       assert_not_nil find(:table_row, { 'Username' => user_to_add.email })
     end
 
+    test 'invalid member create focuses the summary and linked custom control' do
+      visit group_members_path(@namespace)
+
+      click_button I18n.t(:'groups.members.index.add')
+
+      error_message = I18n.t(:'errors.format',
+                             attribute: Member.human_attribute_name(:user),
+                             message: I18n.t(:'errors.messages.blank'))
+
+      within('dialog') do
+        find('#member_access_level').find('option',
+                                          text: I18n.t('activerecord.models.member.access_level.analyst')).select_option
+        click_button I18n.t(:'groups.members.new.add_member_to_group')
+
+        assert_text error_message
+        assert_selector '[data-controller="form-error-summary"]', focused: true
+
+        within '[data-controller="form-error-summary"]' do
+          click_link error_message
+        end
+
+        assert_selector '#group-add-member-select2', focused: true
+      end
+    end
+
     test 'can remove a member from the group' do
       visit group_members_path(@namespace)
 

--- a/test/system/groups/members_test.rb
+++ b/test/system/groups/members_test.rb
@@ -107,7 +107,7 @@ module Groups
 
       click_button I18n.t(:'groups.members.index.add')
 
-      within('dialog') do
+      within('#new-member-dialog') do
         assert_selector 'h1', text: I18n.t(:'groups.members.new.title')
         find('input.select2-input').click
         find("li[data-label='#{user_to_add.email}']").click
@@ -132,13 +132,15 @@ module Groups
       click_button I18n.t(:'groups.members.index.add')
 
       error_message = I18n.t(:'errors.format',
-                             attribute: Member.human_attribute_name(:user),
-                             message: I18n.t(:'errors.messages.blank'))
+                             attribute: Member.human_attribute_name(:user_id),
+                             message: I18n.t(:'errors.messages.required'))
 
-      within('dialog') do
+      within('#new-member-dialog') do
         find('#member_access_level').find('option',
                                           text: I18n.t('activerecord.models.member.access_level.analyst')).select_option
-        click_button I18n.t(:'groups.members.new.add_member_to_group')
+        page.execute_script(
+          "document.querySelector('#new-member-dialog form').requestSubmit()"
+        )
 
         assert_text error_message
         assert_selector '[data-controller="form-error-summary"]', focused: true
@@ -308,7 +310,7 @@ module Groups
 
       click_button I18n.t(:'groups.members.index.add')
 
-      within('dialog') do
+      within('#new-member-dialog') do
         assert_selector 'h1', text: I18n.t(:'groups.members.new.title')
         find('input.select2-input').click
         find("li[data-label='#{user_to_add.email}']").click
@@ -339,7 +341,7 @@ module Groups
 
       click_button I18n.t(:'groups.members.index.add')
 
-      within('dialog') do
+      within('#new-member-dialog') do
         assert_selector 'h1', text: I18n.t(:'groups.members.new.title')
 
         find('input.select2-input').click


### PR DESCRIPTION
## What does this PR do and why?
This updates the group and project member invite dialogs to use the shared form error summary and link the user error back to the Select2 picker. We need this so invite errors are easier to notice and keyboard focus lands on the right control when the form fails.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2073" height="923" alt="image" src="https://github.com/user-attachments/assets/ca60e256-6d60-40a3-9628-a07e89c8483a" />

## How to set up and validate locally
1. Start the app with `bin/dev`.
2. Open a group members page, click **Add member**, choose an access level without choosing a user, and submit the form.
3. Confirm the error summary appears, focus moves to the summary, and clicking the user error in the summary moves focus to the Select2 user picker instead of a hidden control.
4. Repeat the same check on a project members page and confirm the project invite dialog shows the same summary behavior.
5. Run `PARALLEL_WORKERS=4 bin/rails test test/system/groups/members_test.rb` to cover the group modal focus flow.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
