### PR TITLE
Add profile experimental feature opt-in service and tests

### DIFF
--- a/app/forms/profiles/experimental_features/opt_in_form.rb
+++ b/app/forms/profiles/experimental_features/opt_in_form.rb
@@ -34,6 +34,14 @@ module Profiles
         super
       end
 
+      def feature
+        feature_key.to_sym
+      end
+
+      def enabled?
+        enabled
+      end
+
       private
 
       def enabled_must_be_boolean_value

--- a/app/forms/profiles/experimental_features/opt_in_form.rb
+++ b/app/forms/profiles/experimental_features/opt_in_form.rb
@@ -8,10 +8,13 @@ module Profiles
       include ActiveModel::Attributes
       include ActiveModel::Validations
 
+      ENABLED_VALUES = [true, false, 'true', 'false', '1', '0', 1, 0].freeze
+
       attribute :feature_key, :string
       attribute :enabled, :boolean
 
       validates :feature_key, presence: true, format: { with: /\A[a-zA-Z0-9_]+\z/ }
+      validate :enabled_must_be_boolean_value
       validate :feature_must_be_eligible
 
       attr_reader :user, :settings, :result
@@ -24,6 +27,11 @@ module Profiles
         @user = user
         @settings = settings
         super(**attributes)
+      end
+
+      def enabled=(value)
+        @enabled_input = value
+        super
       end
 
       def save # rubocop:disable Naming/PredicateMethod -- ActiveRecord-style form API
@@ -42,8 +50,20 @@ module Profiles
         @opt_in_service ||= OptInService.new(user, settings:)
       end
 
+      def enabled_must_be_boolean_value
+        return if ENABLED_VALUES.include?(@enabled_input)
+
+        errors.add(:enabled, :inclusion)
+      end
+
       def feature_must_be_eligible
         return if feature_key.blank?
+
+        unless opt_in_service.manageable_feature?(feature_key)
+          errors.add(:feature_key, :invalid)
+          return
+        end
+
         return if opt_in_service.eligible?(feature_key)
 
         errors.add(:feature_key, :not_eligible)

--- a/app/forms/profiles/experimental_features/opt_in_form.rb
+++ b/app/forms/profiles/experimental_features/opt_in_form.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Profiles
+  module ExperimentalFeatures
+    # Form object for a single experimental-feature opt-in toggle submission.
+    class OptInForm
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      attribute :feature_key, :string
+      attribute :enabled, :boolean
+
+      validates :feature_key, presence: true, format: { with: /\A[a-zA-Z0-9_]+\z/ }
+      validate :feature_must_be_eligible
+
+      attr_reader :user, :settings, :result
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, 'OptInForm')
+      end
+
+      def initialize(user:, settings: Irida::CurrentSettings.current_application_settings, **attributes)
+        @user = user
+        @settings = settings
+        super(**attributes)
+      end
+
+      def save # rubocop:disable Naming/PredicateMethod -- ActiveRecord-style form API
+        return false unless valid?
+
+        @result = opt_in_service.toggle(feature_key, enabled)
+        return true if @result.success?
+
+        errors.add(:base, :flipper_error) if @result.error == :flipper_error
+        false
+      end
+
+      private
+
+      def opt_in_service
+        @opt_in_service ||= OptInService.new(user, settings:)
+      end
+
+      def feature_must_be_eligible
+        return if feature_key.blank?
+        return if opt_in_service.eligible?(feature_key)
+
+        errors.add(:feature_key, :not_eligible)
+      end
+    end
+  end
+end

--- a/app/forms/profiles/experimental_features/opt_in_form.rb
+++ b/app/forms/profiles/experimental_features/opt_in_form.rb
@@ -17,7 +17,7 @@ module Profiles
       validate :enabled_must_be_boolean_value
       validate :feature_must_be_eligible
 
-      attr_reader :user, :settings, :result
+      attr_reader :user, :settings
 
       def self.model_name
         ActiveModel::Name.new(self, nil, 'OptInForm')
@@ -34,21 +34,7 @@ module Profiles
         super
       end
 
-      def save # rubocop:disable Naming/PredicateMethod -- ActiveRecord-style form API
-        return false unless valid?
-
-        @result = opt_in_service.toggle(feature_key, enabled)
-        return true if @result.success?
-
-        errors.add(:base, :flipper_error) if @result.error == :flipper_error
-        false
-      end
-
       private
-
-      def opt_in_service
-        @opt_in_service ||= OptInService.new(user, settings:)
-      end
 
       def enabled_must_be_boolean_value
         return if ENABLED_VALUES.include?(@enabled_input)
@@ -59,14 +45,35 @@ module Profiles
       def feature_must_be_eligible
         return if feature_key.blank?
 
-        unless opt_in_service.manageable_feature?(feature_key)
+        unless manageable_feature?
           errors.add(:feature_key, :invalid)
           return
         end
 
-        return if opt_in_service.eligible?(feature_key)
+        return if eligible_user?
 
         errors.add(:feature_key, :not_eligible)
+      end
+
+      def manageable_feature?
+        feature_available? && feature_config.present?
+      end
+
+      def eligible_user?
+        return false if feature_config.blank?
+
+        allowlist = feature_config['allowlist']
+        return true if allowlist == 'all'
+
+        Array(allowlist).any? { |email| email.casecmp?(user.email) }
+      end
+
+      def feature_available?
+        FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
+      end
+
+      def feature_config
+        @feature_config ||= (settings.user_opt_in_features || {})[feature_key]
       end
     end
   end

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -36,7 +36,48 @@ class ApplicationSetting < ApplicationRecord
     signup_enabled? && password_authentication_enabled?
   end
 
