### PR TITLE
Bug: Dropdown caret arrow rotation

### DIFF
--- a/app/components/dropdown/v1/component.html.erb
+++ b/app/components/dropdown/v1/component.html.erb
@@ -3,7 +3,6 @@
   data-controller="dropdown--v1<%= tooltip? ? ' pathogen--tooltip' : '' %>"
   data-dropdown--v1-skidding-value="<%= skidding %>"
   data-dropdown--v1-distance-value="<%= distance %>"
-  data-dropdown--v1-caret-value="<%= caret %>"
 >
   <%= render Viral::BaseComponent.new(tag: :button, **system_arguments) do %>
     <% if icon_name.present? %>

--- a/app/components/dropdown/v1/component.html.erb
+++ b/app/components/dropdown/v1/component.html.erb
@@ -25,7 +25,9 @@
     <% end %>
 
     <% if caret %>
-      <%= icon(:caret_down, size: :sm, class: "ml-2 flex-none") %>
+      <span data-dropdown--v1-target="caret" class="ml-2 inline-flex flex-none">
+        <%= icon(:caret_down, size: :sm) %>
+      </span>
     <% end %>
   <% end %>
 

--- a/app/components/dropdown/v2/component.html.erb
+++ b/app/components/dropdown/v2/component.html.erb
@@ -24,7 +24,9 @@
     <% end %>
 
     <% if caret %>
-      <%= icon(:caret_down, size: :sm, class: "ml-2 flex-none") %>
+      <span data-dropdown--v2-target="caret" class="ml-2 inline-flex flex-none">
+        <%= icon(:caret_down, size: :sm) %>
+      </span>
     <% end %>
   <% end %>
 

--- a/app/components/dropdown/v2/component.html.erb
+++ b/app/components/dropdown/v2/component.html.erb
@@ -2,7 +2,6 @@
             data: {
               controller: tooltip? ? "pathogen--tooltip dropdown--v2" : "dropdown--v2",
               "dropdown--v2-distance-value": distance,
-              "dropdown--v2-caret-value": caret
             }) do %>
   <%= render Viral::BaseComponent.new(tag: :button, **system_arguments) do %>
     <% if icon_name.present? %>

--- a/app/javascript/controllers/dropdown/v1_controller.js
+++ b/app/javascript/controllers/dropdown/v1_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["trigger", "menu"];
+  static targets = ["trigger", "menu", "caret"];
   static values = {
     position: String,
     trigger: String,
@@ -9,8 +9,6 @@ export default class extends Controller {
     distance: Number,
     caret: Boolean,
   };
-
-  #caret;
 
   initialize() {
     this.boundOnButtonKeyDown = this.onButtonKeyDown.bind(this);
@@ -21,9 +19,6 @@ export default class extends Controller {
 
   connect() {
     this.element.setAttribute("data-controller-connected", "true");
-    if (this.caretValue) {
-      this.#caret = this.element.querySelector("svg");
-    }
   }
 
   menuTargetConnected(element) {
@@ -53,8 +48,8 @@ export default class extends Controller {
         this.triggerTarget.setAttribute("aria-expanded", "true");
         this.menuTarget.setAttribute("aria-hidden", "false");
         this.menuTarget.removeAttribute("hidden");
-        if (this.#caret) {
-          this.#caret.classList.add("rotate-180");
+        if (this.hasCaretTarget) {
+          this.caretTarget.classList.add("rotate-180");
         }
       },
       onHide: () => {
@@ -64,8 +59,8 @@ export default class extends Controller {
         this.#menuItems(element).forEach((menuitem) => {
           menuitem.setAttribute("tabindex", "-1");
         });
-        if (this.#caret) {
-          this.#caret.classList.remove("rotate-180");
+        if (this.hasCaretTarget) {
+          this.caretTarget.classList.remove("rotate-180");
         }
       },
     });

--- a/app/javascript/controllers/dropdown/v1_controller.js
+++ b/app/javascript/controllers/dropdown/v1_controller.js
@@ -7,7 +7,6 @@ export default class extends Controller {
     trigger: String,
     skidding: Number,
     distance: Number,
-    caret: Boolean,
   };
 
   initialize() {

--- a/app/javascript/controllers/dropdown/v1_controller.js
+++ b/app/javascript/controllers/dropdown/v1_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
   connect() {
     this.element.setAttribute("data-controller-connected", "true");
     if (this.caretValue) {
-      this.#caret = this.element.querySelector("svg.caret-down-icon");
+      this.#caret = this.element.querySelector("svg");
     }
   }
 

--- a/app/javascript/controllers/dropdown/v2_controller.js
+++ b/app/javascript/controllers/dropdown/v2_controller.js
@@ -2,14 +2,13 @@ import { Controller } from "@hotwired/stimulus";
 import FloatingDropdown from "utilities/floating_dropdown";
 
 export default class extends Controller {
-  static targets = ["trigger", "menu"];
+  static targets = ["trigger", "menu", "caret"];
   static values = {
     distance: Number,
     caret: Boolean,
   };
 
   #floatingDropdown = null;
-  #caret;
 
   initialize() {
     this.boundOnButtonKeyDown = this.onButtonKeyDown.bind(this);
@@ -22,10 +21,6 @@ export default class extends Controller {
     this.idempotentConnect();
 
     document.addEventListener("turbo:morph", this.boundOnMorph);
-
-    if (this.caretValue) {
-      this.#caret = this.element.querySelector("svg");
-    }
   }
 
   idempotentConnect() {
@@ -76,8 +71,8 @@ export default class extends Controller {
   }
 
   #onShow() {
-    if (this.#caret) {
-      this.#caret.classList.add("rotate-180");
+    if (this.hasCaretTarget) {
+      this.caretTarget.classList.add("rotate-180");
     }
   }
 
@@ -86,8 +81,8 @@ export default class extends Controller {
       menuitem.setAttribute("tabindex", "-1");
     });
     this.triggerTarget.focus();
-    if (this.#caret) {
-      this.#caret.classList.remove("rotate-180");
+    if (this.hasCaretTarget) {
+      this.caretTarget.classList.remove("rotate-180");
     }
   }
 

--- a/app/javascript/controllers/dropdown/v2_controller.js
+++ b/app/javascript/controllers/dropdown/v2_controller.js
@@ -24,7 +24,7 @@ export default class extends Controller {
     document.addEventListener("turbo:morph", this.boundOnMorph);
 
     if (this.caretValue) {
-      this.#caret = this.element.querySelector("svg.caret-down-icon");
+      this.#caret = this.element.querySelector("svg");
     }
   }
 

--- a/app/javascript/controllers/dropdown/v2_controller.js
+++ b/app/javascript/controllers/dropdown/v2_controller.js
@@ -5,7 +5,6 @@ export default class extends Controller {
   static targets = ["trigger", "menu", "caret"];
   static values = {
     distance: Number,
-    caret: Boolean,
   };
 
   #floatingDropdown = null;


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug for the dropdown caret rotation where the rotation did not happen in non-dev environments. This is due to when setting the caret in JS via `querySelector`, it was using `svg.caret-down-icon`  class, which isn't applied in non-dev environments. This has now been fixed and if caret exists for the dropdown, the `querySelector` will just look for `svg`

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Verify dropdowns with the caret icon still rotates in both v1 and v2

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
