### PR TITLE
Combobox: Arrow SVG changes

### DIFF
--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -43,6 +43,7 @@
       data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onIndicatorClick"
       aria-label="<%= t('combobox_component.show_options') %>"
       title="<%= t('combobox_component.show_options') %>"
+      tabindex="-1"
     >
       <%= icon(:caret_down, size: :sm, color: :subdued) %>
     </button>

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -342,7 +342,7 @@ export default class extends Controller {
     this.listboxTarget.removeAttribute("aria-hidden");
     this.comboboxTarget.setAttribute("aria-expanded", "true");
     if (this.hasIndicatorButtonTarget) {
-      this.indicatorButtonTarget.classList.add("rotate-180");
+      this.indicatorButtonTarget.firstElementChild.classList.add("rotate-180");
     }
   }
 
@@ -351,7 +351,9 @@ export default class extends Controller {
     this.listboxTarget.setAttribute("aria-hidden", "true");
     this.comboboxTarget.setAttribute("aria-expanded", "false");
     if (this.hasIndicatorButtonTarget) {
-      this.indicatorButtonTarget.classList.remove("rotate-180");
+      this.indicatorButtonTarget.firstElementChild.classList.remove(
+        "rotate-180",
+      );
     }
   }
 

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -59,7 +59,7 @@ export default class extends Controller {
     this.boundOnComboboxFocus = this.#onComboboxFocus.bind(this);
 
     this.#floatingDropdown = new FloatingDropdown({
-      trigger: this.comboboxTarget,
+      trigger: this.comboboxTarget.parentElement,
       dropdown: this.listboxTarget,
       manageAria: false,
       onShow: () => this.#onShow(),
@@ -302,7 +302,10 @@ export default class extends Controller {
         "aria-label",
         this.showOptionsLabelValue,
       );
-      this.indicatorButtonTarget.setAttribute("title", this.showOptionsLabelValue);
+      this.indicatorButtonTarget.setAttribute(
+        "title",
+        this.showOptionsLabelValue,
+      );
     }
 
     if (!this.hasIndicatorClearButtonTarget) return;
@@ -338,12 +341,18 @@ export default class extends Controller {
     this.listboxTarget.style.display = "block";
     this.listboxTarget.removeAttribute("aria-hidden");
     this.comboboxTarget.setAttribute("aria-expanded", "true");
+    if (this.hasIndicatorButtonTarget) {
+      this.indicatorButtonTarget.classList.add("rotate-180");
+    }
   }
 
   #onHide() {
     this.listboxTarget.style.display = "none";
     this.listboxTarget.setAttribute("aria-hidden", "true");
     this.comboboxTarget.setAttribute("aria-expanded", "false");
+    if (this.hasIndicatorButtonTarget) {
+      this.indicatorButtonTarget.classList.remove("rotate-180");
+    }
   }
 
   // Combobox events

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -29,6 +29,7 @@ module Combobox
           end
           hidden = find("input[type='hidden']", visible: false)
           assert_equal 'metadata.patient_age', hidden.value
+          assert_no_selector 'button.rotate-180[data-combobox--v1-target="indicatorButton"]'
         end
       end
 

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -11,11 +11,11 @@ module Combobox
           combobox = find("input[role='combobox']")
           assert_equal 'age', combobox.value
           assert_equal 'false', combobox['aria-expanded']
-          assert_no_selector 'button.rotate-180[data-combobox--v1-target="indicatorButton"]'
-          assert_selector 'button[data-combobox--v1-target="indicatorButton"]'
+          assert_no_selector 'svg.caret-down-icon.rotate-180'
+          assert_selector 'svg.caret-down-icon'
           combobox.click
           assert_equal 'true', combobox['aria-expanded']
-          assert_selector 'button.rotate-180[data-combobox--v1-target="indicatorButton"]'
+          assert_selector 'svg.caret-down-icon.rotate-180'
           listbox = find("div[role='listbox']")
           within listbox do
             group = find("div[role='group']")
@@ -29,7 +29,8 @@ module Combobox
           end
           hidden = find("input[type='hidden']", visible: false)
           assert_equal 'metadata.patient_age', hidden.value
-          assert_no_selector 'button.rotate-180[data-combobox--v1-target="indicatorButton"]'
+          assert_no_selector 'svg.caret-down-icon.rotate-180'
+          assert_selector 'svg.caret-down-icon'
         end
       end
 

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -11,8 +11,11 @@ module Combobox
           combobox = find("input[role='combobox']")
           assert_equal 'age', combobox.value
           assert_equal 'false', combobox['aria-expanded']
+          assert_no_selector 'button.rotate-180[data-combobox--v1-target="indicatorButton"]'
+          assert_selector 'button[data-combobox--v1-target="indicatorButton"]'
           combobox.click
           assert_equal 'true', combobox['aria-expanded']
+          assert_selector 'button.rotate-180[data-combobox--v1-target="indicatorButton"]'
           listbox = find("div[role='listbox']")
           within listbox do
             group = find("div[role='group']")


### PR DESCRIPTION
## What does this PR do and why?
This PR updates the following for the `combobox` component's arrow:
1. Arrow now rotates upon open/closing
2. Previously, continuously clicking the arrow did not open/shut the dropdown (only stayed open), this has been fixed
3. Arrow is no longer tabbable.

## Screenshots or screen recordings
Previously:

[Screencast from 2026-05-12 14-56-05.webm](https://github.com/user-attachments/assets/7f6b17d6-87b3-49d4-82ee-9c143e3d3c22)

Now:

[Screencast from 2026-05-12 14-56-31.webm](https://github.com/user-attachments/assets/3ac1b710-5f53-4ea8-972c-31db498948b5)

## How to set up and validate locally
1. Test the combobox and verify the arrow rotates upon open/closing, clicking the arrow continuously open/shuts the dropdown, and the arrow is no longer tabbable.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
