### PR TITLE
feat: Concatenation form object and updated form with form error summary

### DIFF
--- a/app/controllers/projects/samples/attachments/concatenations_controller.rb
+++ b/app/controllers/projects/samples/attachments/concatenations_controller.rb
@@ -11,6 +11,8 @@ module Projects
 
         def new
           authorize! @project, to: :update_sample?
+
+          @concatenation_form = ::ConcatenationForm.new(delete_originals: false)
           render turbo_stream: turbo_stream.update('sample_modal',
                                                    partial: 'modal',
                                                    locals: {
@@ -22,21 +24,18 @@ module Projects
         def create
           authorize! @project, to: :update_sample?
 
-          @concatenated_attachments = ::Attachments::ConcatenationService.new(current_user, @sample,
-                                                                              concatenation_params).execute
+          @concatenation_form = ::ConcatenationForm.new(concatenation_params)
 
-          if @sample.errors.empty?
+          @concatenated_attachments = ::Attachments::ConcatenationService.new(current_user, @sample,
+                                                                              @concatenation_form).execute
+
+          if @concatenation_form.errors.empty?
             render status: :ok, locals: { type: :success, message: t('.success') }
           else
-            error_msg = if @sample.errors[:basename].any?
-                          t(:'general.form.error_notification')
-                        else
-                          error_message(@sample)
-                        end
+            error_msg = t(:'general.form.error_notification')
 
             render status: :unprocessable_content, locals: { type: :danger,
-                                                             message: error_msg,
-                                                             concatenation_params: }
+                                                             message: error_msg }
 
           end
         end
@@ -49,7 +48,7 @@ module Projects
         end
 
         def concatenation_params
-          params.expect(concatenation: [:basename, :delete_originals, { attachment_ids: {} }])
+          params.expect(concatenation_form: [:basename, :delete_originals, { attachment_ids: {} }])
         end
       end
     end

--- a/app/controllers/projects/samples/attachments/concatenations_controller.rb
+++ b/app/controllers/projects/samples/attachments/concatenations_controller.rb
@@ -24,19 +24,15 @@ module Projects
         def create
           authorize! @project, to: :update_sample?
 
-          @concatenation_form = ::ConcatenationForm.new(concatenation_params)
+          @concatenation_form = ::ConcatenationForm.new(concatenation_params.merge(attachable_id: @sample.id,
+                                                                                   attachable_type: @sample.class.name))
 
-          @concatenated_attachments = ::Attachments::ConcatenationService.new(current_user, @sample,
-                                                                              @concatenation_form).execute
+          @concatenated_attachments = ::Attachments::ConcatenationService.new(current_user, @concatenation_form).execute
 
           if @concatenation_form.errors.empty?
             render status: :ok, locals: { type: :success, message: t('.success') }
           else
-            error_msg = t(:'general.form.error_notification')
-
-            render status: :unprocessable_content, locals: { type: :danger,
-                                                             message: error_msg }
-
+            render status: :unprocessable_content
           end
         end
 

--- a/app/forms/concatenation_form.rb
+++ b/app/forms/concatenation_form.rb
@@ -20,6 +20,7 @@ class ConcatenationForm
   validate :attachments_belong_to_attachable, if: -> { attachment_ids.any? }
   validate :attachments_file_formats, if: -> { attachment_ids.any? }
   validate :attachments_file_types, if: -> { attachment_ids.any? }
+  validate :attachments_paired_end_counts, if: -> { attachment_ids.any? && paired_end? }
 
   def initialize(attributes = {})
     super
@@ -88,5 +89,11 @@ class ConcatenationForm
     end
 
     errors.add(:attachment_ids, :mismatching_file_types)
+  end
+
+  def attachments_paired_end_counts
+    return if Attachment.where(id: flattened_attachment_ids).group(:puid).count.values.all? { |count| count == 2 }
+
+    errors.add(:attachment_ids, :mismatching_paired_end_counts)
   end
 end

--- a/app/forms/concatenation_form.rb
+++ b/app/forms/concatenation_form.rb
@@ -17,7 +17,7 @@ class ConcatenationForm
 
   def initialize(attributes = {})
     super
-    self.attachment_ids = attachment_ids.values
+    self.attachment_ids = attachment_ids.values unless attachment_ids.is_a?(Array)
   end
 
   private

--- a/app/forms/concatenation_form.rb
+++ b/app/forms/concatenation_form.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# form object for concatenating attachments
+class ConcatenationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Validations::Callbacks
+
+  attribute :basename, :string
+  attribute :delete_originals, :boolean, default: false
+  attribute :attachment_ids, array: true, default: -> { [] }
+
+  validates :basename, presence: true, format: { with: /\A[a-zA-Z0-9_\-.]+\Z/ }
+  validates :attachment_ids, presence: true, length: { minimum: 2 }
+
+  before_validation :compact_attachment_ids
+
+  def initialize(attributes = {})
+    super
+    self.attachment_ids = attachment_ids.values
+  end
+
+  private
+
+  def compact_attachment_ids
+    self.attachment_ids = attachment_ids.compact_blank if attachment_ids.is_a?(Array)
+  end
+end

--- a/app/forms/concatenation_form.rb
+++ b/app/forms/concatenation_form.rb
@@ -6,23 +6,65 @@ class ConcatenationForm
   include ActiveModel::Attributes
   include ActiveModel::Validations::Callbacks
 
+  attribute :attachable_id, :string
+  attribute :attachable_type, :string
   attribute :basename, :string
   attribute :delete_originals, :boolean, default: false
   attribute :attachment_ids, array: true, default: -> { [] }
 
-  validates :basename, presence: true, format: { with: /\A[a-zA-Z0-9_\-.]+\Z/ }
+  before_validation :compact_attachment_ids
+
+  validates :basename, presence: true, format: { with: /\A[a-zA-Z0-9_\-.]+\Z/, allow_blank: true }
   validates :attachment_ids, presence: true, length: { minimum: 2 }
 
-  before_validation :compact_attachment_ids
+  validate :attachments_belong_to_attachable
 
   def initialize(attributes = {})
     super
     self.attachment_ids = attachment_ids.values unless attachment_ids.is_a?(Array)
   end
 
+  def attachable
+    return @attachable if defined?(@attachable)
+
+    @attachable = attachable_type.constantize.find_by(id: attachable_id)
+  end
+
+  def flattened_attachment_ids
+    return @flattened_attachment_ids if defined?(@flattened_attachment_ids)
+
+    @flattened_attachment_ids = if attachment_ids.all? { |i| i.is_a?(Integer) || i.is_a?(String) }
+                                  attachment_ids
+                                else
+                                  attachment_ids.flatten
+                                end
+  end
+
+  def attachments
+    return @attachments if defined?(@attachments)
+
+    @attachments = attachable.attachments.where(id: flattened_attachment_ids).order(:puid)
+  end
+
+  def paired_end?
+    return @paired_end if defined?(@paired_end)
+
+    @paired_end = attachment_ids.length != flattened_attachment_ids.length
+  end
+
   private
 
   def compact_attachment_ids
     self.attachment_ids = attachment_ids.compact_blank if attachment_ids.is_a?(Array)
+  end
+
+  def attachments_belong_to_attachable
+    return if attachment_ids.empty? ||
+              Attachment.where(id: flattened_attachment_ids,
+                               attachable_id: attachable_id,
+                               attachable_type: attachable_type).count == flattened_attachment_ids.length
+
+    errors.add(:attachment_ids, :mismatching_attachable,
+               attachable_type: I18n.t("activerecord.models.#{attachable_type.underscore}.one"))
   end
 end

--- a/app/forms/concatenation_form.rb
+++ b/app/forms/concatenation_form.rb
@@ -17,7 +17,8 @@ class ConcatenationForm
   validates :basename, presence: true, format: { with: /\A[a-zA-Z0-9_\-.]+\Z/, allow_blank: true }
   validates :attachment_ids, presence: true, length: { minimum: 2 }
 
-  validate :attachments_belong_to_attachable
+  validate :attachments_belong_to_attachable, if: -> { attachment_ids.any? }
+  validate :attachments_file_formats, if: -> { attachment_ids.any? }
 
   def initialize(attributes = {})
     super
@@ -59,12 +60,19 @@ class ConcatenationForm
   end
 
   def attachments_belong_to_attachable
-    return if attachment_ids.empty? ||
-              Attachment.where(id: flattened_attachment_ids,
+    return if Attachment.where(id: flattened_attachment_ids,
                                attachable_id: attachable_id,
                                attachable_type: attachable_type).count == flattened_attachment_ids.length
 
     errors.add(:attachment_ids, :mismatching_attachable,
                attachable_type: I18n.t("activerecord.models.#{attachable_type.underscore}.one"))
+  end
+
+  def attachments_file_formats
+    return if Attachment.where(id: flattened_attachment_ids)
+                        .group(Attachment.metadata_arel_node('format'),
+                               Attachment.metadata_arel_node('compression')).count.length == 1
+
+    errors.add(:attachment_ids, :mismatching_file_formats)
   end
 end

--- a/app/forms/concatenation_form.rb
+++ b/app/forms/concatenation_form.rb
@@ -19,6 +19,7 @@ class ConcatenationForm
 
   validate :attachments_belong_to_attachable, if: -> { attachment_ids.any? }
   validate :attachments_file_formats, if: -> { attachment_ids.any? }
+  validate :attachments_file_types, if: -> { attachment_ids.any? }
 
   def initialize(attributes = {})
     super
@@ -74,5 +75,18 @@ class ConcatenationForm
                                Attachment.metadata_arel_node('compression')).count.length == 1
 
     errors.add(:attachment_ids, :mismatching_file_formats)
+  end
+
+  def attachments_file_types
+    attachment_file_types = Attachment.where(id: flattened_attachment_ids)
+                                      .group(Attachment.metadata_arel_node('type'))
+                                      .count.keys
+    if paired_end?
+      return if attachment_file_types.all? { |t| %w[illumina_pe pe].include?(t) }
+    elsif attachment_file_types.length == 1 && attachment_file_types.none? { |t| %w[illumina_pe pe].include?(t) }
+      return
+    end
+
+    errors.add(:attachment_ids, :mismatching_file_types)
   end
 end

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -68,7 +68,7 @@ module Attachments
       end
 
       # if option is selected then destroy the original files
-      attachments.each(&:destroy) if concatenation_params[:delete_originals]
+      attachments.each(&:destroy) if concatenation_form.delete_originals
 
       concatenated_attachments
     end
@@ -109,7 +109,7 @@ module Attachments
 
     # Concatenates the single end reads into a single-end file
     def concatenate_single_end_reads(attachments)
-      basename = concatenation_params[:basename]
+      basename = concatenation_form.basename
       zipped_extension = attachments.first.metadata['compression'] == 'gzip' ? '.gz' : ''
 
       files = []
@@ -144,7 +144,7 @@ module Attachments
 
     # Gets the filename in the correct format for illumina paired-end and paired-end files
     def concatenated_paired_end_filenames(attachment_type)
-      basename = concatenation_params[:basename]
+      basename = concatenation_form.basename
 
       fwd_filename = attachment_type == 'illumina_pe' ? "#{basename}_S1_L001_R1_001" : "#{basename}_1"
 

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -23,9 +23,7 @@ module Attachments
 
       return [] unless concatenation_form.valid?
 
-      attachments = concatenation_form.attachments
-
-      validate_and_concatenate(attachments, concatenation_form.paired_end?)
+      concatenate(concatenation_form.attachments, concatenation_form.paired_end?)
     rescue Attachments::ConcatenationService::AttachmentConcatenationError => e
       concatenation_form.errors.add(:attachment_ids, e.message)
       []
@@ -36,7 +34,7 @@ module Attachments
     # Calls the validation, concatenate methods for the file type
     # If the user selects to delete the originals the originals
     # are deleted
-    def validate_and_concatenate(attachments, is_paired_end)
+    def concatenate(attachments, is_paired_end)
       concatenated_attachments = if is_paired_end
                                    concatenate_paired_end_reads(attachments)
                                  else
@@ -110,11 +108,6 @@ module Attachments
         elsif attachment.metadata['direction'] == 'reverse'
           reverse_reads << attachment
         end
-      end
-
-      if forward_reads.length != reverse_reads.length
-        raise AttachmentConcatenationError,
-              I18n.t('services.attachments.concatenation.incorrect_file_pairs')
       end
 
       [forward_reads, reverse_reads]

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -11,37 +11,21 @@ module Attachments
 
     attr_accessor :attachable, :attachments, :concatenation_form
 
-    def initialize(user = nil, attachable = nil, concatenation_form = nil)
-      super(user, params)
-      @attachable = attachable
+    def initialize(user = nil, concatenation_form = nil)
+      super(user)
+      @attachable = concatenation_form&.attachable
       @concatenation_form = concatenation_form
     end
 
-    def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength,Metrics/CyclomaticComplexity
+    def execute
       # authorize if user can update sample
       authorize! attachable.project, to: :update_sample? if attachable.instance_of?(Sample)
 
       return [] unless concatenation_form.valid?
 
-      attachment_ids = concatenation_form.attachment_ids
-      is_paired_end = false
+      attachments = concatenation_form.attachments
 
-      unless attachment_ids.all? { |i| i.is_a?(Integer) || i.is_a?(String) }
-        # if multi-dimensional array of ids
-        attachment_ids = attachment_ids.flatten
-        is_paired_end = true
-      end
-
-      attachments = attachable.attachments.where(id: attachment_ids).order(:puid)
-
-      # Checks to make sure the selected attachments to concatenate
-      # do in fact belong to the same sample
-      if attachments.length != attachment_ids.length
-        raise AttachmentConcatenationError,
-              I18n.t('services.attachments.concatenation.incorrect_attachable')
-      end
-
-      validate_and_concatenate(attachments, is_paired_end)
+      validate_and_concatenate(attachments, concatenation_form.paired_end?)
     rescue Attachments::ConcatenationService::AttachmentConcatenationError => e
       concatenation_form.errors.add(:attachment_ids, e.message)
       []
@@ -53,8 +37,6 @@ module Attachments
     # If the user selects to delete the originals the originals
     # are deleted
     def validate_and_concatenate(attachments, is_paired_end)
-      return unless attachments.length.positive?
-
       validate_file_formats(attachments)
 
       concatenated_attachments = []

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -2,7 +2,7 @@
 
 module Attachments
   # Service used to Concatenate Attachments
-  class ConcatenationService < BaseService # rubocop:disable Metrics/ClassLength
+  class ConcatenationService < BaseService
     class AttachmentConcatenationError < StandardError
     end
 
@@ -37,8 +37,6 @@ module Attachments
     # If the user selects to delete the originals the originals
     # are deleted
     def validate_and_concatenate(attachments, is_paired_end)
-      validate_file_formats(attachments)
-
       concatenated_attachments = []
 
       if is_paired_end
@@ -73,18 +71,6 @@ module Attachments
 
         raise AttachmentConcatenationError,
               I18n.t('services.attachments.concatenation.incorrect_file_types')
-      end
-      true
-    end
-
-    # Validates if the file formats all match for the attachments
-    def validate_file_formats(attachments) # rubocop:disable Naming/PredicateMethod
-      attachments.each do |attachment|
-        next unless (attachment.metadata['compression'] != attachments.first.metadata['compression']) ||
-                    (attachment.metadata['format'] != attachments.first.metadata['format'])
-
-        raise AttachmentConcatenationError,
-              I18n.t('services.attachments.concatenation.incorrect_fastq_file_types')
       end
       true
     end

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -3,12 +3,6 @@
 module Attachments
   # Service used to Concatenate Attachments
   class ConcatenationService < BaseService
-    class AttachmentConcatenationError < StandardError
-    end
-
-    class AttachmentConcatenationFilenameError < StandardError
-    end
-
     attr_accessor :attachable, :attachments, :concatenation_form
 
     def initialize(user = nil, concatenation_form = nil)
@@ -24,9 +18,6 @@ module Attachments
       return [] unless concatenation_form.valid?
 
       concatenate(concatenation_form.attachments, concatenation_form.paired_end?)
-    rescue Attachments::ConcatenationService::AttachmentConcatenationError => e
-      concatenation_form.errors.add(:attachment_ids, e.message)
-      []
     end
 
     private

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -9,27 +9,21 @@ module Attachments
     class AttachmentConcatenationFilenameError < StandardError
     end
 
-    attr_accessor :attachable, :attachments, :concatenation_params
+    attr_accessor :attachable, :attachments, :concatenation_form
 
-    def initialize(user = nil, attachable = nil, params = {})
+    def initialize(user = nil, attachable = nil, concatenation_form = nil)
       super(user, params)
       @attachable = attachable
-
-      # single-end params: { attachment_ids = {}, basename: basefilename,
-      #                      delete_originals: true OPTIONAL
-      #                      }
-      # paired-end params: { attachment_ids = {{}, {}, ...}, basename: basefilename,
-      #                      delete_originals: true OPTIONAL
-      #                      }
-      @concatenation_params = params
+      @concatenation_form = concatenation_form
     end
 
-    def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength,Metrics/CyclomaticComplexity
       # authorize if user can update sample
       authorize! attachable.project, to: :update_sample? if attachable.instance_of?(Sample)
 
-      validate_params
-      attachment_ids = concatenation_params[:attachment_ids].values
+      return [] unless concatenation_form.valid?
+
+      attachment_ids = concatenation_form.attachment_ids
       is_paired_end = false
 
       unless attachment_ids.all? { |i| i.is_a?(Integer) || i.is_a?(String) }
@@ -38,7 +32,7 @@ module Attachments
         is_paired_end = true
       end
 
-      attachments = attachable.attachments.where(id: attachment_ids, attachable:).order(:puid)
+      attachments = attachable.attachments.where(id: attachment_ids).order(:puid)
 
       # Checks to make sure the selected attachments to concatenate
       # do in fact belong to the same sample
@@ -49,34 +43,11 @@ module Attachments
 
       validate_and_concatenate(attachments, is_paired_end)
     rescue Attachments::ConcatenationService::AttachmentConcatenationError => e
-      attachable.errors.add(:base, e.message)
-      []
-    rescue Attachments::ConcatenationService::AttachmentConcatenationFilenameError => e
-      attachable.errors.add(:basename, e.message)
+      concatenation_form.errors.add(:attachment_ids, e.message)
       []
     end
 
     private
-
-    # Validates params
-    def validate_params # rubocop:disable Metrics/AbcSize,Naming/PredicateMethod
-      if !concatenation_params.key?(:attachment_ids) || concatenation_params[:attachment_ids].empty?
-        raise AttachmentConcatenationError,
-              I18n.t('services.attachments.concatenation.no_files_selected')
-      end
-
-      if !concatenation_params.key?(:basename) || concatenation_params[:basename].empty?
-        raise AttachmentConcatenationFilenameError,
-              I18n.t('services.attachments.concatenation.filename_missing')
-      end
-
-      if concatenation_params.key?(:basename) && !concatenation_params[:basename].match?(/^[[a-zA-Z0-9_\-.]]*$/)
-        raise AttachmentConcatenationFilenameError,
-              I18n.t('services.attachments.concatenation.incorrect_basename')
-      end
-
-      true
-    end
 
     # Calls the validation, concatenate methods for the file type
     # If the user selects to delete the originals the originals

--- a/app/services/attachments/concatenation_service.rb
+++ b/app/services/attachments/concatenation_service.rb
@@ -37,42 +37,16 @@ module Attachments
     # If the user selects to delete the originals the originals
     # are deleted
     def validate_and_concatenate(attachments, is_paired_end)
-      concatenated_attachments = []
-
-      if is_paired_end
-        validate_paired_end_files(attachments)
-        concatenated_attachments = concatenate_paired_end_reads(attachments)
-      else
-        validate_single_end_files(attachments)
-        concatenated_attachments = concatenate_single_end_reads(attachments)
-      end
+      concatenated_attachments = if is_paired_end
+                                   concatenate_paired_end_reads(attachments)
+                                 else
+                                   concatenate_single_end_reads(attachments)
+                                 end
 
       # if option is selected then destroy the original files
       attachments.each(&:destroy) if concatenation_form.delete_originals
 
       concatenated_attachments
-    end
-
-    # Validates that the single end files are all the same type
-    def validate_single_end_files(attachments) # rubocop:disable Naming/PredicateMethod
-      attachments.each do |attachment|
-        next unless attachment.metadata.key?('type')
-
-        raise AttachmentConcatenationError,
-              I18n.t('services.attachments.concatenation.incorrect_file_types')
-      end
-      true
-    end
-
-    # Validates that the paired end files are all the same type
-    def validate_paired_end_files(attachments) # rubocop:disable Naming/PredicateMethod
-      attachments.each do |attachment|
-        next if attachment.metadata.key?('type') && %w[illumina_pe pe].include?(attachments.first.metadata['type'])
-
-        raise AttachmentConcatenationError,
-              I18n.t('services.attachments.concatenation.incorrect_file_types')
-      end
-      true
     end
 
     # Concatenates the single end reads into a single-end file

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -12,20 +12,35 @@
 
     <%= render FormErrorSummaryComponent.new(entries: summary_entries) %>
 
-    <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
-      <p class="mb-4"><%= t(".description") %></p>
-
-      <div
-        class="scrollbar overflow-auto"
-        data-controller="projects--samples--attachments--files"
-        data-projects--samples--attachments--files-target="field"
-      ></div>
-    </div>
-
-    <div data-projects--samples--attachments--selected-attachments-target="field"></div>
-
     <div class="grid gap-4">
+      <% invalid_attachment_ids = @concatenation_form.errors.include?(:attachment_ids) %>
+
       <%= render partial: "shared/form/required_field_legend" %>
+
+      <div class="form-field" <%= 'invalid' if invalid_attachment_ids %>>
+        <%= form.label :attachment_ids, data: { required: true } %>
+
+        <div
+          class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400"
+          tabindex="0"
+          aria-label="<%= form.field_id(:attachment_ids) %>"
+          <%= "aria-describedby=#{form.field_id(:attachment_ids, "error")}" if invalid_attachment_ids %>
+        >
+          <div
+            class="scrollbar overflow-auto"
+            data-controller="projects--samples--attachments--files"
+            data-projects--samples--attachments--files-target="field"
+          ></div>
+        </div>
+
+        <div data-projects--samples--attachments--selected-attachments-target="field"></div>
+
+        <% if invalid_attachment_ids %>
+          <%= render "shared/form/field_errors",
+          id: form.field_id(:attachment_ids, "error"),
+          errors: @concatenation_form.errors.full_messages_for(:attachment_ids) %>
+        <% end %>
+      </div>
 
       <% invalid_basename = @concatenation_form.errors.include?(:basename) %>
 
@@ -52,7 +67,7 @@
         <% if invalid_basename %>
           <%= render "shared/form/field_errors",
           id: form.field_id(:basename, "error"),
-          errors: @concatenation_form.errors[:basename] %>
+          errors: @concatenation_form.errors.full_messages_for(:basename) %>
         <% end %>
 
         <span id="<%= form.field_id(:basename, "hint") %>" class="field-hint">

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -1,45 +1,39 @@
 <%= viral_dialog(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
-  <%= turbo_frame_tag("concatenation-alert") %>
 
-  <div
-    class="
-      mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
-    "
-  >
-    <p class="mb-4"><%= t(".description") %></p>
-    <div
-      class="overflow-auto scrollbar"
-      data-controller="projects--samples--attachments--files"
-      data-projects--samples--attachments--files-target="field"
-    ></div>
-  </div>
-
-  <%= form_for(:concatenation, url: namespace_project_sample_attachments_concatenation_path,
+  <%= form_with(model: @concatenation_form, url: namespace_project_sample_attachments_concatenation_path,
     data: {
       controller: "projects--samples--attachments--selected-attachments",
-      'projects--samples--attachments--selected-attachments-field-name-value':"concatenation[attachment_ids]",
+      'projects--samples--attachments--selected-attachments-field-name-value':"concatenation_form[attachment_ids]",
       "projects--samples--attachments--selected-attachments-storage-key-value": "files-#{@sample.id}",
       action: 'turbo:submit-end->projects--samples--attachments--selected-attachments#clear'
     }, method: :post, html: { novalidate: true }) do |form| %>
+    <% summary_entries = FormErrorSummaryEntryBuilder.new(builder: form, errors: @concatenation_form.errors).call %>
+
+    <%= render FormErrorSummaryComponent.new(entries: summary_entries) %>
+
+    <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
+      <p class="mb-4"><%= t(".description") %></p>
+
+      <div
+        class="scrollbar overflow-auto"
+        data-controller="projects--samples--attachments--files"
+        data-projects--samples--attachments--files-target="field"
+      ></div>
+    </div>
+
     <div data-projects--samples--attachments--selected-attachments-target="field"></div>
 
     <div class="grid gap-4">
       <%= render partial: "shared/form/required_field_legend" %>
 
-      <% invalid_basename = @sample.errors.include?(:basename) %>
-      <div class="form-field <%= 'invalid' if invalid_basename%>">
+      <% invalid_basename = @concatenation_form.errors.include?(:basename) %>
+
+      <div class="form-field <%= 'invalid' if invalid_basename %>">
         <%= form.label :basename, data: { required: true } %>
+
         <%= form.text_field :basename,
                         required: true,
-                        value:
-                          (
-                            if concatenation_params.nil?
-                              ""
-                            else
-                              concatenation_params[:basename]
-                            end
-                          ),
                         pattern: /^[[a-zA-Z0-9_\-\.]]*$/,
                         title:
                           t(
@@ -54,31 +48,21 @@
                           required: true,
                         },
                         class: "form-control" %>
+
         <% if invalid_basename %>
           <%= render "shared/form/field_errors",
           id: form.field_id(:basename, "error"),
-          errors: @sample.errors[:basename] %>
+          errors: @concatenation_form.errors[:basename] %>
         <% end %>
+
         <span id="<%= form.field_id(:basename, "hint") %>" class="field-hint">
           <%== t(:"projects.samples.attachments.concatenations.create.basename_help") %>
         </span>
       </div>
 
       <div class="flex items-center">
-        <%= form.check_box :delete_originals,
-                       {
-                         checked:
-                           (
-                             if !concatenation_params.nil? &&
-                                  concatenation_params[:delete_originals]
-                               true
-                             else
-                               false
-                             end
-                           ),
-                       },
-                       true,
-                       false %>
+        <%= form.check_box :delete_originals %>
+
         <%= form.label :delete_originals,
                    class: "ml-2 text-sm font-medium text-slate-900 dark:text-slate-300" %>
       </div>

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -8,9 +8,7 @@
       "projects--samples--attachments--selected-attachments-storage-key-value": "files-#{@sample.id}",
       action: 'turbo:submit-end->projects--samples--attachments--selected-attachments#clear'
     }, method: :post, html: { novalidate: true }) do |form| %>
-    <% summary_entries = FormErrorSummaryEntryBuilder.new(builder: form, errors: @concatenation_form.errors).call %>
-
-    <%= render FormErrorSummaryComponent.new(entries: summary_entries) %>
+    <%= form_error_summary(form) %>
 
     <div class="grid gap-4">
       <% invalid_attachment_ids = @concatenation_form.errors.include?(:attachment_ids) %>

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -15,21 +15,21 @@
 
       <%= render partial: "shared/form/required_field_legend" %>
 
-      <div class="form-field" <%= 'invalid' if invalid_attachment_ids %>>
+      <%= tag.div class: class_names("form-field", 'invalid': invalid_attachment_ids) do %>
         <%= form.label :attachment_ids, data: { required: true } %>
 
-        <div
-          class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400"
-          tabindex="0"
-          aria-label="<%= form.field_id(:attachment_ids) %>"
-          <%= "aria-describedby=#{form.field_id(:attachment_ids, "error")}" if invalid_attachment_ids %>
-        >
+        <%= tag.div class: "mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400",
+                    tabindex: 0,
+                    aria: {
+                      label: form.field_id(:attachment_ids),
+                      describedby: (invalid_attachment_ids ? form.field_id(:attachment_ids, "error") : nil)
+                    } do %>
           <div
             class="scrollbar overflow-auto"
             data-controller="projects--samples--attachments--files"
             data-projects--samples--attachments--files-target="field"
           ></div>
-        </div>
+        <% end %>
 
         <div data-projects--samples--attachments--selected-attachments-target="field"></div>
 
@@ -38,11 +38,11 @@
           id: form.field_id(:attachment_ids, "error"),
           errors: @concatenation_form.errors.full_messages_for(:attachment_ids) %>
         <% end %>
-      </div>
+      <% end %>
 
       <% invalid_basename = @concatenation_form.errors.include?(:basename) %>
 
-      <div class="form-field <%= 'invalid' if invalid_basename %>">
+      <%= tag.div class: class_names("form-field", 'invalid': invalid_basename) do %>
         <%= form.label :basename, data: { required: true } %>
 
         <%= form.text_field :basename,
@@ -71,7 +71,7 @@
         <span id="<%= form.field_id(:basename, "hint") %>" class="field-hint">
           <%== t(:"projects.samples.attachments.concatenations.create.basename_help") %>
         </span>
-      </div>
+      <% end %>
 
       <div class="flex items-center">
         <%= form.check_box :delete_originals %>

--- a/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
@@ -2,8 +2,7 @@
   "sample_modal",
   partial: "modal",
   locals: {
-    open: @concatenation_form.errors.any?,
-    concatenation_params: @sample.errors.any? ? concatenation_params : nil,
+    open: @concatenation_form.errors.any?
   },
 ) %>
 

