### PR TITLE
Add form error summary to profile forms

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,12 +131,11 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def build_namespace_path
-    format('%<email>s', email:).sub('@', '_at_')
+    format('%<email>s', email:).sub! '@', '_at_'
   end
 
   def ensure_namespace
     return unless human?
-    return unless email.present? && email.match?(Devise.email_regexp)
 
     if namespace
       namespace.path = build_namespace_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,11 +131,12 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def build_namespace_path
-    format('%<email>s', email:).sub! '@', '_at_'
+    format('%<email>s', email:).sub('@', '_at_')
   end
 
   def ensure_namespace
     return unless human?
+    return unless email.present? && email.match?(Devise.email_regexp)
 
     if namespace
       namespace.path = build_namespace_path

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,15 +1,5 @@
 <%= form_with(model: user, url: profile_path, method: :patch, html: { novalidate: true }) do |f| %>
-
-  <%= if user.errors.any?
-    viral_alert(
-      type: "alert",
-      message: I18n.t(:"general.form.error_notification"),
-      aria: {
-        live: "assertive",
-      },
-      classes: "mb-2",
-    )
-  end %>
+  <%= form_error_summary(f, classes: "mb-2") %>
 
   <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: user, url: profile_path, method: :patch, html: { novalidate: true }) do |f| %>
-  <%= form_error_summary(f, classes: "mb-2", include: [:email]) %>
+  <%= form_error_summary(f, classes: "mb-2", include: [:email, :first_name, :last_name]) %>
 
   <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -4,8 +4,10 @@
   <%= render partial: "shared/form/required_field_legend" %>
 
   <% invalid_email = user.errors.include?(:email) %>
-  <div class="form-field <%= 'invalid' if invalid_email %> mt-2">
+
+  <div class="form-field mt-2 <%= 'invalid' if invalid_email %>">
     <%= f.label :email, t(:"profiles.show.email_address"), data: { required: true } %>
+
     <%= f.email_field :email,
                   required: true,
                   autocomplete: "email",
@@ -14,16 +16,20 @@
                     invalid: invalid_email,
                     required: true,
                   } %>
+
     <%= if invalid_email
       render "shared/form/field_errors",
       id: f.field_id(:email, "error"),
       errors: user.errors.full_messages_for(:email)
     end %>
   </div>
-  <br/>
+
+  <br>
   <% invalid_fn = user.errors.include?(:first_name) %>
+
   <div class="form-field <%= 'invalid' if invalid_fn %>">
     <%= f.label :first_name, t(:"profiles.show.first_name"), data: { required: true } %>
+
     <%= f.text_field :first_name,
                  required: true,
                  autocomplete: "given-name",
@@ -32,16 +38,20 @@
                    invalid: invalid_fn,
                    required: true,
                  } %>
+
     <%= if invalid_fn
       render "shared/form/field_errors",
       id: f.field_id(:first_name, "error"),
       errors: user.errors.full_messages_for(:first_name)
     end %>
   </div>
-  <br/>
+
+  <br>
   <% invalid_ln = user.errors.include?(:last_name) %>
+
   <div class="form-field <%= 'invalid' if invalid_ln %>">
     <%= f.label :last_name, t(:"profiles.show.last_name"), data: { required: true } %>
+
     <%= f.text_field :last_name,
                  required: true,
                  autocomplete: "family-name",
@@ -50,13 +60,16 @@
                    invalid: invalid_ln,
                    required: true,
                  } %>
+
     <%= if invalid_ln
       render "shared/form/field_errors",
       id: f.field_id(:last_name, "error"),
       errors: user.errors.full_messages_for(:last_name)
     end %>
   </div>
-  <br/>
+
+  <br>
+
   <div class="my-2">
     <%= f.submit t(:"profiles.show.email.submit"), class: "button button-primary" %>
   </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: user, url: profile_path, method: :patch, html: { novalidate: true }) do |f| %>
-  <%= form_error_summary(f, classes: "mb-2") %>
+  <%= form_error_summary(f, classes: "mb-2", include: [:email]) %>
 
   <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/profiles/passwords/_form.html.erb
+++ b/app/views/profiles/passwords/_form.html.erb
@@ -7,12 +7,15 @@
   <div class="mb-4">
     <%= render partial: "shared/form/required_field_legend" %>
   </div>
+
   <%= form_with(model: user, url: profile_password_path, method: :patch, html: {class: "space-y-4", novalidate: true}) do |form| %>
     <%= form_error_summary(form) %>
 
     <% invalid_current = user.errors.include?(:current_password) %>
+
     <div class="form-field <%= 'invalid' if invalid_current %>">
       <%= form.label :current_password, data: { required: true } %>
+
       <%= form.password_field :current_password,
                           required: true,
                           aria: {
@@ -30,15 +33,21 @@
                             required: true,
                           },
                           autocomplete: "current-password" %>
+
       <%= render "shared/form/field_errors",
       id: form.field_id(:current_password, "error"),
       errors: user.errors.full_messages_for(:current_password) %>
-      <p id="<%= form.field_id(:current_password, "hint") %>" class="field-hint"><%= t :"profiles.passwords.update.hint" %></p>
+
+      <p id="<%= form.field_id(:current_password, "hint") %>" class="field-hint">
+        <%= t :"profiles.passwords.update.hint" %>
+      </p>
     </div>
 
     <% invalid_password = user.errors.include?(:password) %>
+
     <div class="form-field <%= 'invalid' if invalid_password %>">
       <%= form.label :password, data: { required: true } %>
