### PR TITLE
Show concatenation basename errors in the modal

### DIFF
--- a/app/controllers/projects/samples/attachments/concatenations_controller.rb
+++ b/app/controllers/projects/samples/attachments/concatenations_controller.rb
@@ -28,15 +28,7 @@ module Projects
           if @sample.errors.empty?
             render status: :ok, locals: { type: :success, message: t('.success') }
           else
-            error_msg = if @sample.errors[:basename].any?
-                          t(:'general.form.error_notification')
-                        else
-                          error_message(@sample)
-                        end
-
-            render status: :unprocessable_content, locals: { type: :danger,
-                                                             message: error_msg,
-                                                             concatenation_params: }
+            render status: :unprocessable_content, locals: { concatenation_params: }
 
           end
         end

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -1,19 +1,5 @@
 <%= viral_dialog(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
-  <%= turbo_frame_tag("concatenation-alert") %>
-
-  <div
-    class="
-      mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
-    "
-  >
-    <p class="mb-4"><%= t(".description") %></p>
-    <div
-      class="overflow-auto scrollbar"
-      data-controller="projects--samples--attachments--files"
-      data-projects--samples--attachments--files-target="field"
-    ></div>
-  </div>
 
   <%= form_for(:concatenation, url: namespace_project_sample_attachments_concatenation_path,
     data: {
@@ -22,14 +8,30 @@
       "projects--samples--attachments--selected-attachments-storage-key-value": "files-#{@sample.id}",
       action: 'turbo:submit-end->projects--samples--attachments--selected-attachments#clear'
     }, method: :post, html: { novalidate: true }) do |form| %>
+    <% summary_entries = FormErrorSummaryEntryBuilder.new(builder: form, errors: @sample.errors).call %>
+
+    <%= render FormErrorSummaryComponent.new(entries: summary_entries, include: [:basename]) %>
+
+    <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
+      <p class="mb-4"><%= t(".description") %></p>
+
+      <div
+        class="scrollbar overflow-auto"
+        data-controller="projects--samples--attachments--files"
+        data-projects--samples--attachments--files-target="field"
+      ></div>
+    </div>
+
     <div data-projects--samples--attachments--selected-attachments-target="field"></div>
 
     <div class="grid gap-4">
       <%= render partial: "shared/form/required_field_legend" %>
 
       <% invalid_basename = @sample.errors.include?(:basename) %>
-      <div class="form-field <%= 'invalid' if invalid_basename%>">
+
+      <div class="form-field <%= 'invalid' if invalid_basename %>">
         <%= form.label :basename, data: { required: true } %>
+
         <%= form.text_field :basename,
                         required: true,
                         value:
@@ -54,11 +56,7 @@
                           required: true,
                         },
                         class: "form-control" %>
-        <% if invalid_basename %>
-          <%= render "shared/form/field_errors",
-          id: form.field_id(:basename, "error"),
-          errors: @sample.errors[:basename] %>
-        <% end %>
+
         <span id="<%= form.field_id(:basename, "hint") %>" class="field-hint">
           <%== t(:"projects.samples.attachments.concatenations.create.basename_help") %>
         </span>
@@ -79,6 +77,7 @@
                        },
                        true,
                        false %>
+
         <%= form.label :delete_originals,
                    class: "ml-2 text-sm font-medium text-slate-900 dark:text-slate-300" %>
       </div>

--- a/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
@@ -7,13 +7,9 @@
   },
 ) %>
 
-<% if @sample.errors.any? %>
-  <%= turbo_stream.update "concatenation-alert",
-                      viral_alert(type:, message:, classes: "mb-4") %>
-<% else %>
+<% unless @sample.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>
   <% end %>
-
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -151,13 +151,15 @@ module Groups
       ### VERIFY START ###
       # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
       within('#bot_modal') do
