### PR TITLE
Add form error summary to bot dialogs

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -286,6 +286,10 @@ input[type="search"] {
     @apply text-red-700 dark:text-red-400;
   }
 
+  &.form-field legend {
+    @apply text-red-700 dark:text-red-400;
+  }
+
   &.form-field select {
     @apply border-red-500 dark:border-red-400;
   }

--- a/app/components/form_error_summary_entry_builder.rb
+++ b/app/components/form_error_summary_entry_builder.rb
@@ -8,10 +8,11 @@ class FormErrorSummaryEntryBuilder
     end
   end
 
-  def initialize(builder:, errors: builder.object&.errors, target_overrides: {})
+  def initialize(builder:, errors: builder.object&.errors, target_overrides: {}, attribute_overrides: {})
     @builder = builder
     @errors = errors
     @target_overrides = target_overrides.to_h.transform_keys(&:to_s)
+    @attribute_overrides = attribute_overrides.to_h.transform_keys(&:to_s)
   end
 
   def call
@@ -20,7 +21,8 @@ class FormErrorSummaryEntryBuilder
     errors.attribute_names.uniq.filter_map do |attribute|
       next if attribute == :base
 
-      message = errors.full_messages_for(attribute).to_sentence
+      message = message_for(attribute)
+
       target_id = target_id_for(attribute)
       next if message.blank? || target_id.blank?
 
@@ -30,7 +32,21 @@ class FormErrorSummaryEntryBuilder
 
   private
 
-  attr_reader :builder, :errors, :target_overrides
+  attr_reader :builder, :errors, :target_overrides, :attribute_overrides
+
+  def message_for(attribute)
+    return errors.full_messages_for(attribute).to_sentence if attribute_overrides[attribute.to_s].blank?
+
+    errors[attribute].map do |error|
+      I18n.t(:'errors.format', attribute: attribute_name_for(attribute), message: error)
+    end.to_sentence
+  end
+
+  def attribute_name_for(attribute)
+    attribute_overrides[attribute.to_s].presence ||
+      builder.object&.class&.human_attribute_name(attribute) ||
+      attribute.to_s.humanize
+  end
 
   def target_id_for(attribute)
     target_overrides.fetch(attribute.to_s) do

--- a/app/helpers/form_error_summary_helper.rb
+++ b/app/helpers/form_error_summary_helper.rb
@@ -5,8 +5,12 @@ module FormErrorSummaryHelper
   # Place this near the top of a model-backed form.
   # When migrating an existing form, remove invalid-only autofocus from the target fields so the
   # summary remains the first focus target after a failed submit.
-  def form_error_summary(builder, target_overrides: {}, **system_arguments)
-    entries = FormErrorSummaryEntryBuilder.new(builder:, target_overrides:).call
+  def form_error_summary(builder, target_overrides: {}, attribute_overrides: {}, **system_arguments)
+    entries = FormErrorSummaryEntryBuilder.new(
+      builder:,
+      target_overrides:,
+      attribute_overrides:
+    ).call
     return if entries.blank?
 
     render FormErrorSummaryComponent.new(entries:, **system_arguments)

--- a/app/helpers/form_error_summary_helper.rb
+++ b/app/helpers/form_error_summary_helper.rb
@@ -5,11 +5,10 @@ module FormErrorSummaryHelper
   # Place this near the top of a model-backed form.
   # When migrating an existing form, remove invalid-only autofocus from the target fields so the
   # summary remains the first focus target after a failed submit.
-  def form_error_summary(builder, target_overrides: {}, attribute_overrides: {}, **system_arguments)
+  def form_error_summary(builder, target_overrides: {}, **system_arguments)
     entries = FormErrorSummaryEntryBuilder.new(
       builder:,
-      target_overrides:,
-      attribute_overrides:
+      target_overrides:
     ).call
     return if entries.blank?
 

--- a/app/javascript/controllers/form_error_summary_controller.js
+++ b/app/javascript/controllers/form_error_summary_controller.js
@@ -6,11 +6,59 @@ export default class extends Controller {
     focusWhenVisible(this.element);
   }
 
