### PR TITLE
chore: Mirror pipeline repositories instead of cloning

### DIFF
--- a/lib/irida/pipeline_repository.rb
+++ b/lib/irida/pipeline_repository.rb
@@ -5,39 +5,32 @@ require 'git'
 module Irida
   # Handles Git repository operations for pipeline cloning and verification
   class PipelineRepository
-    def self.clone_repo(uri, sha, clone_dir)
-      new(uri, sha).clone(clone_dir)
+    attr_reader :repo, :repo_dir
+
+    def self.mirror_repo(uri, repo_dir)
+      new(uri, repo_dir)
     end
 
-    def initialize(uri, sha)
-      @uri = uri
-      @sha = sha
-      @remote = uri.to_s
+    def initialize(uri, repo_dir)
+      @repo_dir = repo_dir.to_s
+      @repo = if File.directory?(repo_dir)
+                Git.bare(repo_dir)
+              else
+                Git.clone(uri.to_s, repo_dir, mirror: true)
+              end
+      @repo.fetch(prune: true)
     end
 
-    def clone(clone_dir)
-      if sha_exists_on_remote?
-        Git.clone(@remote, clone_dir, depth: 1, branch: @sha)
+    def file_contents_at(sha, path)
+      object = @repo.object("#{sha}:#{path}")
+      return unless object
+
+      if object.respond_to?(:contents)
+        object.contents
+      elsif object.respond_to?(:content)
+        object.content
       else
-        repo = Git.clone(@remote, clone_dir)
-        repo.checkout(@sha)
-      end
-    end
-
-    private
-
-    def sha_exists_on_remote?
-      remote_ref_includes?(Git.ls_remote(@remote), @sha)
-    end
-
-    def remote_ref_includes?(refs, query)
-      case refs
-      when Hash
-        refs.any? { |key, value| key.to_s == query || remote_ref_includes?(value, query) }
-      when Array
-        refs.any? { |value| remote_ref_includes?(value, query) }
-      else
-        refs.to_s == query
+        object.to_s
       end
     end
   end

--- a/lib/irida/pipeline_repository.rb
+++ b/lib/irida/pipeline_repository.rb
@@ -3,7 +3,7 @@
 require 'git'
 
 module Irida
-  # Handles Git repository operations for pipeline cloning and verification
+  # Handles Git repository operations for pipeline mirroring and getting file contents at revisions
   class PipelineRepository
     attr_reader :repo, :repo_dir
 

--- a/lib/irida/pipeline_repository.rb
+++ b/lib/irida/pipeline_repository.rb
@@ -13,7 +13,7 @@ module Irida
 
     def initialize(uri, repo_dir)
       @repo_dir = repo_dir.to_s
-      @repo = if File.directory?(repo_dir)
+      @repo = if git_repo?(repo_dir)
                 Git.bare(repo_dir)
               else
                 Git.clone(uri.to_s, repo_dir, mirror: true)
@@ -32,6 +32,17 @@ module Irida
       else
         object.to_s
       end
+    end
+
+    private
+
+    def git_repo?(path)
+      g = Git.bare(path)
+      g.lib.fsck('--full')
+      true
+    rescue ArgumentError, Git::GitExecuteError
+      FileUtils.rm_rf(path)
+      false
     end
   end
 end

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -30,6 +30,7 @@ module Irida
     def initialize(**params)
       @pipeline_config_file = params.fetch(:pipeline_config_file, 'config/pipelines/pipelines.json')
       @pipeline_schema_file_dir = params.fetch(:pipeline_schema_file_dir, 'private/pipelines')
+      @pipeline_repo_dir = params.fetch(:pipeline_repo_dir, 'private/pipeline_repos')
       @pipelines = {}
 
       register_pipelines
@@ -93,14 +94,11 @@ module Irida
     end
 
     def clone_and_prepare_schema_locations(uri, version)
