### PR TITLE
Add form error summary to selected legacy Devise forms

### DIFF
--- a/app/javascript/controllers/email_input_controller.js
+++ b/app/javascript/controllers/email_input_controller.js
@@ -6,9 +6,10 @@
  */
 import { Controller } from "@hotwired/stimulus";
 import debounce from "debounce";
+import { focusWhenVisible } from "utilities/focus";
 
 export default class extends Controller {
-  static targets = ["form", "emailField", "errorContainer"];
+  static targets = ["form", "emailField", "errorContainer", "summary"];
 
   static values = {
     emailMissing: { type: String },
@@ -16,9 +17,6 @@ export default class extends Controller {
   };
 
   connect() {
-    // Initialize field state
-    this.isSubmitting = false;
-
     // Validate required Stimulus values
     this.#validateRequiredValues();
 
@@ -45,18 +43,10 @@ export default class extends Controller {
   submit(event) {
     event.preventDefault();
 
-    // Prevent double submission
-    if (this.isSubmitting) return;
-
-    this.isSubmitting = true;
-
     if (this.validateEmail()) {
-      // Use requestAnimationFrame instead of setTimeout for better performance
       requestAnimationFrame(() => {
         this.formTarget.submit();
       });
-    } else {
-      this.isSubmitting = false;
     }
   }
 
@@ -79,6 +69,8 @@ export default class extends Controller {
     if (!email) {
       if (showMissingError) {
         this.showError(this.emailMissingValue, shouldFocus);
+      } else {
+        this.clearError();
       }
       return false;
     }
@@ -95,7 +87,7 @@ export default class extends Controller {
   /**
    * Shows error message and updates field styling
    * @param {string} message - The error message to display
-   * @param {boolean} shouldFocus - Whether to focus the field
+   * @param {boolean} shouldFocus - Whether to focus the summary
    */
   showError(message, shouldFocus = true) {
     const messageTextSpan =
@@ -103,11 +95,6 @@ export default class extends Controller {
     // Update error message
     messageTextSpan.textContent = message;
     this.errorContainerTarget.classList.remove("hidden");
-
-    // Generate a unique ID for ARIA attributes if needed
-    if (!this.errorContainerTarget.id) {
-      this.errorContainerTarget.id = `email-error-${Date.now()}`;
-    }
 
     // Set validity using the Constraint Validation API
     // This makes the :invalid pseudo-class active, which Tailwind's invalid: prefix uses
@@ -121,7 +108,9 @@ export default class extends Controller {
     );
 
     if (shouldFocus) {
-      this.emailFieldTarget.focus();
+      this.showSummary(message);
+    } else {
+      this.hideSummary();
     }
   }
 
@@ -138,6 +127,7 @@ export default class extends Controller {
     // Update accessibility attributes
     this.emailFieldTarget.setAttribute("aria-invalid", "false");
     this.emailFieldTarget.removeAttribute("aria-describedby");
+    this.hideSummary();
   }
 
   /**
@@ -186,5 +176,27 @@ export default class extends Controller {
     if (this.emailFormatValue === undefined) {
       throw new Error("email-format value is required");
     }
+  }
+
+  showSummary(message) {
+    if (!this.hasSummaryTarget) return;
+
+    this.summaryTarget.classList.remove("hidden");
+
+    const summaryLink = this.summaryTarget.querySelector("a");
+    if (summaryLink) {
+      summaryLink.textContent = message;
+    }
+
+    const summaryContent = this.summaryTarget.querySelector(
+      '[data-controller="form-error-summary"]',
+    );
+    focusWhenVisible(summaryContent);
+  }
+
+  hideSummary() {
+    if (!this.hasSummaryTarget) return;
+
+    this.summaryTarget.classList.add("hidden");
   }
 }

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,15 +1,20 @@
 <h2><%= t(".title") %></h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, novalidate: true }) do |f| %>
+  <%= form_error_summary(f) %>
 
   <%= render "devise/shared/hidden_locale_input" %>
 
-  <div class="field">
+  <% invalid_email = resource.errors.include?(:email) %>
+  <div class="field <%= 'invalid' if invalid_email %>">
     <%= f.label :email %><br/>
     <%= f.email_field :email,
-                  autofocus: true,
+                  autofocus: resource.errors.none?,
                   autocomplete: "email",
+                  aria: {
+                    describedby: invalid_email ? f.field_id(:email, "error") : nil,
+                    invalid: invalid_email,
+                  },
                   value:
                     (
                       if resource.pending_reconfirmation?
@@ -18,6 +23,11 @@
                         resource.email
                       end
                     ) %>
+    <% if invalid_email %>
+      <%= render "shared/form/field_errors",
+      id: f.field_id(:email, "error"),
+      errors: resource.errors.full_messages_for(:email) %>
+    <% end %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -6,8 +6,10 @@
   <%= render "devise/shared/hidden_locale_input" %>
 
   <% invalid_email = resource.errors.include?(:email) %>
+
   <div class="field <%= 'invalid' if invalid_email %>">
-    <%= f.label :email %><br/>
+    <%= f.label :email %><br>
+
     <%= f.email_field :email,
                   autofocus: resource.errors.none?,
                   autocomplete: "email",
@@ -23,6 +25,7 @@
                         resource.email
                       end
                     ) %>
+
     <% if invalid_email %>
       <%= render "shared/form/field_errors",
       id: f.field_id(:email, "error"),

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -9,8 +9,10 @@
     <%= render partial: "shared/form/required_field_legend" %>
 
     <% invalid_password = resource.errors.include?(:password) %>
+
     <div class="form-field <%= 'invalid' if invalid_password %>">
       <%= f.label :password, t(".password_label"), data: { required: true } %>
+
       <%= f.password_field :password,
                        autofocus: resource.errors.none?,
                        required: true,
@@ -20,6 +22,7 @@
                          required: true,
                        },
                        autocomplete: "new-password" %>
+
       <% if invalid_password %>
         <%= render "shared/form/field_errors",
         id: f.field_id(:password, "error"),
@@ -28,12 +31,14 @@
     </div>
 
     <% invalid_password_confirmation = resource.errors.include?(:password_confirmation) %>
+
     <div class="form-field <%= 'invalid' if invalid_password_confirmation %>">
       <%= f.label :password_confirmation,
               t(".password_confirmation_label"),
               data: {
                 required: true,
               } %>
+
       <%= f.password_field :password_confirmation,
                        required: true,
                        aria: {
@@ -43,6 +48,7 @@
                          required: true,
                        },
                        autocomplete: "new-password" %>
+
       <% if invalid_password_confirmation %>
         <%= render "shared/form/field_errors",
         id: f.field_id(:password_confirmation, "error"),

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, novalidate: true }) do |f| %>
+  <%= form_error_summary(f) %>
 
   <%= render "devise/shared/hidden_locale_input" %>
 
@@ -8,18 +8,27 @@
   <div class="space-y-4">
     <%= render partial: "shared/form/required_field_legend" %>
 
-    <div class="form-field">
+    <% invalid_password = resource.errors.include?(:password) %>
+    <div class="form-field <%= 'invalid' if invalid_password %>">
       <%= f.label :password, t(".password_label"), data: { required: true } %>
       <%= f.password_field :password,
-                       autofocus: true,
+                       autofocus: resource.errors.none?,
                        required: true,
                        aria: {
+                         describedby: invalid_password ? f.field_id(:password, "error") : nil,
+                         invalid: invalid_password,
                          required: true,
                        },
                        autocomplete: "new-password" %>
+      <% if invalid_password %>
+        <%= render "shared/form/field_errors",
+        id: f.field_id(:password, "error"),
+        errors: resource.errors.full_messages_for(:password) %>
+      <% end %>
     </div>
 
-    <div class="form-field">
+    <% invalid_password_confirmation = resource.errors.include?(:password_confirmation) %>
+    <div class="form-field <%= 'invalid' if invalid_password_confirmation %>">
       <%= f.label :password_confirmation,
               t(".password_confirmation_label"),
               data: {
@@ -28,9 +37,17 @@
       <%= f.password_field :password_confirmation,
                        required: true,
                        aria: {
+                         describedby:
+                           invalid_password_confirmation ? f.field_id(:password_confirmation, "error") : nil,
+                         invalid: invalid_password_confirmation,
                          required: true,
                        },
                        autocomplete: "new-password" %>
+      <% if invalid_password_confirmation %>
+        <%= render "shared/form/field_errors",
+        id: f.field_id(:password_confirmation, "error"),
+        errors: resource.errors.full_messages_for(:password_confirmation) %>
+      <% end %>
     </div>
 
     <%= f.submit t(".submit_button"), class: "button button-primary w-full" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -6,17 +6,39 @@
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), data: {
     email_input_target: "form",
     action: "submit->email-input#submit"
-    }, html: { method: :post, class: "space-y-4" }) do |f| %>
+    }, html: { method: :post, class: "space-y-4", novalidate: true }) do |f| %>
+    <% if resource.errors.any? %>
+      <%= form_error_summary(f) %>
+    <% else %>
+      <% client_summary_entries = [
+           FormErrorSummaryEntryBuilder::Entry.new(
+             attribute: :email,
+             message: t('devise.passwords.new.email.required_error'),
+             target_id: f.field_id(:email)
+           )
+         ] %>
+      <%= render FormErrorSummaryComponent.new(
+        entries: client_summary_entries,
+        classes: "hidden",
+        data: { email_input_target: "summary" }
+      ) %>
+    <% end %>
+
     <div class="space-y-4">
       <%= render "devise/shared/hidden_locale_input" %>
 
       <%= render partial: "shared/form/required_field_legend" %>
 
-      <div class="form-field">
+      <% invalid_email = resource.errors.include?(:email) %>
+
+      <div class="form-field <%= 'invalid' if invalid_email %>">
         <%= f.label :email, data: { required: true } %>
+
         <%= f.email_field :email,
-                      autofocus: true,
+                      autofocus: resource.errors.none?,
                       aria: {
+                        describedby: invalid_email ? f.field_id(:email, "error") : nil,
+                        invalid: invalid_email,
                         required: true,
                       },
                       autocomplete: "email",
@@ -25,17 +47,23 @@
                                   border-slate-300 focus:ring-blue-500 focus:border-blue-500
                                   invalid:border-red-500 invalid:focus:border-red-500 invalid:focus:ring-red-500
                                 ",
-                      data: {
-                        email_input_target: "emailField",
-                        action: "input->email-input#handleInput",
-                      } %>
+                       data: {
+                         email_input_target: "emailField",
+                         action: "input->email-input#handleInput",
+                       } %>
+
+        <% if invalid_email %>
+          <%= render "shared/form/field_errors",
+          id: f.field_id(:email, "error"),
+          errors: resource.errors.full_messages_for(:email) %>
+        <% end %>
       </div>
+
       <!-- Error messages container -->
       <ul
+        id="<%= invalid_email ? nil : f.field_id(:email, 'error') %>"
         data-email-input-target="errorContainer"
-        class="
-          max-w-md text-sm text-slate-500 list-inside dark:text-slate-400 hidden
-        "
+        class="hidden max-w-md list-inside text-sm text-slate-500 dark:text-slate-400"
       >
         <li>
           <%= viral_help_text(state: :error) %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,8 +7,10 @@
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
   <% invalid_email = resource.errors.include?(:email) %>
+
   <div class="form-field <%= 'invalid' if invalid_email %>">
-    <%= f.label :email, data: { required: true } %><br/>
+    <%= f.label :email, data: { required: true } %><br>
+
     <%= f.email_field :email,
                   autofocus: resource.errors.none?,
                   required: true,
@@ -18,6 +20,7 @@
                     required: true,
                   },
                   autocomplete: "email" %>
+
     <% if invalid_email %>
       <%= render "shared/form/field_errors",
       id: f.field_id(:email, "error"),
@@ -30,9 +33,11 @@
   <% end %>
 
   <% invalid_password = resource.errors.include?(:password) %>
+
   <div class="form-field <%= 'invalid' if invalid_password %>">
     <%= f.label :password, data: { required: true } %>
-    <i><%= t(".password_blank_hint") %></i><br/>
+    <i><%= t(".password_blank_hint") %></i><br>
+
     <%= f.password_field :password,
                      required: true,
                      aria: {
@@ -41,10 +46,12 @@
                        required: true,
                      },
                      autocomplete: "new-password" %>
+
     <% if @minimum_password_length %>
-      <br/>
+      <br>
       <em><%= t(".password_length_hint", minimum_password_length: @minimum_password_length) %></em>
     <% end %>
+
     <% if invalid_password %>
       <%= render "shared/form/field_errors",
       id: f.field_id(:password, "error"),
@@ -53,8 +60,10 @@
   </div>
 
   <% invalid_password_confirmation = resource.errors.include?(:password_confirmation) %>
+
   <div class="form-field <%= 'invalid' if invalid_password_confirmation %>">
-    <%= f.label :password_confirmation, data: { required: true } %><br/>
+    <%= f.label :password_confirmation, data: { required: true } %><br>
+
     <%= f.password_field :password_confirmation,
                      required: true,
                      aria: {
@@ -64,6 +73,7 @@
                        required: true,
                      },
                      autocomplete: "new-password" %>
+
     <% if invalid_password_confirmation %>
       <%= render "shared/form/field_errors",
       id: f.field_id(:password_confirmation, "error"),
@@ -72,9 +82,11 @@
   </div>
 
   <% invalid_current_password = resource.errors.include?(:current_password) %>
+
   <div class="form-field <%= 'invalid' if invalid_current_password %>">
     <%= f.label :current_password, data: { required: true } %>
-    <i><%= t(".current_password_hint") %></i><br/>
+    <i><%= t(".current_password_hint") %></i><br>
+
     <%= f.password_field :current_password,
                      required: true,
                      aria: {
@@ -84,6 +96,7 @@
                        required: true,
                      },
                      autocomplete: "current-password" %>
+
     <% if invalid_current_password %>
       <%= render "shared/form/field_errors",
       id: f.field_id(:current_password, "error"),
@@ -98,13 +111,16 @@
 
 <h3><%= t(".cancel_title") %></h3>
 
-<div><%= t(".unhappy") %>
+<div>
+  <%= t(".unhappy") %>
+
   <%= button_to t(".cancel_button"),
   registration_path(resource_name),
   data: {
     confirm: t(".cancel_confirmation"),
     turbo_confirm: t(".cancel_confirmation"),
   },
-  method: :delete %></div>
+  method: :delete %>
+</div>
 
 <%= link_to t(".back_link"), :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,32 +1,43 @@
 <h2><%= t(".title", resource_name: resource_name.to_s.humanize) %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, novalidate: true }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_error_summary(f) %>
   <%= render partial: "shared/form/required_field_legend" %>
 
   <%= render "devise/shared/hidden_locale_input", form: f %>
 
-  <div class="form-field">
+  <% invalid_email = resource.errors.include?(:email) %>
+  <div class="form-field <%= 'invalid' if invalid_email %>">
     <%= f.label :email, data: { required: true } %><br/>
     <%= f.email_field :email,
-                  autofocus: true,
+                  autofocus: resource.errors.none?,
                   required: true,
                   aria: {
+                    describedby: invalid_email ? f.field_id(:email, "error") : nil,
+                    invalid: invalid_email,
                     required: true,
                   },
                   autocomplete: "email" %>
+    <% if invalid_email %>
+      <%= render "shared/form/field_errors",
+      id: f.field_id(:email, "error"),
+      errors: resource.errors.full_messages_for(:email) %>
+    <% end %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div><%= t(".confirmation_message", email: @resource.unconfirmed_email) %></div>
   <% end %>
 
-  <div class="form-field">
+  <% invalid_password = resource.errors.include?(:password) %>
+  <div class="form-field <%= 'invalid' if invalid_password %>">
     <%= f.label :password, data: { required: true } %>
     <i><%= t(".password_blank_hint") %></i><br/>
     <%= f.password_field :password,
                      required: true,
                      aria: {
+                       describedby: invalid_password ? f.field_id(:password, "error") : nil,
+                       invalid: invalid_password,
                        required: true,
                      },
                      autocomplete: "new-password" %>
@@ -34,27 +45,50 @@
       <br/>
       <em><%= t(".password_length_hint", minimum_password_length: @minimum_password_length) %></em>
     <% end %>
+    <% if invalid_password %>
+      <%= render "shared/form/field_errors",
+      id: f.field_id(:password, "error"),
+      errors: resource.errors.full_messages_for(:password) %>
+    <% end %>
   </div>
 
-  <div class="form-field">
+  <% invalid_password_confirmation = resource.errors.include?(:password_confirmation) %>
+  <div class="form-field <%= 'invalid' if invalid_password_confirmation %>">
     <%= f.label :password_confirmation, data: { required: true } %><br/>
     <%= f.password_field :password_confirmation,
                      required: true,
                      aria: {
+                       describedby:
+                         invalid_password_confirmation ? f.field_id(:password_confirmation, "error") : nil,
+                       invalid: invalid_password_confirmation,
                        required: true,
                      },
                      autocomplete: "new-password" %>
+    <% if invalid_password_confirmation %>
+      <%= render "shared/form/field_errors",
+      id: f.field_id(:password_confirmation, "error"),
+      errors: resource.errors.full_messages_for(:password_confirmation) %>
+    <% end %>
   </div>
 
-  <div class="form-field">
+  <% invalid_current_password = resource.errors.include?(:current_password) %>
+  <div class="form-field <%= 'invalid' if invalid_current_password %>">
     <%= f.label :current_password, data: { required: true } %>
     <i><%= t(".current_password_hint") %></i><br/>
     <%= f.password_field :current_password,
                      required: true,
                      aria: {
+                       describedby:
+                         invalid_current_password ? f.field_id(:current_password, "error") : nil,
+                       invalid: invalid_current_password,
                        required: true,
                      },
                      autocomplete: "current-password" %>
+    <% if invalid_current_password %>
+      <%= render "shared/form/field_errors",
+      id: f.field_id(:current_password, "error"),
+      errors: resource.errors.full_messages_for(:current_password) %>
+    <% end %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,11 +1,23 @@
 <h2><%= t(".title") %></h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, novalidate: true }) do |f| %>
+  <%= form_error_summary(f) %>
 
-  <div class="field">
+  <% invalid_email = resource.errors.include?(:email) %>
+  <div class="field <%= 'invalid' if invalid_email %>">
     <%= f.label :email %><br/>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email,
+                  autofocus: resource.errors.none?,
+                  autocomplete: "email",
+                  aria: {
+                    describedby: invalid_email ? f.field_id(:email, "error") : nil,
+                    invalid: invalid_email,
+                  } %>
+    <% if invalid_email %>
+      <%= render "shared/form/field_errors",
+      id: f.field_id(:email, "error"),
+      errors: resource.errors.full_messages_for(:email) %>
+    <% end %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -4,8 +4,10 @@
   <%= form_error_summary(f) %>
 
   <% invalid_email = resource.errors.include?(:email) %>
+
   <div class="field <%= 'invalid' if invalid_email %>">
-    <%= f.label :email %><br/>
+    <%= f.label :email %><br>
+
     <%= f.email_field :email,
                   autofocus: resource.errors.none?,
                   autocomplete: "email",
@@ -13,6 +15,7 @@
                     describedby: invalid_email ? f.field_id(:email, "error") : nil,
                     invalid: invalid_email,
                   } %>
+
     <% if invalid_email %>
       <%= render "shared/form/field_errors",
       id: f.field_id(:email, "error"),

--- a/test/integration/passwords_test.rb
+++ b/test/integration/passwords_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PasswordsViewTest < ActionView::TestCase
+  test 'password reset form renders the error summary and inline field error for email errors' do
+    user = User.new
+    user.errors.add(:email, :blank)
+    configure_devise_view_context(user)
+
+    render template: 'devise/passwords/new'
+
+    assert_select '[data-controller="form-error-summary"]'
+    assert_select '#user_email_error', "Email can't be blank"
+    assert_select 'a[href="#user_email"]', "Email can't be blank"
+  end
+
+  private
+
+  def configure_devise_view_context(resource)
+    view.singleton_class.class_eval do
+      define_method(:resource) { resource }
+      define_method(:resource_name) { :user }
+      define_method(:resource_class) { User }
+      define_method(:devise_mapping) { Devise.mappings[:user] }
+      define_method(:controller_name) { 'passwords' }
+      define_method(:params) { ActionController::Parameters.new }
+    end
+  end
+end

--- a/test/system/passwords_test.rb
+++ b/test/system/passwords_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class PasswordsTest < ApplicationSystemTestCase
+  setup do
+    @settings = Irida::CurrentSettings.current_application_settings
+    @original_password_authentication_enabled = @settings.password_authentication_enabled
+
+    @settings.update(password_authentication_enabled: true)
+  end
+
+  teardown do
+    @settings.update(password_authentication_enabled: @original_password_authentication_enabled)
+  end
+
+  test 'invalid password reset request focuses the summary and linked control' do
+    required_error = I18n.t('devise.passwords.new.email.required_error')
+
+    visit new_user_password_path
+
+    click_button I18n.t(:'devise.passwords.new.submit_button')
+
+    assert_selector '[data-controller="form-error-summary"]', focused: true
+    assert_selector '#user_email_error', text: required_error
+
+    within '[data-controller="form-error-summary"]' do
+      click_link required_error
+    end
+
+    assert_selector '#user_email', focused: true
+    assert_accessible
+  end
+end

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -33,4 +33,22 @@ class RegistrationsTest < ApplicationSystemTestCase
     assert_selector '#user_email', focused: true
     assert_accessible
   end
+
+  test 'invalid account update focuses the summary and linked control' do
+    login_as users(:john_doe)
+
+    visit edit_user_registration_path
+
+    click_button I18n.t('common.actions.update')
+
+    assert_selector '[data-controller="form-error-summary"]', focused: true
+    assert_selector '#user_current_password_error', text: "Current password can't be blank"
+
+    within '[data-controller="form-error-summary"]' do
+      click_link "Current password can't be blank"
+    end
+
+    assert_selector '#user_current_password', focused: true
+    assert_accessible
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
This updates a subset of the legacy Devise auth forms to use the shared form error summary and inline field errors when validation fails. It covers confirmation resend, unlock, password reset edit, and the older `/users/edit` account page, but it does not change the forgot password request page.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2073" height="674" alt="image" src="https://github.com/user-attachments/assets/10f6c82b-0cc9-440c-ad6d-30ce8f943016" />

## How to set up and validate locally
1. Start the app with `bin/dev`.
2. From the sign-in page, open **Didn't receive confirmation instructions?** and **Didn't receive unlock instructions?**, submit blank or invalid email values, and confirm each page shows the shared error summary plus inline field errors.
3. Open a password reset edit page with a valid reset token, submit invalid password values such as blank fields or a mismatched confirmation, and confirm the summary appears first and the inline password field errors render under the fields.
4. If you want to verify the legacy account edit page included in this PR, sign in and visit `/users/edit` directly, then submit without the required current password and confirm the summary gets focus and links to the current password field. Do not use `/-/users/edit`; that route does not exist.
6. Run `PARALLEL_WORKERS=4 bin/rails test test/system/registrations_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