--- a/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
@@ -2,18 +2,14 @@
   "sample_modal",
   partial: "modal",
   locals: {
-    open: @sample.errors.any?,
+    open: @concatenation_form.errors.any?,
     concatenation_params: @sample.errors.any? ? concatenation_params : nil,
   },
 ) %>
 
-<% if @sample.errors.any? %>
-  <%= turbo_stream.update "concatenation-alert",
-                      viral_alert(type:, message:, classes: "mb-4") %>
-<% else %>
+<% unless @concatenation_form.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
     <%= viral_flash(type:, data: message) %>
   <% end %>
-
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
               mismatching_attachable: must all belong to the same %{attachable_type}
               mismatching_file_formats: must all have the same file format and compression
               mismatching_file_types: must all have the same type. Paired-end files can only be concatenated with other paired-end files, and single-end files can only be concatenated with other single-end files.
+              mismatching_paired_end_counts: must all be paired. Forward and reverse read file counts do not match.
             basename:
               invalid: must contain only letters, digits, '-', '.', and '_'.
         sample/search_condition:
@@ -1841,8 +1842,6 @@ en:
         title: Transfer Samples
   services:
     attachments:
-      concatenation:
-        incorrect_file_pairs: Incorrect file pairing. Forward and reverse read file counts do not match.
       destroy:
         associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.
         does_not_belong_to_attachable: This attachment does not belong to this sample.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
             attachment_ids:
               min_length: must have at least %{count} files selected
               mismatching_attachable: must all belong to the same %{attachable_type}