+  def eligible_user_opt_in_features(user)
+    (user_opt_in_features || {}).filter_map do |feature_key, feature_config|
+      next unless flipper_feature_available?(feature_key)
+      next unless user_eligible_for_opt_in_feature?(feature_config, user)
+
+      user_opt_in_feature_payload(feature_key, feature_config, user)
+    end
+  end
+
   private
+
+  def flipper_feature_available?(feature_key)
+    return false if feature_key.blank?
+
+    FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
+  end
+
+  def user_eligible_for_opt_in_feature?(feature_config, user)
+    return false if feature_config.blank?
+
+    allowlist = feature_config['allowlist']
+    return true if allowlist == 'all'
+
+    Array(allowlist).any? { |email| email.casecmp?(user.email) }
+  end
+
+  def user_opt_in_feature_payload(feature_key, feature_config, user)
+    {
+      key: feature_key.to_sym,
+      name: localized_opt_in_feature_value(feature_config['name']),
+      description: localized_opt_in_feature_value(feature_config['description']),
+      enabled: user_opted_in_to_feature?(feature_key, user)
+    }
+  end
+
+  def localized_opt_in_feature_value(translations)
+    translations[I18n.locale.to_s].presence || translations['en']
+  end
+
+  def user_opted_in_to_feature?(feature_key, user)
+    Flipper[feature_key.to_sym].actors_value.include?(user.flipper_id)
+  end
 
   def only_one_instance
     return unless ApplicationSetting.count >= 1

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Profiles
+  module ExperimentalFeatures
+    # Service used to list and toggle user-managed experimental feature opt-ins.
+    class OptInService < BaseService
+      # Value object returned from feature opt-in toggle attempts.
+      class Result
+        attr_reader :feature, :error
+
+        def initialize(success:, feature: nil, error: nil)
+          @success = success
+          @feature = feature
+          @error = error
+        end
+
+        def success?
+          @success
+        end
+      end
+
+      def initialize(user, params = {}, settings: Irida::CurrentSettings.current_application_settings)
+        super(user, params)
+
+        @settings = settings
+      end
+
+      def eligible_features
+        user_opt_in_features.filter_map do |feature_key, feature_config|
+          next unless feature_available?(feature_key)
+          next unless user_eligible?(feature_config)
+
+          feature_payload(feature_key, feature_config)
+        end
+      end
+
+      def toggle(feature_key, enabled)
+        normalized_feature_key = feature_key.to_s
+        feature_config = user_opt_in_features[normalized_feature_key]
+
+        return ineligible_result unless eligible_config?(normalized_feature_key, feature_config)
+
+        update_actor_gate(normalized_feature_key, enabled)
+
+        success_result(normalized_feature_key, feature_config)
+      rescue Flipper::Error => e
+        Rails.logger.error("Unable to update experimental feature opt-in: #{e.message}")
+
+        flipper_error_result(normalized_feature_key, feature_config)
+      end
+
+      def eligible?(feature_key)
+        feature_config = user_opt_in_features[feature_key.to_s]
+
+        eligible_config?(feature_key.to_s, feature_config)
+      end
+
+      private
+
+      attr_reader :settings
+
+      def user_opt_in_features
+        settings.user_opt_in_features || {}
+      end
+
+      def feature_available?(feature_key)
+        return false if feature_key.blank?
+
+        FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
+      end
+
+      def eligible_config?(feature_key, feature_config)
+        feature_available?(feature_key) && user_eligible?(feature_config)
+      end
+
+      def user_eligible?(feature_config)
+        return false if feature_config.blank?
+
+        allowlist = feature_config['allowlist']
+        return true if allowlist == 'all'
+
+        Array(allowlist).any? { |email| email.casecmp?(current_user.email) }
+      end
+
+      def feature_payload(feature_key, feature_config)
+        {
+          key: feature_key.to_sym,
+          name: localized_config_value(feature_config['name']),
+          description: localized_config_value(feature_config['description']),
+          enabled: actor_opted_in?(feature_key)
+        }
+      end
+
+      def localized_config_value(translations)
+        translations[I18n.locale.to_s].presence || translations['en']
+      end
+
+      def actor_opted_in?(feature_key)
+        Flipper[feature_key.to_sym].actors_value.include?(current_user.flipper_id)
+      end
+
+      def update_actor_gate(feature_key, enabled)
+        if enabled
+          Flipper.enable_actor(feature_key.to_sym, current_user)
+        else
+          Flipper.disable_actor(feature_key.to_sym, current_user)
+        end
+      end
+
+      def success_result(feature_key, feature_config)
+        Result.new(success: true, feature: feature_payload(feature_key, feature_config))
+      end
+
+      def ineligible_result
+        Result.new(success: false, error: :not_eligible)
+      end
+
+      def flipper_error_result(feature_key, feature_config)
+        Result.new(
+          success: false,
+          feature: feature_payload(feature_key, feature_config),
+          error: :flipper_error
+        )
+      end
+    end
+  end
+end

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -4,24 +4,12 @@ module Profiles
   module ExperimentalFeatures
     # Service used to list and toggle user-managed experimental feature opt-ins.
     class OptInService < BaseService
-      # Value object returned from feature opt-in toggle attempts.
-      class Result
-        attr_reader :feature, :error
+      attr_reader :opt_in_form
 
