### PR TITLE
Chore(a11y): add accessible link labels to namespace row contents component

### DIFF
--- a/app/components/namespace_row/contents_component.html.erb
+++ b/app/components/namespace_row/contents_component.html.erb
@@ -8,25 +8,22 @@
     data: non_turbo_link_data,
   ) %>
 
-  <%= link_to namespace_path(@namespace), data: non_turbo_link_data, class: "underline hover:decoration-2 font-semibold dark:text-white wrap-anywhere min-w-0" do %>
-    <% if @full_name && @namespace.parent %>
-      <span><%= @namespace.parent.full_name %> /</span>
-      <span class="font-semibold">
-        <%= highlight(
-          @namespace.name,
-          defined?(params[:q][:namespace_name_cont]) &&
-            params[:q][:namespace_name_cont],
-          highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>',
-        ) %>
-      </span>
-    <% else %>
-      <%= highlight(
-        @namespace.name,
-        defined?(@search_params[:name_or_puid_cont]) &&
-          @search_params[:name_or_puid_cont],
-        highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>',
-      ) %>
-    <% end %>
+  <% if @full_name && @namespace.parent %>
+    <span><%= @namespace.parent.full_name %> /</span>
+  <% end %>
+
+  <%= link_to(
+    namespace_path(@namespace),
+    data: non_turbo_link_data,
+    class: "underline hover:decoration-2 font-semibold dark:text-white wrap-anywhere min-w-0",
+    aria: {label: I18n.t(:"components.namespace_row.contents_component.namespace_link.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_name: @namespace.name, namespace_puid: @namespace.puid) }
+  ) do %>
+    <%= highlight(
+      @namespace.name,
+      defined?(@search_params[:name_or_puid_cont]) &&
+        @search_params[:name_or_puid_cont],
+      highlighter: '<mark class="bg-primary-300 dark:bg-primary-600">\1</mark>',
+    ) %>
   <% end %>
 
   <%= render PuidComponent.new(puid: @namespace.puid) %>
@@ -45,7 +42,7 @@
   <div class="mr-2 ml-auto flex flex-col items-end">
     <div class="flex flex-row flex-wrap gap-2 text-slate-500 dark:text-slate-400">
       <% if @namespace.group_namespace? %>
-        <%= pathogen_link(href: namespace_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.subnamespaces.aria-label"), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: namespace_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.subnamespaces.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -65,7 +62,7 @@
             <%= @namespace.children.count %>
           </span>
         <% end %>
-        <%= pathogen_link(href: namespace_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.projects.aria-label"), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: namespace_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.projects.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -85,7 +82,7 @@
             <%= @namespace.project_namespaces.count %>
           </span>
         <% end %>
-        <%= pathogen_link(href: group_samples_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label"), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: group_samples_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -108,7 +105,7 @@
       <% end %>
 
       <% if @namespace.project_namespace? %>
-        <%= pathogen_link(href: namespace_project_samples_path(@namespace.parent, @namespace.project), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label"), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: namespace_project_samples_path(@namespace.parent, @namespace.project), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -264,14 +264,16 @@ en:
     namespace_row:
       contents_component:
         created_at: Created %{date}
+        namespace_link:
+          aria-label: View %{namespace_type} with name %{namespace_name} and persistent unique identifier %{namespace_puid}
         projects:
-          aria-label: Projects
+          aria-label: View projects for %{namespace_type} with persistent unique identifier %{namespace_puid}
           tooltip: "%{count} projects in %{namespace_name}"
         samples:
-          aria-label: Samples
+          aria-label: View samples for %{namespace_type} with persistent unique identifier %{namespace_puid}
           tooltip: "%{count} samples in %{namespace_name}"
         subnamespaces:
-          aria-label: Subgroups
+          aria-label: View subgroups for %{namespace_type} with persistent unique identifier %{namespace_puid}
           tooltip: "%{count} subgroups in %{namespace_name}"
     nextflow:
       email_notification: Receive an email notification when your analysis has completed?

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -264,14 +264,16 @@ fr:
     namespace_row:
       contents_component:
         created_at: Créé le %{date}
+        namespace_link:
+          aria-label: Afficher %{namespace_type} avec le nom %{namespace_name} et l’identifiant unique persistant %{namespace_puid}
         projects:
-          aria-label: Projets
+          aria-label: Afficher les projets pour %{namespace_type} avec l’identifiant unique persistant %{namespace_puid}
           tooltip: "%{count} projets dans %{namespace_name}"
         samples:
-          aria-label: Échantillons
+          aria-label: Afficher les échantillons pour %{namespace_type} avec l’identifiant unique persistant %{namespace_puid}
           tooltip: "%{count} échantillons dans %{namespace_name}"
         subnamespaces:
-          aria-label: Sous-groupes
+          aria-label: Afficher les sous-groupes pour %{namespace_type} avec l’identifiant unique persistant %{namespace_puid}
           tooltip: "%{count} sous-groupes dans %{namespace_name}"
     nextflow:
       email_notification: Vous recevez un avis par courriel lorsque votre analyse est terminée?

--- a/test/system/dashboard/projects_test.rb
+++ b/test/system/dashboard/projects_test.rb
@@ -29,7 +29,10 @@ module Dashboard
       click_on I18n.t(:'components.viral.pagy.pagination_component.previous')
       assert_selector '.treegrid-row', count: 20
 
-      click_link @project.human_name
+      click_link I18n.t(:'components.namespace_row.contents_component.namespace_link.aria-label',
+                        namespace_type: @project.namespace.model_name.human.downcase,
+                        namespace_name: @project.namespace.name,
+                        namespace_puid: @project.namespace.puid)
       assert_current_path(namespace_project_path(@project.parent, @project))
       assert_selector 'h1', text: @project.name
     end
@@ -50,7 +53,10 @@ module Dashboard
       click_on I18n.t(:'components.viral.pagy.pagination_component.previous')
       assert_selector '.treegrid-row', count: 20
 
-      click_link @project.human_name
+      click_link I18n.t(:'components.namespace_row.contents_component.namespace_link.aria-label',
+                        namespace_type: @project.namespace.model_name.human.downcase,
+                        namespace_name: @project.namespace.name,
+                        namespace_puid: @project.namespace.puid)
       assert_current_path(namespace_project_path(@project.parent, @project))
       assert_selector 'h1', text: @project.name
     end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Update links within Namespace Row Contents Component to have accessible labels to help screenreader users differentiate links.

Note: This implementation has been run my accessibility team

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/e935fbfb-f958-4bf4-8096-10307c0ebf4f" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
