### PR TITLE
Add form error summary to personal access token form

### DIFF
--- a/app/views/profiles/personal_access_tokens/_form.html.erb
+++ b/app/views/profiles/personal_access_tokens/_form.html.erb
@@ -1,16 +1,6 @@
 <%= turbo_frame_tag "personal_access_token_form" do %>
   <%= form_for(personal_access_token, url: profile_personal_access_tokens_path, html: { novalidate: true }) do |f| %>
     <div class="grid gap-4">
-      <%= if personal_access_token.errors.any?
-        viral_alert(
-          type: "alert",
-          message: I18n.t(:"general.form.error_notification"),
-          aria: {
-            live: "assertive",
-          },
-        )
-      end %>
-
       <%= render partial: "shared/form/required_field_legend" %>
 
       <%= render partial: "shared/personal_access_tokens/form_fields",

--- a/app/views/shared/personal_access_tokens/_form_fields.html.erb
+++ b/app/views/shared/personal_access_tokens/_form_fields.html.erb
@@ -1,5 +1,11 @@
 <%# locals: (pat:, form:) -%>
 
+<% first_scope = Irida::Auth.all_available_scopes.first&.to_s %>
+<% target_overrides = {} %>
+<% target_overrides[:scopes] = form.field_id(:scopes, first_scope) if first_scope.present? %>
+
+<%= form_error_summary(form, target_overrides:) %>
+
 <% invalid_token_name = pat.errors.include?(:name) %>
 
 <div class="form-field <%= 'invalid' if invalid_token_name %>">
@@ -8,19 +14,18 @@
   <%= form.text_field :name,
                   required: true,
                   class: "form-control",
-                  aria: {
-                    describedby:
-                      (
-                        if invalid_token_name
-                          form.field_id(:name, "error")
-                        else
-                          nil
-                        end
-                      ),
-                    invalid: invalid_token_name,
-                    required: true,
-                  },
-                  autofocus: invalid_token_name %>
+                   aria: {
+                     describedby:
+                       (
+                         if invalid_token_name
+                           form.field_id(:name, "error")
+                         else
+                           nil
+                         end
+                       ),
+                     invalid: invalid_token_name,
+                     required: true,
+                   } %>
 
   <% if invalid_token_name %>
     <%= render "shared/form/field_errors",

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -151,8 +151,8 @@ module Groups
       ### VERIFY START ###
       # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
       within('#bot_modal') do
-        assert_selector '[data-controller="form-error-summary"]'
-        within('[data-controller="form-error-summary"]') do
+        assert_selector '[data-controller="form-error-summary"]', match: :first
+        within(find('[data-controller="form-error-summary"]', match: :first)) do
           assert_text I18n.t(:'general.form.error_summary.title', count: 1)
           assert_text I18n.t(:'general.form.error_notification')
           assert_text I18n.t(:'errors.format',

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -152,12 +152,23 @@ class ProfileTest < ApplicationSystemTestCase
       fill_in 'Token name', with: 'my new token'
       click_button I18n.t(:'profiles.personal_access_tokens.create.submit')
     end
+
+    error_message = I18n.t(:'errors.format',
+                           attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
+                           message: I18n.t(:'errors.messages.blank'))
+
     assert_no_text 'my new token'
     assert_selector(:xpath, "//span[contains(@class, 'token-status')]",
                     count: @active_token_count)
-    assert_text I18n.t(:'errors.format',
-                       attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
-                       message: I18n.t(:'errors.messages.blank'))
+    assert_text error_message
+    assert_selector %(form[action="/-/profile/personal_access_tokens"] [data-controller="form-error-summary"]),
+                    focused: true
+
+    within %(form[action="/-/profile/personal_access_tokens"] [data-controller="form-error-summary"]) do
+      click_link error_message
+    end
+
+    assert_selector %(form[action="/-/profile/personal_access_tokens"] input[type="checkbox"]), focused: true
   end
 
   test 'can revoke personal access tokens' do

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -151,8 +151,8 @@ module Projects
       ### VERIFY START ###
       # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
       within('#bot_modal') do
-        assert_selector '[data-controller="form-error-summary"]'
-        within('[data-controller="form-error-summary"]') do
+        assert_selector '[data-controller="form-error-summary"]', match: :first
+        within(find('[data-controller="form-error-summary"]', match: :first)) do
           assert_text I18n.t(:'general.form.error_summary.title', count: 1)
           assert_text I18n.t(:'general.form.error_notification')
           assert_text I18n.t(:'errors.format',


### PR DESCRIPTION
## What does this PR do and why?
This updates the profile personal access token form to use the shared form error summary when validation fails. We need this so people can see the scopes error at the top of the form and jump straight to the checkbox group that needs fixing.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1902" height="856" alt="image" src="https://github.com/user-attachments/assets/c5757afc-3897-4d17-b5c6-c52b28d79850" />

## How to set up and validate locally
1. Start the app with `bin/dev` and sign in as a regular user.
2. Visit `/-/profile`, open the **Access tokens** tab, click **Add new token**, enter a token name, leave all scope checkboxes unchecked, and submit the form.
3. Confirm an error summary appears at the top of the token form, the summary gets focus after submit, and clicking the scopes error moves focus to the first scope checkbox.
4. Check one scope and submit again to confirm the token is created successfully and the failed validation state does not persist.
5. Run `PARALLEL_WORKERS=4 bin/rails test test/system/profile_test.rb test/controllers/profiles/personal_access_tokens_controller_test.rb test/components/system/form_error_summary_component_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