-        def initialize(success:, feature: nil, error: nil)
-          @success = success
-          @feature = feature
-          @error = error
-        end
+      def initialize(user, opt_in_form = nil, settings: Irida::CurrentSettings.current_application_settings)
+        super(user)
 
-        def success?
-          @success
-        end
-      end
-
-      def initialize(user, params = {}, settings: Irida::CurrentSettings.current_application_settings)
-        super(user, params)
-
+        @opt_in_form = opt_in_form
         @settings = settings
       end
 
@@ -34,31 +22,15 @@ module Profiles
         end
       end
 
-      # Toggles the Flipper actor gate. Call only after OptInForm validation (or equivalent checks).
-      def toggle(feature_key, enabled)
-        normalized_feature_key = feature_key.to_s
-        feature_config = user_opt_in_features[normalized_feature_key]
+      def execute
+        return false unless opt_in_form&.valid?
 
-        update_actor_gate(normalized_feature_key, enabled)
-
-        success_result(normalized_feature_key, feature_config)
+        update_actor_gate(opt_in_form.feature_key, opt_in_form.enabled)
+        true
       rescue Flipper::Error => e
         Rails.logger.error("Unable to update experimental feature opt-in: #{e.message}")
-
-        flipper_error_result(normalized_feature_key, feature_config)
-      end
-
-      def eligible?(feature_key)
-        feature_config = user_opt_in_features[feature_key.to_s]
-
-        eligible_config?(feature_key.to_s, feature_config)
-      end
-
-      def manageable_feature?(feature_key)
-        normalized_feature_key = feature_key.to_s
-        feature_config = user_opt_in_features[normalized_feature_key]
-
-        feature_available?(normalized_feature_key) && feature_config.present?
+        opt_in_form.errors.add(:base, :flipper_error)
+        false
       end
 
       private
@@ -73,10 +45,6 @@ module Profiles
         return false if feature_key.blank?
 
         FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
-      end
-
-      def eligible_config?(feature_key, feature_config)
-        feature_available?(feature_key) && user_eligible?(feature_config)
       end
 
       def user_eligible?(feature_config)
@@ -111,18 +79,6 @@ module Profiles
         else
           Flipper.disable_actor(feature_key.to_sym, current_user)
         end
-      end
-
-      def success_result(feature_key, feature_config)
-        Result.new(success: true, feature: feature_payload(feature_key, feature_config))
-      end
-
-      def flipper_error_result(feature_key, feature_config)
-        Result.new(
-          success: false,
-          feature: feature_payload(feature_key, feature_config),
-          error: :flipper_error
-        )
       end
     end
   end

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -54,6 +54,13 @@ module Profiles
         eligible_config?(feature_key.to_s, feature_config)
       end
 
+      def manageable_feature?(feature_key)
+        normalized_feature_key = feature_key.to_s
+        feature_config = user_opt_in_features[normalized_feature_key]
+
+        feature_available?(normalized_feature_key) && feature_config.present?
+      end
+
       private
 
       attr_reader :settings

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -34,11 +34,10 @@ module Profiles
         end
       end
 
+      # Toggles the Flipper actor gate. Call only after OptInForm validation (or equivalent checks).
       def toggle(feature_key, enabled)
         normalized_feature_key = feature_key.to_s
         feature_config = user_opt_in_features[normalized_feature_key]
-
-        return ineligible_result unless eligible_config?(normalized_feature_key, feature_config)
 
         update_actor_gate(normalized_feature_key, enabled)
 
@@ -109,10 +108,6 @@ module Profiles
 
       def success_result(feature_key, feature_config)
         Result.new(success: true, feature: feature_payload(feature_key, feature_config))
-      end
-
-      def ineligible_result
-        Result.new(success: false, error: :not_eligible)
       end
 
       def flipper_error_result(feature_key, feature_config)

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -2,24 +2,14 @@
 
 module Profiles
   module ExperimentalFeatures
-    # Service used to list and toggle user-managed experimental feature opt-ins.
+    # Service used to toggle user-managed experimental feature opt-ins.
     class OptInService < BaseService
       attr_reader :opt_in_form
 
-      def initialize(user, opt_in_form = nil, settings: Irida::CurrentSettings.current_application_settings)
+      def initialize(user, opt_in_form = nil)
         super(user)
 
         @opt_in_form = opt_in_form
-        @settings = settings
-      end
-
-      def eligible_features
-        user_opt_in_features.filter_map do |feature_key, feature_config|
-          next unless feature_available?(feature_key)
-          next unless user_eligible?(feature_config)
-
-          feature_payload(feature_key, feature_config)
-        end
       end
 
       def execute
@@ -34,44 +24,6 @@ module Profiles
       end
 
       private
-
-      attr_reader :settings
-
-      def user_opt_in_features
-        settings.user_opt_in_features || {}
-      end
-
-      def feature_available?(feature_key)
-        return false if feature_key.blank?
-
-        FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
-      end
-
-      def user_eligible?(feature_config)
-        return false if feature_config.blank?
-
-        allowlist = feature_config['allowlist']
-        return true if allowlist == 'all'
-
-        Array(allowlist).any? { |email| email.casecmp?(current_user.email) }
-      end
-
-      def feature_payload(feature_key, feature_config)
-        {
-          key: feature_key.to_sym,
-          name: localized_config_value(feature_config['name']),
-          description: localized_config_value(feature_config['description']),
-          enabled: actor_opted_in?(feature_key)
-        }
-      end
-
-      def localized_config_value(translations)
-        translations[I18n.locale.to_s].presence || translations['en']
-      end
-
-      def actor_opted_in?(feature_key)
-        Flipper[feature_key.to_sym].actors_value.include?(current_user.flipper_id)
-      end
 
       def update_actor_gate
         if opt_in_form.enabled?

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -25,7 +25,7 @@ module Profiles
       def execute
         return false unless opt_in_form&.valid?
 