-      nextflow_schema_location = nil
-      schema_input_location = nil
+      pipeline_repo_dir = pipeline_repo_dir_for(uri)
+      pipeline_repo = PipelineRepository.mirror_repo(uri, pipeline_repo_dir)
 
-      Dir.mktmpdir('irida_pipeline') do |clone_dir|
-        PipelineRepository.clone_repo(uri, version['name'], clone_dir)
-        nextflow_schema_location = copy_schema_file(clone_dir, uri, version, 'nextflow_schema')
-        schema_input_location = copy_schema_file(clone_dir, uri, version, 'schema_input')
-      end
+      nextflow_schema_location = copy_schema_file(pipeline_repo, uri, version, 'nextflow_schema')
+      schema_input_location = copy_schema_file(pipeline_repo, uri, version, 'schema_input')
 
       [nextflow_schema_location, schema_input_location]
     rescue Git::Error => e
@@ -108,8 +106,15 @@ module Irida
       raise PipelinesInvalidUrlException.new('404', previously_fetched), e.message
     end
 
+    def pipeline_repo_dir_for(uri)
+      path = uri.path.sub(%r{\A/}, '')
+      path += '.git' unless path.end_with?('.git')
+
+      Rails.root.join(@pipeline_repo_dir, path)
+    end
+
     def pipeline_schema_files_exist?(uri, version)
-      pipeline_schema_files_path = File.join(@pipeline_schema_file_dir, uri.path, version['name'])
+      pipeline_schema_files_path = File.join(@pipeline_schema_file_dir, uri.path.sub(%r{\A/}, ''), version['name'])
       File.exist?(File.join(pipeline_schema_files_path, 'nextflow_schema.json')) ||
         File.exist?(File.join(pipeline_schema_files_path, 'assets', 'schema_input.json'))
     end
@@ -126,22 +131,22 @@ module Irida
       data
     end
 
-    def copy_schema_file(clone_dir, uri, version, type)
+    def copy_schema_file(repo, uri, version, type)
       filename = type == 'nextflow_schema' ? "#{type}.json" : "assets/#{type}.json"
-      source_path = File.join(clone_dir, filename)
+      contents = repo.file_contents_at(version['name'], filename)
 
-      pipeline_schema_files_path = File.join(@pipeline_schema_file_dir, uri.path, version['name'])
+      pipeline_schema_files_path = File.join(@pipeline_schema_file_dir, uri.path.sub(%r{\A/}, ''), version['name'])
       schema_location = Rails.root.join(pipeline_schema_files_path, filename)
 
-      write_schema_file(source_path, schema_location)
+      write_schema_file(contents, schema_location)
       schema_location
     end
 
-    def write_schema_file(source_path, schema_location)
+    def write_schema_file(contents, schema_location)
       dir = File.dirname(schema_location)
       FileUtils.mkdir_p(dir) unless File.directory?(dir)
 
-      FileUtils.cp(source_path, schema_location)
+      File.write(schema_location, contents)
     end
   end
 end

--- a/lib/irida/pipelines.rb
+++ b/lib/irida/pipelines.rb
@@ -79,7 +79,7 @@ module Irida
 
     def create_pipeline(pipeline_id, entry, version)
       uri = URI.parse(entry['url'])
-      nextflow_schema_location, schema_input_location = clone_and_prepare_schema_locations(uri, version)
+      nextflow_schema_location, schema_input_location = mirror_and_prepare_schema_locations(uri, version)
 
       Pipeline.new(pipeline_id, entry, version, nextflow_schema_location, schema_input_location)
     rescue PipelinesInvalidUrlException => e
@@ -93,7 +93,7 @@ module Irida
       end
     end
 
-    def clone_and_prepare_schema_locations(uri, version)
+    def mirror_and_prepare_schema_locations(uri, version)
       pipeline_repo_dir = pipeline_repo_dir_for(uri)
       pipeline_repo = PipelineRepository.mirror_repo(uri, pipeline_repo_dir)
 