+  // Some inputs (e.g. datepicker v2, multi-checkbox attributes) don't have a 1:1
+  // mapping between an ActiveModel attribute and a single DOM id. This helper
+  // tries common conventions to find a focusable element for an error entry.
+  resolveTarget(targetId) {
+    if (!targetId) return null;
+
+    const direct = document.getElementById(targetId);
+    if (direct) return direct;
+
+    // Datepicker v2 renders the actual input as "#{id}-input".
+    const datepickerInput = document.getElementById(`${targetId}-input`);
+    if (datepickerInput) return datepickerInput;
+
+    // Multi-checkbox values typically render as "#{baseId}_<value>".
+    const esc =
+      window.CSS && typeof window.CSS.escape === "function"
+        ? window.CSS.escape
+        : (value) => String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+
+    const checkboxLike = document.querySelector(`[id^="${esc(targetId)}_"]`);
+    if (checkboxLike) return checkboxLike;
+
+    return null;
+  }
+
+  focusableElement(element) {
+    if (!element) return null;
+
+    // If it's already focusable, prefer it.
+    if (typeof element.focus === "function" && element.tabIndex >= 0)
+      return element;
+
+    // Otherwise focus the first focusable descendant.
+    const descendant = element.querySelector?.(
+      'input, select, textarea, button, a[href], [tabindex]:not([tabindex="-1"])',
+    );
+    if (descendant) return descendant;
+
+    // As a last resort, make it programmatically focusable.
+    if (typeof element.focus === "function") {
+      element.tabIndex = -1;
+      return element;
+    }
+
+    return null;
+  }
+
   focusField(event) {
     event.preventDefault();
 
     const targetId = event.params.targetId;
-    const target = targetId ? document.getElementById(targetId) : null;
+    const resolved = this.resolveTarget(targetId);
+    const target = this.focusableElement(resolved);
     if (!target) return;
 
     focusWhenVisible(target);

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -15,6 +15,7 @@ class PersonalAccessToken < ApplicationRecord
 
   validates :name, presence: true
   validates :scopes, presence: true
+  validates :expires_at, on: :create, date: true, if: -> { expires_at_before_type_cast.present? }
   validate :validate_scopes
 
   scope :active, -> { not_revoked.not_expired }

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Validator for date inputs. Currently evaluates expires_at for the member and group_link models
+# Validator for date inputs. Currently evaluates expires_at for member, group link, and personal access token models.
 class DateValidator < ActiveModel::EachValidator
   class DateValidatorError < StandardError
   end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -14,7 +14,8 @@ class DateValidator < ActiveModel::EachValidator
     raise DateValidatorError, I18n.t('common.date.errors.invalid_input') if value.nil?
 
     # validate if input matched our expected date input (YYYY-MM-DD)
-    unless expires_at_value.match?(/\A\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\z/)
+    if expires_at_value.is_a?(String) &&
+       !expires_at_value.match?(/\A\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\z/)
       raise DateValidatorError,
             I18n.t('common.date.errors.invalid_format')
     end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -8,16 +8,10 @@ class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return true unless attribute == :expires_at # currently only handles :expires_at
 
-    expires_at_value = record.read_attribute_before_type_cast(attribute) # grab input prior to it be casted as datetime
-
-    # validate if input match any valid date input (YYYY-MM-DD, DD-MM-YYYY, etc.)
-    raise DateValidatorError, I18n.t('common.date.errors.invalid_input') if value.nil?
-
-    # validate if input matched our expected date input (YYYY-MM-DD)
-    if expires_at_value.is_a?(String) &&
-       !expires_at_value.match?(/\A\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\z/)
-      raise DateValidatorError,
-            I18n.t('common.date.errors.invalid_format')
+    # Value is only present when the input can be coerced into a date.
+    if value.blank?
+      record.errors.add(:expires_at, I18n.t('common.date.errors.invalid_input'))
+      return false
     end
 
     # validate if date input is later than today's date

--- a/app/views/groups/bots/_bot_modal.html.erb
+++ b/app/views/groups/bots/_bot_modal.html.erb
@@ -65,6 +65,8 @@
               <%= t("groups.bots.index.bot_listing.new_bot_modal.token_details") %>
             </p>
 
+            <%= form_error_summary(pat_fields) %>
+
             <%= render partial: "shared/personal_access_tokens/form_fields",
             locals: {
               pat: @bot_account.user.personal_access_tokens[0],

--- a/app/views/groups/bots/_bot_modal.html.erb
+++ b/app/views/groups/bots/_bot_modal.html.erb
@@ -11,10 +11,12 @@
 
   <%= form_for(@bot_account, url: group_bots_path, method: :post, html: { novalidate: true }) do |form| %>
     <%= form.fields_for :user do |user_fields| %>
-      <div class="grid gap-4">
+      <% summary_entries = [] %>
+
+      <% members_fields = capture do %>
         <%= user_fields.fields_for :members do |member_fields| %>
+          <% summary_entries.concat(FormErrorSummaryEntryBuilder.new(builder: member_fields).call) %>
           <%= render partial: "shared/form/required_field_legend" %>
-          <%= form_error_summary(member_fields) %>
 
           <% invalid_access_level =
             @bot_account.user.members[0].errors.include?(:access_level) %>
@@ -53,8 +55,12 @@
             <% end %>
           </div>
         <% end %>
+      <% end %>
 
+      <% personal_access_token_fields = capture do %>
         <%= user_fields.fields_for :personal_access_tokens do |pat_fields| %>
+          <% summary_entries.concat(FormErrorSummaryEntryBuilder.new(builder: pat_fields).call) %>
+
           <div
             class="
               grid gap-4 rounded-lg border border-slate-200 bg-white p-6 shadow dark:border-slate-700
@@ -65,8 +71,6 @@
               <%= t("groups.bots.index.bot_listing.new_bot_modal.token_details") %>
             </p>
 
-            <%= form_error_summary(pat_fields) %>
-
             <%= render partial: "shared/personal_access_tokens/form_fields",
             locals: {
               pat: @bot_account.user.personal_access_tokens[0],
@@ -74,6 +78,13 @@
             } %>
           </div>
         <% end %>
+      <% end %>
+
+      <%= render FormErrorSummaryComponent.new(entries: summary_entries, attribute_overrides: { access_level: t("groups.bots.index.bot_listing.new_bot_modal.access_level") }) if summary_entries.any? %>
+
+      <div class="grid gap-4">
+        <%= members_fields %>
+        <%= personal_access_token_fields %>
       </div>
     <% end %>
 

--- a/app/views/groups/bots/_bot_modal.html.erb
+++ b/app/views/groups/bots/_bot_modal.html.erb
@@ -80,7 +80,7 @@
         <% end %>
       <% end %>
 
-      <%= render FormErrorSummaryComponent.new(entries: summary_entries, attribute_overrides: { access_level: t("groups.bots.index.bot_listing.new_bot_modal.access_level") }) if summary_entries.any? %>
+      <%= render FormErrorSummaryComponent.new(entries: summary_entries) if summary_entries.any? %>
 
       <div class="grid gap-4">
         <%= members_fields %>

--- a/app/views/groups/bots/_bot_modal.html.erb
+++ b/app/views/groups/bots/_bot_modal.html.erb
@@ -8,16 +8,12 @@
       <%= t("groups.bots.index.bot_listing.new_bot_modal.description") %>
     </p>
   </div>
-
-  <div class="mb-4">
-    <%= turbo_frame_tag("new_bot_account-error-alert") %>
-  </div>
-
   <%= form_for(@bot_account, url: group_bots_path, method: :post, html: { novalidate: true }) do |form| %>
     <%= form.fields_for :user do |user_fields| %>
       <div class="grid gap-4">
         <%= user_fields.fields_for :members do |member_fields| %>
           <%= render partial: "shared/form/required_field_legend" %>
+          <%= form_error_summary(member_fields) %>
           <% invalid_access_level =
             @bot_account.user.members[0].errors.include?(:access_level) %>
           <div class="form-field <%= 'invalid' if invalid_access_level %>">
@@ -32,20 +28,19 @@
                                  },
                                  {
                                    required: true,
-                                   aria: {
-                                     describedby:
-                                       (
-                                         if invalid_access_level
-                                           member_fields.field_id(:access_level, "error")
-                                         else
-                                           nil
-                                         end
-                                       ),
-                                     invalid: invalid_access_level,
-                                     required: true,
-                                   },
-                                   autofocus: invalid_access_level,
-                                 } %>
+                                    aria: {
+                                      describedby:
+                                        (
+                                          if invalid_access_level
+                                            member_fields.field_id(:access_level, "error")
+                                          else
+                                            nil
+                                          end
+                                        ),
+                                      invalid: invalid_access_level,
+                                      required: true,
+                                    },
+                                  } %>
             <% if invalid_access_level %>
               <%= render "shared/form/field_errors",
               id: member_fields.field_id(:access_level, "error"),