+              mismatching_file_formats: must all have the same file format and compression
             basename:
               invalid: must contain only letters, digits, '-', '.', and '_'.
         sample/search_condition:
@@ -1840,7 +1841,6 @@ en:
   services:
     attachments:
       concatenation:
-        incorrect_fastq_file_types: Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files
         incorrect_file_pairs: Incorrect file pairing. Forward and reverse read file counts do not match.
         incorrect_file_types: Files are not of the same type. Paired-end files can only be concatenated with other paired-end files, and single-end files can only be concatenated with other single-end files.
       destroy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
               min_length: must have at least %{count} files selected
               mismatching_attachable: must all belong to the same %{attachable_type}
               mismatching_file_formats: must all have the same file format and compression
+              mismatching_file_types: must all have the same type. Paired-end files can only be concatenated with other paired-end files, and single-end files can only be concatenated with other single-end files.
             basename:
               invalid: must contain only letters, digits, '-', '.', and '_'.
         sample/search_condition:
@@ -1842,7 +1843,6 @@ en:
     attachments:
       concatenation:
         incorrect_file_pairs: Incorrect file pairing. Forward and reverse read file counts do not match.
-        incorrect_file_types: Files are not of the same type. Paired-end files can only be concatenated with other paired-end files, and single-end files can only be concatenated with other single-end files.
       destroy:
         associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.
         does_not_belong_to_attachable: This attachment does not belong to this sample.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1599,7 +1599,6 @@ en:
             basename_help: The base filename can contain only letters, digits, '-', '.', and '_'
             success: Files were successfully concatenated.
           modal:
