### PR TITLE
Add form error summary to metadata template dialogs

### DIFF
--- a/app/components/sortable_lists/v1/list_component.html.erb
+++ b/app/components/sortable_lists/v1/list_component.html.erb
@@ -19,6 +19,9 @@
     aria-roledescription="<%= t('components.sortable_lists.v1.list_component.aria_role_description', list: title) %>"
     aria-required="<%= required %>"
     aria-multiselectable="true"
+    <% if describedby.present? %>
+      aria-describedby="<%= describedby %>"
+    <% end %>
   >
     <%= render SortableLists::V1::ListItemComponent.with_collection(list_items) %>
   </ul>

--- a/app/components/sortable_lists/v1/list_component.rb
+++ b/app/components/sortable_lists/v1/list_component.rb
@@ -4,17 +4,19 @@ module SortableLists
   module V1
     # This component creates the individual lists for the sortable_lists component.
     class ListComponent < ::Component
-      attr_reader :id, :group, :title, :list_items, :required, :available_list, :selected_list
+      attr_reader :id, :group, :title, :list_items, :required, :describedby, :available_list, :selected_list
 
       # rubocop:disable Metrics/ParameterLists
 
       # If creating multiple lists to utilize the same list values, assign them the same group.
-      def initialize(id: nil, group: nil, title: nil, list_items: [], required: false, **system_arguments)
+      def initialize(id: nil, group: nil, title: nil, list_items: [], required: false, describedby: nil,
+                     **system_arguments)
         @id = id
         @group = group
         @title = title
         @list_items = list_items
         @required = required
+        @describedby = describedby
         @system_arguments = system_arguments
         @system_arguments[:list_classes] =
           class_names('border border-slate-300 rounded-lg block dark:bg-slate-800 dark:border-slate-600 max-h-[225px]

--- a/app/javascript/controllers/form_error_summary_controller.js
+++ b/app/javascript/controllers/form_error_summary_controller.js
@@ -61,7 +61,9 @@ export default class extends Controller {
     const target = this.focusableElement(resolved);
     if (!target) return;
 
-    focusWhenVisible(target);
+    // Force the visible focus indicator: pointer-activated links don't otherwise trigger :focus-visible
+    // on the target (e.g. listboxes, divs), so the user wouldn't see where focus landed.
+    focusWhenVisible(target, { focusOptions: { focusVisible: true } });
     target.scrollIntoView({ block: "center", inline: "nearest" });
   }
 }