--- a/lib/tasks/pipeline_json_validator.rake
+++ b/lib/tasks/pipeline_json_validator.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git'
+require 'irida/pipeline_repository'
 
 # Rake task to validate pipeline JSON configuration files against a JSON schema
 # USAGE:
@@ -121,27 +122,32 @@ namespace :pipeline_json_validator do # rubocop:disable Metrics/BlockLength
 
   # Verify that each pipeline version URL exists and is reachable
   def verify_url_exists_and_reachable(json_data) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+    tmpdir = Dir.mktmpdir('pipeline_repos_for_validation')
     progressbar = ProgressBar.create(title: 'Checking URLs', total: json_data.size, format: '%t: |%B| %p%% %e')
     json_data.each_value do |pipeline_hash|
       base_url = pipeline_hash['url']
+      begin
+        refs = Git.ls_remote(base_url)
 
-      pipeline_hash['versions'].each do |version|
-        next unless version.key?('name')
+        pipeline_hash['versions'].each do |version|
+          next unless version.key?('name')
 
-        begin
-          refs = Git.ls_remote(base_url)
-          version_exists = version_exists_in_remote?(refs, version['name'])
+          begin
+            version_exists = version_exists_in_remote?(refs, version['name'])
 
-          # If version not found in remote refs, try cloning and checking
-          version_exists ||= check_version_in_cloned_repo(base_url, version['name'])
+            # If version not found in remote refs, try cloning and checking
+            version_exists ||= check_version_in_cloned_repo(base_url, version['name'], tmpdir)
 
-          @errors << "Version/branch '#{version['name']}' not found in repository: #{base_url}" unless version_exists
-        rescue Git::Error => e
-          @errors << "Repository not accessible at #{base_url}: #{e.message}"
+            @errors << "Version/branch '#{version['name']}' not found in repository: #{base_url}" unless version_exists
+          end
         end
+      rescue Git::Error => e
+        @errors << "Repository not accessible at #{base_url}: #{e.message}"
       end
       progressbar.increment
     end
+  ensure
+    FileUtils.remove_entry tmpdir
   end
 
   # Check if a version/branch exists in the remote references
@@ -156,19 +162,22 @@ namespace :pipeline_json_validator do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  # Check if version exists by cloning the repository and attempting checkout
-  def check_version_in_cloned_repo(base_url, version_name)
-    Dir.mktmpdir('irida_pipeline_validate') do |clone_dir|
-      try_clone_and_checkout(base_url, version_name, clone_dir)
-    end
+  # Check if version exists by mirroring the repository and attempting checkout
+  def check_version_in_cloned_repo(repo_url, version_name, tmpdir)
+    uri = URI.parse(repo_url)
+    path = uri.path.sub(%r{\A/}, '')
+    path += '.git' unless path.end_with?('.git')
+
+    clone_dir = File.join(tmpdir, path)
+    try_mirror_and_checkout(uri, version_name, clone_dir)
   rescue Git::Error
     false
   end
 
   # Attempt to clone and checkout a specific version
-  def try_clone_and_checkout(base_url, version_name, clone_dir)
-    repo = Git.clone(base_url, clone_dir)
-    repo.checkout(version_name)
+  def try_mirror_and_checkout(uri, version_name, clone_dir)
+    pipeline_repo = Irida::PipelineRepository.mirror_repo(uri, clone_dir)
+    pipeline_repo.repo.revparse(version_name)
     true
   rescue Git::Error
     false

--- a/test/jobs/workflow_executions/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_executions/workflow_execution_status_job_test.rb
@@ -10,35 +10,32 @@ module WorkflowExecutions
     include FaradayTestHelpers
     include ActiveJob::Continuation::TestHelper
 
