### PR TITLE
Sortable Lists: Update aria announcments for moving options

### DIFF
--- a/app/components/sortable_lists/v1/component.html.erb
+++ b/app/components/sortable_lists/v1/component.html.erb
@@ -53,6 +53,7 @@
   <div
     class="sr-only"
     aria-live="polite"
+    role="status"
     data-sortable-lists--v1--two-lists-selection-target="ariaLiveUpdate"
     data-translations="<%= aria_live_translations %>"
   ></div>

--- a/app/components/sortable_lists/v1/component.rb
+++ b/app/components/sortable_lists/v1/component.rb
@@ -38,7 +38,7 @@ module SortableLists
           moved_list_multiple: I18n.t('shared.sortable_lists.aria_live_update.moved_list_multiple'),
           moved_list_single: I18n.t('shared.sortable_lists.aria_live_update.moved_list_single'),
           words_connector: I18n.t('support.array.words_connector'),
-          last_words_connector: I18n.t('support.array.last_word_connector'),
+          last_word_connector: I18n.t('support.array.last_word_connector'),
           two_words_connector: I18n.t('support.array.two_words_connector')
         }.to_json
       end

--- a/app/components/sortable_lists/v1/component.rb
+++ b/app/components/sortable_lists/v1/component.rb
@@ -24,11 +24,12 @@ module SortableLists
 
       def load_translations
         {
-          added: I18n.t('shared.sortable_lists.aria_live_update.added'),
-          list_order_changed: I18n.t('shared.sortable_lists.aria_live_update.list_order_changed'),
+          added_multiple: I18n.t('shared.sortable_lists.aria_live_update.added_multiple'),
+          added_single: I18n.t('shared.sortable_lists.aria_live_update.added_single'),
           move_down: I18n.t('shared.sortable_lists.aria_live_update.move_down'),
           move_up: I18n.t('shared.sortable_lists.aria_live_update.move_up'),
-          removed: I18n.t('shared.sortable_lists.aria_live_update.removed')
+          removed_multiple: I18n.t('shared.sortable_lists.aria_live_update.removed_multiple'),
+          removed_single: I18n.t('shared.sortable_lists.aria_live_update.removed_single')
         }.to_json
       end
     end

--- a/app/components/sortable_lists/v1/component.rb
+++ b/app/components/sortable_lists/v1/component.rb
@@ -33,12 +33,10 @@ module SortableLists
 
       def load_translations
         {
-          added_multiple: I18n.t('shared.sortable_lists.aria_live_update.added_multiple'),
-          added_single: I18n.t('shared.sortable_lists.aria_live_update.added_single'),
           move_down: I18n.t('shared.sortable_lists.aria_live_update.move_down'),
           move_up: I18n.t('shared.sortable_lists.aria_live_update.move_up'),
-          removed_multiple: I18n.t('shared.sortable_lists.aria_live_update.removed_multiple'),
-          removed_single: I18n.t('shared.sortable_lists.aria_live_update.removed_single')
+          moved_list_multiple: I18n.t('shared.sortable_lists.aria_live_update.moved_list_multiple'),
+          moved_list_single: I18n.t('shared.sortable_lists.aria_live_update.moved_list_single')
         }.to_json
       end
     end

--- a/app/components/sortable_lists/v1/component.rb
+++ b/app/components/sortable_lists/v1/component.rb
@@ -33,10 +33,12 @@ module SortableLists
 
       def load_translations
         {
-          added: I18n.t('shared.sortable_lists.aria_live_update.added'),
+          added_multiple: I18n.t('shared.sortable_lists.aria_live_update.added_multiple'),
+          added_single: I18n.t('shared.sortable_lists.aria_live_update.added_single'),
           move_down: I18n.t('shared.sortable_lists.aria_live_update.move_down'),
           move_up: I18n.t('shared.sortable_lists.aria_live_update.move_up'),
-          removed: I18n.t('shared.sortable_lists.aria_live_update.removed')
+          removed_multiple: I18n.t('shared.sortable_lists.aria_live_update.removed_multiple'),
+          removed_single: I18n.t('shared.sortable_lists.aria_live_update.removed_single')
         }.to_json
       end
     end

--- a/app/components/sortable_lists/v1/component.rb
+++ b/app/components/sortable_lists/v1/component.rb
@@ -36,7 +36,10 @@ module SortableLists
           move_down: I18n.t('shared.sortable_lists.aria_live_update.move_down'),
           move_up: I18n.t('shared.sortable_lists.aria_live_update.move_up'),
           moved_list_multiple: I18n.t('shared.sortable_lists.aria_live_update.moved_list_multiple'),
-          moved_list_single: I18n.t('shared.sortable_lists.aria_live_update.moved_list_single')
+          moved_list_single: I18n.t('shared.sortable_lists.aria_live_update.moved_list_single'),
+          words_connector: I18n.t('support.array.words_connector'),
+          last_words_connector: I18n.t('support.array.last_word_connector'),
+          two_words_connector: I18n.t('support.array.two_words_connector')
         }.to_json
       end
     end

--- a/app/components/sortable_lists/v1/list_component.html.erb
+++ b/app/components/sortable_lists/v1/list_component.html.erb
@@ -27,6 +27,7 @@
       aria-describedby="<%= described_by_ids %>"
       aria-required="<%= aria_required %>"
       aria-multiselectable="true"