+
       <%= form.password_field :password,
                           required: true,
                           aria: {
@@ -56,6 +65,7 @@
                             required: true,
                           },
                           autocomplete: "new-password" %>
+
       <% if @minimum_password_length %>
         <p id="<%= form.field_id(:password, "hint") %>" class="field-hint">
           <%= t(
@@ -64,14 +74,17 @@
           ) %>
         </p>
       <% end %>
+
       <%= render "shared/form/field_errors",
       id: form.field_id(:password, "error"),
       errors: user.errors.full_messages_for(:password) %>
     </div>
 
     <% invalid_password_confirmation = user.errors.include?(:password_confirmation) %>
+
     <div class="form-field mt-2 <%= 'invalid' if invalid_password_confirmation %>">
       <%= form.label :password_confirmation, data: { required: true } %>
+
       <%= form.password_field :password_confirmation,
                           required: true,
                           aria: {
@@ -87,16 +100,21 @@
                             required: true,
                           },
                           autocomplete: "new-password" %>
+
       <%= render "shared/form/field_errors",
       id: form.field_id(:password_confirmation, "error"),
       errors: user.errors.full_messages_for(:password_confirmation) %>
     </div>
-    <div class="flex items-center justify-between my-2">
+
+    <div class="my-2 flex items-center justify-between">
       <%= form.submit t(:"profiles.passwords.update.submit"),
                   class: "button button-primary" %>
-      <p class="field-hint"><%= link_to t("profiles.passwords.update.forgot"),
+
+      <p class="field-hint">
+        <%= link_to t("profiles.passwords.update.forgot"),
         profile_password_path(@user),
-        class: "link" %></p>
+        class: "link" %>
+      </p>
     </div>
   <% end %>
 </div>

--- a/app/views/profiles/passwords/_form.html.erb
+++ b/app/views/profiles/passwords/_form.html.erb
@@ -8,16 +8,7 @@
     <%= render partial: "shared/form/required_field_legend" %>
   </div>
   <%= form_with(model: user, url: profile_password_path, method: :patch, html: {class: "space-y-4", novalidate: true}) do |form| %>
-
-    <%= if user.errors.any?
-      viral_alert(
-        type: "alert",
-        message: I18n.t(:"general.form.error_notification"),
-        aria: {
-          live: "assertive",
-        },
-      )
-    end %>
+    <%= form_error_summary(form) %>
 
     <% invalid_current = user.errors.include?(:current_password) %>
     <div class="form-field <%= 'invalid' if invalid_current %>">
@@ -40,6 +31,7 @@
                           },
                           autocomplete: "current-password" %>
       <%= render "shared/form/field_errors",
+      id: form.field_id(:current_password, "error"),
       errors: user.errors.full_messages_for(:current_password) %>
       <p id="<%= form.field_id(:current_password, "hint") %>" class="field-hint"><%= t :"profiles.passwords.update.hint" %></p>
     </div>
@@ -73,6 +65,7 @@
         </p>
       <% end %>
       <%= render "shared/form/field_errors",
+      id: form.field_id(:password, "error"),
       errors: user.errors.full_messages_for(:password) %>
     </div>
 
@@ -95,6 +88,7 @@
                           },
                           autocomplete: "new-password" %>
       <%= render "shared/form/field_errors",
+      id: form.field_id(:password_confirmation, "error"),
       errors: user.errors.full_messages_for(:password_confirmation) %>
     </div>
     <div class="flex items-center justify-between my-2">

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -18,7 +18,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'should update namespace when email changes' do
-    @user.email = 'john.doe@example'
+    @user.email = 'john.doe@example.com'
     namespace_path_before = @user.namespace.path
     namespace_name_before = @user.namespace.name
     assert @user.save
@@ -51,6 +51,15 @@ class UserTest < ActiveSupport::TestCase
 
   test 'ensure_namespace with valid user with namespace' do
     assert_equal 'john.doe@localhost', @user.send(:ensure_namespace)
+  end
+
+  test 'invalid email should not add namespace errors' do
+    @user.email = 'not-an-email'
+
+    assert_not @user.valid?
+    assert @user.errors.include?(:email)
+    assert_not @user.errors.include?(:namespace_name)
+    assert_not @user.errors.include?(:namespace_path)
   end
 
   test 'ensure_namespace with bot' do


### PR DESCRIPTION
## What does this PR do and why?
This updates the profile details form and the profile password form to use the shared form error summary when validation fails. We need this so people can see all form errors in one place and jump to the field that needs fixing.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Profile Edit**
<img width="2073" height="923" alt="image" src="https://github.com/user-attachments/assets/6155a042-63c6-40f2-9925-cda88b3ea791" />

**Password Reset**
<img width="2073" height="923" alt="image" src="https://github.com/user-attachments/assets/6e5cbd3d-3c70-4596-8379-1ee05f6b18dd" />

## How to set up and validate locally
1. Start the app with `bin/dev` and sign in as a regular user.
2. Visit `/-/profile`, clear one or more required fields on the account form, submit, and confirm an error summary appears at the top and links to the invalid profile fields.
3. From the profile page, open the **Password** tab, submit invalid password values such as a blank new password or mismatched confirmation, and confirm the error summary appears and its links move focus to the related password fields.
4. Confirm the inline field errors still render under each invalid field on both forms, including current password, new password, and password confirmation.
5. Run `PARALLEL_WORKERS=4 bin/rails test test/system/profile_test.rb test/controllers/profiles_controller_test.rb test/controllers/profiles/passwords_controller_test.rb test/components/form_error_summary_component_test.rb test/components/system/form_error_summary_component_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
