### PR TITLE
(a11y) Advanced search description and error messaging

### DIFF
--- a/app/components/advanced_search/v1/component.html.erb
+++ b/app/components/advanced_search/v1/component.html.erb
@@ -49,6 +49,8 @@
         <%= t("components.advanced_search_component.v1.rules") %>
       </p>
 
+      <%= helpers.form_error_summary(@form) %>
+
       <div class="mb-4"><%= render partial: "shared/form/required_field_legend" %></div>
 
       <div class="hidden" data-advanced-search--v1-target="submitError">

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -29,9 +29,7 @@
                                  "data-action": "change->advanced-search--v1#handleFieldChange",
                                  "aria-label": field_label,
                                  "aria-invalid": invalid_field,
-                                 "aria-describedby":
-                                   conditions_form.field_id(:field, "error"),
-                                 autofocus: invalid_field,
+                                 "aria-describedby": conditions_form.field_id(:field, "error")
                                } %>
       <% else %>
         <%= render ComboboxComponent.new(
@@ -44,9 +42,8 @@
           aria: {
             label: field_label,
             invalid: invalid_field,
-            describedby: conditions_form.field_id(:field, "error"),
+            describedby: conditions_form.field_id(:field, "error")
           },
-          autofocus: invalid_field,
         ) %>
       <% end %>
 
@@ -71,8 +68,7 @@
                                "aria-label": operator_label,
                                "aria-invalid": invalid_operator,
                                "aria-describedby":
-                                 conditions_form.field_id(:operator, "error"),
-                               autofocus: invalid_operator,
+                                 conditions_form.field_id(:operator, "error")
                              } %>
 
       <%= render "shared/form/field_errors",

--- a/app/components/advanced_search/v1/value_component.html.erb
+++ b/app/components/advanced_search/v1/value_component.html.erb
@@ -35,8 +35,7 @@
                                    multiple: true,
                                    "aria-label": value_label,
                                    "aria-invalid": invalid_value,
-                                   "aria-describedby": @conditions_form.field_id(:value, "error"),
-                                   autofocus: invalid_value
+                                   "aria-describedby": @conditions_form.field_id(:value, "error")
                                  } %>
     <% end %>
   <% elsif @options.nil? %>
@@ -44,8 +43,7 @@
                                 "aria-label": value_label,
                                 "aria-invalid": invalid_value,
                                 "aria-describedby":
-                                  @conditions_form.field_id(:value, "error"),
-                                autofocus: invalid_value %>
+                                  @conditions_form.field_id(:value, "error") %>
   <% else %>
     <%= @conditions_form.select :value,
                                options_for_select(@options, selected_values.first),
@@ -53,8 +51,7 @@
                                {
                                  "aria-label": value_label,
                                  "aria-invalid": invalid_value,
-                                 "aria-describedby": @conditions_form.field_id(:value, "error"),
-                                 autofocus: invalid_value
+                                 "aria-describedby": @conditions_form.field_id(:value, "error")
                                } %>
   <% end %>
 

--- a/app/components/form_error_summary_entry_builder.rb
+++ b/app/components/form_error_summary_entry_builder.rb
@@ -2,6 +2,22 @@
 
 # Builds one linked summary entry per invalid form attribute.
 class FormErrorSummaryEntryBuilder