-            description: 'The following files were selected to be concatenated:'
             submit_button: Concatenate
             title: Concatenate Files
         create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,8 +26,9 @@ en:
           attributes:
             attachment_ids:
               min_length: must have at least %{count} files selected
+              mismatching_attachable: must all belong to the same %{attachable_type}
             basename:
-              invalid: must contain only letters, digits, '_', '-', and '.'.
+              invalid: must contain only letters, digits, '-', '.', and '_'.
         sample/search_condition:
           attributes:
             field:
@@ -1839,7 +1840,6 @@ en:
   services:
     attachments:
       concatenation:
-        incorrect_attachable: All or some of then selected files do not belong to the sample.
         incorrect_fastq_file_types: Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files
         incorrect_file_pairs: Incorrect file pairing. Forward and reverse read file counts do not match.
         incorrect_file_types: Files are not of the same type. Paired-end files can only be concatenated with other paired-end files, and single-end files can only be concatenated with other single-end files.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,10 @@
 en:
   activemodel:
     attributes:
+      concatenation_form:
+        attachment_ids: Files
+        basename: Base filename
+        delete_originals: Delete original files after concatenation?
       sample/query:
         group: Group
       sample/search_condition:
@@ -18,6 +22,12 @@ en:
         condition: Condition
     errors:
       models:
+        concatenation_form:
+          attributes:
+            attachment_ids:
+              min_length: must have at least %{count} files selected
+            basename:
+              invalid: must contain only letters, digits, '_', '-', and '.'.
         sample/search_condition:
           attributes:
             field:
@@ -1830,13 +1840,10 @@ en:
   services:
     attachments:
       concatenation:
-        filename_missing: Base filename can't be blank.
         incorrect_attachable: All or some of then selected files do not belong to the sample.
-        incorrect_basename: The base filename can contain only letters, digits, '-', '.', and '_'
         incorrect_fastq_file_types: Incorrect file types. '.fastq' files can only be concatenated with other '.fastq' files. '.fastq.gz' files can only be concatenated with other '.fastq.gz' files
         incorrect_file_pairs: Incorrect file pairing. Forward and reverse read file counts do not match.
         incorrect_file_types: Files are not of the same type. Paired-end files can only be concatenated with other paired-end files, and single-end files can only be concatenated with other single-end files.
-        no_files_selected: No files were selected to concatenate. Please select files then try again.
       destroy:
         associated_att_does_not_belong_to_attachable: This associated attachment does not belong to the sample.
         does_not_belong_to_attachable: This attachment does not belong to this sample.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -29,7 +29,7 @@ fr:
               mismatching_attachable: tous les fichiers sélectionnés doivent appartenir au même %{attachable_type}
               mismatching_file_formats: tous les fichiers sélectionnés doivent avoir le même format et la même compression
               mismatching_file_types: tous les fichiers sélectionnés doivent être du même type. Les fichiers jumelés ne peuvent être concaténés qu’avec d’autres fichiers jumelés, et les fichiers uniques ne peuvent être concaténés qu’avec d’autres fichiers uniques.
-              mismatching_pair_end_counts: tous les fichiers sélectionnés doivent être jumelés. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
+              mismatching_paired_end_counts: tous les fichiers sélectionnés doivent être jumelés. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
             basename:
               invalid: doit contenir uniquement des lettres, chiffres, « - », « . » et « _ »
         sample/search_condition:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -27,6 +27,7 @@ fr:
             attachment_ids:
               min_length: doit sélectionner au moins %{count} fichier(s) à concaténer
               mismatching_attachable: tous les fichiers sélectionnés doivent appartenir au même %{attachable_type}
+              mismatching_file_formats: tous les fichiers sélectionnés doivent avoir le même format et la même compression
             basename:
               invalid: doit contenir uniquement des lettres, chiffres, « - », « . » et « _ »
         sample/search_condition:
