### PR TITLE
Add form error summary to group link share modals

### DIFF
--- a/app/views/groups/group_links/_form.html.erb
+++ b/app/views/groups/group_links/_form.html.erb
@@ -14,10 +14,12 @@ if Flipper.enabled?(:v2_select2, Current.user)
     { controller: "select2--v1" }
   end, html: { novalidate: true }) do |form| %>
   <% form_id = "invite-group-select2" %>
+
   <div class="grid gap-4">
     <%= form_error_summary(form, target_overrides: { group_id: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
+
     <% invalid_group_id = new_group_link.errors.include?(:group_id) %>
 
     <div class="form-field <%= 'invalid' if invalid_group_id %>">

--- a/app/views/groups/group_links/_form.html.erb
+++ b/app/views/groups/group_links/_form.html.erb
@@ -14,9 +14,13 @@ if Flipper.enabled?(:v2_select2, Current.user)
     { controller: "select2--v1" }
   end, html: { novalidate: true }) do |form| %>
   <% form_id = "invite-group-select2" %>
+  <% expires_at_input_id = "#{form.field_id(:expires_at)}-input" %>
 
   <div class="grid gap-4">
-    <%= form_error_summary(form, target_overrides: { group_id: form_id }) %>
+    <%= form_error_summary(
+      form,
+      target_overrides: { group_id: form_id, expires_at: expires_at_input_id }
+    ) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/groups/group_links/_form.html.erb
+++ b/app/views/groups/group_links/_form.html.erb
@@ -13,23 +13,14 @@ if Flipper.enabled?(:v2_select2, Current.user)
   else
     { controller: "select2--v1" }
   end, html: { novalidate: true }) do |form| %>
+  <% form_id = "invite-group-select2" %>
   <div class="grid gap-4">
-    <%= if new_group_link.errors.any?
-      viral_alert(
-        type: "alert",
-        message: I18n.t(:"general.form.error_notification"),
-        aria: {
-          live: "assertive",
-        },
-      )
-    end %>
+    <%= form_error_summary(form, target_overrides: { group_id: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
     <% invalid_group_id = new_group_link.errors.include?(:group_id) %>
 
     <div class="form-field <%= 'invalid' if invalid_group_id %>">
-      <% form_id = "invite-group-select2" %>
-
       <%= form.label :group_id, t("groups.group_links.new.label.group_id"),
                      for: form_id,
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
@@ -94,8 +85,7 @@ if Flipper.enabled?(:v2_select2, Current.user)
                       ].join(" "),
                       invalid: invalid_group_access_level,
                       required: true,
-                    },
-                    autofocus: invalid_group_access_level,
+                     },
                     value: new_group_link.group_access_level,
                   } %>
 

--- a/app/views/projects/group_links/_form.html.erb
+++ b/app/views/projects/group_links/_form.html.erb
@@ -14,9 +14,13 @@ if Flipper.enabled?(:v2_select2, Current.user)
     { remote: true, controller: "select2--v1" }
   end, html: { novalidate: true }) do |form| %>
   <% form_id = "share_group_id_input" %>
+  <% expires_at_input_id = "#{form.field_id(:expires_at)}-input" %>
 
   <div class="grid gap-4">
-    <%= form_error_summary(form, target_overrides: { group_id: form_id }) %>
+    <%= form_error_summary(
+      form,
+      target_overrides: { group_id: form_id, expires_at: expires_at_input_id }
+    ) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/projects/group_links/_form.html.erb
+++ b/app/views/projects/group_links/_form.html.erb
@@ -14,10 +14,12 @@ if Flipper.enabled?(:v2_select2, Current.user)
     { remote: true, controller: "select2--v1" }
   end, html: { novalidate: true }) do |form| %>
   <% form_id = "share_group_id_input" %>
+
   <div class="grid gap-4">
     <%= form_error_summary(form, target_overrides: { group_id: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
+
     <% invalid_group_id = new_group_link.errors.include?(:group_id) %>
 
     <div class="form-field <%= 'invalid' if invalid_group_id %>">

--- a/app/views/projects/group_links/_form.html.erb
+++ b/app/views/projects/group_links/_form.html.erb
@@ -13,23 +13,14 @@ if Flipper.enabled?(:v2_select2, Current.user)
   else
     { remote: true, controller: "select2--v1" }
   end, html: { novalidate: true }) do |form| %>
+  <% form_id = "share_group_id_input" %>
   <div class="grid gap-4">
-    <%= if new_group_link.errors.any?
-      viral_alert(
-        type: "alert",
-        message: I18n.t(:"general.form.error_notification"),
-        aria: {
-          live: "assertive",
-        },
-      )
-    end %>
+    <%= form_error_summary(form, target_overrides: { group_id: form_id }) %>
 
     <%= render partial: "shared/form/required_field_legend" %>
     <% invalid_group_id = new_group_link.errors.include?(:group_id) %>
 
     <div class="form-field <%= 'invalid' if invalid_group_id %>">
-      <% form_id = "share_group_id_input" %>
-
       <%= form.label :group_id, t("projects.group_links.new.label.shared_group"),
                      for: form_id,
                      class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
@@ -97,12 +88,11 @@ if Flipper.enabled?(:v2_select2, Current.user)
                       invalid: invalid_group_access_level,
                       required: true,
                     },
-                    data: {
-                      placeholder: I18n.t('common.actions.select'),
-                    },
-                    autofocus: invalid_group_access_level,
-                    value: new_group_link.group_access_level,
-                  } %>
+                     data: {
+                       placeholder: I18n.t('common.actions.select'),
+                     },
+                     value: new_group_link.group_access_level,
+                   } %>
 
       <% if invalid_group_access_level %>
         <%= render "shared/form/field_errors",


### PR DESCRIPTION
## What does this PR do and why?
This updates the group and project sharing modals to show the shared form error summary when validation fails. We need this so people can see all errors in one place and jump to the right field, including the group picker.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2073" height="923" alt="image" src="https://github.com/user-attachments/assets/a7401aca-07e7-4445-963e-417f0bc74bd3" />

## How to set up and validate locally
1. Start the app with `bin/dev`.
2. Sign in as a user who can manage sharing, open a group members page, switch to the **Groups** tab, and click **Invite group**.
3. Submit the modal with required fields missing and confirm an error summary appears at the top, the summary gets focus, and clicking the group-related error moves focus to the group select control.
4. Repeat the same check from a project members page on the **Groups** tab using the project share modal, and confirm the summary links to the custom group picker target there as well.
5. Run `bin/rails test test/system/groups/group_links_test.rb test/system/projects/group_links_test.rb test/components/form_error_summary_component_test.rb test/components/system/form_error_summary_component_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
