### PR TITLE
Dropdown: rotate caret arrow and close dropdown upon tabbing out

### DIFF
--- a/app/components/dropdown/v1/component.html.erb
+++ b/app/components/dropdown/v1/component.html.erb
@@ -3,6 +3,7 @@
   data-controller="dropdown--v1<%= tooltip? ? ' pathogen--tooltip' : '' %>"
   data-dropdown--v1-skidding-value="<%= skidding %>"
   data-dropdown--v1-distance-value="<%= distance %>"
+  data-dropdown--v1-caret-value="<%= caret %>"
 >
   <%= render Viral::BaseComponent.new(tag: :button, **system_arguments) do %>
     <% if icon_name.present? %>

--- a/app/components/dropdown/v2/component.html.erb
+++ b/app/components/dropdown/v2/component.html.erb
@@ -2,6 +2,7 @@
             data: {
               controller: tooltip? ? "pathogen--tooltip dropdown--v2" : "dropdown--v2",
               "dropdown--v2-distance-value": distance,
+              "dropdown--v2-caret-value": caret
             }) do %>
   <%= render Viral::BaseComponent.new(tag: :button, **system_arguments) do %>
     <% if icon_name.present? %>

--- a/app/javascript/controllers/dropdown/v1_controller.js
+++ b/app/javascript/controllers/dropdown/v1_controller.js
@@ -7,7 +7,10 @@ export default class extends Controller {
     trigger: String,
     skidding: Number,
     distance: Number,
+    caret: Boolean,
   };
+
+  #caret;
 
   initialize() {
     this.boundOnButtonKeyDown = this.onButtonKeyDown.bind(this);
@@ -18,6 +21,9 @@ export default class extends Controller {
 
   connect() {
     this.element.setAttribute("data-controller-connected", "true");
+    if (this.caretValue) {
+      this.#caret = this.element.querySelector("svg.caret-down-icon");
+    }
   }
 
   menuTargetConnected(element) {
@@ -47,6 +53,9 @@ export default class extends Controller {
         this.triggerTarget.setAttribute("aria-expanded", "true");
         this.menuTarget.setAttribute("aria-hidden", "false");
         this.menuTarget.removeAttribute("hidden");
+        if (this.#caret) {
+          this.#caret.classList.add("rotate-180");
+        }
       },
       onHide: () => {
         this.triggerTarget.setAttribute("aria-expanded", "false");
@@ -55,6 +64,9 @@ export default class extends Controller {
         this.#menuItems(element).forEach((menuitem) => {
           menuitem.setAttribute("tabindex", "-1");
         });
+        if (this.#caret) {
+          this.#caret.classList.remove("rotate-180");
+        }
       },
     });
   }

--- a/app/javascript/controllers/dropdown/v2_controller.js
+++ b/app/javascript/controllers/dropdown/v2_controller.js
@@ -5,9 +5,11 @@ export default class extends Controller {
   static targets = ["trigger", "menu"];
   static values = {
     distance: Number,
+    caret: Boolean,
   };
 
   #floatingDropdown = null;
+  #caret;
 
   initialize() {
     this.boundOnButtonKeyDown = this.onButtonKeyDown.bind(this);
@@ -20,6 +22,10 @@ export default class extends Controller {
     this.idempotentConnect();
 
     document.addEventListener("turbo:morph", this.boundOnMorph);
+
+    if (this.caretValue) {
+      this.#caret = this.element.querySelector("svg.caret-down-icon");
+    }
   }
 
   idempotentConnect() {
@@ -27,6 +33,7 @@ export default class extends Controller {
       trigger: this.triggerTarget,
       dropdown: this.menuTarget,
       distance: this.distanceValue,
+      onShow: () => this.#onShow(),
       onHide: () => this.#onHide(),
     });
   }
@@ -68,11 +75,16 @@ export default class extends Controller {
     });
   }
 
+  #onShow() {
+    this.#caret.classList.add("rotate-180");
+  }
+
   #onHide() {
     this.#menuItems(this.menuTarget).forEach((menuitem) => {
       menuitem.setAttribute("tabindex", "-1");
     });
     this.triggerTarget.focus();
+    this.#caret.classList.remove("rotate-180");
   }
 
   onButtonClick(event) {
@@ -196,8 +208,9 @@ export default class extends Controller {
         if (event.shiftKey) {
           event.preventDefault();
           this.triggerTarget.focus();
-          this.#floatingDropdown.hide();
         }
+
+        this.#floatingDropdown.hide();
         break;
     }
   }

--- a/app/javascript/controllers/dropdown/v2_controller.js
+++ b/app/javascript/controllers/dropdown/v2_controller.js
@@ -76,7 +76,9 @@ export default class extends Controller {
   }
 
   #onShow() {
-    this.#caret.classList.add("rotate-180");
+    if (this.#caret) {
+      this.#caret.classList.add("rotate-180");
+    }
   }
 
   #onHide() {
@@ -84,7 +86,9 @@ export default class extends Controller {
       menuitem.setAttribute("tabindex", "-1");
     });
     this.triggerTarget.focus();
-    this.#caret.classList.remove("rotate-180");
+    if (this.#caret) {
+      this.#caret.classList.remove("rotate-180");
+    }
   }
 
   onButtonClick(event) {


### PR DESCRIPTION
## What does this PR do and why?
This PR adds rotating the `caret arrow` when opening/closing the dropdown when caret is present, to both V1 and V2 dropdowns.

For V2, also added closing the dropdown when `Tabbing` out of the dropdown listing.

## Screenshots or screen recordings
Before:

[Screencast from 2026-05-14 11-15-15.webm](https://github.com/user-attachments/assets/cbebe1aa-cb79-42f4-b214-1c34f92b7a5f)

Now:

[Screencast from 2026-05-14 11-15-52.webm](https://github.com/user-attachments/assets/4523e8d0-5b32-4131-b6c4-096953b52e9d)


## How to set up and validate locally
1. Test for V1 and V2 dropdowns that the caret rotates upon open and closing.
2. For V2, verify with keyboard focus when the dropdown is open, tabbing out closes the dropdown.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