@@ -1844,7 +1845,6 @@ fr:
   services:
     attachments:
       concatenation:
-        incorrect_fastq_file_types: Types de fichiers incorrects. Les fichiers '.fastq' ne peuvent être concaténés qu’avec d’autres fichiers '.fastq'. Les fichiers '.fastq.gz' ne peuvent être concaténés qu’avec d’autres fichiers '.fastq.gz'
         incorrect_file_pairs: Jumelage de fichiers incorrect. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
         incorrect_file_types: Les dossiers ne sont pas du même type. Les fichiers jumelés ne peuvent être concaténés qu’avec d’autres fichiers jumelés, et les fichiers uniques ne peuvent être concaténés qu’avec d’autres fichiers uniques.
       destroy:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -29,6 +29,7 @@ fr:
               mismatching_attachable: tous les fichiers sélectionnés doivent appartenir au même %{attachable_type}
               mismatching_file_formats: tous les fichiers sélectionnés doivent avoir le même format et la même compression
               mismatching_file_types: tous les fichiers sélectionnés doivent être du même type. Les fichiers jumelés ne peuvent être concaténés qu’avec d’autres fichiers jumelés, et les fichiers uniques ne peuvent être concaténés qu’avec d’autres fichiers uniques.
+              mismatching_pair_end_counts: tous les fichiers sélectionnés doivent être jumelés. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
             basename:
               invalid: doit contenir uniquement des lettres, chiffres, « - », « . » et « _ »
         sample/search_condition:
@@ -1845,8 +1846,6 @@ fr:
         title: Transférer des échantillons
   services:
     attachments:
-      concatenation:
-        incorrect_file_pairs: Jumelage de fichiers incorrect. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
       destroy:
         associated_att_does_not_belong_to_attachable: Cette pièce jointe n’appartient pas à l’échantillon.
         does_not_belong_to_attachable: Cette pièce jointe n’appartient pas à cet échantillon.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -28,6 +28,7 @@ fr:
               min_length: doit sélectionner au moins %{count} fichier(s) à concaténer
               mismatching_attachable: tous les fichiers sélectionnés doivent appartenir au même %{attachable_type}
               mismatching_file_formats: tous les fichiers sélectionnés doivent avoir le même format et la même compression
+              mismatching_file_types: tous les fichiers sélectionnés doivent être du même type. Les fichiers jumelés ne peuvent être concaténés qu’avec d’autres fichiers jumelés, et les fichiers uniques ne peuvent être concaténés qu’avec d’autres fichiers uniques.
             basename:
               invalid: doit contenir uniquement des lettres, chiffres, « - », « . » et « _ »
         sample/search_condition:
@@ -1846,7 +1847,6 @@ fr:
     attachments:
       concatenation:
         incorrect_file_pairs: Jumelage de fichiers incorrect. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
-        incorrect_file_types: Les dossiers ne sont pas du même type. Les fichiers jumelés ne peuvent être concaténés qu’avec d’autres fichiers jumelés, et les fichiers uniques ne peuvent être concaténés qu’avec d’autres fichiers uniques.
       destroy:
         associated_att_does_not_belong_to_attachable: Cette pièce jointe n’appartient pas à l’échantillon.
         does_not_belong_to_attachable: Cette pièce jointe n’appartient pas à cet échantillon.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1844,7 +1844,6 @@ fr:
   services:
     attachments:
       concatenation:
-        incorrect_attachable: Tous ou certains des fichiers sélectionnés n’appartiennent pas à l’échantillon.
         incorrect_fastq_file_types: Types de fichiers incorrects. Les fichiers '.fastq' ne peuvent être concaténés qu’avec d’autres fichiers '.fastq'. Les fichiers '.fastq.gz' ne peuvent être concaténés qu’avec d’autres fichiers '.fastq.gz'
         incorrect_file_pairs: Jumelage de fichiers incorrect. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
         incorrect_file_types: Les dossiers ne sont pas du même type. Les fichiers jumelés ne peuvent être concaténés qu’avec d’autres fichiers jumelés, et les fichiers uniques ne peuvent être concaténés qu’avec d’autres fichiers uniques.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -22,7 +22,7 @@ fr:
         condition: Condition
     errors:
       models:
-        concatenation:
+        concatenation_form:
           attributes:
             attachment_ids:
               min_length: doit sélectionner au moins %{count} fichier(s) à concaténer
@@ -1603,7 +1603,6 @@ fr:
             basename_help: Le nom de fichier de base ne peut contenir que des lettres, des chiffres, '-', '.' et '_'
             success: Les dossiers ont été concaténés avec succès.
           modal:
-            description: 'Les fichiers suivants ont été sélectionnés pour être concaténés :'
             submit_button: Concaténer
             title: Concaténer les fichiers
         create:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -26,8 +26,9 @@ fr:
           attributes:
             attachment_ids:
               min_length: doit sélectionner au moins %{count} fichier(s) à concaténer
+              mismatching_attachable: tous les fichiers sélectionnés doivent appartenir au même %{attachable_type}
             basename:
-              invalid: doit contenir uniquement des lettres, chiffres, « _ », « - » et « . »
+              invalid: doit contenir uniquement des lettres, chiffres, « - », « . » et « _ »
         sample/search_condition:
           attributes:
             field:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,6 +2,10 @@
 fr:
   activemodel:
     attributes:
+      concatenation_form:
+        attachment_ids: Fichiers
+        basename: Nom de base du fichier de concaténation
+        delete_originals: Supprimer les fichiers originaux après la concaténation?
       sample/query:
         group: Groupe
       sample/search_condition:
@@ -18,6 +22,12 @@ fr:
         condition: Condition
     errors:
       models:
+        concatenation:
+          attributes:
+            attachment_ids:
+              min_length: doit sélectionner au moins %{count} fichier(s) à concaténer
+            basename:
+              invalid: doit contenir uniquement des lettres, chiffres, « _ », « - » et « . »
         sample/search_condition:
           attributes:
             field:
@@ -1834,13 +1844,10 @@ fr:
   services:
     attachments:
       concatenation:
-        filename_missing: Le nom de fichier de base doit exister.
         incorrect_attachable: Tous ou certains des fichiers sélectionnés n’appartiennent pas à l’échantillon.
-        incorrect_basename: Le nom de fichier de base ne peut contenir que des lettres, des chiffres, '-', '.' et '_'
         incorrect_fastq_file_types: Types de fichiers incorrects. Les fichiers '.fastq' ne peuvent être concaténés qu’avec d’autres fichiers '.fastq'. Les fichiers '.fastq.gz' ne peuvent être concaténés qu’avec d’autres fichiers '.fastq.gz'
         incorrect_file_pairs: Jumelage de fichiers incorrect. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
         incorrect_file_types: Les dossiers ne sont pas du même type. Les fichiers jumelés ne peuvent être concaténés qu’avec d’autres fichiers jumelés, et les fichiers uniques ne peuvent être concaténés qu’avec d’autres fichiers uniques.
-        no_files_selected: Aucun fichier n’a été sélectionné pour la concaténation. Veuillez sélectionner les fichiers, puis réessayer.
       destroy:
         associated_att_does_not_belong_to_attachable: Cette pièce jointe n’appartient pas à l’échantillon.
         does_not_belong_to_attachable: Cette pièce jointe n’appartient pas à cet échantillon.

--- a/test/controllers/projects/samples/attachments/concatenations_controller_test.rb
+++ b/test/controllers/projects/samples/attachments/concatenations_controller_test.rb
@@ -34,7 +34,7 @@ module Projects
           post namespace_project_sample_attachments_concatenation_path(@namespace, @project1, @sample1,
                                                                        format: :turbo_stream),
                params: {
-                 concatenation: {
+                 concatenation_form: {
                    basename: 'blah',
                    attachment_ids: { '0' => @attachment1.id, '1' => @attachment2.id }
                  }

--- a/test/services/attachments/concatenation_service_test.rb
+++ b/test/services/attachments/concatenation_service_test.rb
@@ -11,410 +11,458 @@ module Attachments
 
     test 'concatenate single end files' do
       sample = samples(:sampleC)
-      params = { attachment_ids: { '0' => attachments(:attachmentG).id, '1' => attachments(:attachmentH).id },
-                 basename: 'new-concatenated-file' }
+      params = {
+        attachable_id: sample.id, attachable_type: sample.class.name,
+        attachment_ids: { '0' => attachments(:attachmentG).id, '1' => attachments(:attachmentH).id },
+        basename: 'new-concatenated-file'
+      }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_difference -> { Attachment.count } => 1 do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        attachmentg_file_size = sample.attachments.find_by(id: attachments(:attachmentG).id).file.byte_size
-        attachmenth_file_size = sample.attachments.find_by(id: attachments(:attachmentH).id).file.byte_size
-
-        concatenated_file_size = sample.attachments.last.file.byte_size
-
-        assert_equal concatenated_file_size, (attachmentg_file_size + attachmenth_file_size)
-
-        assert_equal 'new-concatenated-file_1.fastq', sample.attachments.last.file.filename.to_s
-
-        assert_equal 'fastq', sample.attachments.last.metadata['format']
-
-        assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      attachmentg_file_size = attachments(:attachmentG).file.byte_size
+      attachmenth_file_size = attachments(:attachmentH).file.byte_size
+
+      concatenated_file_size = sample.attachments.last.file.byte_size
+
+      assert_equal concatenated_file_size, (attachmentg_file_size + attachmenth_file_size)
+
+      assert_equal 'new-concatenated-file_1.fastq', sample.attachments.last.file.filename.to_s
+
+      assert_equal 'fastq', sample.attachments.last.metadata['format']
+
+      assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'concatenate single end files with spaces in provided basename' do
       sample = samples(:sampleC)
-      params = { attachment_ids: { '0' => attachments(:attachmentG).id, '1' => attachments(:attachmentH).id },
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => attachments(:attachmentG).id, '1' => attachments(:attachmentH).id },
                  basename: 'new concatenated file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        assert sample.errors[:basename].include?(I18n.t('services.attachments.concatenation.incorrect_basename'))
-
-        assert_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      assert concatenation_form.errors.of_kind?(:basename, :invalid)
+
+      assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'concatenate paired end files' do
       sample = samples(:sampleB)
-      params = { attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
                                    '1' => [attachments(:attachmentPEFWD2).id, attachments(:attachmentPEREV2).id] },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_difference -> { Attachment.count } => 2 do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        attachmentfwd1_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD1).id).file.byte_size