--- a/app/views/groups/bots/_bot_modal.html.erb
+++ b/app/views/groups/bots/_bot_modal.html.erb
@@ -8,16 +8,20 @@
       <%= t("groups.bots.index.bot_listing.new_bot_modal.description") %>
     </p>
   </div>
+
   <%= form_for(@bot_account, url: group_bots_path, method: :post, html: { novalidate: true }) do |form| %>
     <%= form.fields_for :user do |user_fields| %>
       <div class="grid gap-4">
         <%= user_fields.fields_for :members do |member_fields| %>
           <%= render partial: "shared/form/required_field_legend" %>
           <%= form_error_summary(member_fields) %>
+
           <% invalid_access_level =
             @bot_account.user.members[0].errors.include?(:access_level) %>
+
           <div class="form-field <%= 'invalid' if invalid_access_level %>">
             <%= member_fields.label :access_level, data: { required: true } %>
+
             <%= member_fields.select :access_level,
                                  @access_levels,
                                  {
@@ -41,6 +45,7 @@
                                       required: true,
                                     },
                                   } %>
+
             <% if invalid_access_level %>
               <%= render "shared/form/field_errors",
               id: member_fields.field_id(:access_level, "error"),
@@ -52,11 +57,13 @@
         <%= user_fields.fields_for :personal_access_tokens do |pat_fields| %>
           <div
             class="
-              grid gap-4 p-6 bg-white border rounded-lg shadow border-slate-200
-              dark:bg-slate-800 dark:border-slate-700
+              grid gap-4 rounded-lg border border-slate-200 bg-white p-6 shadow dark:border-slate-700
+              dark:bg-slate-800
             "
           >
-            <p class="font-semibold dark:text-white"><%= t("groups.bots.index.bot_listing.new_bot_modal.token_details") %></p>
+            <p class="font-semibold dark:text-white">
+              <%= t("groups.bots.index.bot_listing.new_bot_modal.token_details") %>
+            </p>
 
             <%= render partial: "shared/personal_access_tokens/form_fields",
             locals: {
@@ -67,13 +74,11 @@
         <% end %>
       </div>
     <% end %>
+
     <div class="mt-4">
       <%= form.submit t('common.controls.submit'), class: "button button-primary" %>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="click->viral--dialog#close"
-      >
+
+      <button type="button" class="button button-default" data-action="click->viral--dialog#close">
         <%= t('common.actions.cancel') %>
       </button>
     </div>

--- a/app/views/groups/bots/create.turbo_stream.erb
+++ b/app/views/groups/bots/create.turbo_stream.erb
@@ -4,7 +4,6 @@
                       open: @bot_account.invalid?,
                       bot_account: @bot_account,
                     } %>
-<%= turbo_stream.update "new_bot_account-error-alert", viral_alert(type:, message:) %>
 <% if @bot_account.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>

--- a/app/views/groups/bots/create.turbo_stream.erb
+++ b/app/views/groups/bots/create.turbo_stream.erb
@@ -4,6 +4,7 @@
                       open: @bot_account.invalid?,
                       bot_account: @bot_account,
                     } %>
+
 <% if @bot_account.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>

--- a/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -5,6 +5,7 @@
         "groups.bots.index.bot_listing.generate_personal_access_token_modal.title",
       ),
   ) %>
+
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= t(
@@ -13,22 +14,22 @@
       ) %>
     </p>
   </div>
+
   <%= form_for(@personal_access_token, url: group_bot_personal_access_tokens_path, method: :post, html: { novalidate: true}) do |form| %>
     <div class="grid gap-4">
       <%= render partial: "shared/form/required_field_legend" %>
