### PR TITLE
PAT: Add last_used_ip to table_component

### DIFF
--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -31,6 +31,14 @@
       <% end %>
     <% end %>
 
+    <% table.with_column(t("personal_access_tokens.table.header.last_used_ip")) do |row| %>
+      <% if row[:last_used_ips].empty? %>
+        <%= t("personal_access_tokens.table.never_used") %>
+      <% else %>
+        <%= row[:last_used_ips].last %>
+      <% end %>
+    <% end %>
+
     <% if @revoked_pats %>
       <% table.with_column(t("personal_access_tokens.table.header.revocation_date")) do |row| %>
         <% if row[:revoked] == true %>

--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -31,7 +31,7 @@
       <% end %>
     <% end %>
 
-    <% table.with_column(t("personal_access_tokens.table.header.last_used_ip")) do |row| %>
+    <% table.with_column(t("personal_access_tokens.table.header.last_used_ips")) do |row| %>
       <% if row[:last_used_ips].empty? %>
         <%= t("personal_access_tokens.table.never_used") %>
       <% else %>

--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -35,7 +35,7 @@
       <% if row[:last_used_ips].empty? %>
         <%= t("personal_access_tokens.table.never_used") %>
       <% else %>
-        <%= row[:last_used_ips].last %>
+        <%= row[:last_used_ips].join(", ") %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1246,11 +1246,13 @@ en:
         expires_at: Expiration Date
         integration_host: Integration ID
         last_used_at: Last Used
+        last_used_ip: Last Used IP
         name: Token name
         revocation_date: Revocation Date
         scopes: Scopes
         status: Status
       never: Never
+      never_used: Never used
       revoke: Revoke
       revoke_aria_label: 'Revoke personal access token: %{name}'
       revoke_confirmation: Are you sure you want to revoke this personal access token?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1246,7 +1246,7 @@ en:
         expires_at: Expiration Date
         integration_host: Integration ID
         last_used_at: Last Used
-        last_used_ip: Last Used IP
+        last_used_ips: Last Used IPs
         name: Token name
         revocation_date: Revocation Date
         scopes: Scopes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1250,11 +1250,13 @@ fr:
         expires_at: Date d'expiration
         integration_host: Integration ID
         last_used_at: Dernière utilisation
+        last_used_ip: Dernière adresse IP utilisée
         name: Nom du jeton
         revocation_date: Date de révocation
         scopes: Portées
         status: Statut
       never: Jamais
+      never_used: Jamais utilisé
       revoke: Révoquer
       revoke_aria_label: 'Révoquer le jeton d’accès personnel : %{name}'
       revoke_confirmation: Êtes-vous sûr de vouloir révoquer ce jeton d’accès personnel?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1250,7 +1250,7 @@ fr:
         expires_at: Date d'expiration
         integration_host: Integration ID
         last_used_at: Dernière utilisation
-        last_used_ip: Dernière adresse IP utilisée
+        last_used_ips: Dernières IP utilisées
         name: Nom du jeton
         revocation_date: Date de révocation
         scopes: Portées

--- a/test/fixtures/personal_access_tokens.yml
+++ b/test/fixtures/personal_access_tokens.yml
@@ -51,6 +51,17 @@ john_doe_non_expirable_pat:
   token_digest: <%= Devise.token_generator.digest(PersonalAccessToken, :token_digest, "b8rH5_yCXFi-fxirkvfz") %>
   last_used_at: nil
 
+john_doe_valid_pat_used:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:john_doe, :uuid) %>
+  scopes:
+    - api
+  name: Valid PAT
+  revoked: false
+  expires_at: <%= 10.days.from_now.to_date %>
+  token_digest: <%= Devise.token_generator.digest(PersonalAccessToken, :token_digest, "JQ2w5maQc4zgvC8GGMEr") %>
+  last_used_at: <%= 1.day.ago %>
+  last_used_ips: ['192.168.1.2', '192.168.1.1']
+
 jane_doe_valid_pat:
   user_id: <%= ActiveRecord::FixtureSet.identify(:jane_doe, :uuid) %>
   scopes:

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,7 +27,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '#personal_access_tokens' do
-    assert_equal 5, @user.personal_access_tokens.size
+    assert_equal 6, @user.personal_access_tokens.size
   end
 
   test '#destroy removes dependant user namespace, and projects' do

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -231,7 +231,7 @@ module Groups
             assert_selector 'td:nth-child(3)', text: 'read_api, api'
 
             assert_selector 'td:nth-child(4)', text: I18n.l(token.created_at.getlocal.to_date, format: :long)
-            assert_selector 'td:nth-child(6)',
+            assert_selector 'td:nth-child(7)',
                             text: I18n.l(DateTime.parse(token.expires_at.to_s).getlocal.to_date, format: :long)
           end
         end
@@ -276,7 +276,7 @@ module Groups
             assert_selector 'td:nth-child(3)', text: 'read_api, api'
 
             assert_selector 'td:nth-child(4)', text: I18n.l(expired_token.created_at.getlocal.to_date, format: :long)