-        attachmentfwd2_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD2).id).file.byte_size
-
-        attachmentrev1_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV1).id).file.byte_size
-        attachmentrev2_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV2).id).file.byte_size
-
-        concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
-        concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
-
-        assert_equal concatenatedfwd_file_size, (attachmentfwd1_file_size + attachmentfwd2_file_size)
-
-        assert_equal concatenatedrev_file_size, (attachmentrev1_file_size + attachmentrev2_file_size)
-
-        assert_equal 'new-concatenated-file_1.fastq', sample.attachments.last(2).first.file.filename.to_s
-        assert_equal 'new-concatenated-file_2.fastq', sample.attachments.last(2).last.file.filename.to_s
-
-        assert_equal attachments(:attachmentPEFWD1).file.download + attachments(:attachmentPEFWD2).file.download,
-                     sample.attachments.last(2).first.file.download
-        assert_equal attachments(:attachmentPEREV1).file.download + attachments(:attachmentPEREV2).file.download,
-                     sample.attachments.last(2).last.file.download
-
-        assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
-        assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
-
-        assert_equal 'pe', sample.attachments.last(2).first.metadata['type']
-        assert_equal 'pe', sample.attachments.last(2).last.metadata['type']
-
-        assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      attachmentfwd1_file_size = attachments(:attachmentPEFWD1).file.byte_size
+      attachmentfwd2_file_size = attachments(:attachmentPEFWD2).file.byte_size
+
+      attachmentrev1_file_size = attachments(:attachmentPEREV1).file.byte_size
+      attachmentrev2_file_size = attachments(:attachmentPEREV2).file.byte_size
+
+      concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
+      concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
+
+      assert_equal concatenatedfwd_file_size, (attachmentfwd1_file_size + attachmentfwd2_file_size)
+
+      assert_equal concatenatedrev_file_size, (attachmentrev1_file_size + attachmentrev2_file_size)
+
+      assert_equal 'new-concatenated-file_1.fastq', sample.attachments.last(2).first.file.filename.to_s
+      assert_equal 'new-concatenated-file_2.fastq', sample.attachments.last(2).last.file.filename.to_s
+
+      assert_equal attachments(:attachmentPEFWD1).file.download + attachments(:attachmentPEFWD2).file.download,
+                   sample.attachments.last(2).first.file.download
+      assert_equal attachments(:attachmentPEREV1).file.download + attachments(:attachmentPEREV2).file.download,
+                   sample.attachments.last(2).last.file.download
+
+      assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
+      assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
+
+      assert_equal 'pe', sample.attachments.last(2).first.metadata['type']
+      assert_equal 'pe', sample.attachments.last(2).last.metadata['type']
+
+      assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'concatenate paired end files with spaces in provided basename' do
       sample = samples(:sampleB)
-      params = { attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
                                    '1' => [attachments(:attachmentPEFWD2).id, attachments(:attachmentPEREV2).id] },
                  basename: 'new concatenated file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        assert sample.errors[:basename].include?(I18n.t('services.attachments.concatenation.incorrect_basename'))
-
-        assert_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      assert concatenation_form.errors.of_kind?(:basename, :invalid)
+
+      assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'concatenate illumina paired end files' do
       sample = samples(:sampleC)
-      params = { attachment_ids: { '0' => [attachments(:attachmentPEFWD4).id, attachments(:attachmentPEREV4).id],
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => [attachments(:attachmentPEFWD4).id, attachments(:attachmentPEREV4).id],
                                    '1' => [attachments(:attachmentPEFWD5).id, attachments(:attachmentPEREV5).id] },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_difference -> { Attachment.count } => 2 do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        attachmentfwd4_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD4).id).file.byte_size
-        attachmentfwd5_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD5).id).file.byte_size
-
-        attachmentrev4_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV4).id).file.byte_size
-        attachmentrev5_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV5).id).file.byte_size
-
-        concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
-        concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
-
-        assert_equal concatenatedfwd_file_size, (attachmentfwd4_file_size + attachmentfwd5_file_size)
-
-        assert_equal concatenatedrev_file_size, (attachmentrev4_file_size + attachmentrev5_file_size)
-
-        assert_equal 'new-concatenated-file_S1_L001_R1_001.fastq', sample.attachments.last(2).first.file.filename.to_s
-        assert_equal 'new-concatenated-file_S1_L001_R2_001.fastq', sample.attachments.last(2).last.file.filename.to_s
-
-        assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
-        assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
-
-        assert_equal 'illumina_pe', sample.attachments.last(2).first.metadata['type']
-        assert_equal 'illumina_pe', sample.attachments.last(2).last.metadata['type']
-
-        assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      attachmentfwd4_file_size = attachments(:attachmentPEFWD4).file.byte_size
+      attachmentfwd5_file_size = attachments(:attachmentPEFWD5).file.byte_size
+
+      attachmentrev4_file_size = attachments(:attachmentPEREV4).file.byte_size
+      attachmentrev5_file_size = attachments(:attachmentPEREV5).file.byte_size
+
+      concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
+      concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
+
+      assert_equal concatenatedfwd_file_size, (attachmentfwd4_file_size + attachmentfwd5_file_size)
+
+      assert_equal concatenatedrev_file_size, (attachmentrev4_file_size + attachmentrev5_file_size)
+
+      assert_equal 'new-concatenated-file_S1_L001_R1_001.fastq', sample.attachments.last(2).first.file.filename.to_s
+      assert_equal 'new-concatenated-file_S1_L001_R2_001.fastq', sample.attachments.last(2).last.file.filename.to_s
+
+      assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
+      assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
+
+      assert_equal 'illumina_pe', sample.attachments.last(2).first.metadata['type']
+      assert_equal 'illumina_pe', sample.attachments.last(2).last.metadata['type']
+
+      assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'should concatenate more than 2 pairs of paired-end files' do
       sample = samples(:sampleB)
-      params = { attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
                                    '1' => [attachments(:attachmentPEFWD2).id,
                                            attachments(:attachmentPEREV2).id],
                                    '2' => [attachments(:attachmentPEFWD3).id,
                                            attachments(:attachmentPEREV3).id] },
                  basename: 'new-concatenated-file' }
 
+      concatenation_form = ConcatenationForm.new(params)
+
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_difference -> { Attachment.count } => 2 do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        attachmentfwd1_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD1).id).file.byte_size
-        attachmentfwd2_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD2).id).file.byte_size
-        attachmentfwd3_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD3).id).file.byte_size
-
-        attachmentrev1_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV1).id).file.byte_size
-        attachmentrev2_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV2).id).file.byte_size
-        attachmentrev3_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV3).id).file.byte_size
-
-        concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
-        concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
-
-        assert_equal concatenatedfwd_file_size,
-                     (attachmentfwd1_file_size + attachmentfwd2_file_size + attachmentfwd3_file_size)
-
-        assert_equal concatenatedrev_file_size,
-                     (attachmentrev1_file_size + attachmentrev2_file_size + attachmentrev3_file_size)
-
-        assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
-        assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
-
-        assert_equal 'pe', sample.attachments.last(2).first.metadata['type']
-        assert_equal 'pe', sample.attachments.last(2).last.metadata['type']
-
-        assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      attachmentfwd1_file_size = attachments(:attachmentPEFWD1).file.byte_size
+      attachmentfwd2_file_size = attachments(:attachmentPEFWD2).file.byte_size
+      attachmentfwd3_file_size = attachments(:attachmentPEFWD3).file.byte_size
+
+      attachmentrev1_file_size = attachments(:attachmentPEREV1).file.byte_size
+      attachmentrev2_file_size = attachments(:attachmentPEREV2).file.byte_size
+      attachmentrev3_file_size = attachments(:attachmentPEREV3).file.byte_size
+
+      concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
+      concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
+
+      assert_equal concatenatedfwd_file_size,
+                   (attachmentfwd1_file_size + attachmentfwd2_file_size + attachmentfwd3_file_size)
+
+      assert_equal concatenatedrev_file_size,
+                   (attachmentrev1_file_size + attachmentrev2_file_size + attachmentrev3_file_size)
+
+      assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
+      assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
+
+      assert_equal 'pe', sample.attachments.last(2).first.metadata['type']
+      assert_equal 'pe', sample.attachments.last(2).last.metadata['type']
+
+      assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'concatenate fastq.gz files' do
       sample = samples(:sampleB)