+
       <%= render partial: "shared/personal_access_tokens/form_fields",
       locals: {
         pat: @personal_access_token,
         form: form,
       } %>
     </div>
+
     <div class="mt-4">
       <%= form.submit t('common.controls.submit'), class: "button button-primary" %>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="click->viral--dialog#close"
-      >
+
+      <button type="button" class="button button-default" data-action="click->viral--dialog#close">
         <%= t('common.actions.cancel') %>
       </button>
     </div>

--- a/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -13,11 +13,6 @@
       ) %>
     </p>
   </div>
-
-  <div class="mb-4">
-    <%= turbo_frame_tag("personal-access-token-error-alert") %>
-  </div>
-
   <%= form_for(@personal_access_token, url: group_bot_personal_access_tokens_path, method: :post, html: { novalidate: true}) do |form| %>
     <div class="grid gap-4">
       <%= render partial: "shared/form/required_field_legend" %>

--- a/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
@@ -4,8 +4,6 @@
                       open: @personal_access_token.errors.any?,
                       personal_access_token: @personal_access_token,
                     } %>
-<%= turbo_stream.update "personal-access-token-error-alert",
-                    viral_alert(type:, message:) %>
 <% if @personal_access_token.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>

--- a/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
@@ -4,6 +4,7 @@
                       open: @personal_access_token.errors.any?,
                       personal_access_token: @personal_access_token,
                     } %>
+
 <% if @personal_access_token.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>

--- a/app/views/projects/bots/_bot_modal.html.erb
+++ b/app/views/projects/bots/_bot_modal.html.erb
@@ -2,21 +2,26 @@
   <% dialog.with_header(
     title: t("projects.bots.index.bot_listing.new_bot_modal.title"),
   ) %>
+
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= t("projects.bots.index.bot_listing.new_bot_modal.description") %>
     </p>
   </div>
+
   <%= form_for(@bot_account, url: namespace_project_bots_path, method: :post, html: { novalidate: true }) do |form| %>
     <%= form.fields_for :user do |user_fields| %>
       <div class="grid gap-4">
         <%= user_fields.fields_for :members do |member_fields| %>
           <%= render partial: "shared/form/required_field_legend" %>
           <%= form_error_summary(member_fields) %>
+
           <% invalid_access_level =
             @bot_account.user.members[0].errors.include?(:access_level) %>
+
           <div class="form-field <%= 'invalid' if invalid_access_level %>">
             <%= member_fields.label :access_level, data: { required: true } %>
+
             <%= member_fields.select :access_level,
                                  @access_levels,
                                  {
@@ -40,6 +45,7 @@
                                       required: true,
                                     },
                                   } %>
+
             <% if invalid_access_level %>
               <%= render "shared/form/field_errors",
               id: member_fields.field_id(:access_level, "error"),
@@ -51,11 +57,13 @@
         <%= user_fields.fields_for :personal_access_tokens do |pat_fields| %>
           <div
             class="
-              grid gap-4 p-6 bg-white border rounded-lg shadow border-slate-200
-              dark:bg-slate-800 dark:border-slate-700
+              grid gap-4 rounded-lg border border-slate-200 bg-white p-6 shadow dark:border-slate-700
+              dark:bg-slate-800
             "
           >