-        assert_selector '[data-controller="form-error-summary"]'
-        within('[data-controller="form-error-summary"]') do
-          assert_text I18n.t(:'general.form.error_summary.title', count: 1)
-          assert_text I18n.t(:'general.form.error_notification')
-          assert_text I18n.t(:'errors.format',
-                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
-                             message: I18n.t(:'errors.messages.blank'))
+        within('form') do
+          assert_selector 'div[data-controller="form-error-summary"]', match: :first
+          within('div[data-controller="form-error-summary"]', match: :first) do
+            assert_text I18n.t(:'general.form.error_summary.title', count: 1)
+            assert_text I18n.t(:'general.form.error_notification')
+            assert_text I18n.t(:'errors.format',
+                               attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
+                               message: I18n.t(:'errors.messages.blank'))
+          end
         end
       end
       ### VERIFY END ###

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -151,13 +151,15 @@ module Projects
       ### VERIFY START ###
       # Turbo replaces the frame; do not assert inside a stale within('#dialog') from before submit.
       within('#bot_modal') do
-        assert_selector '[data-controller="form-error-summary"]'
-        within('[data-controller="form-error-summary"]') do
-          assert_text I18n.t(:'general.form.error_summary.title', count: 1)
-          assert_text I18n.t(:'general.form.error_notification')
-          assert_text I18n.t(:'errors.format',
-                             attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
-                             message: I18n.t(:'errors.messages.blank'))
+        within('form') do
+          assert_selector 'div[data-controller="form-error-summary"]', match: :first
+          within('div[data-controller="form-error-summary"]', match: :first) do
+            assert_text I18n.t(:'general.form.error_summary.title', count: 1)
+            assert_text I18n.t(:'general.form.error_notification')
+            assert_text I18n.t(:'errors.format',
+                               attribute: I18n.t(:'activerecord.attributes.personal_access_token.scopes'),
+                               message: I18n.t(:'errors.messages.blank'))
+          end
         end
       end
       ### VERIFY END ###

--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -321,8 +321,11 @@ module Projects
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
-        within %(turbo-frame[id="concatenation-alert"]) do
-          assert_text I18n.t('services.attachments.concatenation.incorrect_file_types')
+        assert_no_selector 'html[aria-busy="true"]'
+        assert_selector 'dialog[open]'
+        within '#sample-attachments' do
+          assert_selector 'table #attachments-table-body tr', count: 6
+          assert_no_text 'concatenated_file'
         end
       end
 
@@ -345,8 +348,11 @@ module Projects
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
-        within %(turbo-frame[id="concatenation-alert"]) do
-          assert_text I18n.t('services.attachments.concatenation.incorrect_fastq_file_types')
+        assert_no_selector 'html[aria-busy="true"]'
+        assert_selector 'dialog[open]'
+        within '#sample-attachments' do
+          assert_selector 'table #attachments-table-body tr', count: 6
+          assert_no_text 'concatenated_file'
         end
       end
 


### PR DESCRIPTION
## What does this PR do and why?
This updates the attachment concatenation modal to show basename validation errors directly in the form instead of a separate alert area. This updates the form to use the new modal summary component.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1325" height="696" alt="image" src="https://github.com/user-attachments/assets/00a90567-d572-4567-90a9-71038a5e9d8f" />

## How to set up and validate locally
1. Start the app with bin/dev, sign in as a user who can edit sample attachments, and open a sample attachments page.
2. Select files (upload some if needed from `test/fixtures/files`), and open Concatenate, then enter an invalid basename such as "concatenated file" (with a space) and submit.
3. Confirm the modal stays open, the basename input remains filled, and you see the form error summary indicating the basename is invalid.
4. In the same modal, change basename to a valid value such as "concatenated_file" and submit again.
5. Confirm concatenation succeeds, the modal closes, and the sample attachments table refreshes with the new concatenated attachment(s).
6. Run targeted automated checks:
   - bin/rails test test/controllers/projects/samples/attachments/concatenations_controller_test.rb
   - bin/rails test test/services/attachments/concatenation_service_test.rb
   - bin/rails test test/system/projects/samples/attachments_test.rb -n "/basename/"

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
