### PR TITLE
Add always send option to otel metrics

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -31,7 +31,9 @@ if ENV['OTEL_EXPORTER_OTLP_METRICS_ENDPOINT']
   Rails.application.config.after_initialize do
     # start the metrics reporting thread
     send_interval = ENV['OTEL_METRICS_SEND_INTERVAL']&.to_i || 10
-    Irida::MetricsReporter.instance.run(send_interval)
+    always_send_all = ENV['OTEL_METRICS_ALWAYS_SEND']&.casecmp('true')&.zero? || false
+    queue_list = %w[default transactional_messages]
+    Irida::MetricsReporter.instance.run(send_interval, always_send_all, queue_list)
   end
 
   at_exit do

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -31,9 +31,8 @@ if ENV['OTEL_EXPORTER_OTLP_METRICS_ENDPOINT']
   Rails.application.config.after_initialize do
     # start the metrics reporting thread
     send_interval = ENV['OTEL_METRICS_SEND_INTERVAL']&.to_i || 10
-    always_send_all = ENV['OTEL_METRICS_ALWAYS_SEND']&.casecmp('true')&.zero? || false
     queue_list = %w[default transactional_messages]
-    Irida::MetricsReporter.instance.run(send_interval, always_send_all, queue_list)
+    Irida::MetricsReporter.instance.run(send_interval, queue_list)
   end
 
   at_exit do

--- a/docs-site/docs/configuration/options.md
+++ b/docs-site/docs/configuration/options.md
@@ -38,5 +38,4 @@ Primary ENV Variable which sets what type of environment to run
 | `RAILS_ENABLE_WEB_CONSOLE`            | Development mode only: When set, a rails console will be present on every webpage.                                         | `nil`                                      |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | When set, custom metrics telemetry will be sent to the metrics endpoint specified. (example: "localhost:4318/v1/metrics"). | `nil`                                      |
 | `OTEL_METRICS_SEND_INTERVAL`          | Number of seconds to sleep between telemetry batch send calls.                                                             | `10`                                       |
-| `OTEL_METRICS_ALWAYS_SEND`            | When set, configured metrics telemetry will send even when there is no update to the value sent.                           | `nil`                                      |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | When set, configured trace telemetry will be sent to the traces endpoint specified. (example: "localhost:4318/v1/traces"). | `nil`                                      |

--- a/docs-site/docs/configuration/options.md
+++ b/docs-site/docs/configuration/options.md
@@ -38,4 +38,5 @@ Primary ENV Variable which sets what type of environment to run
 | `RAILS_ENABLE_WEB_CONSOLE`            | Development mode only: When set, a rails console will be present on every webpage.                                         | `nil`                                      |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | When set, custom metrics telemetry will be sent to the metrics endpoint specified. (example: "localhost:4318/v1/metrics"). | `nil`                                      |
 | `OTEL_METRICS_SEND_INTERVAL`          | Number of seconds to sleep between telemetry batch send calls.                                                             | `10`                                       |
+| `OTEL_METRICS_ALWAYS_SEND`            | When set, configured metrics telemetry will send even when there is no update to the value sent.                           | `nil`                                      |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | When set, configured trace telemetry will be sent to the traces endpoint specified. (example: "localhost:4318/v1/traces"). | `nil`                                      |

--- a/lib/irida/job_queue_metrics.rb
+++ b/lib/irida/job_queue_metrics.rb
@@ -4,11 +4,10 @@ require 'singleton'
 
 module Irida
   # Functions for creating instruments and updating values on metrics meter
-  class JobQueueMetrics # rubocop:disable Metrics/ClassLength
+  class JobQueueMetrics
     include Singleton
 
-    def init(always_send_all, queue_list)
-      @always_send_all = always_send_all
+    def init(queue_list)
       @queue_list = queue_list
     end
 
@@ -26,7 +25,7 @@ module Irida
         latency_hash[queue_name] = latency
       end
 
-      latency_to_send = build_data_to_send(latency_hash, job_queue_latency_previous_value_map)
+      latency_to_send = add_queue_defaults(latency_hash)
 
       latency_to_send.each do |queue_name, latency|
         metric_update_queue_min_latency(queue_name, latency)
@@ -39,7 +38,7 @@ module Irida
                      .group(:queue_name)
                      .count
 
-      queue_counts_to_send = build_data_to_send(queue_counts, job_queue_count_previous_value_map)
+      queue_counts_to_send = add_queue_defaults(queue_counts)
 
       queue_counts_to_send.each do |queue_name, count|
         metric_update_job_queue_count(queue_name, count)