-            <p class="font-semibold dark:text-white"><%= t("projects.bots.index.bot_listing.new_bot_modal.token_details") %></p>
+            <p class="font-semibold dark:text-white">
+              <%= t("projects.bots.index.bot_listing.new_bot_modal.token_details") %>
+            </p>
 
             <%= render partial: "shared/personal_access_tokens/form_fields",
             locals: {
@@ -66,16 +74,13 @@
         <% end %>
       </div>
     <% end %>
+
     <div class="mt-4">
       <%= form.submit t('common.controls.submit'), class: "button button-primary" %>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="click->viral--dialog#close"
-      >
+
+      <button type="button" class="button button-default" data-action="click->viral--dialog#close">
         <%= t('common.actions.cancel') %>
       </button>
     </div>
-
   <% end %>
 <% end %>

--- a/app/views/projects/bots/_bot_modal.html.erb
+++ b/app/views/projects/bots/_bot_modal.html.erb
@@ -11,10 +11,12 @@
 
   <%= form_for(@bot_account, url: namespace_project_bots_path, method: :post, html: { novalidate: true }) do |form| %>
     <%= form.fields_for :user do |user_fields| %>
-      <div class="grid gap-4">
+      <% summary_entries = [] %>
+
+      <% members_fields = capture do %>
         <%= user_fields.fields_for :members do |member_fields| %>
+          <% summary_entries.concat(FormErrorSummaryEntryBuilder.new(builder: member_fields).call) %>
           <%= render partial: "shared/form/required_field_legend" %>
-          <%= form_error_summary(member_fields) %>
 
           <% invalid_access_level =
             @bot_account.user.members[0].errors.include?(:access_level) %>
@@ -53,8 +55,12 @@
             <% end %>
           </div>
         <% end %>
+      <% end %>
 
+      <% personal_access_token_fields = capture do %>
         <%= user_fields.fields_for :personal_access_tokens do |pat_fields| %>
+          <% summary_entries.concat(FormErrorSummaryEntryBuilder.new(builder: pat_fields).call) %>
+
           <div
             class="
               grid gap-4 rounded-lg border border-slate-200 bg-white p-6 shadow dark:border-slate-700
@@ -65,8 +71,6 @@
               <%= t("projects.bots.index.bot_listing.new_bot_modal.token_details") %>
             </p>
 
-            <%= form_error_summary(pat_fields) %>
-
             <%= render partial: "shared/personal_access_tokens/form_fields",
             locals: {
               pat: @bot_account.user.personal_access_tokens[0],
@@ -74,6 +78,13 @@
             } %>
           </div>
         <% end %>
+      <% end %>
+
+      <%= render FormErrorSummaryComponent.new(entries: summary_entries) if summary_entries.any? %>
+
+      <div class="grid gap-4">
+        <%= members_fields %>
+        <%= personal_access_token_fields %>
       </div>
     <% end %>
 

--- a/app/views/projects/bots/_bot_modal.html.erb
+++ b/app/views/projects/bots/_bot_modal.html.erb
@@ -65,6 +65,8 @@
               <%= t("projects.bots.index.bot_listing.new_bot_modal.token_details") %>
             </p>
 
+            <%= form_error_summary(pat_fields) %>
+
             <%= render partial: "shared/personal_access_tokens/form_fields",
             locals: {
               pat: @bot_account.user.personal_access_tokens[0],

--- a/app/views/projects/bots/_bot_modal.html.erb
+++ b/app/views/projects/bots/_bot_modal.html.erb
@@ -7,16 +7,12 @@
       <%= t("projects.bots.index.bot_listing.new_bot_modal.description") %>
     </p>
   </div>
-
-  <div class="mb-4">
-    <%= turbo_frame_tag("new_bot_account-error-alert") %>
-  </div>
-
   <%= form_for(@bot_account, url: namespace_project_bots_path, method: :post, html: { novalidate: true }) do |form| %>
     <%= form.fields_for :user do |user_fields| %>
       <div class="grid gap-4">
         <%= user_fields.fields_for :members do |member_fields| %>
           <%= render partial: "shared/form/required_field_legend" %>
+          <%= form_error_summary(member_fields) %>
           <% invalid_access_level =
             @bot_account.user.members[0].errors.include?(:access_level) %>
           <div class="form-field <%= 'invalid' if invalid_access_level %>">
@@ -31,20 +27,19 @@
                                  },
                                  {
                                    required: true,
-                                   aria: {
-                                     describedby:
-                                       (
-                                         if invalid_access_level
-                                           member_fields.field_id(:access_level, "error")
-                                         else
-                                           nil
-                                         end
-                                       ),
-                                     invalid: invalid_access_level,
-                                     required: true,
-                                   },
-                                   autofocus: invalid_access_level,
-                                 } %>
+                                    aria: {
+                                      describedby:
+                                        (
+                                          if invalid_access_level
+                                            member_fields.field_id(:access_level, "error")
+                                          else
+                                            nil
+                                          end
+                                        ),
+                                      invalid: invalid_access_level,
+                                      required: true,
+                                    },
+                                  } %>
             <% if invalid_access_level %>
               <%= render "shared/form/field_errors",
               id: member_fields.field_id(:access_level, "error"),

--- a/app/views/projects/bots/create.turbo_stream.erb
+++ b/app/views/projects/bots/create.turbo_stream.erb
@@ -4,7 +4,6 @@
                       open: @bot_account.invalid?,
                       bot_account: @bot_account,
                     } %>
-<%= turbo_stream.update "new_bot_account-error-alert", viral_alert(type:, message:) %>
 <% if @bot_account.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>

--- a/app/views/projects/bots/create.turbo_stream.erb
+++ b/app/views/projects/bots/create.turbo_stream.erb
@@ -4,6 +4,7 @@
                       open: @bot_account.invalid?,
                       bot_account: @bot_account,
                     } %>
+
 <% if @bot_account.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>
@@ -14,6 +15,5 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -13,11 +13,6 @@
       ) %>
     </p>
   </div>
-
-  <div class="mb-4">
-    <%= turbo_frame_tag("personal-access-token-error-alert") %>
-  </div>
-
   <%= form_for(@personal_access_token, url: namespace_project_bot_personal_access_tokens_path, method: :post,  html: { novalidate: true}) do |form| %>
     <div class="grid gap-4">
       <%= render partial: "shared/form/required_field_legend" %>

--- a/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -5,6 +5,7 @@
         "projects.bots.index.bot_listing.generate_personal_access_token_modal.title",
       ),
   ) %>
+
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= t(
@@ -13,23 +14,22 @@
       ) %>
     </p>
   </div>
+
   <%= form_for(@personal_access_token, url: namespace_project_bot_personal_access_tokens_path, method: :post,  html: { novalidate: true}) do |form| %>
     <div class="grid gap-4">
       <%= render partial: "shared/form/required_field_legend" %>
+
       <%= render partial: "shared/personal_access_tokens/form_fields",
       locals: {
         pat: @personal_access_token,
         form: form,
       } %>
-
     </div>
+
     <div class="mt-4">
       <%= form.submit t('common.controls.submit'), class: "button button-primary" %>
-      <button
-        type="button"
-        class="button button-default"
-        data-action="click->viral--dialog#close"
-      >
+
+      <button type="button" class="button button-default" data-action="click->viral--dialog#close">
         <%= t('common.actions.cancel') %>
       </button>
     </div>

--- a/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
@@ -4,9 +4,6 @@
                       open: @personal_access_token.errors.any?,
                       personal_access_token: @personal_access_token,
                     } %>
-
-<%= turbo_stream.update "personal-access-token-error-alert",
-                    viral_alert(type:, message:) %>
 <% if @personal_access_token.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>

--- a/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
@@ -4,6 +4,7 @@
                       open: @personal_access_token.errors.any?,
                       personal_access_token: @personal_access_token,
                     } %>