-            assert_selector 'td:nth-child(7)',
+            assert_selector 'td:nth-child(8)',
                             text: I18n.l(DateTime.parse(expired_token.expires_at.to_s).getlocal.to_date, format: :long)
           end
 
@@ -285,9 +285,9 @@ module Groups
             assert_selector 'td:nth-child(3)', text: 'read_api, api'
 
             assert_selector 'td:nth-child(4)', text: I18n.l(revoked_token.created_at.getlocal.to_date, format: :long)
-            assert_selector 'td:nth-child(6)',
-                            text: I18n.l(DateTime.parse(revoked_token.updated_at.to_s).getlocal.to_date, format: :long)
             assert_selector 'td:nth-child(7)',
+                            text: I18n.l(DateTime.parse(revoked_token.updated_at.to_s).getlocal.to_date, format: :long)
+            assert_selector 'td:nth-child(8)',
                             text: I18n.l(DateTime.parse(revoked_token.expires_at.to_s).getlocal.to_date, format: :long)
           end
         end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -107,10 +107,10 @@ class ProfileTest < ApplicationSystemTestCase
     PersonalAccessTokens::CreateService.new(@user, valid_params).execute
 
     active_token_count = @user.personal_access_tokens.active.count
-    assert_equal 4, active_token_count
+    assert_equal 5, active_token_count
 
     expiring_token_count = @user.personal_access_tokens.expiring_in_two_weeks.count
-    assert_equal 2, expiring_token_count
+    assert_equal 3, expiring_token_count
 
     visit profile_path
     click_link I18n.t(:'profiles.sidebar.access_tokens')
@@ -277,6 +277,21 @@ class ProfileTest < ApplicationSystemTestCase
     within %(tr[id="#{dom_id(token_to_rotate)}"]) do
       assert_no_button I18n.t(:'personal_access_tokens.table.rotate')
     end
+  end
+
+  test 'can view last_used_ip of personal access tokens' do
+    visit profile_path
+    click_link I18n.t(:'profiles.sidebar.access_tokens')
+
+    not_used_pat = personal_access_tokens(:john_doe_non_expirable_pat)
+    used_pat = personal_access_tokens(:john_doe_valid_pat_used)
+
+    assert_selector 'div#access-tokens-table'
+    assert_selector "table tbody tr[id='personal_access_token_#{not_used_pat.id}'] td:nth-child(6)",
+                    text: I18n.t('personal_access_tokens.table.never_used')
+
+    assert_selector "table tbody tr[id='personal_access_token_#{used_pat.id}'] td:nth-child(6)",
+                    text: '192.168.1.1'
   end
 
   test 'empty personal access tokens state' do

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -231,7 +231,7 @@ module Projects
             assert_selector 'td:nth-child(3)', text: 'read_api, api'
 
             assert_selector 'td:nth-child(4)', text: I18n.l(token.created_at.getlocal.to_date, format: :long)
-            assert_selector 'td:nth-child(6)',
+            assert_selector 'td:nth-child(7)',
                             text: I18n.l(DateTime.parse(token.expires_at.to_s).getlocal.to_date, format: :long)
           end
         end

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -276,7 +276,7 @@ module Projects
             assert_selector 'td:nth-child(3)', text: 'read_api, api'
 
             assert_selector 'td:nth-child(4)', text: I18n.l(expired_token.created_at.getlocal.to_date, format: :long)
-            assert_selector 'td:nth-child(7)',
+            assert_selector 'td:nth-child(8)',
                             text: I18n.l(DateTime.parse(expired_token.expires_at.to_s).getlocal.to_date, format: :long)
           end
 
@@ -285,8 +285,8 @@ module Projects
             assert_selector 'td:nth-child(3)', text: 'read_api, api'
 
             assert_selector 'td:nth-child(4)', text: I18n.l(revoked_token.created_at.getlocal.to_date, format: :long)
-            assert_selector 'td:nth-child(6)', text: I18n.l(revoked_token.updated_at.getlocal.to_date, format: :long)
-            assert_selector 'td:nth-child(7)',
+            assert_selector 'td:nth-child(7)', text: I18n.l(revoked_token.updated_at.getlocal.to_date, format: :long)
+            assert_selector 'td:nth-child(8)',
                             text: I18n.l(DateTime.parse(revoked_token.expires_at.to_s).getlocal.to_date, format: :long)
           end
         end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds the `last_used_ips` column to the PAT table

## Screenshots or screen recordings
<img width="1918" height="961" alt="image" src="https://github.com/user-attachments/assets/6c856664-be9d-4ee5-9c1e-13be3877e901" />

<img width="1918" height="961" alt="image" src="https://github.com/user-attachments/assets/e023d649-720d-4cf9-bf2d-ad6587dfde8d" />

## How to set up and validate locally
1. Create and/or update an existing PAT with IP addresses, and verify they appear in the table.

You can update a PAT with IP addresses with the following `rails c` command:
```
PersonalAccessToken.last.update(last_used_ips: ['192.168.1.1', '192.168.1.2', '192.168.1.3', '192.168.1.4', '192.168.1.5'])
```

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