-    def setup # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-      @original_clone_repo_method = Irida::PipelineRepository.method(:clone_repo)
+    def setup # rubocop:disable Metrics/MethodLength
+      @original_mirror_repo_method = Irida::PipelineRepository.method(:mirror_repo)
       @workflow_execution = workflow_executions(:irida_next_example_submitted)
       @workflow_execution.email_notification = true
       @workflow_execution.save!
       @workflow_execution.create_logidze_snapshot!
       @stubs = faraday_test_adapter_stubs
 
-      @test_schema_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json').read
+      test_schema_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json').read
 
-      # Use a closure to capture @test_schema_body for the clone_repo implementation
-      schema_body = @test_schema_body
-      clone_repo_impl = lambda do |_uri, _sha, clone_dir|
-        FileUtils.mkdir_p(clone_dir)
-        File.write(File.join(clone_dir, 'nextflow_schema.json'), schema_body)
-
-        # Create assets/schema_input.json
-        FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
-        File.write(File.join(clone_dir, 'assets', 'schema_input.json'), schema_body)
-        nil
+      file_contents_at_impl = lambda do |_sha, _path|
+        test_schema_body
+      end
+      clone_repo_impl = lambda do |_uri, _repo_dir|
+        Object.new.tap do |repo|
+          repo.define_singleton_method(:file_contents_at, file_contents_at_impl)
+        end
       end
 
-      Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
+      Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
     end
 
     def teardown
       # reset connections after each test to clear cache
       Faraday.default_connection = nil
-      Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, @original_clone_repo_method)
+      Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @original_mirror_repo_method)
     end
 
     test 'successful job execution' do

--- a/test/jobs/workflow_executions/workflow_execution_status_job_test.rb
+++ b/test/jobs/workflow_executions/workflow_execution_status_job_test.rb
@@ -23,13 +23,13 @@ module WorkflowExecutions
       file_contents_at_impl = lambda do |_sha, _path|
         test_schema_body
       end
-      clone_repo_impl = lambda do |_uri, _repo_dir|
+      mirror_repo_impl = lambda do |_uri, _repo_dir|
         Object.new.tap do |repo|
           repo.define_singleton_method(:file_contents_at, file_contents_at_impl)
         end
       end
 
-      Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
+      Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, mirror_repo_impl)
     end
 
     def teardown

--- a/test/lib/irida/pipelines_overrides_test.rb
+++ b/test/lib/irida/pipelines_overrides_test.rb
@@ -33,7 +33,7 @@ class PipelinesOverrides < ActiveSupport::TestCase
     end
 
     # Mock mirror_repo to simulate Git operations
-    clone_repo_impl = lambda do |_uri, repo_dir|
+    mirror_repo_impl = lambda do |_uri, repo_dir|
       FileUtils.mkdir_p(repo_dir)
 
       Object.new.tap do |repo|
@@ -41,7 +41,7 @@ class PipelinesOverrides < ActiveSupport::TestCase
       end
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, mirror_repo_impl)
   end
 
   teardown do

--- a/test/lib/irida/pipelines_overrides_test.rb
+++ b/test/lib/irida/pipelines_overrides_test.rb
@@ -6,7 +6,7 @@ require 'mocha/minitest'
 
 class PipelinesOverrides < ActiveSupport::TestCase
   setup do
-    @original_clone_repo_method = Irida::PipelineRepository.method(:clone_repo)
+    @original_mirror_repo_method = Irida::PipelineRepository.method(:mirror_repo)
     @pipeline_schema_file_dir = "#{ActiveStorage::Blob.service.root}/pipelines"
 
     # Read in schema file to json
@@ -16,29 +16,37 @@ class PipelinesOverrides < ActiveSupport::TestCase
       'test/fixtures/files/nextflow/samplesheet_schema_fastmatch.json'
     ).read
 