-        update_actor_gate(opt_in_form.feature_key, opt_in_form.enabled)
+        update_actor_gate
         true
       rescue Flipper::Error => e
         Rails.logger.error("Unable to update experimental feature opt-in: #{e.message}")
@@ -73,11 +73,11 @@ module Profiles
         Flipper[feature_key.to_sym].actors_value.include?(current_user.flipper_id)
       end
 
-      def update_actor_gate(feature_key, enabled)
-        if enabled
-          Flipper.enable_actor(feature_key.to_sym, current_user)
+      def update_actor_gate
+        if opt_in_form.enabled?
+          Flipper.enable_actor(opt_in_form.feature, current_user)
         else
-          Flipper.disable_actor(feature_key.to_sym, current_user)
+          Flipper.disable_actor(opt_in_form.feature, current_user)
         end
       end
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -929,7 +929,7 @@ if Rails.env.development?
         'fr' => "Activer la nouvelle grille de données pour le tableau d'échantillons."
       }
     },
-    'client_linelist_exports' => {
+    'client_linelist_exports_v1' => {
       'allowlist' => ['user1@email.com'],
       'name' => {
         'en' => 'Client Linelist Exports',
@@ -942,6 +942,8 @@ if Rails.env.development?
     }
   }
   app_setting.update!(
-    user_opt_in_features: default_opt_in_features.merge(app_setting.user_opt_in_features)
+    user_opt_in_features: default_opt_in_features.merge(
+      app_setting.user_opt_in_features.except('client_linelist_exports')
+    )
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -942,8 +942,6 @@ if Rails.env.development?
     }
   }
   app_setting.update!(
-    user_opt_in_features: default_opt_in_features.merge(
-      app_setting.user_opt_in_features.except('client_linelist_exports')
-    )
+    user_opt_in_features: default_opt_in_features.merge(app_setting.user_opt_in_features)
   )
 end

--- a/test/forms/profiles/experimental_features/opt_in_form_test.rb
+++ b/test/forms/profiles/experimental_features/opt_in_form_test.rb
@@ -9,97 +9,73 @@ module Profiles
         @user = users(:john_doe)
 
         ApplicationSetting.delete_all
-        Flipper.disable_actor(:data_grid_samples_table, @user)
       end
 
-      test 'save is invalid when feature_key is blank' do
+      test 'is invalid when feature_key is blank' do
         with_user_opt_in_features(user_opt_in_feature_config) do
           form = build_form(feature_key: '', enabled: true)
 
-          assert_not form.save
+          assert_not form.valid?
           assert_predicate form.errors[:feature_key], :any?
-          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
         end
       end
 
-      test 'save is invalid when feature_key format is invalid' do
+      test 'is invalid when feature_key format is invalid' do
         with_user_opt_in_features(user_opt_in_feature_config) do
           form = build_form(feature_key: 'bad-key!', enabled: true)
 
-          assert_not form.save
+          assert_not form.valid?
           assert_predicate form.errors[:feature_key], :any?
-          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
         end
       end
 
-      test 'save is invalid when enabled is not a boolean-like value' do
+      test 'is invalid when enabled is not a boolean-like value' do
         with_user_opt_in_features(user_opt_in_feature_config) do
           form = build_form(feature_key: 'data_grid_samples_table', enabled: 'yes')
 
-          assert_not form.save
+          assert_not form.valid?
           assert_includes form.errors.details[:enabled].pluck(:error), :inclusion
-          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
         end
       end
 
-      test 'save is invalid when user is not on allowlist' do
+      test 'is invalid when user is not on allowlist' do
         config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
 
         with_user_opt_in_features(config) do
           form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
 
-          assert_not form.save
+          assert_not form.valid?
           assert_includes form.errors.details[:feature_key].pluck(:error), :not_eligible
-          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
         end
       end
 
-      test 'save is invalid for unknown feature key' do
+      test 'is invalid for unknown feature key' do
         config = user_opt_in_feature_config(feature_key: :unknown_experiment, allowlist: 'all')
 
         with_user_opt_in_features(config) do
           form = build_form(feature_key: 'unknown_experiment', enabled: true)
 
-          assert_not form.save
+          assert_not form.valid?
           assert_includes form.errors.details[:feature_key].pluck(:error), :invalid
           assert_not Flipper.exist?(:unknown_experiment)
         end
       end
 
-      test 'save enables actor gate for eligible feature' do
+      test 'is valid for eligible feature' do
         with_user_opt_in_features(user_opt_in_feature_config) do
           form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
 
-          assert form.save
-          assert_predicate form.result, :success?
-          assert_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
-        end
-      ensure
-        Flipper.disable_actor(:data_grid_samples_table, @user)
-      end
-
-      test 'save disables actor gate for eligible feature' do
-        Flipper.enable_actor(:data_grid_samples_table, @user)
-
-        with_user_opt_in_features(user_opt_in_feature_config) do
-          form = build_form(feature_key: 'data_grid_samples_table', enabled: false)
-
-          assert form.save
-          assert_predicate form.result, :success?
-          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+          assert_predicate form, :valid?
         end
       end
 