+
 <% if @personal_access_token.persisted? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>
@@ -14,6 +15,5 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/config/locales/common.en.yml
+++ b/config/locales/common.en.yml
@@ -20,8 +20,8 @@ en:
       submit: Submit
     date:
       errors:
-        invalid_format: Invalid date format
-        invalid_input: Invalid date input
+        invalid_format: must be in YYYY-MM-DD format (for example, 2026-05-01)
+        invalid_input: must be in YYYY-MM-DD format (for example, 2026-05-01)
         invalid_min_date: Date is before minimum date
     labels:
       access_level: Access Level

--- a/config/locales/common.en.yml
+++ b/config/locales/common.en.yml
@@ -20,7 +20,6 @@ en:
       submit: Submit
     date:
       errors:
-        invalid_format: must be in YYYY-MM-DD format (for example, 2026-05-01)
         invalid_input: must be in YYYY-MM-DD format (for example, 2026-05-01)
         invalid_min_date: Date is before minimum date
     labels:

--- a/config/locales/common.fr.yml
+++ b/config/locales/common.fr.yml
@@ -20,7 +20,6 @@ fr:
       submit: Envoyer
     date:
       errors:
-        invalid_format: Format de date invalide
         invalid_input: Saisie de date invalide
         invalid_min_date: La date est antérieure à la date minimale
     labels:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -782,6 +782,7 @@ en:
             description: Generating a new personal access token for %{bot_account}
             title: New Personal Access Token
           new_bot_modal:
+            access_level: Access Level
             description: This will create a bot user with email format 'inxt_grp_GROUP_PUID_bot_n@iridanext.com', add them as a member to the Group with 'Access level' role, and then create a personal access token for the bot using the details below
             select_access_level: Select access level
             title: New Bot Account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -782,7 +782,6 @@ en:
             description: Generating a new personal access token for %{bot_account}
             title: New Personal Access Token
           new_bot_modal:
-            access_level: Access Level
             description: This will create a bot user with email format 'inxt_grp_GROUP_PUID_bot_n@iridanext.com', add them as a member to the Group with 'Access level' role, and then create a personal access token for the bot using the details below
             select_access_level: Select access level
             title: New Bot Account

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -784,7 +784,6 @@ fr:
             description: Génération d’un nouveau jeton d’accès personnel pour %{bot_account}
             title: Nouveau jeton d’accès personnel
           new_bot_modal:
-            access_level: Niveau d’accès
             description: Cela créera un utilisateur de bot avec le format de courriel « inxt_grp_GROUP_PUID_bot_n@iridanext.com », l’ajoutera en tant que membre au groupe avec le rôle de « niveau d’accès », puis créera un jeton d’accès personnel pour le bot en utilisant les détails ci-dessous
             select_access_level: Sélectionnez le niveau d’accès
             title: Nouveau compte de bot

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -784,6 +784,7 @@ fr:
             description: Génération d’un nouveau jeton d’accès personnel pour %{bot_account}
             title: Nouveau jeton d’accès personnel
           new_bot_modal:
+            access_level: Niveau d’accès
             description: Cela créera un utilisateur de bot avec le format de courriel « inxt_grp_GROUP_PUID_bot_n@iridanext.com », l’ajoutera en tant que membre au groupe avec le rôle de « niveau d’accès », puis créera un jeton d’accès personnel pour le bot en utilisant les détails ci-dessous
             select_access_level: Sélectionnez le niveau d’accès
             title: Nouveau compte de bot

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -86,6 +86,18 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     assert_selector 'a[href="#namespace-select"]', text: 'Namespace required'
   end
 
+  test 'attribute overrides use custom label in generated messages' do
+    user = build_user
+    user.errors.add(:email, :blank)
+
+    entry = FormErrorSummaryEntryBuilder.new(
+      builder: build_form_builder('user', user),
+      attribute_overrides: { email: 'Email address' }
+    ).call.first
+
+    assert_equal "Email address can't be blank", entry.message
+  end
+
   private
 
   def build_form_builder(object_name, object)

--- a/test/components/previews/form_error_summary_component_preview.rb
+++ b/test/components/previews/form_error_summary_component_preview.rb
@@ -7,7 +7,17 @@ class FormErrorSummaryComponentPreview < ViewComponent::Preview
                              entry(attribute: :email, message: "Email can't be blank", target_id: 'user_email'),
                              entry(attribute: :namespace,
                                    message: 'Namespace required',
-                                   target_id: 'namespace-select')
+                                   target_id: 'namespace-select'),
+
+                             # Exercise focus fallbacks:
+                             # - datepicker v2 input renders as "#{id}-input"
+                             entry(attribute: :expires_at,
+                                   message: "Expiration date can't be blank",
+                                   target_id: 'expires_at'),
+                             # - multi-checkbox renders as "#{baseId}_<value>"
+                             entry(attribute: :scopes,
+                                   message: "Scopes can't be blank",
+                                   target_id: 'personal_access_token_scopes')
                            ]
                          })
   end

--- a/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
+++ b/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
@@ -34,4 +34,57 @@
       <li><%= viral_help_text(state: :error) { 'Namespace required' } %></li>
     </ul>
   </div>
