### PR TITLE
chore: devenv.sh strictPorts

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -76,8 +76,9 @@ lib.mkMerge [
     # https://devenv.sh/processes/
     # processes.dev.exec = "${lib.getExe pkgs.watchexec} -n -- ls -la";
     processes.sapporo-service = {
+      ports.http.allocate = 1122;
       exec = ''
-        SKIP_CHOWN_OUTPUTS=True SAPPORO_HOST=0.0.0.0 SAPPORO_PORT=1122 SAPPORO_DEBUG=True SAPPORO_RUN_SH=${config.git.root}/.devenv/sapporo-service/sapporo/run_irida_next.sh poetry run sapporo
+        SKIP_CHOWN_OUTPUTS=True SAPPORO_HOST=0.0.0.0 SAPPORO_PORT=${toString config.processes.sapporo-service.ports.http.value} SAPPORO_DEBUG=True SAPPORO_RUN_SH=${config.git.root}/.devenv/sapporo-service/sapporo/run_irida_next.sh poetry run sapporo
       '';
       cwd = "${config.git.root}/.devenv/sapporo-service/sapporo";
     };

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -2,7 +2,8 @@ inputs:
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling
   nixpkgs-ruby:
-    url: github:bobvanderlinden/nixpkgs-ruby
     inputs:
       nixpkgs:
         follows: nixpkgs
+    url: github:bobvanderlinden/nixpkgs-ruby
+strictPorts: true


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the devenv.sh config to use strictPorts option so that we always use port 5432 for postges and port 1122 for sapporo.

https://devenv.sh/processes/#strict-port-mode

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