+  NESTED_ATTRIBUTE_PATH_SEGMENT = '[a-z][a-z0-9_]*_attributes'
+  NESTED_ATTRIBUTE_PATH_SEGMENT_WITH_INDEX = "#{NESTED_ATTRIBUTE_PATH_SEGMENT}\\[\\d+\\]".freeze
+  FIELD_ID_ATTRIBUTE_PATH_REGEXP = /
+    \A
+    (?:
+      #{NESTED_ATTRIBUTE_PATH_SEGMENT_WITH_INDEX}
+      (?:\.(?:#{NESTED_ATTRIBUTE_PATH_SEGMENT_WITH_INDEX}|#{NESTED_ATTRIBUTE_PATH_SEGMENT}))*
+      (?:\.[a-z][a-z0-9_]*)?
+    |
+      #{NESTED_ATTRIBUTE_PATH_SEGMENT}
+      (?:\.(?:#{NESTED_ATTRIBUTE_PATH_SEGMENT_WITH_INDEX}|#{NESTED_ATTRIBUTE_PATH_SEGMENT}))+
+      (?:\.[a-z][a-z0-9_]*)?
+    )
+    \z
+  /x
+
   Entry = Data.define(:attribute, :message, :target_id) do
     def href
       "##{target_id}"
@@ -50,7 +66,21 @@ class FormErrorSummaryEntryBuilder
 
   def target_id_for(attribute)
     target_overrides.fetch(attribute.to_s) do
-      builder.field_id(attribute)
+      builder.field_id(*field_id_parts_for(attribute))
+    end
+  end
+
+  def field_id_parts_for(attribute)
+    attribute_string = attribute.to_s
+
+    return [attribute_string] unless FIELD_ID_ATTRIBUTE_PATH_REGEXP.match?(attribute_string)
+
+    attribute_string.split('.').flat_map do |segment|
+      if (match = segment.match(/\A([a-z][a-z0-9_]*_attributes)\[(\d+)\]\z/))
+        [match[1], match[2]]
+      else
+        [segment]
+      end
     end
   end
 end

--- a/app/models/advanced_search_query_form.rb
+++ b/app/models/advanced_search_query_form.rb
@@ -56,6 +56,28 @@ class AdvancedSearchQueryForm
     self.model_class_attribute = model_class
   end
 
+  def self.human_attribute_name(attribute, options = {})
+    # Match attributes of the form: groups[GROUP_INDEX].conditions[CONDITION_INDEX].ATTRIBUTE
+    # where GROUP_INDEX and CONDITION_INDEX are 0-based integers and ATTRIBUTE contains no dots
+    if attribute.is_a?(String)
+      m = attribute.match(/\Agroups_attributes\[(\d+)\]\.conditions_attributes\[(\d+)\]\.([^.]+)\z/)
+      if m
+        group_idx = m[1].to_i
+        condition_idx = m[2].to_i
+        attr_name = "groups_attributes.conditions_attributes.#{m[3]}"
+
+        # Ensure we don't mutate the passed options and add 1 to convert to 1-based indices
+        options = options ? options.dup : {}
+        options[:group_index] = group_idx + 1
+        options[:condition_index] = condition_idx + 1
+
+        return super(attr_name, options)
+      end
+    end
+
+    super
+  end
+
   def initialize(...)
     super
 

--- a/app/validators/advanced_search/group_validator.rb
+++ b/app/validators/advanced_search/group_validator.rb
@@ -77,8 +77,8 @@ module AdvancedSearch
 
     def validate_fields(group)
       group.conditions.each_with_index do |condition, condition_index|
-        validate_key(condition)
         validate_blank_field(condition)
+        validate_field(condition) if condition.field.present?
         validate_date_and_numeric_field(condition)
 
         validate_unique_condition(group, condition, condition_index)
@@ -91,7 +91,7 @@ module AdvancedSearch
       group.errors.add :base, :invalid
     end
 
-    def validate_key(condition)
+    def validate_field(condition)
       return if allowed_fields.include?(condition.field) || METADATA_FIELD_PATTERN.match?(condition.field)
 
       condition.errors.add :field, :not_a_metadata

--- a/app/validators/advanced_search/group_validator.rb
+++ b/app/validators/advanced_search/group_validator.rb
@@ -6,15 +6,17 @@ module AdvancedSearch
   # Subclasses must implement:
   # - allowed_fields
   # - date_fields
-  class GroupValidator < ActiveModel::Validator
+  class GroupValidator < ActiveModel::Validator # rubocop:disable Metrics/ClassLength
     METADATA_FIELD_PATTERN = /^metadata\..+$/
     DATE_OPERATOR_DISALLOWED = %w[contains not_contains in not_in].freeze
     BETWEEN_OPERATORS = %w[>= <=].freeze
     EXISTS_OPERATORS = %w[exists not_exists].freeze
+    GROUP_CONDITION_ERROR_ATTRIBUTE_FORMAT =
+      'groups_attributes[%<group_index>d].conditions_attributes[%<condition_index>d].%<attribute>s'
 
-    def validate(record)
+    def validate(record) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
       if structurally_empty_search?(record)
-        record.errors.add :groups, :invalid
+        record.errors.add :base, :invalid
         return
       end
 
@@ -26,7 +28,27 @@ module AdvancedSearch
 
       return unless record.groups.any? { |group| group.errors.any? }
 
-      record.errors.add :groups, :invalid
+      record.groups.each_with_index do |group, group_index|
+        next unless group.errors.any?
+
+        group.conditions.each_with_index do |condition, condition_index|
+          next unless condition.errors.any?
+
+          condition.errors.each do |error|
+            next if error.attribute.eql? :base
+
+            record.errors.add format(
+              GROUP_CONDITION_ERROR_ATTRIBUTE_FORMAT,
+              group_index: group_index,
+              condition_index: condition_index,
+              attribute: error.attribute
+            ).to_sym,
+                              error.message
+          end
+        end
+      end
+
+      record.errors.add :base, :invalid
     end
 
     private
@@ -60,11 +82,13 @@ module AdvancedSearch
         validate_date_and_numeric_field(condition)
 
         validate_unique_condition(group, condition, condition_index)
+
+        next unless condition.errors.any?
       end
 
       return unless group.conditions.any? { |condition| condition.errors.any? }
 
-      group.errors.add :conditions, :invalid
+      group.errors.add :base, :invalid
     end
 
     def validate_key(condition)
@@ -118,10 +142,6 @@ module AdvancedSearch
       else
         validate_uniqueness(condition, common_field_conditions)
       end
-
-      return unless condition.errors.any?
-
-      group.errors.add :conditions, :invalid
     end
 
     def validate_uniqueness(unique_field_condition, common_field_conditions)

--- a/app/validators/advanced_search/group_validator.rb
+++ b/app/validators/advanced_search/group_validator.rb
@@ -127,7 +127,7 @@ module AdvancedSearch
     def validate_uniqueness(unique_field_condition, common_field_conditions)
       return if common_field_conditions.one?
 
-      unique_field_condition.errors.add :operator, :taken
+      unique_field_condition.errors.add :field, :taken
     end
 
     def validate_between(unique_field_condition, common_field_conditions)
@@ -136,7 +136,7 @@ module AdvancedSearch
       return if common_field_conditions.count == 2 &&
                 common_field_conditions.collect(&:operator).sort == BETWEEN_OPERATORS.sort
 
-      unique_field_condition.errors.add :operator, :taken
+      unique_field_condition.errors.add :field, :taken
     end
   end
 end

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -143,7 +143,7 @@ en:
           not_in: not in
         remove_condition_aria_label: Remove condition
         remove_group_button: Remove group
-        rules: Operators cannot be used on the same field within a group more than once, except for '>=' and '<='. To filter by date range, the value should be of the format 'YYYY-MM-DD' and the metadata field should end with '_date'.
+        rules: Only one condition can be specified per field within a group, with the exception that you can specify two conditions if using the '>=' and '<=' operators. To filter by date range, the value should be of the format 'YYYY-MM-DD' and the metadata field must end with '_date'.
         title: Advanced search
     attachments:
       dialogs:

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -143,7 +143,7 @@ fr:
           not_in: not in (pas dans)
         remove_condition_aria_label: Supprimer la condition
         remove_group_button: Supprimer le groupe
-        rules: Les opérateurs ne peuvent pas être utilisés sur le même champ au sein d’un groupe plus d’une fois, à l’exception de « >= » et « <= ». Pour filtrer par plage de dates, la valeur doit être au format « AAAA-MM-JJ » et le champ de métadonnées doit se terminer par « _date ».
+        rules: Une seule condition peut être spécifiée par champ dans un groupe, sauf que vous pouvez spécifier deux conditions si vous utilisez les opérateurs '>=' et '<='. Pour filtrer par plage de dates, la valeur doit être au format « AAAA-MM-JJ » et le champ de métadonnées doit se terminer par « _date ».
         title: Recherche avancée
     attachments:
       dialogs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,15 @@ en:
         condition: Condition
     errors:
       models:
+        advanced_search_condition:
+          attributes:
+            field:
+              not_a_metadata: is an invalid metadata field
+              taken: exists within another condition in this group
+            operator:
+              not_a_date_operator: cannot be used on dates
+            value:
+              not_a_date: must be formatted YYYY-MM-DD
         concatenation_form:
           attributes:
             attachment_ids:
@@ -42,14 +51,6 @@ en:
               cannot_be_same_as_old_parent: must be different from the current parent group
               namespace_group_exists: already has a group with the same name/path
               namespace_not_found: does not exist
-        sample/search_condition:
-          attributes:
-            field:
-              not_a_metadata: is an invalid metadata field
-            operator:
-              not_a_date_operator: cannot be used on dates
-            value:
-              not_a_date: must be formatted YYYY-MM-DD
   activerecord:
     attributes:
       attachment:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,10 @@ en:
         delete_originals: Delete original files after concatenation?
       groups/transfer_form:
         new_parent_id: Parent group
+      groups_attributes/conditions_attributes:
+        field: Group %{group_index} Condition %{condition_index} Field
+        operator: Group %{group_index} Condition %{condition_index} Operator
+        value: Group %{group_index} Condition %{condition_index} Value
       sample/query:
         group: Group
       sample/search_condition:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,15 @@ en:
         condition: Condition
     errors:
       models:
+        advanced_search_condition:
+          attributes:
+            field:
+              not_a_metadata: is an invalid metadata field
+              taken: exists within another condition in this group
+            operator:
+              not_a_date_operator: cannot be used on dates
+            value:
+              not_a_date: must be formatted YYYY-MM-DD
         concatenation_form:
           attributes:
             attachment_ids:
@@ -32,14 +41,6 @@ en:
               mismatching_paired_end_counts: must all be paired. Forward and reverse read file counts do not match.
             basename:
               invalid: must contain only letters, digits, '-', '.', and '_'.
-        sample/search_condition:
-          attributes:
-            field:
-              not_a_metadata: is an invalid metadata field
-            operator:
-              not_a_date_operator: cannot be used on dates
-            value:
-              not_a_date: must be formatted YYYY-MM-DD
   activerecord:
     attributes:
       attachment:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,6 +24,15 @@ fr:
         condition: Condition
     errors:
       models:
+        advanced_search_condition:
+          attributes:
+            field:
+              not_a_metadata: est un champ de métadonnées non valide
+              taken: existe déjà dans une autre condition de ce groupe
+            operator:
+              not_a_date_operator: ne peut pas être utilisé sur les dates
+            value:
+              not_a_date: doit être formaté AAAA-MM-JJ
         concatenation_form:
           attributes:
             attachment_ids:
@@ -42,14 +51,6 @@ fr:
               cannot_be_same_as_old_parent: doit être différent du groupe parent actuel
               namespace_group_exists: existe déjà un groupe portant le même nom/chemin
               namespace_not_found: n'existe pas
-        sample/search_condition:
-          attributes:
-            field:
-              not_a_metadata: est un champ de métadonnées non valide
-            operator:
-              not_a_date_operator: ne peut pas être utilisé sur les dates
-            value:
-              not_a_date: doit être formaté AAAA-MM-JJ
   activerecord:
     attributes:
       attachment:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -22,6 +22,15 @@ fr:
         condition: Condition
     errors:
       models:
+        advanced_search_condition:
+          attributes:
+            field:
+              not_a_metadata: est un champ de métadonnées non valide
+              taken: existe déjà dans une autre condition de ce groupe
+            operator:
+              not_a_date_operator: ne peut pas être utilisé sur les dates
+            value:
+              not_a_date: doit être formaté AAAA-MM-JJ
         concatenation_form:
           attributes:
             attachment_ids:
@@ -32,14 +41,6 @@ fr:
               mismatching_paired_end_counts: tous les fichiers sélectionnés doivent être jumelés. Le nombre de fichiers en lecture directe et inversée ne correspond pas.
             basename:
               invalid: doit contenir uniquement des lettres, chiffres, « - », « . » et « _ »
-        sample/search_condition:
-          attributes:
-            field:
-              not_a_metadata: est un champ de métadonnées non valide
-            operator:
-              not_a_date_operator: ne peut pas être utilisé sur les dates
-            value:
-              not_a_date: doit être formaté AAAA-MM-JJ
   activerecord:
     attributes:
       attachment:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -8,6 +8,10 @@ fr:
         delete_originals: Supprimer les fichiers originaux après la concaténation?
       groups/transfer_form:
         new_parent_id: Groupe parent
+      groups_attributes/conditions_attributes:
+        field: Groupe %{group_index} Condition %{condition_index} Champ
+        operator: Groupe %{group_index} Condition %{condition_index} Opérateur
+        value: Groupe %{group_index} Condition %{condition_index} Valeur
       sample/query:
         group: Groupe
       sample/search_condition:

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -94,6 +94,20 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     assert_equal 'project_namespace_attributes_path', entry.target_id
   end
 
+  test 'entry builder derives indexed nested target ids' do
+    user = build_user
+    nested_attribute = 'members_attributes[0].email'
+    user.errors.add(nested_attribute, 'is invalid')
+
+    entry = FormErrorSummaryEntryBuilder.new(
+      builder: build_form_builder('user', user),
+      attribute_overrides: { nested_attribute => 'Email address' }
+    ).call.first
+
+    assert_equal nested_attribute.to_sym, entry.attribute
+    assert_equal 'user_members_0_email', entry.target_id
+  end
+
   test 'override path uses validation attributes and raw target ids' do
     namespace = Namespaces::ProjectNamespace.new
     namespace.errors.add(:namespace, 'required')

--- a/test/components/form_error_summary_component_test.rb
+++ b/test/components/form_error_summary_component_test.rb
@@ -105,7 +105,7 @@ class FormErrorSummaryComponentTest < ViewComponentTestCase
     ).call.first
 
     assert_equal nested_attribute.to_sym, entry.attribute
-    assert_equal 'user_members_0_email', entry.target_id
+    assert_equal 'user_members_attributes_0_email', entry.target_id
   end
 
   test 'override path uses validation attributes and raw target ids' do

--- a/test/components/form_error_summary_entry_builder_test.rb
+++ b/test/components/form_error_summary_entry_builder_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FormErrorSummaryEntryBuilderRegexTest < ActiveSupport::TestCase
+  test 'field id attribute path regexp matches valid indexed nested attributes' do
+    regexp = FormErrorSummaryEntryBuilder::FIELD_ID_ATTRIBUTE_PATH_REGEXP
+
+    assert_match regexp, 'members_attributes[0].email'
+    assert_match regexp, 'members_attributes[0].widgets_attributes[1].name'
+    assert_match regexp, 'members_attributes[0].email_attributes'
+    assert_match regexp, 'members_attributes[0].email_attributes.blah_attributes'
+    assert_match regexp, 'foo_attributes.bar_attributes.baz'
+    assert_match regexp, 'foo_attributes[2].bar'
+  end
+
+  test 'field id attribute path regexp rejects invalid patterns' do
+    regexp = FormErrorSummaryEntryBuilder::FIELD_ID_ATTRIBUTE_PATH_REGEXP
+
+    assert_no_match regexp, 'members[0].email'
+    assert_no_match regexp, 'members_attributes.email'
+    assert_no_match regexp, 'members_attributes[0][1].email'
+    assert_no_match regexp, 'members_attributes[0].email[1]'
+  end
+
+  test 'field id parts generation returns expected segments for valid attribute paths' do
+    builder = build_form_builder('user', build_user)
+    entry_builder = FormErrorSummaryEntryBuilder.new(builder: builder)
+
+    assert_equal %w[members_attributes 0 email], entry_builder.send(:field_id_parts_for, 'members_attributes[0].email')
+    assert_equal %w[members_attributes 0 widgets_attributes 1 name],
+                 entry_builder.send(:field_id_parts_for, 'members_attributes[0].widgets_attributes[1].name')
+    assert_equal %w[members_attributes 0 email_attributes],
+                 entry_builder.send(:field_id_parts_for, 'members_attributes[0].email_attributes')
+  end
+
+  test 'field id parts generation falls back to raw attribute for invalid paths' do
+    builder = build_form_builder('user', build_user)
+    entry_builder = FormErrorSummaryEntryBuilder.new(builder: builder)
+
+    assert_equal ['members[0].email'], entry_builder.send(:field_id_parts_for, 'members[0].email')
+  end
+
+  private
+
+  def build_form_builder(object_name, object)
+    template = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
+    ActionView::Helpers::FormBuilder.new(object_name, object, template, {})
+  end
+
+  def build_user
+    User.new(
+      email: 'test@example.com',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      password: 'Password123!',
+      password_confirmation: 'Password123!',
+      locale: I18n.default_locale.to_s
+    )
+  end
+end

--- a/test/models/sample/query_test.rb
+++ b/test/models/sample/query_test.rb
@@ -40,8 +40,8 @@ class QueryTest < ActiveSupport::TestCase
     query = Sample::Query.new(search_params)
     assert query.advanced_query?
     assert_not query.valid?
-    assert query.errors.added? :groups, :invalid
-    assert query.groups[0].errors.added? :conditions, :invalid
+    assert query.errors.added? :base, :invalid
+    assert query.groups[0].errors.added? :base, :invalid
     assert query.groups[0].conditions[1].errors.added? :field, :blank
     assert query.groups[0].conditions[1].errors.added? :operator, :blank
     assert query.groups[0].conditions[1].errors.added? :value, :blank
@@ -57,8 +57,8 @@ class QueryTest < ActiveSupport::TestCase
     query = Sample::Query.new(search_params)
     assert query.advanced_query?
     assert_not query.valid?
-    assert query.errors.added? :groups, :invalid
-    assert query.groups[0].errors.added? :conditions, :invalid
+    assert query.errors.added? :base, :invalid
+    assert query.groups[0].errors.added? :base, :invalid
     assert query.groups[0].conditions[0].errors.added? :value, :not_a_date
   end
 
@@ -101,8 +101,8 @@ class QueryTest < ActiveSupport::TestCase
     query = Sample::Query.new(search_params)
     assert query.advanced_query?
     assert_not query.valid?
-    assert query.errors.added? :groups, :invalid
-    assert query.groups[0].errors.added? :conditions, :invalid
+    assert query.errors.added? :base, :invalid
+    assert query.groups[0].errors.added? :base, :invalid
     assert query.groups[0].conditions[1].errors.added? :field, :taken
   end
 
@@ -118,8 +118,8 @@ class QueryTest < ActiveSupport::TestCase
     query = Sample::Query.new(search_params)
     assert query.advanced_query?
     assert_not query.valid?
-    assert query.errors.added? :groups, :invalid
-    assert query.groups[0].errors.added? :conditions, :invalid
+    assert query.errors.added? :base, :invalid
+    assert query.groups[0].errors.added? :base, :invalid
     assert query.groups[0].conditions[1].errors.added? :field, :taken
   end
 
@@ -148,8 +148,8 @@ class QueryTest < ActiveSupport::TestCase
     query = Sample::Query.new(search_params)
     assert query.advanced_query?
     assert_not query.valid?
-    assert query.errors.added? :groups, :invalid
-    assert query.groups[0].errors.added? :conditions, :invalid
+    assert query.errors.added? :base, :invalid
+    assert query.groups[0].errors.added? :base, :invalid
     assert query.groups[0].conditions[0].errors.added? :value, :not_a_number
   end
 
@@ -164,8 +164,8 @@ class QueryTest < ActiveSupport::TestCase
     query = Sample::Query.new(search_params)
     assert query.advanced_query?
     assert_not query.valid?
-    assert query.errors.added? :groups, :invalid
-    assert query.groups[0].errors.added? :conditions, :invalid
+    assert query.errors.added? :base, :invalid
+    assert query.groups[0].errors.added? :base, :invalid
     assert query.groups[0].conditions[0].errors.added? :operator, :not_a_date_operator
   end
 

--- a/test/models/sample/query_test.rb
+++ b/test/models/sample/query_test.rb
@@ -103,7 +103,7 @@ class QueryTest < ActiveSupport::TestCase
     assert_not query.valid?
     assert query.errors.added? :groups, :invalid
     assert query.groups[0].errors.added? :conditions, :invalid
-    assert query.groups[0].conditions[1].errors.added? :operator, :taken
+    assert query.groups[0].conditions[1].errors.added? :field, :taken
   end
 
   test 'invalid advanced query with non unique fields using between operator' do
@@ -120,7 +120,7 @@ class QueryTest < ActiveSupport::TestCase
     assert_not query.valid?
     assert query.errors.added? :groups, :invalid
     assert query.groups[0].errors.added? :conditions, :invalid
-    assert query.groups[0].conditions[1].errors.added? :operator, :taken
+    assert query.groups[0].conditions[1].errors.added? :field, :taken
   end
 
   test 'valid advanced query with non unique fields using between operator' do

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -3220,7 +3220,7 @@ module Projects
         end
       end
       click_button I18n.t(:'components.advanced_search_component.v1.apply_filter_button')
-      assert_text I18n.t(:'errors.messages.taken')
+      assert_text I18n.t(:'activemodel.errors.models.advanced_search_condition.attributes.field.taken')
       ### actions and VERIFY END ###
     end
 

--- a/test/validators/advanced_search/group_validator_test.rb
+++ b/test/validators/advanced_search/group_validator_test.rb
@@ -212,7 +212,7 @@ module AdvancedSearch
 
       assert_not record.valid?
       second = record.groups.first.conditions.last
-      assert second.errors.added?(:operator, :taken)
+      assert second.errors.added?(:field, :taken)
 
       record2 = DummyRecord.new(
         groups: [DummyGroup.new(conditions: [
@@ -233,7 +233,7 @@ module AdvancedSearch
 
       assert_not record3.valid?
       third = record3.groups.first.conditions.last
-      assert third.errors.added?(:operator, :taken)
+      assert third.errors.added?(:field, :taken)
     end
   end
 end

--- a/test/validators/advanced_search/group_validator_test.rb
+++ b/test/validators/advanced_search/group_validator_test.rb
@@ -68,14 +68,14 @@ module AdvancedSearch
       record = DummyRecord.new(groups: [])
 
       assert_not record.valid?
-      assert record.errors.added?(:groups, :invalid)
+      assert record.errors.added?(:base, :invalid)
     end
 
     test 'rejects structurally empty search with groups but no conditions' do
       record = DummyRecord.new(groups: [DummyGroup.new(conditions: [])])
 
       assert_not record.valid?
-      assert record.errors.added?(:groups, :invalid)
+      assert record.errors.added?(:base, :invalid)
     end
 
     test 'rejects invalid field names and bubbles up group/record errors' do
@@ -84,12 +84,11 @@ module AdvancedSearch
       )
 
       assert_not record.valid?
-      assert record.errors.added?(:groups, :invalid)
+      assert record.errors.added?(:base, :invalid)
 
       group = record.groups.first
       condition = group.conditions.first
 
-      assert group.errors.added?(:conditions, :invalid)
       assert condition.errors.added?(:field, :not_a_metadata)
     end
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes an accessibility issue within the advanced search dialog, where the description and error reporting of conflicting conditions wasn't easily understandable. In addition the advanced search dialog has been updated to include a form error summary.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

Before:

Help text:

<img width="1280" height="1027" alt="image" src="https://github.com/user-attachments/assets/c15e6bf7-5ffc-4078-b634-87f593e3cf81" />

Conflicting condition error messaging:

<img width="1280" height="1027" alt="image" src="https://github.com/user-attachments/assets/1570ed68-cce3-44cb-98b0-1915dc90e98d" />

After:

Help text:

<img width="1280" height="1027" alt="image" src="https://github.com/user-attachments/assets/5f07a6d1-a7bd-4426-b115-6aff2f522c03" />

Conflict condition error messaging:

<img width="1280" height="1027" alt="image" src="https://github.com/user-attachments/assets/dca9ee02-e00c-4a55-827c-8c017891613b" />

Form error summary:

<img width="795" height="792" alt="image" src="https://github.com/user-attachments/assets/fc8cb8ea-c71d-4632-ae24-bc02714866ea" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Start server with `bin/setup`
2. Login as user of your choice and navigate to the project samples page of your choice
3. Click `Advanced search`
4. Confirm that help description is easier to understand
5. Fill condition 1 with field: Sample Name, Operator: =, Value: blah
6. Add condition to group 1 (condition 2) with Field: Sample Name, Operator: =, Value: blah
7. Click Apply Filter and confirm that error is displayed on Condition 2 Field
8. Change condition 1 to Field: Created, Operator: >=, Value: 2026-01-01
9. Change condition 2 to Field: Created, Operator: <=, Value: 2027-01-01
10. Click Apply Filter and confirm that modal disappears and search results are returned, and clicking Advanced Search doesn't show any errors

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