-      test 'save adds flipper_error when toggle fails' do
-        Flipper.expects(:enable_actor).raises(Flipper::Error, 'adapter failed')
-        Rails.logger.expects(:error).with(regexp_matches(/adapter failed/))
+      test 'matches allowlist emails case-insensitively' do
+        config = user_opt_in_feature_config(allowlist: [@user.email.upcase])
 
-        with_user_opt_in_features(user_opt_in_feature_config) do
+        with_user_opt_in_features(config) do
           form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
 
-          assert_not form.save
-          assert_includes form.errors.details[:base].pluck(:error), :flipper_error
-          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+          assert_predicate form, :valid?
         end
       end
 

--- a/test/forms/profiles/experimental_features/opt_in_form_test.rb
+++ b/test/forms/profiles/experimental_features/opt_in_form_test.rb
@@ -32,6 +32,16 @@ module Profiles
         end
       end
 
+      test 'save is invalid when enabled is not a boolean-like value' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: 'yes')
+
+          assert_not form.save
+          assert_includes form.errors.details[:enabled].pluck(:error), :inclusion
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
       test 'save is invalid when user is not on allowlist' do
         config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
 
@@ -51,7 +61,7 @@ module Profiles
           form = build_form(feature_key: 'unknown_experiment', enabled: true)
 
           assert_not form.save
-          assert_includes form.errors.details[:feature_key].pluck(:error), :not_eligible
+          assert_includes form.errors.details[:feature_key].pluck(:error), :invalid
           assert_not Flipper.exist?(:unknown_experiment)
         end
       end

--- a/test/forms/profiles/experimental_features/opt_in_form_test.rb
+++ b/test/forms/profiles/experimental_features/opt_in_form_test.rb
@@ -69,6 +69,22 @@ module Profiles
         end
       end
 
+      test 'exposes feature symbol for valid opt in' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
+
+          assert_predicate form, :valid?
+          assert_equal :data_grid_samples_table, form.feature
+        end
+      end
+
+      test 'exposes boolean enabled state' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          assert_predicate build_form(feature_key: 'data_grid_samples_table', enabled: '1'), :enabled?
+          assert_not_predicate build_form(feature_key: 'data_grid_samples_table', enabled: '0'), :enabled?
+        end
+      end
+
       test 'matches allowlist emails case-insensitively' do
         config = user_opt_in_feature_config(allowlist: [@user.email.upcase])
 

--- a/test/forms/profiles/experimental_features/opt_in_form_test.rb
+++ b/test/forms/profiles/experimental_features/opt_in_form_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Profiles
+  module ExperimentalFeatures
+    class OptInFormTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:john_doe)
+
+        ApplicationSetting.delete_all
+        Flipper.disable_actor(:data_grid_samples_table, @user)
+      end
+
+      test 'save is invalid when feature_key is blank' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          form = build_form(feature_key: '', enabled: true)
+
+          assert_not form.save
+          assert_predicate form.errors[:feature_key], :any?
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
+      test 'save is invalid when feature_key format is invalid' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          form = build_form(feature_key: 'bad-key!', enabled: true)
+
+          assert_not form.save
+          assert_predicate form.errors[:feature_key], :any?
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
+      test 'save is invalid when user is not on allowlist' do
+        config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
+
+        with_user_opt_in_features(config) do
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
+
+          assert_not form.save
+          assert_includes form.errors.details[:feature_key].pluck(:error), :not_eligible
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
+      test 'save is invalid for unknown feature key' do
+        config = user_opt_in_feature_config(feature_key: :unknown_experiment, allowlist: 'all')
+
+        with_user_opt_in_features(config) do
+          form = build_form(feature_key: 'unknown_experiment', enabled: true)
+
+          assert_not form.save
+          assert_includes form.errors.details[:feature_key].pluck(:error), :not_eligible
+          assert_not Flipper.exist?(:unknown_experiment)
+        end
+      end
+
+      test 'save enables actor gate for eligible feature' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
+
+          assert form.save
+          assert_predicate form.result, :success?
+          assert_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      ensure
+        Flipper.disable_actor(:data_grid_samples_table, @user)
+      end
+
+      test 'save disables actor gate for eligible feature' do
+        Flipper.enable_actor(:data_grid_samples_table, @user)
+
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: false)
+
+          assert form.save
+          assert_predicate form.result, :success?
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
+      test 'save adds flipper_error when toggle fails' do
+        Flipper.expects(:enable_actor).raises(Flipper::Error, 'adapter failed')
+        Rails.logger.expects(:error).with(regexp_matches(/adapter failed/))
+
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
+
+          assert_not form.save
+          assert_includes form.errors.details[:base].pluck(:error), :flipper_error
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
+      test 'param_key is opt_in_form for form_with' do
+        assert_equal 'opt_in_form', OptInForm.model_name.param_key
+      end
+
+      private
+
+      def build_form(**attributes)
+        OptInForm.new(user: @user, **attributes)
+      end
+    end
+  end
+end

--- a/test/models/application_setting_test.rb
+++ b/test/models/application_setting_test.rb
@@ -169,4 +169,68 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     settings.update(max_personal_access_token_lifetime_in_days: 20)
     assert_equal 20, settings.max_personal_access_token_lifetime_in_days
   end