@@ -65,41 +64,6 @@ module Irida
 
     def job_queue_latency_previous_value_map
       @job_queue_latency_previous_value_map ||= {}
-    end
-
-    # This method reduces number of call to the instruments by
-    #  only reporting when the value is different than what was sent previously
-    # It also includes a 0 when a value was previously passed but is not reported by GoodJob
-    #  This prevents the issue of large counts/latency being shown on metrics graphs when the queue's are actually empty
-    def build_data_to_send(data_map, previous_data_map) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/PerceivedComplexity
-      # if the env variable to always send all metrics is set, skip logic and send all data
-      return add_queue_defaults(data_map) if @always_send_all
-
-      data_to_send = {}
-      keys = (data_map.keys + previous_data_map.keys).uniq
-      keys.each do |queue_name|
-        if previous_data_map.key?(queue_name)
-          if data_map.key?(queue_name)
-            # unless this is a new value, don't update it
-            unless previous_data_map[queue_name] == data_map[queue_name]
-              previous_data_map[queue_name] = data_map[queue_name]
-              data_to_send[queue_name] = data_map[queue_name]
-            end
-          else
-            # queue_name not in GoodJob query, so its value is 0
-            # unless this is a new value, don't update it
-            unless previous_data_map[queue_name].zero?
-              previous_data_map[queue_name] = 0
-              data_to_send[queue_name] = 0
-            end
-          end
-        else
-          previous_data_map[queue_name] = data_map[queue_name]
-          data_to_send[queue_name] = data_map[queue_name]
-        end
-      end
-
-      data_to_send
     end
 
     def job_queue_instrument_map

--- a/lib/irida/job_queue_metrics.rb
+++ b/lib/irida/job_queue_metrics.rb
@@ -4,8 +4,13 @@ require 'singleton'
 
 module Irida
   # Functions for creating instruments and updating values on metrics meter
-  class JobQueueMetrics
+  class JobQueueMetrics # rubocop:disable Metrics/ClassLength
     include Singleton
+
+    def init(always_send_all, queue_list)
+      @always_send_all = always_send_all
+      @queue_list = queue_list
+    end
 
     def update_minimum_queue_times
       now = Time.now.utc
@@ -43,6 +48,13 @@ module Irida
 
     private
 
+    def add_queue_defaults(queue_hash)
+      @queue_list.each do |queue_name|
+        queue_hash[queue_name] ||= 0
+      end
+      queue_hash
+    end
+
     def meter
       @meter ||= OpenTelemetry.meter_provider.meter('JOB_QUEUE_METER')
     end
@@ -59,7 +71,10 @@ module Irida
     #  only reporting when the value is different than what was sent previously
     # It also includes a 0 when a value was previously passed but is not reported by GoodJob
     #  This prevents the issue of large counts/latency being shown on metrics graphs when the queue's are actually empty
-    def build_data_to_send(data_map, previous_data_map) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    def build_data_to_send(data_map, previous_data_map) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/PerceivedComplexity
+      # if the env variable to always send all metrics is set, skip logic and send all data
+      return add_queue_defaults(data_map) if @always_send_all
+
       data_to_send = {}
       keys = (data_map.keys + previous_data_map.keys).uniq
       keys.each do |queue_name|

--- a/lib/irida/metrics_reporter.rb
+++ b/lib/irida/metrics_reporter.rb
@@ -8,7 +8,7 @@ module Irida
   class MetricsReporter # rubocop:disable Style/Documentation
     include Singleton
 
-    def run(sleep_time)
+    def run(sleep_time, always_send_all, queue_list)
       if running?
         Rails.logger.debug { "TelemetryReporter is already running on process #{@proc_id}" }
         return
@@ -18,7 +18,7 @@ module Irida
         return
       end
 
-      run!(sleep_time)
+      run!(sleep_time, always_send_all, queue_list)
     end
 
     def stop
@@ -36,9 +36,10 @@ module Irida
 
     private
 
-    def run!(sleep_time)
+    def run!(sleep_time, always_send_all, queue_list)
       @proc_id = Process.pid
       @sleep_time = sleep_time
+      Irida::JobQueueMetrics.instance.init(always_send_all, queue_list)
 
       # start the reporting loop
       proc_loop

--- a/lib/irida/metrics_reporter.rb
+++ b/lib/irida/metrics_reporter.rb
@@ -8,7 +8,7 @@ module Irida
   class MetricsReporter # rubocop:disable Style/Documentation
     include Singleton
 
