### PR TITLE
Reactionview: add config.validation_mode

### DIFF
--- a/config/initializers/reactionview.rb
+++ b/config/initializers/reactionview.rb
@@ -7,6 +7,10 @@ ReActionView.configure do |config|
   # Enable debug mode in development (adds debug attributes to HTML)
   config.debug_mode = Rails.env.development? && ENV['HERB_DEBUG'].present?
 
+  # TEMPORARY FIX while we wait for reactionview to fix .debug_mode
+  # Disable validation mode in non-development environments so it doesn't inject <template> tags into emails
+  config.validation_mode = Rails.env.development? ? :overlay : :none
+
   # Add custom transform visitors to process templates before compilation
   # config.transform_visitors = [
   #   Herb::Visitor::new

--- a/test/system/projects/samples/metadata_test.rb
+++ b/test/system/projects/samples/metadata_test.rb
@@ -817,10 +817,10 @@ module Projects
         fill_in 'sample_value_2', with: '     value 4 '
         click_on I18n.t('projects.samples.metadata.form.submit_button')
 
+        assert_no_selector 'h1.dialog--title', text: I18n.t('projects.samples.metadata.new_metadata_modal.title')
+
         assert_text I18n.t('projects.samples.metadata.fields.create.multi_success',
                            keys: ['metadata field 3', 'metadata field 4'].join(', '))
-
-        assert_no_selector 'h1.dialog--title', text: I18n.t('projects.samples.metadata.new_metadata_modal.title')
 
         assert_selector 'table tbody tr', count: 4
         assert_selector 'table tbody tr:nth-child(3) td:nth-child(2)', text: 'metadata field 3'


### PR DESCRIPTION
## What does this PR do and why?
This PR specifies `config.validation_mode` as a temporary workaround in order to hide `template` tags appearing in non-dev environment e-mails.

Issue on `reactionview` repo: https://github.com/marcoroth/reactionview/issues/95

## Screenshots or screen recordings
Template tag appearance:

<img width="1652" height="799" alt="image" src="https://github.com/user-attachments/assets/eb7f77db-ac51-4df5-9ff3-dbcf773798e0" />

## How to set up and validate locally
1. Verify tests pass

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