-      params = { attachment_ids: { '0' => attachments(:attachmentE).id, '1' => attachments(:attachmentF).id },
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => attachments(:attachmentE).id, '1' => attachments(:attachmentF).id },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_difference -> { Attachment.count } => 1 do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        attachmentgz1_file_size = sample.attachments.find_by(id: attachments(:attachmentE).id).file.byte_size
-        attachmentgz2_file_size = sample.attachments.find_by(id: attachments(:attachmentF).id).file.byte_size
-
-        concatenatedgz_file_size = sample.attachments.last.file.byte_size
-
-        assert_equal concatenatedgz_file_size, (attachmentgz1_file_size + attachmentgz2_file_size)
-
-        assert_equal 'new-concatenated-file_1.fastq.gz', sample.attachments.last.file.filename.to_s
-
-        assert_equal 'fastq', sample.attachments.last.metadata['format']
-        assert_equal 'gzip', sample.attachments.last.metadata['compression']
-
-        assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      attachmentgz1_file_size = attachments(:attachmentE).file.byte_size
+      attachmentgz2_file_size = attachments(:attachmentF).file.byte_size
+
+      concatenatedgz_file_size = sample.attachments.last.file.byte_size
+
+      assert_equal concatenatedgz_file_size, (attachmentgz1_file_size + attachmentgz2_file_size)
+
+      assert_equal 'new-concatenated-file_1.fastq.gz', sample.attachments.last.file.filename.to_s
+
+      assert_equal 'fastq', sample.attachments.last.metadata['format']
+      assert_equal 'gzip', sample.attachments.last.metadata['compression']
+
+      assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'concatenate fq files' do
       sample = samples(:sampleC)
-      params = { attachment_ids: { '0' => [attachments(:attachmentPEFWD6).id, attachments(:attachmentPEREV6).id],
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => [attachments(:attachmentPEFWD6).id, attachments(:attachmentPEREV6).id],
                                    '1' => [attachments(:attachmentPEFWD7).id, attachments(:attachmentPEREV7).id] },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_difference -> { Attachment.count } => 2 do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        attachmentfwd6_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD6).id).file.byte_size
-        attachmentfwd7_file_size = sample.attachments.find_by(id: attachments(:attachmentPEFWD7).id).file.byte_size
-
-        attachmentrev6_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV6).id).file.byte_size
-        attachmentrev7_file_size = sample.attachments.find_by(id: attachments(:attachmentPEREV7).id).file.byte_size
-
-        concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
-        concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
-
-        assert_equal concatenatedfwd_file_size, (attachmentfwd6_file_size + attachmentfwd7_file_size)
-
-        assert_equal concatenatedrev_file_size, (attachmentrev6_file_size + attachmentrev7_file_size)
-
-        assert_equal 'new-concatenated-file_S1_L001_R1_001.fastq', sample.attachments.last(2).first.file.filename.to_s
-        assert_equal 'new-concatenated-file_S1_L001_R2_001.fastq', sample.attachments.last(2).last.file.filename.to_s
-
-        assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
-        assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
-
-        assert_equal 'illumina_pe', sample.attachments.last(2).first.metadata['type']
-        assert_equal 'illumina_pe', sample.attachments.last(2).last.metadata['type']
-
-        assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      attachmentfwd6_file_size = attachments(:attachmentPEFWD6).file.byte_size
+      attachmentfwd7_file_size = attachments(:attachmentPEFWD7).file.byte_size
+
+      attachmentrev6_file_size = attachments(:attachmentPEREV6).file.byte_size
+      attachmentrev7_file_size = attachments(:attachmentPEREV7).file.byte_size
+
+      concatenatedfwd_file_size = sample.attachments.last(2).first.file.byte_size
+      concatenatedrev_file_size = sample.attachments.last(2).last.file.byte_size
+
+      assert_equal concatenatedfwd_file_size, (attachmentfwd6_file_size + attachmentfwd7_file_size)
+
+      assert_equal concatenatedrev_file_size, (attachmentrev6_file_size + attachmentrev7_file_size)
+
+      assert_equal 'new-concatenated-file_S1_L001_R1_001.fastq', sample.attachments.last(2).first.file.filename.to_s
+      assert_equal 'new-concatenated-file_S1_L001_R2_001.fastq', sample.attachments.last(2).last.file.filename.to_s
+
+      assert_equal 'fastq', sample.attachments.last(2).first.metadata['format']
+      assert_equal 'fastq', sample.attachments.last(2).last.metadata['format']
+
+      assert_equal 'illumina_pe', sample.attachments.last(2).first.metadata['type']
+      assert_equal 'illumina_pe', sample.attachments.last(2).last.metadata['type']
+
+      assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'concatenate fq.gz files' do
       sample = samples(:sampleC)
-      params = { attachment_ids: { '0' => attachments(:attachmentI).id, '1' => attachments(:attachmentJ).id },
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => attachments(:attachmentI).id, '1' => attachments(:attachmentJ).id },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_difference -> { Attachment.count } => 1 do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        attachmentgz1_file_size = sample.attachments.find_by(id: attachments(:attachmentI).id).file.byte_size
-        attachmentgz2_file_size = sample.attachments.find_by(id: attachments(:attachmentJ).id).file.byte_size
-
-        concatenatedgz_file_size = sample.attachments.last.file.byte_size
-
-        assert_equal concatenatedgz_file_size, (attachmentgz1_file_size + attachmentgz2_file_size)
-
-        assert_equal 'new-concatenated-file_1.fastq.gz', sample.attachments.last.file.filename.to_s
-
-        assert_equal 'fastq', sample.attachments.last.metadata['format']
-        assert_equal 'gzip', sample.attachments.last.metadata['compression']
-
-        assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      attachmentgz1_file_size = attachments(:attachmentI).file.byte_size
+      attachmentgz2_file_size = attachments(:attachmentJ).file.byte_size
+
+      concatenatedgz_file_size = sample.attachments.last.file.byte_size
+
+      assert_equal concatenatedgz_file_size, (attachmentgz1_file_size + attachmentgz2_file_size)
+
+      assert_equal 'new-concatenated-file_1.fastq.gz', sample.attachments.last.file.filename.to_s
+
+      assert_equal 'fastq', sample.attachments.last.metadata['format']
+      assert_equal 'gzip', sample.attachments.last.metadata['compression']
+
+      assert_not_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'shouldn\'t concatenate single end with paired end files' do
       sample = samples(:sampleB)
-      params = { attachment_ids: { '1' => attachments(:attachmentPEFWD1).id, '0' => attachments(:attachmentD).id },
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '1' => attachments(:attachmentPEFWD1).id, '0' => attachments(:attachmentD).id },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        assert sample.errors.full_messages.include?(I18n.t('services.attachments.concatenation.incorrect_file_types'))
-
-        assert_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      assert concatenation_form.errors.of_kind?(:attachment_ids,
+                                                I18n.t('services.attachments.concatenation.incorrect_file_types'))
+
+      assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'shouldn\'t concatenate fastq with fastq.gz files' do
       sample = samples(:sampleB)
-      params = { attachment_ids: { '0' => attachments(:attachmentD).id, '1' => attachments(:attachmentE).id },
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => attachments(:attachmentD).id, '1' => attachments(:attachmentE).id },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        assert sample.errors.full_messages.include?(
-          I18n.t('services.attachments.concatenation.incorrect_fastq_file_types')
-        )
-
-        assert_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      assert concatenation_form.errors.of_kind?(:attachment_ids,
+                                                I18n.t('services.attachments.concatenation.incorrect_fastq_file_types'))
+
+      assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'shouldn\'t concatenate files as they do not belong to the sample' do
       user = users(:john_doe)
       sample = samples(:sample2)
-      params = { attachment_ids: { '0' => attachments(:attachmentA).id, '1' => attachments(:attachmentB).id },
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => attachments(:attachmentA).id, '1' => attachments(:attachmentB).id },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       assert_nil sample.attachments_updated_at
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(user, sample, params).execute
+          Attachments::ConcatenationService.new(user, concatenation_form).execute
         end
-
-        assert sample.errors.full_messages.include?(I18n.t('services.attachments.concatenation.incorrect_attachable'))
-
-        assert_nil sample.reload.attachments_updated_at
       end
+
+      assert concatenation_form.errors.of_kind?(:attachment_ids, :mismatching_attachable)
+
+      assert_nil sample.reload.attachments_updated_at
     end
 
     test 'shouldn\'t concatenate files when a base file name is not provided' do