+
+  <div class="form-field">
+    <label for="expires_at-input">Expiration date</label>
+
+    <input
+      id="expires_at-input"
+      aria-describedby="expires_at_error"
+      aria-invalid="true"
+      autocomplete="off"
+      class="block w-full"
+      type="text"
+    >
+
+    <ul id="expires_at_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
+      <li><%= viral_help_text(state: :error) { "Expiration date can't be blank" } %></li>
+    </ul>
+  </div>
+
+  <div class="form-field">
+    <fieldset>
+      <legend>Scopes</legend>
+
+      <div class="flex items-center gap-2">
+        <input
+          id="personal_access_token_scopes_api"
+          name="personal_access_token[scopes][]"
+          type="checkbox"
+          value="api"
+          aria-describedby="personal_access_token_scopes_error"
+          aria-invalid="true"
+        >
+
+        <label for="personal_access_token_scopes_api">api</label>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <input
+          id="personal_access_token_scopes_read_api"
+          name="personal_access_token[scopes][]"
+          type="checkbox"
+          value="read_api"
+          aria-describedby="personal_access_token_scopes_error"
+          aria-invalid="true"
+        >
+
+        <label for="personal_access_token_scopes_read_api">read_api</label>
+      </div>
+    </fieldset>
+
+    <ul id="personal_access_token_scopes_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
+      <li><%= viral_help_text(state: :error) { "Scopes can't be blank" } %></li>
+    </ul>
+  </div>
 </div>

--- a/test/components/system/form_error_summary_component_test.rb
+++ b/test/components/system/form_error_summary_component_test.rb
@@ -20,6 +20,16 @@ module System
       end
       assert_selector '#namespace-select', focused: true
 
+      within '[data-controller="form-error-summary"]' do
+        click_link "Expiration date can't be blank"
+      end
+      assert_selector '#expires_at-input', focused: true
+
+      within '[data-controller="form-error-summary"]' do
+        click_link "Scopes can't be blank"
+      end
+      assert_selector '#personal_access_token_scopes_api', focused: true
+
       assert_accessible
     end
   end

--- a/test/controllers/groups/bots_controller_test.rb
+++ b/test/controllers/groups/bots_controller_test.rb
@@ -69,6 +69,29 @@ module Groups
       assert_response :success
     end
 
+    test 'should return expires_at validation errors when creating a bot account with invalid token date' do
+      sign_in users(:john_doe)
+
+      namespace = groups(:group_one)
+
+      post group_bots_path(namespace, format: :turbo_stream),
+           params: { namespace_bot: { user_attributes: {
+             members_attributes: {
+               '0': { access_level: Member::AccessLevel::UPLOADER }
+             },
+             personal_access_tokens_attributes: {
+               '0': {
+                 name: 'newtesttoken',
+                 expires_at: 'not-a-date',
+                 scopes: ['read_api']
+               }
+             }
+           } } }
+
+      assert_response :unprocessable_content
+      assert_includes response.body, I18n.t('common.date.errors.invalid_input')
+    end
+
     test 'should not create a new bot account for a user with incorrect permissions' do
       sign_in users(:ryan_doe)
 

--- a/test/controllers/projects/bots_controller_test.rb
+++ b/test/controllers/projects/bots_controller_test.rb
@@ -74,6 +74,30 @@ module Projects
       assert_response :success
     end
 
+    test 'should return expires_at validation errors when creating a bot account with invalid token date' do
+      sign_in users(:john_doe)
+
+      namespace = groups(:group_one)
+      project = projects(:project1)
+
+      post namespace_project_bots_path(namespace, project, format: :turbo_stream),
+           params: { namespace_bot: { user_attributes: {
+             members_attributes: {
+               '0': { access_level: Member::AccessLevel::UPLOADER }
+             },
+             personal_access_tokens_attributes: {
+               '0': {
+                 name: 'newtesttoken',
+                 expires_at: 'not-a-date',
+                 scopes: ['read_api']
+               }
+             }
+           } } }
+
+      assert_response :unprocessable_content
+      assert_includes response.body, I18n.t('common.date.errors.invalid_input')
+    end
+
     test 'should not create a new bot account for a user with incorrect permissions' do
       sign_in users(:ryan_doe)
 

--- a/test/jobs/personal_access_tokens/cleanup_job_test.rb
+++ b/test/jobs/personal_access_tokens/cleanup_job_test.rb
@@ -33,9 +33,10 @@ module PersonalAccessTokens
       token = PersonalAccessToken.create!(
         user: users(:john_doe),
         name: 'Expired but young PAT',
-        scopes: ['api'],
-        expires_at: (@current_date - 10.days).to_date
+        scopes: ['api']
       )
+      # DateValidator forbids past expires_at on create; set in DB for an expired date still after the job cutoff.
+      token.update_columns(expires_at: (@current_date - 10.days).to_date) # rubocop:disable Rails/SkipsModelValidations
 
       assert_no_difference -> { PersonalAccessToken.where(id: token.id).count } do
         PersonalAccessTokens::CleanupJob.perform_now

--- a/test/services/personal_access_tokens/rotate_service_test.rb
+++ b/test/services/personal_access_tokens/rotate_service_test.rb
@@ -24,6 +24,18 @@ module PersonalAccessTokens
       end
     end
 
+    test 'rotate personal access token preserves cast expires_at date' do
+      personal_access_token = personal_access_tokens(:john_doe_valid_pat)
+
+      assert_instance_of Date, personal_access_token.expires_at
+
+      new_token = PersonalAccessTokens::RotateService.new(@user, personal_access_token).execute
+
+      assert_predicate new_token, :persisted?
+      assert_equal personal_access_token.expires_at, new_token.expires_at
+      assert_empty new_token.errors[:expires_at]
+    end
+
     test 'should not rotate personal access token for another user' do
       user = users(:jane_doe)
       jane_doe_personal_access_token = personal_access_tokens(:jane_doe_valid_pat)

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -143,18 +143,22 @@ module Groups
                from: I18n.t(:'activerecord.attributes.member.access_level')
 
         assert_html5_inputs_valid