-    # Mock clone_repo to simulate Git operations
-    clone_repo_impl = lambda do |_uri, sha, clone_dir|
-      FileUtils.mkdir_p(clone_dir)
+    file_contents_at_impl = lambda do |sha, path|
       if ['2.0.2', '2.0.1', '2.0.0'].include?(sha)
         # iridanextexample
-        File.write(File.join(clone_dir, 'nextflow_schema.json'), body)
-        FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
-        File.write(File.join(clone_dir, 'assets', 'schema_input.json'), body)
+        body
       elsif ['0.4.1', '0.4.0'].include?(sha)
         # fastmatchirida
-        File.write(File.join(clone_dir, 'nextflow_schema.json'), nextflow_fastmatch_body)
-        FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
-        File.write(File.join(clone_dir, 'assets', 'schema_input.json'), nextflow_samplesheet_fastmatch_body)
+        if path == 'nextflow_schema.json'
+          nextflow_fastmatch_body
+        elsif path == 'assets/schema_input.json'
+          nextflow_samplesheet_fastmatch_body
+        else
+          ''
+        end
       end
-      nil
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
+    # Mock mirror_repo to simulate Git operations
+    clone_repo_impl = lambda do |_uri, repo_dir|
+      FileUtils.mkdir_p(repo_dir)
+
+      Object.new.tap do |repo|
+        repo.define_singleton_method(:file_contents_at, file_contents_at_impl)
+      end
+    end
+
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
   end
 
   teardown do
     FileUtils.remove_dir(@pipeline_schema_file_dir, true)
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, @original_clone_repo_method)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @original_mirror_repo_method)
   end
 
   test 'pipelines with overrides' do

--- a/test/lib/irida/pipelines_schema_test.rb
+++ b/test/lib/irida/pipelines_schema_test.rb
@@ -5,28 +5,26 @@ require 'webmock/minitest'
 
 class PipelinesSchemaTest < ActiveSupport::TestCase
   setup do
-    @original_clone_repo_method = Irida::PipelineRepository.method(:clone_repo)
+    @original_mirror_repo_method = Irida::PipelineRepository.method(:mirror_repo)
     @pipeline_schema_file_dir = "#{ActiveStorage::Blob.service.root}/pipelines"
 
-    @test_schema_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json').read
+    test_schema_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json').read
 
-    # Use a closure to capture @test_schema_body for the clone_repo implementation
-    schema_body = @test_schema_body
-    clone_repo_impl = lambda do |_uri, _sha, clone_dir|
-      FileUtils.mkdir_p(clone_dir)
-      File.write(File.join(clone_dir, 'nextflow_schema.json'), schema_body)
-
-      # Create assets/schema_input.json
-      FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
-      File.write(File.join(clone_dir, 'assets', 'schema_input.json'), schema_body)
-      nil
+    file_contents_at_impl = lambda do |_sha, _path|
+      test_schema_body
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
+    clone_repo_impl = lambda do |_uri, _repo_dir|
+      Object.new.tap do |repo|
+        repo.define_singleton_method(:file_contents_at, file_contents_at_impl)
+      end
+    end
+
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
   end
 
   teardown do
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, @original_clone_repo_method)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @original_mirror_repo_method)
     FileUtils.remove_dir(@pipeline_schema_file_dir, true)
   end
 

--- a/test/lib/irida/pipelines_schema_test.rb
+++ b/test/lib/irida/pipelines_schema_test.rb
@@ -14,13 +14,13 @@ class PipelinesSchemaTest < ActiveSupport::TestCase
       test_schema_body
     end
 
-    clone_repo_impl = lambda do |_uri, _repo_dir|
+    mirror_repo_impl = lambda do |_uri, _repo_dir|
       Object.new.tap do |repo|
         repo.define_singleton_method(:file_contents_at, file_contents_at_impl)
       end
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, mirror_repo_impl)
   end
 
   teardown do

--- a/test/lib/irida/pipelines_test.rb
+++ b/test/lib/irida/pipelines_test.rb
@@ -15,13 +15,13 @@ class PipelinesTest < ActiveSupport::TestCase
       schema_body
     end
 
