### PR TITLE
Bug: Fix Advanced Search legend reindexing

### DIFF
--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -388,9 +388,8 @@ export default class AdvancedSearchController extends Controller {
     const legend = Array.from(container.children).find(
       (child) => child.tagName === "LEGEND",
     );
-    const legendTemplate =
-      container.dataset["advancedSearch--V1LegendTemplate"];
 
+    const legendTemplate = container.dataset["advancedSearch-V1LegendTemplate"];
     if (!legend || !legendTemplate) {
       return;
     }

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -252,9 +252,22 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
 
       assert_selector 'dialog h1', text: I18n.t(:'components.advanced_search_component.v1.title')
       within 'dialog' do
+        assert_no_selector 'legend',
+                           text: I18n.t('components.advanced_search_component.v1.group', index: '3')
         click_button I18n.t(:'components.advanced_search_component.v1.add_group_button')
 
+        assert_selector 'legend',
+                        text: I18n.t('components.advanced_search_component.v1.group', index: '1')
+
+        assert_selector 'legend',
+                        text: I18n.t('components.advanced_search_component.v1.group', index: '2')
+
+        assert_selector 'legend',
+                        text: I18n.t('components.advanced_search_component.v1.group', index: '3')
+
         within all("fieldset[data-advanced-search--v1-target='groupsContainer']").last do
+          assert_no_selector 'legend',
+                             text: I18n.t('components.advanced_search_component.v1.condition', index: '2')
           click_button I18n.t(:'components.advanced_search_component.v1.add_condition_button')
           assert_selector :xpath,
                           "//*[@name='q[groups_attributes][2][conditions_attributes][0][field]']",
@@ -262,6 +275,12 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
           assert_selector :xpath,
                           "//*[@name='q[groups_attributes][2][conditions_attributes][1][field]']",
                           visible: :all
+
+          assert_selector 'legend',
+                          text: I18n.t('components.advanced_search_component.v1.condition', index: '1')
+
+          assert_selector 'legend',
+                          text: I18n.t('components.advanced_search_component.v1.condition', index: '2')
 
           within all("fieldset[data-advanced-search--v1-target='conditionsContainer']").first do
             find("button[data-action='advanced-search--v1#removeCondition']").click
@@ -273,7 +292,26 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
           assert_no_selector :xpath,
                              "//*[@name='q[groups_attributes][2][conditions_attributes][1][field]']",
                              visible: :all
+
+          assert_selector 'legend',
+                          text: I18n.t('components.advanced_search_component.v1.condition', index: '1')
+
+          assert_no_selector 'legend',
+                             text: I18n.t('components.advanced_search_component.v1.condition', index: '2')
         end
+
+        within all("fieldset[data-advanced-search--v1-target='groupsContainer']").first do
+          click_button I18n.t('components.advanced_search_component.v1.remove_group_button')
+        end
+
+        assert_selector 'legend',
+                        text: I18n.t('components.advanced_search_component.v1.group', index: '1')
+
+        assert_selector 'legend',
+                        text: I18n.t('components.advanced_search_component.v1.group', index: '2')
+
+        assert_no_selector 'legend',
+                           text: I18n.t('components.advanced_search_component.v1.group', index: '3')
       end
     end
   end


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug in the Advanced Search component where the legend label was not reindexing.
Added assertions to an existing test to capture this.

## Screenshots or screen recordings
Issue:

[Screencast from 2026-05-20 14-06-18.webm](https://github.com/user-attachments/assets/2ceddbe5-e74c-493e-8ba7-461dddfe4012)

Fix:

[Screencast from 2026-05-20 14-06-59.webm](https://github.com/user-attachments/assets/74e07c21-a5a0-40c9-9ca3-058090dffd8f)

## How to set up and validate locally
1. Open an advanced search dialog and add multiple conditions/groups, and then remove them and verify the Group/Condition # labels re-index properly

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