-    def run(sleep_time, always_send_all, queue_list)
+    def run(sleep_time, queue_list)
       if running?
         Rails.logger.debug { "TelemetryReporter is already running on process #{@proc_id}" }
         return
@@ -18,7 +18,7 @@ module Irida
         return
       end
 
-      run!(sleep_time, always_send_all, queue_list)
+      run!(sleep_time, queue_list)
     end
 
     def stop
@@ -36,10 +36,10 @@ module Irida
 
     private
 
-    def run!(sleep_time, always_send_all, queue_list)
+    def run!(sleep_time, queue_list)
       @proc_id = Process.pid
       @sleep_time = sleep_time
-      Irida::JobQueueMetrics.instance.init(always_send_all, queue_list)
+      Irida::JobQueueMetrics.instance.init(queue_list)
 
       # start the reporting loop
       proc_loop

--- a/test/jobs/opentelemetry_job_metrics_test.rb
+++ b/test/jobs/opentelemetry_job_metrics_test.rb
@@ -7,6 +7,7 @@ class OpenTelemetryJobMetricsTest < ActiveJob::TestCase
   def setup
     # Set up a mock OpenTelemetry Meter to handle calls from the job metrics singleton
     @job_queue_metrics = Irida::JobQueueMetrics.instance
+    @job_queue_metrics.init(%w[default])
     @mock_meter = Minitest::Mock.new
     @job_queue_metrics.instance_variable_set(:@meter, @mock_meter)
   end
@@ -94,6 +95,8 @@ class OpenTelemetryJobMetricsTest < ActiveJob::TestCase
     # mock instrument on meter that records values
     mock_queue_count_instrument = Minitest::Mock.new
     mock_queue_count_instrument.expect(:record, nil, [3])
+    mock_queue_count_instrument.expect(:record, nil, [3])
+    mock_queue_count_instrument.expect(:record, nil, [0])
     mock_queue_count_instrument.expect(:record, nil, [0])
     # using 'default' as our queue name
     @mock_meter.expect(:create_gauge, mock_queue_count_instrument, ['default_queue_count'], description: String)
@@ -105,7 +108,7 @@ class OpenTelemetryJobMetricsTest < ActiveJob::TestCase
     travel_to(3.minutes.from_now) do
       # run metrics while job is queued
       @job_queue_metrics.update_queue_counts
-      # run metrics while job is queued AGAIN to verify repeat data points don't get resent
+      # run metrics while job is queued AGAIN to verify repeat data points get resent
       @job_queue_metrics.update_queue_counts
       # don't let job procs hang
       GoodJob.perform_inline
@@ -113,7 +116,7 @@ class OpenTelemetryJobMetricsTest < ActiveJob::TestCase
 
     # run metrics again after jobs have finished
     @job_queue_metrics.update_queue_counts
-    # run metrics again after jobs have finished AGAIN to verify repeat data points don't get resent
+    # run metrics again after jobs have finished AGAIN to verify repeat data points get resent
     @job_queue_metrics.update_queue_counts
 
     # verify objects called as expected
@@ -127,7 +130,11 @@ class OpenTelemetryJobMetricsTest < ActiveJob::TestCase
     mock_queue_latency_instrument.expect(:record, nil) do |latency|
       latency > 55 && latency < 65 # Expect latency to be about a minute
     end
+    mock_queue_latency_instrument.expect(:record, nil) do |latency|
+      latency > 55 && latency < 65 # Expect latency to be about a minute
+    end
     mock_queue_latency_instrument.expect(:record, nil, [0]) # should be 0 when jobs are cleared