+
+  test 'eligible_user_opt_in_features returns features with all-user allowlist' do
+    user = users(:john_doe)
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: user_opt_in_feature_config)
+
+    features = settings.eligible_user_opt_in_features(user)
+
+    assert_equal [:data_grid_samples_table], features.pluck(:key)
+    assert_equal 'Data Grid Samples Table', features.first[:name]
+    assert_equal 'Enable the new data grid for the samples table.', features.first[:description]
+    assert_not features.first[:enabled]
+  end
+
+  test 'eligible_user_opt_in_features uses case-insensitive email allowlist matching' do
+    user = users(:john_doe)
+    config = user_opt_in_feature_config(allowlist: [user.email.upcase])
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: config)
+
+    features = settings.eligible_user_opt_in_features(user)
+
+    assert_equal [:data_grid_samples_table], features.pluck(:key)
+  end
+
+  test 'eligible_user_opt_in_features excludes users missing from email allowlist' do
+    user = users(:john_doe)
+    config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: config)
+
+    assert_empty settings.eligible_user_opt_in_features(user)
+  end
+
+  test 'eligible_user_opt_in_features excludes feature keys missing from flipper feature config' do
+    user = users(:john_doe)
+    config = user_opt_in_feature_config(feature_key: :unknown_experiment, allowlist: 'all')
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: config)
+
+    assert_empty settings.eligible_user_opt_in_features(user)
+  end
+
+  test 'eligible_user_opt_in_features reports actor-specific enabled state' do
+    user = users(:john_doe)
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: user_opt_in_feature_config)
+
+    Flipper.enable_actor(:data_grid_samples_table, user)
+
+    feature = settings.eligible_user_opt_in_features(user).first
+
+    assert feature[:enabled]
+  ensure
+    Flipper.disable_actor(:data_grid_samples_table, user)
+  end
+
+  test 'eligible_user_opt_in_features localizes feature metadata with english fallback' do
+    user = users(:john_doe)
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: user_opt_in_feature_config)
+
+    I18n.with_locale(:fr) do
+      feature = settings.eligible_user_opt_in_features(user).first
+
+      assert_equal 'Tableau de donnees des echantillons', feature[:name]
+      assert_equal "Activer la nouvelle grille de donnees pour le tableau d'echantillons.",
+                   feature[:description]
+    end
+  end
 end

--- a/test/services/profiles/experimental_features/opt_in_service_test.rb
+++ b/test/services/profiles/experimental_features/opt_in_service_test.rb
@@ -13,67 +13,6 @@ module Profiles
         Flipper.disable_actor(:v2_datepicker, @user)
       end
 
-      test 'eligible_features returns features with all-user allowlist' do
-        with_user_opt_in_features(user_opt_in_feature_config) do
-          features = OptInService.new(@user).eligible_features
-
-          assert_equal [:data_grid_samples_table], features.pluck(:key)
-          assert_equal 'Data Grid Samples Table', features.first[:name]
-          assert_equal 'Enable the new data grid for the samples table.', features.first[:description]
-          assert_not features.first[:enabled]
-        end
-      end
-
-      test 'eligible_features uses case-insensitive email allowlist matching' do
-        config = user_opt_in_feature_config(allowlist: [@user.email.upcase])
-
-        with_user_opt_in_features(config) do
-          features = OptInService.new(@user).eligible_features
-
-          assert_equal [:data_grid_samples_table], features.pluck(:key)
-        end
-      end
-
-      test 'eligible_features excludes users missing from email allowlist' do
-        config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
-
-        with_user_opt_in_features(config) do
-          assert_empty OptInService.new(@user).eligible_features
-        end
-      end
-
-      test 'eligible_features excludes feature keys missing from flipper feature config' do
-        config = user_opt_in_feature_config(feature_key: :unknown_experiment, allowlist: 'all')
-
-        with_user_opt_in_features(config) do
-          assert_empty OptInService.new(@user).eligible_features
-        end
-      end
-
-      test 'eligible_features reports actor-specific enabled state' do
-        Flipper.enable_actor(:data_grid_samples_table, @user)
-
-        with_user_opt_in_features(user_opt_in_feature_config) do
-          feature = OptInService.new(@user).eligible_features.first
-
-          assert feature[:enabled]
-        end
-      ensure
-        Flipper.disable_actor(:data_grid_samples_table, @user)
-      end
-
-      test 'eligible_features localizes feature metadata with english fallback' do
-        I18n.with_locale(:fr) do
-          with_user_opt_in_features(user_opt_in_feature_config) do
-            feature = OptInService.new(@user).eligible_features.first
-
-            assert_equal 'Tableau de donnees des echantillons', feature[:name]
-            assert_equal "Activer la nouvelle grille de donnees pour le tableau d'echantillons.",
-                         feature[:description]
-          end
-        end
-      end
-
       test 'execute enables actor gate for a valid form' do
         with_user_opt_in_features(user_opt_in_feature_config) do
           form = build_form(feature_key: 'data_grid_samples_table', enabled: true)

--- a/test/services/profiles/experimental_features/opt_in_service_test.rb
+++ b/test/services/profiles/experimental_features/opt_in_service_test.rb
@@ -100,30 +100,6 @@ module Profiles
         end
       end
 