+      data-title="<%= title %>"
     <% end %>
   >
     <%= render SortableLists::V1::ListItemComponent.with_collection(list_items, interactive:) %>

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -450,13 +450,14 @@ export default class extends Controller {
       sourceList.focus();
     }
 
+    const translationKey = selectedOptions.length > 1 ? "multiple" : "single";
     const ariaLiveUpdateString =
       sourceList === this.selectedList
-        ? this.#ariaLiveTranslations["removed"]
-        : this.#ariaLiveTranslations["added"];
+        ? this.#ariaLiveTranslations[`removed_${translationKey}`]
+        : this.#ariaLiveTranslations[`added_${translationKey}`];
 
     this.#updateAriaLive(
-      ariaLiveUpdateString.concat(selectedOptionsText.join(", ")),
+      selectedOptionsText.join(", ").concat(ariaLiveUpdateString),
     );
 
     this.#checkStates();
@@ -601,12 +602,10 @@ export default class extends Controller {
       targetOption,
     );
 
-    const ariaLiveText = this.#ariaLiveTranslations[
-      direction === "up" ? "move_up" : "move_down"
-    ].replace(
-      /OPTION_PLACEHOLDER/g,
-      selectedOption.lastElementChild.textContent,
+    const ariaLiveText = selectedOption.lastElementChild.textContent.concat(
+      this.#ariaLiveTranslations[direction === "up" ? "move_up" : "move_down"],
     );
+
     this.#updateAriaLive(ariaLiveText);
   }
 

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -47,18 +47,7 @@ export default class extends Controller {
   connect() {
     this.#boundSubmitClickCapture = this.#onSubmitClickCapture.bind(this);
 
-    // check if aria-live exists as it's added after file selection in import metadata (can't be done in connect())
-    if (!this.#ariaLiveTranslations && this.hasAriaLiveUpdateTarget) {
-      this.#ariaLiveTranslations = JSON.parse(
-        this.ariaLiveUpdateTarget.getAttribute("data-translations"),
-      );
-
-      this.#wordConnector = new WordConnector({
-        wordsConnector: this.#ariaLiveTranslations["words_connector"],
-        twoWordsConnector: this.#ariaLiveTranslations["two_words_connector"],
-        lastWordConnector: this.#ariaLiveTranslations["last_word_connector"],
-      });
-    }
+    this.#ensureAriaLiveReady();
     // Get a handle on the available and selected lists
     this.idempotentConnect();
   }
@@ -67,8 +56,10 @@ export default class extends Controller {
     this.availableList = document.getElementById(this.availableListValue);
     this.selectedList = document.getElementById(this.selectedListValue);
 
-    this.#availableListName = this.availableList.getAttribute("data-title");
-    this.#selectedListName = this.selectedList.getAttribute("data-title");
+    this.#availableListName =
+      this.availableList?.getAttribute("data-title") || "";
+    this.#selectedListName =
+      this.selectedList?.getAttribute("data-title") || "";
 
     if (this.availableList && this.selectedList) {
       // Get a handle on the original available list
@@ -104,6 +95,25 @@ export default class extends Controller {
         this.#boundSubmitClickCapture,
         true,
       );
+    }
+  }
+
+  #ensureAriaLiveReady() {
+    // check if aria-live exists as it's added after file selection in import metadata (can't be done in connect())
+    if (
+      !this.#ariaLiveTranslations &&
+      this.hasAriaLiveUpdateTarget &&
+      !this.#wordConnector
+    ) {
+      this.#ariaLiveTranslations = JSON.parse(
+        this.ariaLiveUpdateTarget.getAttribute("data-translations"),
+      );
+
+      this.#wordConnector = new WordConnector({
+        wordsConnector: this.#ariaLiveTranslations["words_connector"],
+        twoWordsConnector: this.#ariaLiveTranslations["two_words_connector"],
+        lastWordConnector: this.#ariaLiveTranslations["last_word_connector"],
+      });
     }
   }
 
@@ -842,14 +852,13 @@ export default class extends Controller {
   }
 
   #updateAriaLive(translationKey, list, items) {
-    if (this.hasAriaLiveUpdateTarget && this.#wordConnector) {
-      const connectedItems = this.#wordConnector.connectWords(items);
-      const updateString = this.#ariaLiveTranslations[translationKey]
-        .replace(/LIST_PLACEHOLDER/g, list)
-        .replace(/ITEMS_PLACEHOLDER/g, connectedItems);
+    this.#ensureAriaLiveReady();
+    const connectedItems = this.#wordConnector.connectWords(items);
+    const updateString = this.#ariaLiveTranslations[translationKey]
+      .replace(/LIST_PLACEHOLDER/g, list)
+      .replace(/ITEMS_PLACEHOLDER/g, connectedItems);
 
-      announce(updateString, { element: this.ariaLiveUpdateTarget });
-    }
+    announce(updateString, { element: this.ariaLiveUpdateTarget });
   }
 
   #initializeLists() {

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -114,7 +114,9 @@ export default class extends Controller {
         twoWordsConnector: this.#ariaLiveTranslations["two_words_connector"],
         lastWordConnector: this.#ariaLiveTranslations["last_word_connector"],
       });
+      return true;
     }
+    return false;
   }
 
   #cleanupAvailableList() {
@@ -853,7 +855,7 @@ export default class extends Controller {
   }
 
   #updateAriaLive(translationKey, list, items, position = null) {