-    @clone_repo_impl = lambda do |_uri, _repo_dir|
+    @mirror_repo_impl = lambda do |_uri, _repo_dir|
       Object.new.tap do |repo|
         repo.define_singleton_method(:file_contents_at, file_contents_at_impl)
       end
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @mirror_repo_impl)
 
     @pipelines = Irida::Pipelines.new(pipeline_config_file: 'test/config/pipelines/pipelines.json',
                                       pipeline_schema_file_dir: @pipeline_schema_file_dir)
@@ -73,11 +73,11 @@ class PipelinesTest < ActiveSupport::TestCase
     Rails.logger.expects(:error).with('Pipeline phac-nml/iridanextexample_1.0.2 could not be updated').once
 
     # Override the mock to raise an exception for this test (simulating fetch failure)
-    clone_repo_impl = lambda do |_uri, _repo_dir|
+    mirror_repo_impl = lambda do |_uri, _repo_dir|
       raise Git::Error, 'Failed to clone'
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, mirror_repo_impl)
 
     pipeline_refresh = Irida::Pipelines.new(
       pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_cached_pipeline/pipelines.json',
@@ -89,7 +89,7 @@ class PipelinesTest < ActiveSupport::TestCase
     assert_not pl.executable
   ensure
     # Restore the original mock
-    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @mirror_repo_impl)
   end
 
   test 'raises exception and logs error on git repo not accessible' do
@@ -97,11 +97,11 @@ class PipelinesTest < ActiveSupport::TestCase
     Rails.logger.expects(:error).with('Pipeline phac-nml/iridanextexample_1.0.2 could not be registered').once
 
     # Override the clone_repo to raise a 503 error
-    clone_repo_impl = lambda do |_uri, _repo_dir|
+    mirror_repo_impl = lambda do |_uri, _repo_dir|
       raise Irida::Pipelines::PipelinesInvalidUrlException.new('503', false)
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, mirror_repo_impl)
 
     pipelines = Irida::Pipelines.new(
       pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_cached_pipeline/pipelines.json',
@@ -112,6 +112,6 @@ class PipelinesTest < ActiveSupport::TestCase
     assert_nil pipelines.pipelines['phac-nml/iridanextexample_1.0.2']
   ensure
     # Restore the original mock
-    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @mirror_repo_impl)
   end
 end

--- a/test/lib/irida/pipelines_test.rb
+++ b/test/lib/irida/pipelines_test.rb
@@ -6,22 +6,22 @@ require 'mocha/minitest'
 
 class PipelinesTest < ActiveSupport::TestCase
   setup do
+    @original_mirror_repo_method = Irida::PipelineRepository.method(:mirror_repo)
     @pipeline_schema_file_dir = "#{ActiveStorage::Blob.service.root}/pipelines"
     @test_schema_body = Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json').read
 
-    # Use a closure to capture @test_schema_body for the clone_repo implementation
     schema_body = @test_schema_body
-    clone_repo_impl = lambda do |_uri, _sha, clone_dir|
-      FileUtils.mkdir_p(clone_dir)
-      File.write(File.join(clone_dir, 'nextflow_schema.json'), schema_body)
-
-      # Create assets/schema_input.json
-      FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
-      File.write(File.join(clone_dir, 'assets', 'schema_input.json'), schema_body)
-      nil
+    file_contents_at_impl = lambda do |_sha, _path|
+      schema_body
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
+    @clone_repo_impl = lambda do |_uri, _repo_dir|
+      Object.new.tap do |repo|
+        repo.define_singleton_method(:file_contents_at, file_contents_at_impl)
+      end
+    end
+
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @clone_repo_impl)
 
     @pipelines = Irida::Pipelines.new(pipeline_config_file: 'test/config/pipelines/pipelines.json',
                                       pipeline_schema_file_dir: @pipeline_schema_file_dir)