-      params = { attachment_ids: { '0' => attachments(:attachmentA).id, '1' => attachments(:attachmentB).id } }
+      params = { attachable_id: @sample.id, attachable_type: @sample.class.name,
+                 attachment_ids: { '0' => attachments(:attachmentA).id, '1' => attachments(:attachmentB).id } }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = @sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(@user, @sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        assert @sample.errors[:basename].include?(I18n.t('services.attachments.concatenation.filename_missing'))
-
-        assert_equal @sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      assert concatenation_form.errors.of_kind?(:basename, :blank)
+
+      assert_equal @sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'should throw an error if no files are selected for concatenation' do
-      params = { attachment_ids: {},
+      params = { attachable_id: @sample.id, attachable_type: @sample.class.name,
+                 attachment_ids: {},
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = @sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(@user, @sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        assert @sample.errors.full_messages.include?(I18n.t('services.attachments.concatenation.no_files_selected'))
-
-        assert_equal @sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      assert concatenation_form.errors.of_kind?(:attachment_ids, :blank)
+
+      assert_equal @sample.reload.attachments_updated_at, prev_timestamp
     end
 
     test 'should throw an error if foward reads file count doesn\'t equal to reverse reads file count' do
       sample = samples(:sampleB)
-      params = { attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
+      params = { attachable_id: sample.id, attachable_type: sample.class.name,
+                 attachment_ids: { '0' => [attachments(:attachmentPEFWD1).id, attachments(:attachmentPEREV1).id],
                                    '1' => attachments(:attachmentPEFWD2).id },
                  basename: 'new-concatenated-file' }
+
+      concatenation_form = ConcatenationForm.new(params)
 
       prev_timestamp = sample.attachments_updated_at
       assert_not_nil prev_timestamp
 
       Timecop.travel(Time.zone.now + 5) do
         assert_no_difference -> { Attachment.count } do
-          Attachments::ConcatenationService.new(@user, sample, params).execute
+          Attachments::ConcatenationService.new(@user, concatenation_form).execute
         end
-
-        assert sample.errors.full_messages.include?(I18n.t('services.attachments.concatenation.incorrect_file_pairs'))
-
-        assert_equal sample.reload.attachments_updated_at, prev_timestamp
       end
+
+      assert concatenation_form.errors.of_kind?(:attachment_ids,
+                                                I18n.t('services.attachments.concatenation.incorrect_file_pairs'))
+
+      assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end
   end
 end

--- a/test/services/attachments/concatenation_service_test.rb
+++ b/test/services/attachments/concatenation_service_test.rb
@@ -457,8 +457,7 @@ module Attachments
         end
       end
 
-      assert concatenation_form.errors.of_kind?(:attachment_ids,
-                                                I18n.t('services.attachments.concatenation.incorrect_file_pairs'))
+      assert concatenation_form.errors.of_kind?(:attachment_ids, :mismatching_paired_end_counts)
 
       assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end

--- a/test/services/attachments/concatenation_service_test.rb
+++ b/test/services/attachments/concatenation_service_test.rb
@@ -349,8 +349,7 @@ module Attachments
         end
       end
 
-      assert concatenation_form.errors.of_kind?(:attachment_ids,
-                                                I18n.t('services.attachments.concatenation.incorrect_file_types'))
+      assert concatenation_form.errors.of_kind?(:attachment_ids, :mismatching_file_types)
 
       assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end

--- a/test/services/attachments/concatenation_service_test.rb
+++ b/test/services/attachments/concatenation_service_test.rb
@@ -372,8 +372,7 @@ module Attachments
         end
       end
 
-      assert concatenation_form.errors.of_kind?(:attachment_ids,
-                                                I18n.t('services.attachments.concatenation.incorrect_fastq_file_types'))
+      assert concatenation_form.errors.of_kind?(:attachment_ids, :mismatching_file_formats)
 
       assert_equal sample.reload.attachments_updated_at, prev_timestamp
     end

--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -202,7 +202,7 @@ module Projects
         within('dialog[open]') do
           assert_text 'test_file_A.fastq'
           assert_text 'test_file_B.fastq'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated_file'
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated_file'
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
@@ -232,7 +232,7 @@ module Projects
           assert_text 'test_file_rev_2.fastq'
           assert_text 'test_file_fwd_3.fastq'
           assert_text 'test_file_rev_3.fastq'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated_file'
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated_file'
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
@@ -252,8 +252,8 @@ module Projects
         within('dialog[open]') do
           assert_text 'test_file_A.fastq'
           assert_text 'test_file_B.fastq'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated_file'
-          check I18n.t('helpers.label.concatenation.delete_originals')
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated_file'
+          check I18n.t('activemodel.attributes.concatenation_form.delete_originals')
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
@@ -283,8 +283,8 @@ module Projects
           assert_text 'test_file_rev_2.fastq'
           assert_text 'test_file_fwd_3.fastq'
           assert_text 'test_file_rev_3.fastq'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated_file'
-          check I18n.t('helpers.label.concatenation.delete_originals')
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated_file'
+          check I18n.t('activemodel.attributes.concatenation_form.delete_originals')
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
@@ -317,13 +317,11 @@ module Projects
           assert_text 'test_file_fwd_3.fastq'
           assert_text 'test_file_rev_3.fastq'
           assert_text 'test_file_D.fastq'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated_file'
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated_file'
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
-        within %(turbo-frame[id="concatenation-alert"]) do
-          assert_text I18n.t('services.attachments.concatenation.incorrect_file_types')
-        end
+        assert_text I18n.t('services.attachments.concatenation.incorrect_file_types')
       end
 
       test 'should not concatenate compressed and uncompressed attachment files' do
@@ -341,13 +339,11 @@ module Projects
         within('dialog[open]') do
           assert_text 'test_file_D.fastq'
           assert_text 'test_file_2.fastq.gz'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated_file'
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated_file'
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
-        within %(turbo-frame[id="concatenation-alert"]) do
-          assert_text I18n.t('services.attachments.concatenation.incorrect_fastq_file_types')
-        end
+        assert_text I18n.t('services.attachments.concatenation.incorrect_fastq_file_types')
       end
 
       test 'user with guest access should not be able to see the concatenate attachment files button' do
@@ -379,8 +375,8 @@ module Projects
           assert_text 'test_file_rev_2.fastq'
           assert_text 'test_file_fwd_3.fastq'
           assert_text 'test_file_rev_3.fastq'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated file'
-          check I18n.t('helpers.label.concatenation.delete_originals')
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated file'
+          check I18n.t('activemodel.attributes.concatenation_form.delete_originals')
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           !assert_html5_inputs_valid
         end
@@ -406,11 +402,11 @@ module Projects
           assert_text 'test_file_rev_2.fastq'
           assert_text 'test_file_fwd_3.fastq'
           assert_text 'test_file_rev_3.fastq'
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated file'
-          check I18n.t('helpers.label.concatenation.delete_originals')
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated file'
+          check I18n.t('activemodel.attributes.concatenation_form.delete_originals')
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_text I18n.t('general.form.error_notification')
-          fill_in I18n.t('helpers.label.concatenation.basename'), with: 'concatenated_file'
+          fill_in I18n.t('activemodel.attributes.concatenation_form.basename'), with: 'concatenated_file'
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end

--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -321,7 +321,9 @@ module Projects
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
-        assert_text I18n.t('services.attachments.concatenation.incorrect_file_types')
+        assert_text(
+          I18n.t('activemodel.errors.models.concatenation_form.attributes.attachment_ids.mismatching_file_types')
+        )
       end
 
       test 'should not concatenate compressed and uncompressed attachment files' do

--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -343,7 +343,9 @@ module Projects
           click_on I18n.t('projects.samples.attachments.concatenations.modal.submit_button')
           assert_html5_inputs_valid
         end
-        assert_text I18n.t('services.attachments.concatenation.incorrect_fastq_file_types')
+        assert_text(
+          I18n.t('activemodel.errors.models.concatenation_form.attributes.attachment_ids.mismatching_file_formats')
+        )
       end
 
       test 'user with guest access should not be able to see the concatenate attachment files button' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR establishes a new form object pattern, which is to be used for forms that are not specific to a model. Following this pattern allows us to utilize the `form_error_summary` introduced in #1750 without having to do any special mapping or overriding.

Summary of changes:
* `app/forms/concatenation_form.rb` is a form object used to encapsulate an attachment concatenation request, it includes validation for concatenation params and has methods to retrieve attachments.
* `app/controllers/project/samples/attachment/concatenations_controller.rb` has been updated to use this new form object for `new` and `create` endpoints.
* `app/views/project/samples/attachment/concatenations/` views have been updated to use the new form object and to use the `form_error_summary` helper
* `app/services/attachments/concatenation_service.rb` has been updated to only require the user and concatenation_form as params. In addition validations have been moved out of the service and into the form object.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="797" height="713" alt="image" src="https://github.com/user-attachments/assets/99e30f27-a4f7-41a6-b15e-3b1095217955" />

<img width="795" height="886" alt="image" src="https://github.com/user-attachments/assets/4ae80a76-c2af-4de5-917d-564f895e1433" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Stop existing server process and start new with `/bin/setup`
2. Create a new Project, and then create a new Sample in that project
3. Upload various data
4. Test different concatenation requests (e.g. only single end, only pair end, mixed single and pair end, mixed file formats, mixed compression).

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.