-    this.#ensureAriaLiveReady();
+    if (!this.#ensureAriaLiveReady()) return;
     let updateString;
     const connectedItems = this.#wordConnector.connectWords(items);
     if (["move_up", "move_down"].includes(translationKey)) {

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { createHiddenInput } from "utilities/form";
 import { announce } from "utilities/live_region";
+import SentenceConstructor from "utilities/sentence_constructor";
 
 export default class extends Controller {
   static targets = [
@@ -41,9 +42,23 @@ export default class extends Controller {
   #availableListName;
   #selectedListName;
 
+  #sentenceConstructor = null;
+
   connect() {
     this.#boundSubmitClickCapture = this.#onSubmitClickCapture.bind(this);
 
+    // check if aria-live exists as it's added after file selection in import metadata (can't be done in connect())
+    if (!this.#ariaLiveTranslations && this.hasAriaLiveUpdateTarget) {
+      this.#ariaLiveTranslations = JSON.parse(
+        this.ariaLiveUpdateTarget.getAttribute("data-translations"),
+      );
+
+      this.#sentenceConstructor = new SentenceConstructor({
+        wordsConnector: this.#ariaLiveTranslations["words_connector"],
+        twoWordsConnector: this.#ariaLiveTranslations["two_words_connector"],
+        lastWordConnector: this.#ariaLiveTranslations["last_words_connector"],
+      });
+    }
     // Get a handle on the available and selected lists
     this.idempotentConnect();
   }
@@ -54,13 +69,6 @@ export default class extends Controller {
 
     this.#availableListName = this.availableList.getAttribute("data-title");
     this.#selectedListName = this.selectedList.getAttribute("data-title");
-
-    // check if aria-live exists as it's added after file selection in import metadata (can't be done in connect())
-    if (!this.#ariaLiveTranslations && this.hasAriaLiveUpdateTarget) {
-      this.#ariaLiveTranslations = JSON.parse(
-        this.ariaLiveUpdateTarget.getAttribute("data-translations"),
-      );
-    }
 
     if (this.availableList && this.selectedList) {
       // Get a handle on the original available list
@@ -465,7 +473,7 @@ export default class extends Controller {
     this.#updateAriaLive(
       `moved_list_${translationKey}`,
       listName,
-      selectedOptionsText.join(", "),
+      selectedOptionsText,
     );
 
     this.#checkStates();
@@ -834,10 +842,11 @@ export default class extends Controller {
   }
 
   #updateAriaLive(translationKey, list, items) {
-    if (this.hasAriaLiveUpdateTarget) {
+    if (this.hasAriaLiveUpdateTarget && this.#sentenceConstructor) {
+      const connectedItems = this.#sentenceConstructor.createSentence(items);
       const updateString = this.#ariaLiveTranslations[translationKey]
         .replace(/LIST_PLACEHOLDER/g, list)
-        .replace(/ITEMS_PLACEHOLDER/g, items);
+        .replace(/ITEMS_PLACEHOLDER/g, connectedItems);
 
       announce(updateString, { element: this.ariaLiveUpdateTarget });
     }

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -47,7 +47,6 @@ export default class extends Controller {
   connect() {
     this.#boundSubmitClickCapture = this.#onSubmitClickCapture.bind(this);
 
-    this.#ensureAriaLiveReady();
     // Get a handle on the available and selected lists
     this.idempotentConnect();
   }

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -484,7 +484,6 @@ export default class extends Controller {
       `moved_list_${translationKey}`,
       listName,
       selectedOptionsText,
-      null,
     );
 
     this.#checkStates();
@@ -853,7 +852,7 @@ export default class extends Controller {
     list.append(template);
   }
 
-  #updateAriaLive(translationKey, list, items, position) {
+  #updateAriaLive(translationKey, list, items, position = null) {
     this.#ensureAriaLiveReady();
     let updateString;
     const connectedItems = this.#wordConnector.connectWords(items);

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -484,6 +484,7 @@ export default class extends Controller {
       `moved_list_${translationKey}`,
       listName,
       selectedOptionsText,
+      null,
     );
 
     this.#checkStates();
@@ -622,8 +623,9 @@ export default class extends Controller {
   }
 
   #moveOptionHorizontally(selectedOption, targetOption, direction) {
+    const list = selectedOption.parentElement;
     const listName =
-      selectedOption.parentElement === this.selectedList
+      list === this.selectedList
         ? this.#selectedListName
         : this.#availableListName;
     targetOption.remove();
@@ -632,10 +634,18 @@ export default class extends Controller {
       targetOption,
     );
 
+    const listItems = Array.from(list.querySelectorAll("li"));
+    const selectedOptionText = selectedOption.lastElementChild.textContent;
+    const position =
+      listItems.findIndex(
+        (item) => item.innerText.trim() === selectedOptionText,
+      ) + 1;
+
     this.#updateAriaLive(
       direction === "up" ? "move_up" : "move_down",
       listName,
       selectedOption.lastElementChild.textContent,
+      position,
     );
   }
 
@@ -851,12 +861,21 @@ export default class extends Controller {
     list.append(template);
   }
 
-  #updateAriaLive(translationKey, list, items) {
+  #updateAriaLive(translationKey, list, items, position) {
     this.#ensureAriaLiveReady();
+    let updateString;
     const connectedItems = this.#wordConnector.connectWords(items);
-    const updateString = this.#ariaLiveTranslations[translationKey]
-      .replace(/LIST_PLACEHOLDER/g, list)
-      .replace(/ITEMS_PLACEHOLDER/g, connectedItems);
+    if (["move_up", "move_down"].includes(translationKey)) {
+      updateString = this.#ariaLiveTranslations[translationKey]
+        .replace(/LIST_PLACEHOLDER/g, list)
+        .replace(/ITEM_PLACEHOLDER/g, connectedItems)
+        .replace(/POSITION_PLACEHOLDER/g, position);
+    } else {
+      // handles moved_list_single/multiple
+      updateString = this.#ariaLiveTranslations[translationKey]
+        .replace(/LIST_PLACEHOLDER/g, list)
+        .replace(/ITEMS_PLACEHOLDER/g, connectedItems);
+    }
 
     announce(updateString, { element: this.ariaLiveUpdateTarget });
   }

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -38,6 +38,9 @@ export default class extends Controller {
   #ariaLiveTranslations;
   #boundSubmitClickCapture;
 
+  #availableListName;
+  #selectedListName;
+
   connect() {
     this.#boundSubmitClickCapture = this.#onSubmitClickCapture.bind(this);
 
@@ -48,6 +51,9 @@ export default class extends Controller {
   idempotentConnect() {
     this.availableList = document.getElementById(this.availableListValue);
     this.selectedList = document.getElementById(this.selectedListValue);
+
+    this.#availableListName = this.availableList.getAttribute("data-title");
+    this.#selectedListName = this.selectedList.getAttribute("data-title");
 
     // check if aria-live exists as it's added after file selection in import metadata (can't be done in connect())
     if (!this.#ariaLiveTranslations && this.hasAriaLiveUpdateTarget) {
@@ -451,13 +457,15 @@ export default class extends Controller {
     }
 
     const translationKey = selectedOptions.length > 1 ? "multiple" : "single";
-    const ariaLiveUpdateString =
+    const listName =
       sourceList === this.selectedList
-        ? this.#ariaLiveTranslations[`removed_${translationKey}`]
-        : this.#ariaLiveTranslations[`added_${translationKey}`];
+        ? this.#availableListName
+        : this.#selectedListName;
 
     this.#updateAriaLive(
-      selectedOptionsText.join(", ").concat(ariaLiveUpdateString),
+      `moved_list_${translationKey}`,
+      listName,
+      selectedOptionsText.join(", "),
     );
 
     this.#checkStates();
@@ -596,17 +604,21 @@ export default class extends Controller {
   }
 
   #moveOptionHorizontally(selectedOption, targetOption, direction) {
+    const listName =
+      selectedOption.parentElement === this.selectedList
+        ? this.#selectedListName
+        : this.#availableListName;
     targetOption.remove();
     selectedOption.insertAdjacentElement(
       direction === "up" ? "afterend" : "beforebegin",
       targetOption,
     );
 
-    const ariaLiveText = selectedOption.lastElementChild.textContent.concat(
-      this.#ariaLiveTranslations[direction === "up" ? "move_up" : "move_down"],
+    this.#updateAriaLive(
+      direction === "up" ? "move_up" : "move_down",
+      listName,
+      selectedOption.lastElementChild.textContent,
     );
-
-    this.#updateAriaLive(ariaLiveText);
   }
 
   // handles up and down buttons
@@ -821,8 +833,12 @@ export default class extends Controller {
     list.append(template);
   }
 
-  #updateAriaLive(updateString) {
+  #updateAriaLive(translationKey, list, items) {
     if (this.hasAriaLiveUpdateTarget) {
+      const updateString = this.#ariaLiveTranslations[translationKey]
+        .replace(/LIST_PLACEHOLDER/g, list)
+        .replace(/ITEMS_PLACEHOLDER/g, items);
+
       announce(updateString, { element: this.ariaLiveUpdateTarget });
     }
   }

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -624,10 +624,6 @@ export default class extends Controller {
 
   #moveOptionHorizontally(selectedOption, targetOption, direction) {
     const list = selectedOption.parentElement;
-    const listName =
-      list === this.selectedList
-        ? this.#selectedListName
-        : this.#availableListName;
     targetOption.remove();
     selectedOption.insertAdjacentElement(
       direction === "up" ? "afterend" : "beforebegin",
@@ -635,15 +631,11 @@ export default class extends Controller {
     );
 
     const listItems = Array.from(list.querySelectorAll("li"));
-    const selectedOptionText = selectedOption.lastElementChild.textContent;
-    const position =
-      listItems.findIndex(
-        (item) => item.innerText.trim() === selectedOptionText,
-      ) + 1;
+    const position = listItems.indexOf(selectedOption) + 1;
 
     this.#updateAriaLive(
       direction === "up" ? "move_up" : "move_down",
-      listName,
+      this.#selectedListName,
       selectedOption.lastElementChild.textContent,
       position,
     );

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -518,13 +518,14 @@ export default class extends Controller {
       this.#updateListAttributes(selectedOptions[0]);
     }
 
+    const translationKey = selectedOptions.length > 1 ? "multiple" : "single";
     const ariaLiveUpdateString =
       sourceList === this.selectedList
-        ? this.#ariaLiveTranslations["removed"]
-        : this.#ariaLiveTranslations["added"];
+        ? this.#ariaLiveTranslations[`removed_${translationKey}`]
+        : this.#ariaLiveTranslations[`added_${translationKey}`];
 
     this.#updateAriaLive(
-      ariaLiveUpdateString.concat(selectedOptionsText.join(", ")),
+      selectedOptionsText.join(", ").concat(ariaLiveUpdateString),
     );
 
     this.#checkStates();
@@ -652,12 +653,10 @@ export default class extends Controller {
       targetOption,
     );
 
-    const ariaLiveText = this.#ariaLiveTranslations[
-      direction === "up" ? "move_up" : "move_down"
-    ].replace(
-      /OPTION_PLACEHOLDER/g,
-      selectedOption.lastElementChild.textContent,
+    const ariaLiveText = selectedOption.lastElementChild.textContent.concat(
+      this.#ariaLiveTranslations[direction === "up" ? "move_up" : "move_down"],
     );
+
     this.#updateAriaLive(ariaLiveText);
   }
 

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -56,7 +56,7 @@ export default class extends Controller {
       this.#sentenceConstructor = new SentenceConstructor({
         wordsConnector: this.#ariaLiveTranslations["words_connector"],
         twoWordsConnector: this.#ariaLiveTranslations["two_words_connector"],
-        lastWordConnector: this.#ariaLiveTranslations["last_words_connector"],
+        lastWordConnector: this.#ariaLiveTranslations["last_word_connector"],
       });
     }
     // Get a handle on the available and selected lists

--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { createHiddenInput } from "utilities/form";
 import { announce } from "utilities/live_region";
-import SentenceConstructor from "utilities/sentence_constructor";
+import WordConnector from "utilities/word_connector";
 
 export default class extends Controller {
   static targets = [
@@ -42,7 +42,7 @@ export default class extends Controller {
   #availableListName;
   #selectedListName;
 
-  #sentenceConstructor = null;
+  #wordConnector = null;
 
   connect() {
     this.#boundSubmitClickCapture = this.#onSubmitClickCapture.bind(this);
@@ -53,7 +53,7 @@ export default class extends Controller {
         this.ariaLiveUpdateTarget.getAttribute("data-translations"),
       );
 
-      this.#sentenceConstructor = new SentenceConstructor({
+      this.#wordConnector = new WordConnector({
         wordsConnector: this.#ariaLiveTranslations["words_connector"],
         twoWordsConnector: this.#ariaLiveTranslations["two_words_connector"],
         lastWordConnector: this.#ariaLiveTranslations["last_word_connector"],
@@ -842,8 +842,8 @@ export default class extends Controller {
   }
 
   #updateAriaLive(translationKey, list, items) {
-    if (this.hasAriaLiveUpdateTarget && this.#sentenceConstructor) {
-      const connectedItems = this.#sentenceConstructor.createSentence(items);
+    if (this.hasAriaLiveUpdateTarget && this.#wordConnector) {
+      const connectedItems = this.#wordConnector.connectWords(items);
       const updateString = this.#ariaLiveTranslations[translationKey]
         .replace(/LIST_PLACEHOLDER/g, list)
         .replace(/ITEMS_PLACEHOLDER/g, connectedItems);

--- a/app/javascript/utilities/sentence_constructor.js
+++ b/app/javascript/utilities/sentence_constructor.js
@@ -1,0 +1,36 @@
+export default class SentenceConstructor {
+  // Private Fields
+
+  #wordsConnector; // connector for 3 or more words, eg: ", "
+  #twoWordsConnector; // connects two words, eg: " and "
+  #lastWordConnector; // connects last word for 3 or more words, eg: ", and "
+
+  // Initialize sentence constructor connectors
+  constructor({
+    wordsConnector = ", ",
+    twoWordsConnector = " and ",
+    lastWordConnector = ", and ",
+  }) {
+    this.#wordsConnector = wordsConnector;
+    this.#twoWordsConnector = twoWordsConnector;
+    this.#lastWordConnector = lastWordConnector;
+  }
+
+  // connect words based on array size
+  createSentence(words) {
+    if (Array.isArray(words)) {
+      switch (words.length) {
+        case 0:
+          return "";
+        case 1:
+          return words[0];
+        case 2:
+          return `${words[0]}${this.#twoWordsConnector}${words[1]}`;
+        default:
+          return `${words.slice(0, -1).join(this.#wordsConnector)}${this.#lastWordConnector}${words[words.length - 1]}`;
+      }
+    } else {
+      return words;
+    }
+  }
+}

--- a/app/javascript/utilities/word_connector.js
+++ b/app/javascript/utilities/word_connector.js
@@ -1,4 +1,4 @@
-export default class SentenceConstructor {
+export default class WordConnector {
   // Private Fields
 
   #wordsConnector; // connector for 3 or more words, eg: ", "
@@ -17,7 +17,7 @@ export default class SentenceConstructor {
   }
 
   // connect words based on array size
-  createSentence(words) {
+  connectWords(words) {
     if (Array.isArray(words)) {
       switch (words.length) {
         case 0:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2074,12 +2074,10 @@ en:
         success: Success
     sortable_lists:
       aria_live_update:
-        added_multiple: " were moved to the selected list."
-        added_single: " was moved to the selected list"
-        move_down: " was moved down the selected list."
-        move_up: " was moved up the selected list."
-        removed_multiple: " were moved to the available list."
-        removed_single: " was moved to the available list."
+        move_down: ITEMS_PLACEHOLDER was moved down LIST_PLACEHOLDER.
+        move_up: ITEMS_PLACEHOLDER was moved up LIST_PLACEHOLDER.
+        moved_list_multiple: 'The following items were moved to LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
+        moved_list_single: 'The following item was moved to LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
     workflow_executions:
       actions_dropdown:
         cancel_workflow_executions: Cancel workflow executions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2047,11 +2047,12 @@ en:
         success: Success
     sortable_lists:
       aria_live_update:
-        added: 'The following options have been added: '
-        list_order_changed: 'Options ordering changed for LIST_PLACEHOLDER list. The ordering is the following: '
-        move_down: Option OPTION_PLACEHOLDER was moved down.
-        move_up: Option OPTION_PLACEHOLDER was moved up.
-        removed: 'The following options have been removed: '
+        added_multiple: " were moved to the selected list."
+        added_single: " was moved to the selected list"
+        move_down: " was moved down the selected list."
+        move_up: " was moved up the selected list."
+        removed_multiple: " were moved to the available list."
+        removed_single: " was moved to the available list."
     workflow_executions:
       actions_dropdown:
         cancel_workflow_executions: Cancel workflow executions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2074,8 +2074,8 @@ en:
         success: Success
     sortable_lists:
       aria_live_update:
-        move_down: ITEMS_PLACEHOLDER was moved down LIST_PLACEHOLDER.
-        move_up: ITEMS_PLACEHOLDER was moved up LIST_PLACEHOLDER.
+        move_down: ITEM_PLACEHOLDER was moved down to position POSITION_PLACEHOLDER in LIST_PLACEHOLDER.
+        move_up: ITEM_PLACEHOLDER was moved up to position POSITION_PLACEHOLDER in LIST_PLACEHOLDER.
         moved_list_multiple: 'The following items were moved to LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
         moved_list_single: 'The following item was moved to LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
     workflow_executions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2074,10 +2074,12 @@ en:
         success: Success
     sortable_lists:
       aria_live_update:
-        added: 'The following options have been added: '
-        move_down: Option OPTION_PLACEHOLDER was moved down.
-        move_up: Option OPTION_PLACEHOLDER was moved up.
-        removed: 'The following options have been removed: '
+        added_multiple: " were moved to the selected list."
+        added_single: " was moved to the selected list"
+        move_down: " was moved down the selected list."
+        move_up: " was moved up the selected list."
+        removed_multiple: " were moved to the available list."
+        removed_single: " was moved to the available list."
     workflow_executions:
       actions_dropdown:
         cancel_workflow_executions: Cancel workflow executions

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2078,10 +2078,12 @@ fr:
         success: Réussite
     sortable_lists:
       aria_live_update:
-        added: 'Les options suivantes ont été ajoutées : '
-        move_down: L’option OPTION_PLACEHOLDER a été déplacée vers le bas.
-        move_up: L’option OPTION_PLACEHOLDER a été déplacée vers le haut.
-        removed: 'Les options suivantes ont été retirées : '
+        added_multiple: " ont été déplacées vers la liste sélectionnée."
+        added_single: " ont été déplacées vers la liste sélectionnée."
+        move_down: " ont été déplacées plus bas dans la liste sélectionnée."
+        move_up: " ont été déplacées vers le haut de la liste de sélection."
+        removed_multiple: " ont été déplacées vers la liste des produits disponibles."
+        removed_single: " ont été déplacées vers la liste des produits disponibles."
     workflow_executions:
       actions_dropdown:
         cancel_workflow_executions: Annuler les exécutions de flux de travail

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2079,7 +2079,7 @@ fr:
     sortable_lists:
       aria_live_update:
         move_down: ITEM_PLACEHOLDER a été déplacé vers le bas à la position POSITION_PLACEHOLDER dans LIST_PLACEHOLDER.
-        move_up: ITEM_PLACEHOLDER a été déplacé vers la haut à la position POSITION_PLACEHOLDER dans LIST_PLACEHOLDER.
+        move_up: ITEM_PLACEHOLDER a été déplacé vers le haut à la position POSITION_PLACEHOLDER dans LIST_PLACEHOLDER.
         moved_list_multiple: 'Les éléments suivants ont été déplacés vers LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
         moved_list_single: 'L''élément suivant a été déplacé vers LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
     workflow_executions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2078,8 +2078,8 @@ fr:
         success: Réussite
     sortable_lists:
       aria_live_update:
-        move_down: ITEMS_PLACEHOLDER ont été déplacées plus bas dans LIST_PLACEHOLDER.
-        move_up: ITEMS_PLACEHOLDER nt été déplacées vers le haut de LIST_PLACEHOLDER.
+        move_down: ITEM_PLACEHOLDER a été déplacé vers le bas à la position POSITION_PLACEHOLDER dans LIST_PLACEHOLDER.
+        move_up: ITEM_PLACEHOLDER a été déplacé vers la haut à la position POSITION_PLACEHOLDER dans LIST_PLACEHOLDER.
         moved_list_multiple: 'Les éléments suivants ont été déplacés vers LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
         moved_list_single: 'L''élément suivant a été déplacé vers LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
     workflow_executions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2078,12 +2078,10 @@ fr:
         success: Réussite
     sortable_lists:
       aria_live_update:
-        added_multiple: " ont été déplacées vers la liste sélectionnée."
-        added_single: " ont été déplacées vers la liste sélectionnée."
-        move_down: " ont été déplacées plus bas dans la liste sélectionnée."
-        move_up: " ont été déplacées vers le haut de la liste de sélection."
-        removed_multiple: " ont été déplacées vers la liste des produits disponibles."
-        removed_single: " ont été déplacées vers la liste des produits disponibles."
+        move_down: ITEMS_PLACEHOLDER ont été déplacées plus bas dans LIST_PLACEHOLDER.
+        move_up: ITEMS_PLACEHOLDER nt été déplacées vers le haut de LIST_PLACEHOLDER.
+        moved_list_multiple: 'Les éléments suivants ont été déplacés vers LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
+        moved_list_single: 'L''élément suivant a été déplacé vers LIST_PLACEHOLDER: ITEMS_PLACEHOLDER'
     workflow_executions:
       actions_dropdown:
         cancel_workflow_executions: Annuler les exécutions de flux de travail

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2051,11 +2051,12 @@ fr:
         success: Réussite
     sortable_lists:
       aria_live_update:
-        added: 'Les options suivantes ont été ajoutées : '
-        list_order_changed: 'L’ordre des options a changé pour la liste LIST_PLACEHOLDER. L’ordre est le suivant : '
-        move_down: L’option OPTION_PLACEHOLDER a été déplacée vers le bas.
-        move_up: L’option OPTION_PLACEHOLDER a été déplacée vers le haut.
-        removed: 'Les options suivantes ont été retirées : '
+        added_multiple: " ont été déplacées vers la liste sélectionnée."
+        added_single: " ont été déplacées vers la liste sélectionnée."
+        move_down: " ont été déplacées plus bas dans la liste sélectionnée."
+        move_up: " ont été déplacées vers le haut de la liste de sélection."
+        removed_multiple: " ont été déplacées vers la liste des produits disponibles."
+        removed_single: " ont été déplacées vers la liste des produits disponibles."
     workflow_executions:
       actions_dropdown:
         cancel_workflow_executions: Annuler les exécutions de flux de travail

--- a/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
+++ b/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
@@ -3,10 +3,12 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import SortableListsController from "../../../../../app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js";
 
 const translations = JSON.stringify({
-  added: "Added: ",
-  removed: "Removed: ",
-  move_up: "Moved OPTION_PLACEHOLDER up",
-  move_down: "Moved OPTION_PLACEHOLDER down",
+  move_down: "ITEMS_PLACEHOLDER was moved down LIST_PLACEHOLDER.",
+  move_up: "ITEMS_PLACEHOLDER was moved up LIST_PLACEHOLDER.",
+  moved_list_multiple:
+    "The following items were moved to LIST_PLACEHOLDER: ITEMS_PLACEHOLDER",
+  moved_list_single:
+    "The following item was moved to LIST_PLACEHOLDER: ITEMS_PLACEHOLDER",
 });
 
 function option(id, text, selected = false) {
@@ -65,7 +67,8 @@ function renderFixture({
         aria-required="false"
         aria-multiselectable="true"
         data-action="focus->sortable-lists--v1--two-lists-selection#handleListFocus blur->sortable-lists--v1--two-lists-selection#handleListBlur keydown->sortable-lists--v1--two-lists-selection#handleKeyboardInput"
-      >${available.join("")}</ul>
+        data-title="Available list"
+        >${available.join("")}</ul>
       <button
         type="button"
         aria-disabled="true"
@@ -82,7 +85,8 @@ function renderFixture({
         aria-required="true"
         aria-multiselectable="true"
         data-action="focus->sortable-lists--v1--two-lists-selection#handleListFocus blur->sortable-lists--v1--two-lists-selection#handleListBlur keydown->sortable-lists--v1--two-lists-selection#handleKeyboardInput"
-      >${selected.join("")}</ul>
+        data-title="Selected list"
+        >${selected.join("")}</ul>
       <button
         type="button"
         aria-disabled="true"
@@ -437,6 +441,6 @@ describe("sortable lists two-lists selection controller", () => {
       document.querySelector(
         '[data-sortable-lists--v1--two-lists-selection-target="ariaLiveUpdate"]',
       ),
-    ).toHaveTextContent("Moved Two up");
+    ).toHaveTextContent("Two was moved up Selected list.");
   });
 });

--- a/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
+++ b/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
@@ -3,8 +3,10 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import SortableListsController from "../../../../../app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js";
 
 const translations = JSON.stringify({
-  move_down: "ITEMS_PLACEHOLDER was moved down LIST_PLACEHOLDER.",
-  move_up: "ITEMS_PLACEHOLDER was moved up LIST_PLACEHOLDER.",
+  move_down:
+    "ITEM_PLACEHOLDER was moved down to position POSITION_PLACEHOLDER in LIST_PLACEHOLDER.",
+  move_up:
+    "ITEM_PLACEHOLDER was moved up to position POSITION_PLACEHOLDER in LIST_PLACEHOLDER.",
   moved_list_multiple:
     "The following items were moved to LIST_PLACEHOLDER: ITEMS_PLACEHOLDER",
   moved_list_single:
@@ -441,6 +443,6 @@ describe("sortable lists two-lists selection controller", () => {
       document.querySelector(
         '[data-sortable-lists--v1--two-lists-selection-target="ariaLiveUpdate"]',
       ),
-    ).toHaveTextContent("Two was moved up Selected list.");
+    ).toHaveTextContent("Two was moved up to position 1 in Selected list.");
   });
 });

--- a/test/javascript/utilities/word_connector.test.js
+++ b/test/javascript/utilities/word_connector.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import WordConnector from "../../../app/javascript/utilities/word_connector.js";
+
+describe("word_connector", () => {
+  describe("connectWords", () => {
+    it("one word", () => {
+      const wordConnector = new WordConnector({
+        wordsConnector: ", ",
+        twoWordsConnector: " and ",
+        lastWordConnector: ", and ",
+      });
+
+      const connectedWords = wordConnector.connectWords(["word1"]);
+
+      expect(connectedWords).toBe("word1");
+    });
+
+    it("two words", () => {
+      const wordConnector = new WordConnector({
+        wordsConnector: ", ",
+        twoWordsConnector: " and ",
+        lastWordConnector: ", and ",
+      });
+
+      const connectedWords = wordConnector.connectWords(["word1", "word2"]);
+
+      expect(connectedWords).toBe("word1 and word2");
+    });
+
+    it("three words", () => {
+      const wordConnector = new WordConnector({
+        wordsConnector: ", ",
+        twoWordsConnector: " and ",
+        lastWordConnector: ", and ",
+      });
+
+      const connectedWords = wordConnector.connectWords([
+        "word1",
+        "word2",
+        "word3",
+      ]);
+
+      expect(connectedWords).toBe("word1, word2, and word3");
+    });
+
+    it("four words", () => {
+      const wordConnector = new WordConnector({
+        wordsConnector: ", ",
+        twoWordsConnector: " and ",
+        lastWordConnector: ", and ",
+      });
+
+      const connectedWords = wordConnector.connectWords([
+        "word1",
+        "word2",
+        "word3",
+        "word4",
+      ]);
+
+      expect(connectedWords).toBe("word1, word2, word3, and word4");
+    });
+
+    it("string", () => {
+      const wordConnector = new WordConnector({
+        wordsConnector: ", ",
+        twoWordsConnector: " and ",
+        lastWordConnector: ", and ",
+      });
+
+      const connectedWords = wordConnector.connectWords("word1, word2, word3");
+
+      expect(connectedWords).toBe("word1, word2, word3");
+    });
+  });
+});

--- a/test/javascript/utilities/word_connector.test.js
+++ b/test/javascript/utilities/word_connector.test.js
@@ -2,38 +2,25 @@ import { describe, it, expect } from "vitest";
 import WordConnector from "../../../app/javascript/utilities/word_connector.js";
 
 describe("word_connector", () => {
+  const wordConnector = new WordConnector({
+    wordsConnector: ", ",
+    twoWordsConnector: " and ",
+    lastWordConnector: ", and ",
+  });
   describe("connectWords", () => {
     it("one word", () => {
-      const wordConnector = new WordConnector({
-        wordsConnector: ", ",
-        twoWordsConnector: " and ",
-        lastWordConnector: ", and ",
-      });
-
       const connectedWords = wordConnector.connectWords(["word1"]);
 
       expect(connectedWords).toBe("word1");
     });
 
     it("two words", () => {
-      const wordConnector = new WordConnector({
-        wordsConnector: ", ",
-        twoWordsConnector: " and ",
-        lastWordConnector: ", and ",
-      });
-
       const connectedWords = wordConnector.connectWords(["word1", "word2"]);
 
       expect(connectedWords).toBe("word1 and word2");
     });
 
     it("three words", () => {
-      const wordConnector = new WordConnector({
-        wordsConnector: ", ",
-        twoWordsConnector: " and ",
-        lastWordConnector: ", and ",
-      });
-
       const connectedWords = wordConnector.connectWords([
         "word1",
         "word2",
@@ -44,12 +31,6 @@ describe("word_connector", () => {
     });
 
     it("four words", () => {
-      const wordConnector = new WordConnector({
-        wordsConnector: ", ",
-        twoWordsConnector: " and ",
-        lastWordConnector: ", and ",
-      });
-
       const connectedWords = wordConnector.connectWords([
         "word1",
         "word2",
@@ -61,12 +42,6 @@ describe("word_connector", () => {
     });
 
     it("string", () => {
-      const wordConnector = new WordConnector({
-        wordsConnector: ", ",
-        twoWordsConnector: " and ",
-        lastWordConnector: ", and ",
-      });
-
       const connectedWords = wordConnector.connectWords("word1, word2, word3");
 
       expect(connectedWords).toBe("word1, word2, word3");

--- a/test/javascript/utilities/word_connector.test.js
+++ b/test/javascript/utilities/word_connector.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import WordConnector from "../../../app/javascript/utilities/word_connector.js";
 
 describe("word_connector", () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,9 +18,9 @@ export default defineConfig({
         jsRoot,
         "utilities/floating_dropdown.js",
       ),
-      "utilities/sentence_constructor": resolve(
+      "utilities/word_connector": resolve(
         jsRoot,
-        "utilities/sentence_constructor.js",
+        "utilities/word_connector.js",
       ),
     },
   },

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,6 +18,10 @@ export default defineConfig({
         jsRoot,
         "utilities/floating_dropdown.js",
       ),
+      "utilities/sentence_constructor": resolve(
+        jsRoot,
+        "utilities/sentence_constructor.js",
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## What does this PR do and why?
This PR updates the aria announcements used for moving items between the sortable lists.
The announcements now specify the options and which list they were moved to.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. With a screen reader enabled, open a dialog with the sortable lists component (linelist export), and move options around between selected/available lists, as well as up and down the selected list. Verify the announcement strings specify the items moved, and to which list. Also verify singular/plural forms of announcements

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