-      test 'toggle rejects ineligible feature without mutating actor gate' do
-        config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
-
-        with_user_opt_in_features(config) do
-          result = OptInService.new(@user).toggle(:data_grid_samples_table, true)
-
-          assert_not result.success?
-          assert_equal :not_eligible, result.error
-          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
-        end
-      end
-
-      test 'toggle rejects unknown feature without mutating actor gate' do
-        config = user_opt_in_feature_config(feature_key: :unknown_experiment, allowlist: 'all')
-
-        with_user_opt_in_features(config) do
-          result = OptInService.new(@user).toggle(:unknown_experiment, true)
-
-          assert_not result.success?
-          assert_equal :not_eligible, result.error
-          assert_not Flipper.exist?(:unknown_experiment)
-        end
-      end
-
       test 'toggle catches and logs flipper errors' do
         Flipper.expects(:enable_actor).raises(Flipper::Error, 'adapter failed')
         Rails.logger.expects(:error).with(regexp_matches(/adapter failed/))

--- a/test/services/profiles/experimental_features/opt_in_service_test.rb
+++ b/test/services/profiles/experimental_features/opt_in_service_test.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Profiles
+  module ExperimentalFeatures
+    class OptInServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:john_doe)
+
+        ApplicationSetting.delete_all
+        Flipper.disable_actor(:data_grid_samples_table, @user)
+        Flipper.disable_actor(:v2_datepicker, @user)
+      end
+
+      test 'eligible_features returns features with all-user allowlist' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          features = OptInService.new(@user).eligible_features
+
+          assert_equal [:data_grid_samples_table], features.pluck(:key)
+          assert_equal 'Data Grid Samples Table', features.first[:name]
+          assert_equal 'Enable the new data grid for the samples table.', features.first[:description]
+          assert_not features.first[:enabled]
+        end
+      end
+
+      test 'eligible_features uses case-insensitive email allowlist matching' do
+        config = user_opt_in_feature_config(allowlist: [@user.email.upcase])
+
+        with_user_opt_in_features(config) do
+          features = OptInService.new(@user).eligible_features
+
+          assert_equal [:data_grid_samples_table], features.pluck(:key)
+        end
+      end
+
+      test 'eligible_features excludes users missing from email allowlist' do
+        config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
+
+        with_user_opt_in_features(config) do
+          assert_empty OptInService.new(@user).eligible_features
+        end
+      end
+
+      test 'eligible_features excludes feature keys missing from flipper feature config' do
+        config = user_opt_in_feature_config(feature_key: :unknown_experiment, allowlist: 'all')
+
+        with_user_opt_in_features(config) do
+          assert_empty OptInService.new(@user).eligible_features
+        end
+      end
+
+      test 'eligible_features reports actor-specific enabled state' do
+        Flipper.enable_actor(:data_grid_samples_table, @user)
+
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          feature = OptInService.new(@user).eligible_features.first
+
+          assert feature[:enabled]
+        end
+      ensure
+        Flipper.disable_actor(:data_grid_samples_table, @user)
+      end
+
+      test 'eligible_features localizes feature metadata with english fallback' do
+        I18n.with_locale(:fr) do
+          with_user_opt_in_features(user_opt_in_feature_config) do
+            feature = OptInService.new(@user).eligible_features.first
+
+            assert_equal 'Tableau de donnees des echantillons', feature[:name]
+            assert_equal "Activer la nouvelle grille de donnees pour le tableau d'echantillons.",
+                         feature[:description]
+          end
+        end
+      end
+
+      test 'toggle enables actor gate for eligible feature' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          result = OptInService.new(@user).toggle(:data_grid_samples_table, true)
+
+          assert result.success?
+          assert_nil result.error
+          assert_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+          assert result.feature[:enabled]
+        end
+      ensure
+        Flipper.disable_actor(:data_grid_samples_table, @user)
+      end
+
+      test 'toggle disables actor gate for eligible feature' do
+        Flipper.enable_actor(:data_grid_samples_table, @user)
+
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          result = OptInService.new(@user).toggle('data_grid_samples_table', false)
+
+          assert result.success?
+          assert_nil result.error
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+          assert_not result.feature[:enabled]
+        end
+      end
+
+      test 'toggle rejects ineligible feature without mutating actor gate' do
+        config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
+
+        with_user_opt_in_features(config) do
+          result = OptInService.new(@user).toggle(:data_grid_samples_table, true)
+
+          assert_not result.success?
+          assert_equal :not_eligible, result.error
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
+      test 'toggle rejects unknown feature without mutating actor gate' do
+        config = user_opt_in_feature_config(feature_key: :unknown_experiment, allowlist: 'all')
+
+        with_user_opt_in_features(config) do
+          result = OptInService.new(@user).toggle(:unknown_experiment, true)
+
+          assert_not result.success?
+          assert_equal :not_eligible, result.error
+          assert_not Flipper.exist?(:unknown_experiment)
+        end
+      end
+
+      test 'toggle catches and logs flipper errors' do
+        Flipper.expects(:enable_actor).raises(Flipper::Error, 'adapter failed')
+        Rails.logger.expects(:error).with(regexp_matches(/adapter failed/))
+
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          result = OptInService.new(@user).toggle(:data_grid_samples_table, true)
+
+          assert_not result.success?
+          assert_equal :flipper_error, result.error
+          assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        end
+      end
+
+      test 'eligible? returns true only for available features allowlisted for user' do
+        config = user_opt_in_feature_config.merge(
+          user_opt_in_feature_config(feature_key: :v2_datepicker, allowlist: [users(:jane_doe).email])
+        )
+
+        with_user_opt_in_features(config) do
+          service = OptInService.new(@user)
+
+          assert service.eligible?(:data_grid_samples_table)
+          assert_not service.eligible?(:v2_datepicker)
+          assert_not service.eligible?(:unknown_experiment)
+        end
+      end
+    end
+  end
+end