+    mock_queue_latency_instrument.expect(:record, nil, [0])
     # using 'default' as our queue name
     @mock_meter.expect(
       :create_gauge, mock_queue_latency_instrument, ['default_queue_min_wait_time'], unit: String, description: String
@@ -140,7 +147,7 @@ class OpenTelemetryJobMetricsTest < ActiveJob::TestCase
     travel_to(3.minutes.from_now) do
       # run metrics while job is queued
       @job_queue_metrics.update_minimum_queue_times
-      # run metrics while job is queued AGAIN to verify repeat data points don't get resent
+      # run metrics while job is queued AGAIN to verify repeat data points get resent
       @job_queue_metrics.update_minimum_queue_times
       # don't let job procs hang
       GoodJob.perform_inline
@@ -148,11 +155,55 @@ class OpenTelemetryJobMetricsTest < ActiveJob::TestCase
 
     # run metrics again after jobs have finished
     @job_queue_metrics.update_minimum_queue_times
-    # run metrics again after jobs have finished AGAIN to verify repeat data points don't get resent
+    # run metrics again after jobs have finished AGAIN to verify repeat data points get resent
     @job_queue_metrics.update_minimum_queue_times
 
     # verify objects called as expected
     assert mock_queue_latency_instrument.verify
+    assert @mock_meter.verify
+  end
+
+  test 'test_multiple_queues' do
+    @job_queue_metrics.init(%w[default other])
+
+    # mock instrument on meter that records values
+    mock_queue_count_instrument_default = Minitest::Mock.new
+    mock_queue_count_instrument_other = Minitest::Mock.new
+    mock_queue_count_instrument_default.expect(:record, nil, [1])
+    mock_queue_count_instrument_default.expect(:record, nil, [1])
+    mock_queue_count_instrument_default.expect(:record, nil, [0])
+    mock_queue_count_instrument_default.expect(:record, nil, [0])
+    mock_queue_count_instrument_other.expect(:record, nil, [3])
+    mock_queue_count_instrument_other.expect(:record, nil, [3])
+    mock_queue_count_instrument_other.expect(:record, nil, [0])
+    mock_queue_count_instrument_other.expect(:record, nil, [0])
+    # using 'default' as our queue name
+    @mock_meter.expect(:create_gauge, mock_queue_count_instrument_default, ['default_queue_count'], description: String)
+    # using 'other' as our queue name
+    @mock_meter.expect(:create_gauge, mock_queue_count_instrument_other, ['other_queue_count'], description: String)
+
+    # queue some jobs
+    DummyJob.set(wait: 2.minutes).perform_later(1)
+    DummyJob.set(wait: 2.minutes, queue: :other).perform_later(1)
+    DummyJob.set(wait: 2.minutes, queue: :other).perform_later(1)
+    DummyJob.set(wait: 2.minutes, queue: :other).perform_later(1)
+    travel_to(3.minutes.from_now) do
+      # run metrics while job is queued
+      @job_queue_metrics.update_queue_counts
+      # run metrics while job is queued AGAIN to verify repeat data points get resent
+      @job_queue_metrics.update_queue_counts
+      # don't let job procs hang
+      GoodJob.perform_inline
+    end
+
+    # run metrics again after jobs have finished
+    @job_queue_metrics.update_queue_counts
+    # run metrics again after jobs have finished AGAIN to verify repeat data points get resent
+    @job_queue_metrics.update_queue_counts
+
+    # verify objects called as expected
+    assert mock_queue_count_instrument_default.verify
+    assert mock_queue_count_instrument_other.verify
     assert @mock_meter.verify
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Changes OTEL Telemetry data to always send, even when values are identical to previous report, and when values are 0.

This should fix an issue on Azure deployments where job instance scaling is not occurring correctly because of trying to average values when nil is reported instead of previous value.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Modify your `launch.json` file to include relevant env vars
```json
{
        "type": "ruby_lsp",
        "name": "Debug rails",
        "request": "launch",
        "program": "bin/rails s",
        "env": {
              "RAILS_ENABLE_WEB_CONSOLE": "true",
              "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4318/v1/metrics",
              "OTEL_METRICS_SEND_INTERVAL": "5",
        }
      },
```
2. Add breakpoints on line 30 and 43 of `lib/irida/job_queue_metrics`. These will allow us to inspect `queue_counts_to_send` and `latency_to_send`.
3. start `devenv up`
4. start the debugger
5. open another terminal and launch a rails console with `rails c`
6. run the following in the rails console to queue 500 jobs
```ruby
500.times do
  WaitJob.perform_later()
end
```
7. your debugger is likely paused at this point, click continue (F9) to advance past the breakpoints you have set until it runs freely again. You should be able to see jobs starting to be processed in the debugger output.
8. Wait for the debugger to pause again, then inspect the relevant data that will be sent, repeat for second breakpoint
<img width="2442" height="1466" alt="image" src="https://github.com/user-attachments/assets/bbe77a00-0803-4d31-bbe9-6ce40e6caae2" />

9. We should see a number of jobs in the "default" queue/latency, and 0 jobs in the "transactional_messages" queue/latency
10. let the breakpoints advance again so until it pauses again, verify that as the value in "default" falls, the "transactional_messages" value stays at 0 and is included.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