+      end
+      ### ACTIONS END ###
 
-        click_button I18n.t('common.controls.submit')
-        ### ACTIONS END ###
+      click_button I18n.t('common.controls.submit')
 
-        ### VERIFY START ###
-        assert_selector '#new_bot_account-error-alert'
-        within('#new_bot_account-error-alert') do
+      ### VERIFY START ###
+      # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
+      within('#bot_modal') do
+        assert_selector '[data-controller="form-error-summary"]'
+        within('[data-controller="form-error-summary"]') do
+          assert_text I18n.t(:'general.form.error_summary.title', count: 1)
           assert_text I18n.t(:'general.form.error_notification')
+          assert_text I18n.t(:'errors.format',
+                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
+                             message: I18n.t(:'errors.messages.blank'))
         end
-        assert_text I18n.t(:'errors.format',
-                           attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
-                           message: I18n.t(:'errors.messages.blank'))
       end
       ### VERIFY END ###
     end

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -143,18 +143,22 @@ module Projects
                from: I18n.t(:'activerecord.attributes.member.access_level')
 
         assert_html5_inputs_valid
+      end
+      ### ACTIONS END ###
 
-        click_button I18n.t('common.controls.submit')
-        ### ACTIONS END ###
+      click_button I18n.t('common.controls.submit')
 
-        ### VERIFY START ###
-        assert_selector '#new_bot_account-error-alert'
-        within('#new_bot_account-error-alert') do
+      ### VERIFY START ###
+      # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
+      within('#bot_modal') do
+        assert_selector '[data-controller="form-error-summary"]'
+        within('[data-controller="form-error-summary"]') do
+          assert_text I18n.t(:'general.form.error_summary.title', count: 1)
           assert_text I18n.t(:'general.form.error_notification')
+          assert_text I18n.t(:'errors.format',
+                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
+                             message: I18n.t(:'errors.messages.blank'))
         end
-        assert_text I18n.t(:'errors.format',
-                           attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
-                           message: I18n.t(:'errors.messages.blank'))
       end
       ### VERIFY END ###
     end

--- a/test/validators/date_validator_test.rb
+++ b/test/validators/date_validator_test.rb
@@ -32,12 +32,12 @@ class DateValidatorTest < ActiveSupport::TestCase
                  member.errors[:expires_at].first)
   end
 
-  test 'member expires_at without YYYY-MM-DD format' do
+  test 'member expires_at with parseable non-YYYY-MM-DD format' do
     invalid_date_format = (Time.zone.today - 10.days).strftime('%d-%m-%Y')
     member = create_group_member(invalid_date_format)
 
     assert_not member.valid?
-    assert_equal(I18n.t('common.date.errors.invalid_format'),
+    assert_equal(I18n.t('common.date.errors.invalid_min_date'),
                  member.errors[:expires_at].first)
   end
 
@@ -72,12 +72,12 @@ class DateValidatorTest < ActiveSupport::TestCase
                  group_link.errors[:expires_at].first)
   end
 
-  test 'group link expires_at without YYYY-MM-DD format' do
+  test 'group link expires_at with parseable non-YYYY-MM-DD format' do
     invalid_date_format = (Time.zone.today - 10.days).strftime('%d-%m-%Y')
     group_link = create_group_link(invalid_date_format)
 
     assert_not group_link.valid?
-    assert_equal(I18n.t('common.date.errors.invalid_format'),
+    assert_equal(I18n.t('common.date.errors.invalid_min_date'),
                  group_link.errors[:expires_at].first)
   end
 

--- a/test/validators/date_validator_test.rb
+++ b/test/validators/date_validator_test.rb
@@ -90,6 +90,17 @@ class DateValidatorTest < ActiveSupport::TestCase
                  group_link.errors[:expires_at].first)
   end
 
+  test 'personal access token with cast expires_at date' do
+    personal_access_token = PersonalAccessToken.new(
+      name: 'Rotated token',
+      scopes: %w[api],
+      expires_at: Time.zone.today + 1.day,
+      user: @user
+    )
+
+    assert personal_access_token.valid?
+  end
+
   private
 
   def create_group_member(expires_at_date)


### PR DESCRIPTION
## What does this PR do and why?
This updates the group and project bot dialogs to use the shared form error summary when validation fails. We need this so people see one clear error summary in the modal and can jump to the field that needs fixing without a second generic alert competing for attention.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2171" height="1189" alt="image" src="https://github.com/user-attachments/assets/4d1b3b3e-fca1-422b-80a1-519160649be4" />

## How to set up and validate locally
1. Start the app with `bin/dev` and sign in as a user who can manage bots.
2. Visit a group bots page, open **Add new bot**, submit the modal with required token fields missing, and confirm the error summary appears inside the dialog, the summary gets focus, and there is no separate generic error alert frame above the form.
3. Repeat the same check on a project bots page with **Add new bot**, and confirm the modal stays open and shows the linked summary for the invalid fields.
4. From an existing bot row on both the group and project bots pages, open **Generate new token**, submit invalid token details, and confirm the dialog shows the shared error summary instead of a duplicate generic alert.
5. Run `PARALLEL_WORKERS=4 bin/rails test test/system/groups/bots_test.rb test/system/projects/bots_test.rb test/controllers/concerns/bot_actions_concern_test.rb test/controllers/concerns/bot_personal_access_token_actions_concern_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