--- a/test/services/profiles/experimental_features/opt_in_service_test.rb
+++ b/test/services/profiles/experimental_features/opt_in_service_test.rb
@@ -74,57 +74,54 @@ module Profiles
         end
       end
 
-      test 'toggle enables actor gate for eligible feature' do
+      test 'execute enables actor gate for a valid form' do
         with_user_opt_in_features(user_opt_in_feature_config) do
-          result = OptInService.new(@user).toggle(:data_grid_samples_table, true)
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
 
-          assert result.success?
-          assert_nil result.error
+          assert OptInService.new(@user, form).execute
           assert_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
-          assert result.feature[:enabled]
         end
       ensure
         Flipper.disable_actor(:data_grid_samples_table, @user)
       end
 
-      test 'toggle disables actor gate for eligible feature' do
+      test 'execute disables actor gate for a valid form' do
         Flipper.enable_actor(:data_grid_samples_table, @user)
 
         with_user_opt_in_features(user_opt_in_feature_config) do
-          result = OptInService.new(@user).toggle('data_grid_samples_table', false)
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: false)
 
-          assert result.success?
-          assert_nil result.error
+          assert OptInService.new(@user, form).execute
           assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
-          assert_not result.feature[:enabled]
         end
       end
 
-      test 'toggle catches and logs flipper errors' do
+      test 'execute returns false when the form is invalid' do
+        form = mock('opt_in_form')
+        form.expects(:valid?).returns(false)
+        Flipper.expects(:enable_actor).never
+        Flipper.expects(:disable_actor).never
+
+        assert_not OptInService.new(@user, form).execute
+      end
+
+      test 'execute adds flipper_error when toggle fails' do
         Flipper.expects(:enable_actor).raises(Flipper::Error, 'adapter failed')
         Rails.logger.expects(:error).with(regexp_matches(/adapter failed/))
 
         with_user_opt_in_features(user_opt_in_feature_config) do
-          result = OptInService.new(@user).toggle(:data_grid_samples_table, true)
+          form = build_form(feature_key: 'data_grid_samples_table', enabled: true)
 
-          assert_not result.success?
-          assert_equal :flipper_error, result.error
+          assert_not OptInService.new(@user, form).execute
+          assert_includes form.errors.details[:base].pluck(:error), :flipper_error
           assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
         end
       end
 
-      test 'eligible? returns true only for available features allowlisted for user' do
-        config = user_opt_in_feature_config.merge(
-          user_opt_in_feature_config(feature_key: :v2_datepicker, allowlist: [users(:jane_doe).email])
-        )
+      private
 
-        with_user_opt_in_features(config) do
-          service = OptInService.new(@user)
-
-          assert service.eligible?(:data_grid_samples_table)
-          assert_not service.eligible?(:v2_datepicker)
-          assert_not service.eligible?(:unknown_experiment)
-        end
+      def build_form(**attributes)
+        OptInForm.new(user: @user, **attributes)
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,7 @@ require 'test_helpers/workflow_execution_advanced_search_helper'
 require 'test_helpers/dashboard_sorting_helper'
 require 'test_helpers/sorting_test_helper'
 require 'test_helpers/w3c_validation_helpers'
+require 'test_helpers/user_opt_in_features_test_helper'
 require 'turbo/broadcastable/test_helper'
 require 'minitest/retry'
 
@@ -74,6 +75,7 @@ module ActiveSupport
     include Turbo::Broadcastable::TestHelper
     include W3cValidationHelpers
     include SortingTestHelper
+    include UserOptInFeaturesTestHelper
 
     PublicActivity.enabled = true
   end

--- a/test/test_helpers/user_opt_in_features_test_helper.rb
+++ b/test/test_helpers/user_opt_in_features_test_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module UserOptInFeaturesTestHelper
+  def with_user_opt_in_features(features)
+    settings = ApplicationSetting.current || ApplicationSetting.create_from_defaults
+    previous_features = settings.user_opt_in_features.deep_dup
+
+    settings.update!(user_opt_in_features: features.deep_stringify_keys)
+
+    yield settings
+  ensure
+    settings&.update!(user_opt_in_features: previous_features) if settings&.persisted?
+  end
+
+  def user_opt_in_feature_config(feature_key: :data_grid_samples_table, allowlist: 'all')
+    {
+      feature_key.to_s => {
+        'allowlist' => allowlist,
+        'name' => {
+          'en' => 'Data Grid Samples Table',
+          'fr' => 'Tableau de donnees des echantillons'
+        },
+        'description' => {
+          'en' => 'Enable the new data grid for the samples table.',
+          'fr' => "Activer la nouvelle grille de donnees pour le tableau d'echantillons."
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
This adds the server-side foundation for user-managed experimental feature opt-ins on profile pages. It includes a service for eligibility and Flipper actor toggling, plus a form object that validates toggle params before updates.

It also hardens input handling by rejecting malformed `enabled` values and classifying unknown feature keys as invalid input.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Enter the project Ruby environment: `devenv shell`.
2. Run focused tests:
   - `bin/rails test test/services/profiles/experimental_features/opt_in_service_test.rb`
   - `bin/rails test test/forms/profiles/experimental_features/opt_in_form_test.rb`
3. Optional broader check: `PARALLEL_WORKERS=4 bin/rails test test/services/profiles/experimental_features test/forms/profiles/experimental_features`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.