@@ -29,6 +29,7 @@ class PipelinesTest < ActiveSupport::TestCase
 
   teardown do
     FileUtils.remove_dir(@pipeline_schema_file_dir, true)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @original_mirror_repo_method)
   end
 
   test 'registers pipelines' do
@@ -72,11 +73,11 @@ class PipelinesTest < ActiveSupport::TestCase
     Rails.logger.expects(:error).with('Pipeline phac-nml/iridanextexample_1.0.2 could not be updated').once
 
     # Override the mock to raise an exception for this test (simulating fetch failure)
-    clone_repo_impl = lambda do |_uri, _sha, _clone_dir|
+    clone_repo_impl = lambda do |_uri, _repo_dir|
       raise Git::Error, 'Failed to clone'
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
 
     pipeline_refresh = Irida::Pipelines.new(
       pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_cached_pipeline/pipelines.json',
@@ -86,16 +87,9 @@ class PipelinesTest < ActiveSupport::TestCase
     pl = pipeline_refresh.pipelines['phac-nml/iridanextexample_1.0.2']
     assert_not_nil pl
     assert_not pl.executable
-
+  ensure
     # Restore the original mock
-    clone_repo_impl_default = lambda do |_uri, _sha, clone_dir|
-      FileUtils.mkdir_p(clone_dir)
-      File.write(File.join(clone_dir, 'nextflow_schema.json'), schema_body)
-      FileUtils.mkdir_p(File.join(clone_dir, 'assets'))
-      File.write(File.join(clone_dir, 'assets', 'schema_input.json'), schema_body)
-      nil
-    end
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl_default)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @clone_repo_impl)
   end
 
   test 'raises exception and logs error on git repo not accessible' do
@@ -103,11 +97,11 @@ class PipelinesTest < ActiveSupport::TestCase
     Rails.logger.expects(:error).with('Pipeline phac-nml/iridanextexample_1.0.2 could not be registered').once
 
     # Override the clone_repo to raise a 503 error
-    clone_repo_impl = lambda do |_uri, _sha, _clone_dir|
+    clone_repo_impl = lambda do |_uri, _repo_dir|
       raise Irida::Pipelines::PipelinesInvalidUrlException.new('503', false)
     end
 
-    Irida::PipelineRepository.singleton_class.send(:define_method, :clone_repo, clone_repo_impl)
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, clone_repo_impl)
 
     pipelines = Irida::Pipelines.new(
       pipeline_config_file: 'test/config/pipelines_fail_to_get_etag_for_cached_pipeline/pipelines.json',
@@ -116,5 +110,8 @@ class PipelinesTest < ActiveSupport::TestCase
 
     # For non-cached, the pipeline should not be registered
     assert_nil pipelines.pipelines['phac-nml/iridanextexample_1.0.2']
+  ensure
+    # Restore the original mock
+    Irida::PipelineRepository.singleton_class.send(:define_method, :mirror_repo, @clone_repo_impl)
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR is a follow up to #1741 where pipeline registration was updated to use git operations instead of using github urls. In this PR instead of cloning the pipeline repo for each version, we mirror the repo once and then effectively use `git cat-file ...` to get the requested file at the given sha per version. This speeds up pipeline registration when multiple versions of pipelines are registered, and between restarts as we only need to update our mirrors instead of cloning fresh each time.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Stop server if running
2. Delete `private/piplines` directory
3. Startup server with `bin/setup`
4. Ensure that all expected pipelines are registered
5. Stop server
6. Delete one of the `.git` folders in `private/pipeline_repos`
7. Start server with `bin/dev`
8. Ensure that all expected pipelines are registered
9. Stop server
10. Delete all folders instead of the one of the `.git` folders in `private/pipeline_repos`
11. Start server with `bin/dev`
12. Ensure that all expected pipelines are registered

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