--- a/app/javascript/utilities/focus.js
+++ b/app/javascript/utilities/focus.js
@@ -32,6 +32,8 @@ export function isVisible(element) {
  * @param {HTMLElement} element - The element to focus
  * @param {Object} options - Configuration options
  * @param {number} options.maxFrames - Maximum animation frames to wait (default: 30, ~500ms at 60fps)
+ * @param {FocusOptions} options.focusOptions - Options forwarded to HTMLElement.focus()
+ *   (e.g. `{ focusVisible: true }` to force the visible focus indicator after a pointer-initiated action).
  * @returns {void}
  *
  * @example
@@ -41,8 +43,15 @@ export function isVisible(element) {
  * @example
  * // Focus with custom timeout
  * focusWhenVisible(dialogCloseButton, { maxFrames: 60 });
+ *
+ * @example
+ * // Force the visible focus indicator (e.g. when activating an error summary link)
+ * focusWhenVisible(target, { focusOptions: { focusVisible: true } });
  */
-export function focusWhenVisible(element, { maxFrames = 30 } = {}) {
+export function focusWhenVisible(
+  element,
+  { maxFrames = 30, focusOptions } = {},
+) {
   // maxFrames = 30 ≈ 500ms at 60fps - prevents infinite loop during CSS transitions
   if (!element) return;
 
@@ -50,7 +59,7 @@ export function focusWhenVisible(element, { maxFrames = 30 } = {}) {
 
   const attempt = () => {
     if (isVisible(element)) {
-      element.focus();
+      element.focus(focusOptions);
       return;
     }
 

--- a/app/views/shared/metadata_templates/_create.turbo_stream.erb
+++ b/app/views/shared/metadata_templates/_create.turbo_stream.erb
@@ -16,7 +16,4 @@
       ) %>
     <% end %>
   <% end %>
-<% else %>
-  <%= turbo_stream.update "metadata_template_error_alert",
-                      viral_alert(type:, message:, classes: "mb-4") %>
 <% end %>

--- a/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
@@ -1,5 +1,6 @@
 <%= viral_dialog(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("metadata_templates.edit_template_dialog.title")) %>
+
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>
     <%= render partial: "shared/metadata_templates/form",
     locals: {

--- a/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
@@ -1,6 +1,5 @@
 <%= viral_dialog(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("metadata_templates.edit_template_dialog.title")) %>
-  <%= turbo_frame_tag "metadata_template_error_alert" %>
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>
     <%= render partial: "shared/metadata_templates/form",
     locals: {

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -8,6 +8,7 @@
   <%= form_for(@metadata_template, url: template_path, method:, html: { novalidate: true }) do |form| %>
     <%= form_error_summary(form) %>
     <%= render partial: "shared/form/required_field_legend" %>
+
     <% invalid_name = @metadata_template.errors&.include?(:name) %>
     <% name_hint_id = form.field_id(:name, "hint") %>
     <% name_error_id = invalid_name ? form.field_id(:name, "error") : nil %>
@@ -30,7 +31,7 @@
         <div class="form-field <%= 'invalid' if invalid_name %>">
           <%= form.label :name, data: { required: true } %>
 
-           <%= form.text_field :name,
+          <%= form.text_field :name,
                            required: true,
                            class: "form-control",
                            aria: {
@@ -53,7 +54,7 @@
         <div class="form-field <%= 'invalid' if invalid_description %>">
           <%= form.label :description %>
 
-           <%= form.text_area :description,
+          <%= form.text_area :description,
                           rows: 3,
                           class: "form-control",
                           aria: {

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -101,8 +101,6 @@
           class="outline-hidden"
           tabindex="-1"
           aria-describedby="<%= fields_describedby.presence %>"
-          aria-invalid="<%= invalid_fields %>"
-          aria-required="true"
         >
           <%= render SortableListsComponent.new do |sortable_lists| %>
             <%= sortable_lists.with_list(

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -17,6 +17,9 @@
     <% description_hint_id = form.field_id(:description, "hint") %>
     <% description_error_id = invalid_description ? form.field_id(:description, "error") : nil %>
     <% description_describedby = [description_hint_id, description_error_id].compact.join(" ") %>
+    <% invalid_fields = @metadata_template.errors&.include?(:fields) %>
+    <% fields_error_id = invalid_fields ? form.field_id(:fields, "error") : nil %>
+    <% fields_describedby = [fields_error_id].compact.join(" ") %>
 
     <div class="grid gap-5">
       <section aria-labelledby="metadata-template-details-heading" class="grid gap-4">
@@ -93,7 +96,14 @@
           },
         ) %>
 
-        <div id="<%= form.field_id(:fields) %>" class="outline-hidden" tabindex="-1">
+        <div
+          id="<%= form.field_id(:fields) %>"
+          class="outline-hidden"
+          tabindex="-1"
+          aria-describedby="<%= fields_describedby.presence %>"
+          aria-invalid="<%= invalid_fields %>"
+          aria-required="true"
+        >
           <%= render SortableListsComponent.new do |sortable_lists| %>
             <%= sortable_lists.with_list(
               id: "available-list",
@@ -111,6 +121,12 @@
             ) %>
           <% end %>
         </div>
+
+        <% if invalid_fields %>
+          <%= render "shared/form/field_errors",
+          id: fields_error_id,
+          errors: @metadata_template.errors.full_messages_for(:fields) %>
+        <% end %>
       </section>
 
       <div class="hidden" data-sortable-lists--v1--two-lists-selection-target="field"></div>

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -93,22 +93,24 @@
           },
         ) %>
 
-        <%= render SortableListsComponent.new do |sortable_lists| %>
-          <%= sortable_lists.with_list(
-            id: "available-list",
-            title: t("metadata_templates.form.available"),
-            list_items: @available_metadata_fields,
-            group: "metadata_selection",
-          ) %>
+        <div id="<%= form.field_id(:fields) %>" class="outline-hidden" tabindex="-1">
+          <%= render SortableListsComponent.new do |sortable_lists| %>
+            <%= sortable_lists.with_list(
+              id: "available-list",
+              title: t("metadata_templates.form.available"),
+              list_items: @available_metadata_fields,
+              group: "metadata_selection",
+            ) %>
 
-          <%= sortable_lists.with_list(
-            id: "selected-list",
-            title: t("metadata_templates.form.selected"),
-            list_items: @current_template_fields,
-            group: "metadata_selection",
-            required: true,
-          ) %>
-        <% end %>
+            <%= sortable_lists.with_list(
+              id: "selected-list",
+              title: t("metadata_templates.form.selected"),
+              list_items: @current_template_fields,
+              group: "metadata_selection",
+              required: true,
+            ) %>
+          <% end %>
+        </div>
       </section>
 
       <div class="hidden" data-sortable-lists--v1--two-lists-selection-target="field"></div>

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -6,6 +6,7 @@
   class="font-normal text-slate-500 dark:text-slate-400"
 >
   <%= form_for(@metadata_template, url: template_path, method:, html: { novalidate: true }) do |form| %>
+    <%= form_error_summary(form) %>
     <%= render partial: "shared/form/required_field_legend" %>
     <% invalid_name = @metadata_template.errors&.include?(:name) %>
     <% name_hint_id = form.field_id(:name, "hint") %>
@@ -29,15 +30,14 @@
         <div class="form-field <%= 'invalid' if invalid_name %>">
           <%= form.label :name, data: { required: true } %>
 
-          <%= form.text_field :name,
-                          required: true,
-                          class: "form-control",
-                          aria: {
-                            describedby: name_describedby,
-                            invalid: invalid_name,
-                            required: true,
-                          },
-                          autofocus: invalid_name %>
+           <%= form.text_field :name,
+                           required: true,
+                           class: "form-control",
+                           aria: {
+                             describedby: name_describedby,
+                             invalid: invalid_name,
+                             required: true,
+                           } %>
 
           <p id="<%= name_hint_id %>" class="mt-2 text-xs font-medium text-slate-600 dark:text-slate-300">
             <%= t("metadata_templates.form.name_hint") %>
@@ -53,14 +53,13 @@
         <div class="form-field <%= 'invalid' if invalid_description %>">
           <%= form.label :description %>
 
-          <%= form.text_area :description,
-                         rows: 3,
-                         class: "form-control",
-                         aria: {
-                           describedby: description_describedby,
-                           invalid: invalid_description,
-                         },
-                         autofocus: invalid_description %>
+           <%= form.text_area :description,
+                          rows: 3,
+                          class: "form-control",
+                          aria: {
+                            describedby: description_describedby,
+                            invalid: invalid_description,
+                          } %>
 
           <p id="<%= description_hint_id %>" class="mt-2 text-xs font-medium text-slate-600 dark:text-slate-300">
             <%= t("metadata_templates.form.description_hint") %>

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -6,7 +6,7 @@
   class="font-normal text-slate-500 dark:text-slate-400"
 >
   <%= form_for(@metadata_template, url: template_path, method:, html: { novalidate: true }) do |form| %>
-    <%= form_error_summary(form) %>
+    <%= form_error_summary(form, target_overrides: { fields: "selected-list" }) %>
     <%= render partial: "shared/form/required_field_legend" %>
 
     <% invalid_name = @metadata_template.errors&.include?(:name) %>
@@ -96,29 +96,23 @@
           },
         ) %>
 
-        <div
-          id="<%= form.field_id(:fields) %>"
-          class="outline-hidden"
-          tabindex="-1"
-          aria-describedby="<%= fields_describedby.presence %>"
-        >
-          <%= render SortableListsComponent.new do |sortable_lists| %>
-            <%= sortable_lists.with_list(
-              id: "available-list",
-              title: t("metadata_templates.form.available"),
-              list_items: @available_metadata_fields,
-              group: "metadata_selection",
-            ) %>
+        <%= render SortableListsComponent.new do |sortable_lists| %>
+          <%= sortable_lists.with_list(
+            id: "available-list",
+            title: t("metadata_templates.form.available"),
+            list_items: @available_metadata_fields,
+            group: "metadata_selection",
+          ) %>
 
-            <%= sortable_lists.with_list(
-              id: "selected-list",
-              title: t("metadata_templates.form.selected"),
-              list_items: @current_template_fields,
-              group: "metadata_selection",
-              required: true,
-            ) %>
-          <% end %>
-        </div>
+          <%= sortable_lists.with_list(
+            id: "selected-list",
+            title: t("metadata_templates.form.selected"),
+            list_items: @current_template_fields,
+            group: "metadata_selection",
+            required: true,
+            describedby: fields_describedby.presence,
+          ) %>
+        <% end %>
 
         <% if invalid_fields %>
           <%= render "shared/form/field_errors",

--- a/app/views/shared/metadata_templates/_new_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_new_template_dialog.html.erb
@@ -1,5 +1,6 @@
 <%= viral_dialog(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("metadata_templates.new_template_dialog.title")) %>
+
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>
     <%= render partial: "shared/metadata_templates/form",
     locals: {

--- a/app/views/shared/metadata_templates/_new_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_new_template_dialog.html.erb
@@ -1,6 +1,5 @@
 <%= viral_dialog(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("metadata_templates.new_template_dialog.title")) %>
-  <%= turbo_frame_tag "metadata_template_error_alert" %>
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>
     <%= render partial: "shared/metadata_templates/form",
     locals: {

--- a/app/views/shared/metadata_templates/_update.turbo_stream.erb
+++ b/app/views/shared/metadata_templates/_update.turbo_stream.erb
@@ -19,7 +19,4 @@
       },
     ) %>
   <% end %>
-<% else %>
-  <%= turbo_stream.update "metadata_template_error_alert",
-                      viral_alert(type:, message:, classes: "mb-4") %>
 <% end %>

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -184,6 +184,29 @@ module Projects
                                           message: I18n.t('errors.messages.blank'))
     end
 
+    test 'fields error summary entry focuses sortable list section' do
+      project = projects(:project1)
+
+      visit namespace_project_metadata_templates_url(project.namespace.parent, project)
+
+      click_on I18n.t('projects.metadata_templates.index.new_button')
+
+      assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
+      assert_text I18n.t('metadata_templates.form.metadata')
+
+      find('input#metadata_template_name').fill_in with: 'Template with missing fields'
+      submit_button_text = I18n.t('metadata_templates.new_template_dialog.submit_button')
+      submit_button = find("input[type='submit'][value='#{submit_button_text}']", visible: :all)
+      execute_script("arguments[0].removeAttribute('disabled')", submit_button)
+      click_button submit_button_text
+
+      within '[data-controller="form-error-summary"]' do
+        find("a[data-form-error-summary-target-id-param='metadata_template_fields']").click
+      end
+
+      assert_selector '#metadata_template_fields', focused: true
+    end
+
     test 'cannot create a template with duplicate fields with same ordering in another template' do
       project = projects(:project1)
       existing_metadata_template = metadata_templates(:valid_metadata_template)

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -204,7 +204,7 @@ module Projects
         find("a[data-form-error-summary-target-id-param='metadata_template_fields']").click
       end
 
-      assert_selector '#metadata_template_fields', focused: true
+      assert_selector '#metadata_template_fields :focus'
     end
 
     test 'cannot create a template with duplicate fields with same ordering in another template' do

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -201,10 +201,11 @@ module Projects
       click_button submit_button_text
 
       within '[data-controller="form-error-summary"]' do
-        find("a[data-form-error-summary-target-id-param='metadata_template_fields']").click
+        find("a[data-form-error-summary-target-id-param='selected-list']").click
       end
 
-      assert_selector '#metadata_template_fields :focus'
+      assert_selector 'ul#selected-list:focus'
+      assert_selector "ul#selected-list[aria-describedby='metadata_template_fields_error']"
     end
 
     test 'cannot create a template with duplicate fields with same ordering in another template' do


### PR DESCRIPTION
## What does this PR do and why?
This updates the metadata template create and edit dialogs to use the shared form error summary when validation fails. We need this so people see form errors in one place inside the dialog and do not get a second generic Turbo alert above the form.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2073" height="1308" alt="image" src="https://github.com/user-attachments/assets/84e3d9fd-e1a5-445a-98d4-f01b69607547" />

## How to set up and validate locally
1. Start the app with `bin/dev` and sign in as a user who can manage metadata templates.
2. Visit a group metadata templates page, open **New template**, move one or more fields into the selected list, submit without a name, and confirm the dialog stays open, an error summary appears at the top of the form, and there is no separate generic error alert frame above the dialog content.
3. Repeat the same invalid-name flow on a project metadata templates page and confirm the summary appears inside the modal there as well.
4. Open an existing template in the edit dialog, submit invalid values such as a blank name, and confirm the error summary appears in the same dialog instead of a separate Turbo alert.
5. Run `PARALLEL_WORKERS=4 bin/rails test test/system/groups/metadata_templates_test.rb test/system/projects/metadata_templates_test.rb test/controllers/concerns/metadata_templates_actions_concern_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
