### PR TITLE
fix(a11y): link sortable list panels to their guidance descriptions

### DIFF
--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -63,10 +63,13 @@
             <%= t("data_exports.new_linelist_export_dialog.metadata") %>
           </h2>
 
+          <% sortable_lists_guidance_id = "linelist-export-fields-guidance-v2" %>
+
           <%= render Viral::SortableListsGuidanceComponent.new(
             title: t("data_exports.new_linelist_export_dialog.fields_instructions_title"),
             instructions: t("data_exports.new_linelist_export_dialog.fields_instructions"),
             keyboard_help: t("data_exports.new_linelist_export_dialog.keyboard_help"),
+            id_prefix: sortable_lists_guidance_id,
             available: {
               title: t("data_exports.new_linelist_export_dialog.available_list_title"),
               description: t("data_exports.new_linelist_export_dialog.available_description"),
@@ -84,13 +87,15 @@
           ) do |sortable_lists| %>
               <%= sortable_lists.with_list(
               id: "available-list",
-              title: t("data_exports.new_linelist_export_dialog.available"),
+              title: t("data_exports.new_linelist_export_dialog.available_list_title"),
               list_items: metadata_fields,
+              describedby: "#{sortable_lists_guidance_id}-available-description",
             ) %>
 
               <%= sortable_lists.with_list(
               id: "selected-list",
-              title: t("data_exports.new_linelist_export_dialog.selected"),
+              title: t("data_exports.new_linelist_export_dialog.selected_list_title"),
+              describedby: "#{sortable_lists_guidance_id}-selected-description",
             ) %>
             <% end %>
           </div>

--- a/app/components/viral/sortable_lists_guidance_component.html.erb
+++ b/app/components/viral/sortable_lists_guidance_component.html.erb
@@ -12,12 +12,7 @@
   </p>
 
   <ul class="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-    <li
-      class="
-        flex gap-2.5 rounded-md bg-white p-3 ring-1 ring-slate-200 ring-inset dark:bg-slate-900/40
-        dark:ring-slate-700
-      "
-    >
+    <li class="flex gap-2.5 rounded-md bg-white p-3 ring-1 ring-slate-200 ring-inset dark:bg-slate-900/40 dark:ring-slate-700">
       <span
         class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded bg-slate-100 dark:bg-slate-700/70"
         aria-hidden="true"
@@ -25,7 +20,7 @@
         <%= icon(available[:icon], size: :sm, color: :subdued, "aria-hidden": true) %>
       </span>
 
-      <div>
+      <div id="<%= available_description_id %>">
         <p class="text-xs font-semibold tracking-wide text-slate-700 uppercase dark:text-slate-100">
           <%= available[:title] %>
         </p>
@@ -34,12 +29,7 @@
       </div>
     </li>
 
-    <li
-      class="
-        flex gap-2.5 rounded-md bg-white p-3 ring-1 ring-slate-200 ring-inset dark:bg-slate-900/40
-        dark:ring-slate-700
-      "
-    >
+    <li class="flex gap-2.5 rounded-md bg-white p-3 ring-1 ring-slate-200 ring-inset dark:bg-slate-900/40 dark:ring-slate-700">
       <span
         class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded bg-green-100 dark:bg-green-900/40"
         aria-hidden="true"
@@ -47,7 +37,7 @@
         <%= icon(selected[:icon], size: :sm, color: :success, "aria-hidden": true) %>
       </span>
 
-      <div>
+      <div id="<%= selected_description_id %>">
         <p class="text-xs font-semibold tracking-wide text-slate-700 uppercase dark:text-slate-100">
           <%= selected[:title] %>
         </p>

--- a/app/components/viral/sortable_lists_guidance_component.rb
+++ b/app/components/viral/sortable_lists_guidance_component.rb
@@ -9,16 +9,27 @@ module Viral
   # @param keyboard_help [String] keyboard shortcut help
   # @param available [Hash] keys: title, description, icon (default: :plus)
   # @param selected [Hash] keys: title, description, icon (default: :list_bullets)
+  # @param id_prefix [String] stable ID prefix used by aria-describedby references
   class SortableListsGuidanceComponent < Viral::Component
     attr_reader :title, :instructions, :keyboard_help, :available, :selected, :id_prefix
 
-    def initialize(title:, instructions:, keyboard_help:, available:, selected:)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(title:, instructions:, keyboard_help:, available:, selected:, id_prefix: nil)
       @title = title
       @instructions = instructions
       @keyboard_help = keyboard_help
       @available = { icon: :plus }.merge(available)
       @selected = { icon: :list_bullets }.merge(selected)
-      @id_prefix = "sortable-lists-guidance-#{SecureRandom.hex(4)}"
+      @id_prefix = id_prefix || "sortable-lists-guidance-#{SecureRandom.hex(4)}"
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    def available_description_id
+      "#{id_prefix}-available-description"
+    end
+
+    def selected_description_id
+      "#{id_prefix}-selected-description"
     end
   end
 end

--- a/app/views/data_exports/_new_linelist_export_dialog.html.erb
+++ b/app/views/data_exports/_new_linelist_export_dialog.html.erb
@@ -83,10 +83,12 @@
 
         <% unless @namespace.metadata_fields.empty? %>
           <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100"><%= t(".metadata") %></h2>
+          <% sortable_lists_guidance_id = "linelist-export-fields-guidance" %>
           <%= render Viral::SortableListsGuidanceComponent.new(
             title: t(".fields_instructions_title"),
             instructions: t(".fields_instructions"),
             keyboard_help: t(".keyboard_help"),
+            id_prefix: sortable_lists_guidance_id,
             available: {
               title: t(".available_list_title"),
               description: t(".available_description"),
@@ -102,13 +104,15 @@
             ) do |sortable_lists| %>
             <%= sortable_lists.with_list(
               id: "available-list",
-              title: t(".available"),
+              title: t(".available_list_title"),
               list_items: @namespace.metadata_fields,
+              describedby: "#{sortable_lists_guidance_id}-available-description",
             ) %>
 
             <%= sortable_lists.with_list(
               id: "selected-list",
-              title: t(".selected"),
+              title: t(".selected_list_title"),
+              describedby: "#{sortable_lists_guidance_id}-selected-description",
             ) %>
           <% end %>
           <template id="sortable-list-item-template" data-sortable-lists--v1--two-lists-selection-target="itemTemplate">

--- a/app/views/data_exports/_new_sample_export_dialog.html.erb
+++ b/app/views/data_exports/_new_sample_export_dialog.html.erb
@@ -80,11 +80,13 @@
         <%= render partial: "shared/form/required_field_legend" %>
 
         <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100"><%= t(".select_formats") %></h2>
+        <% sortable_lists_guidance_id = "sample-export-format-guidance" %>
 
         <%= render Viral::SortableListsGuidanceComponent.new(
           title: t(".fields_instructions_title"),
           instructions: t(".fields_instructions"),
           keyboard_help: t(".keyboard_help"),
+          id_prefix: sortable_lists_guidance_id,
           available: {
             title: t(".available_list_title"),
             description: t(".available_description"),
@@ -98,14 +100,16 @@
         <%= render SortableListsComponent.new do |sortable_lists| %>
           <%= sortable_lists.with_list(
             id: "available-list",
-            title: t(".available"),
+            title: t(".available_list_title"),
+            describedby: "#{sortable_lists_guidance_id}-available-description",
           ) %>
 
           <%= sortable_lists.with_list(
             id: "selected-list",
-            title: t(".selected"),
+            title: t(".selected_list_title"),
             list_items: formats,
             required: true,
+            describedby: "#{sortable_lists_guidance_id}-selected-description",
           ) %>
         <% end %>
 

--- a/app/views/shared/metadata_templates/_form.html.erb
+++ b/app/views/shared/metadata_templates/_form.html.erb
@@ -20,6 +20,9 @@
     <% invalid_fields = @metadata_template.errors&.include?(:fields) %>
     <% fields_error_id = invalid_fields ? form.field_id(:fields, "error") : nil %>
     <% fields_describedby = [fields_error_id].compact.join(" ") %>
+    <% sortable_lists_guidance_id = "metadata-template-fields-guidance" %>
+    <% available_fields_describedby = "#{sortable_lists_guidance_id}-available-description" %>
+    <% selected_fields_describedby = ["#{sortable_lists_guidance_id}-selected-description", fields_describedby.presence].compact.join(" ") %>
 
     <div class="grid gap-5">
       <section aria-labelledby="metadata-template-details-heading" class="grid gap-4">
@@ -86,6 +89,7 @@
           title: t("metadata_templates.form.fields_instructions_title"),
           instructions: t("metadata_templates.form.fields_instructions"),
           keyboard_help: t("metadata_templates.form.keyboard_help"),
+          id_prefix: sortable_lists_guidance_id,
           available: {
             title: t("metadata_templates.form.available_list_title"),
             description: t("metadata_templates.form.available_description"),
@@ -99,16 +103,17 @@
         <%= render SortableListsComponent.new do |sortable_lists| %>
           <%= sortable_lists.with_list(
             id: "available-list",
-            title: t("metadata_templates.form.available"),
+            title: t("metadata_templates.form.available_list_title"),
             list_items: @available_metadata_fields,
+            describedby: available_fields_describedby,
           ) %>
 
           <%= sortable_lists.with_list(
             id: "selected-list",
-            title: t("metadata_templates.form.selected"),
+            title: t("metadata_templates.form.selected_list_title"),
             list_items: @current_template_fields,
             required: true,
-            describedby: fields_describedby.presence,
+            describedby: selected_fields_describedby,
           ) %>
         <% end %>
 

--- a/app/views/shared/samples/metadata/file_imports/_form_fields.html.erb
+++ b/app/views/shared/samples/metadata/file_imports/_form_fields.html.erb
@@ -89,11 +89,13 @@
 
   <div data-metadata--file-import-target="metadataColumns" aria-hidden="true" class="grid hidden gap-4">
     <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100"><%= t(".metadata_columns") %></h2>
+    <% sortable_lists_guidance_id = "metadata-file-import-fields-guidance" %>
 
     <%= render Viral::SortableListsGuidanceComponent.new(
               title: t(".fields_instructions_title"),
               instructions: t(".fields_instructions"),
               keyboard_help: t(".keyboard_help"),
+              id_prefix: sortable_lists_guidance_id,
               available: {
                 title: t(".available_list_title"),
                 description: t(".available_description"),
@@ -107,13 +109,15 @@
     <%= render SortableListsComponent.new do |sortable_lists| %>
       <%= sortable_lists.with_list(
                 id: "available-list",
-                title: t(".available"),
+                title: t(".available_list_title"),
+                describedby: "#{sortable_lists_guidance_id}-available-description",
               ) %>
 
       <%= sortable_lists.with_list(
                 id: "selected-list",
-                title: t(".selected"),
+                title: t(".selected_list_title"),
                 required: true,
+                describedby: "#{sortable_lists_guidance_id}-selected-description",
               ) %>
     <% end %>
   </div>

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -222,10 +222,13 @@
               <%= t("shared.samples.spreadsheet_imports.dialog.metadata") %>
             </h2>
 
+            <% sortable_lists_guidance_id = "sample-spreadsheet-import-fields-guidance" %>
+
             <%= render Viral::SortableListsGuidanceComponent.new(
               title: t("shared.samples.spreadsheet_imports.dialog.fields_instructions_title"),
               instructions: t("shared.samples.spreadsheet_imports.dialog.fields_instructions"),
               keyboard_help: t("shared.samples.spreadsheet_imports.dialog.keyboard_help"),
+              id_prefix: sortable_lists_guidance_id,
               available: {
                 title: t("shared.samples.spreadsheet_imports.dialog.available_list_title"),
                 description: t("shared.samples.spreadsheet_imports.dialog.available_description"),
@@ -239,12 +242,14 @@
             <%= render SortableListsComponent.new do |sortable_lists| %>
               <%= sortable_lists.with_list(
                 id: "available-list",
-                title: t("shared.samples.spreadsheet_imports.dialog.available"),
+                title: t("shared.samples.spreadsheet_imports.dialog.available_list_title"),
+                describedby: "#{sortable_lists_guidance_id}-available-description",
               ) %>
 
               <%= sortable_lists.with_list(
                 id: "selected-list",
-                title: t("shared.samples.spreadsheet_imports.dialog.selected"),
+                title: t("shared.samples.spreadsheet_imports.dialog.selected_list_title"),
+                describedby: "#{sortable_lists_guidance_id}-selected-description",
               ) %>
             <% end %>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1976,7 +1976,7 @@ en:
             ok_button: OK
           form_fields:
             available_description: Metadata columns from your file that will not be imported into sample metadata.
-            available_list_title: Not imported
+            available_list_title: Available metadata
             description: Importing a metadata spreadsheet allows multiple metadata fields to multiple samples be added, updated or removed at once.
             fields_instructions: Select the metadata columns to import by moving them to the selected list. The ordering of the selected list determines import order.
             fields_instructions_title: How the lists work
@@ -1993,7 +1993,7 @@ en:
             sample_id_column: Sample Identifier Column
             select_sample_id_column: Select a Sample Identifier Column
             selected_description: Metadata columns that will be imported into sample metadata.
-            selected_list_title: Will be imported
+            selected_list_title: Selected metadata
             submit_button: Import Metadata
           success:
             description: The metadata was imported successfully!
@@ -2013,7 +2013,7 @@ en:
       spreadsheet_imports:
         dialog:
           available_description: Metadata fields from your file that will not be imported into sample metadata.
-          available_list_title: Not imported
+          available_list_title: Available metadata
           description: Importing a sample spreadsheet allows multiple samples with or without metadata fields to be added at once.
           fields_instructions: Select the metadata fields to import by moving them to the selected list. The ordering of the selected list determines import order.
           fields_instructions_title: How the lists work
@@ -2037,7 +2037,7 @@ en:
           select_sample_name_column: Select a Sample Name Column
           select_static_project: Select Static Project
           selected_description: Metadata fields that will be imported into sample metadata.
-          selected_list_title: Will be imported
+          selected_list_title: Selected metadata
           static_project: Static Project
           static_project_description: Assigns each sample to the static project if either the Project ID column isn't assigned, or if the Project ID column is assigned but the project value within the spreadsheet is either empty or invalid
           static_project_empty_state: No projects are associated with that name or ID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -541,7 +541,6 @@ en:
         zero: Workflow Executions (0 selected)
       title: Analysis Export
     new_linelist_export_dialog:
-      available: Available
       available_description: Metadata fields that will not be included in the export.
       available_list_title: Not in export
       close_progress: Close export progress
@@ -556,7 +555,6 @@ en:
       no_selection: Please select at least 1 sample before exporting.
       preparing_export: Preparing linelist export for %{count} rows...
       preparing_rows: Preparing %{count} rows
-      selected: Selected
       selected_count: 'Selected samples: %{count}'
       selected_description: Metadata fields included in the export. Reorder this list to control column order.
       selected_list_title: In export
@@ -566,7 +564,6 @@ en:
       xlsx: ".xlsx"
       xlsx_load_error: Unable to load the XLSX export library. Please retry or export as CSV.
     new_sample_export_dialog:
-      available: Available
       available_description: File formats not included in this export. By default, all formats are included.
       available_list_title: Not in export
       fields_instructions: Select file formats to restrict which files are included in the export. Move formats to the selected list to include only those formats.
@@ -574,7 +571,6 @@ en:
       keyboard_help: Keyboard shortcuts are available on the list action buttons.
       samples: Samples
       select_formats: Select File Formats
-      selected: Selected
       selected_description: File formats included in the export. Only files matching these formats will be exported.
       selected_list_title: In export
       title: Sample Export
@@ -1162,7 +1158,6 @@ en:
     edit_template_dialog:
       title: Edit Metadata Template
     form:
-      available: Available
       available_description: Fields not currently included in this template. Move fields to the selected list to make them available in this template.
       available_list_title: Not currently in template
       description_hint: Optional. Describe when this template should be used.
@@ -1173,7 +1168,6 @@ en:
       keyboard_help: Keyboard shortcuts are available on the list action buttons.
       metadata: Metadata fields
       name_hint: Required. Choose a descriptive template name.
-      selected: Selected
       selected_description: Fields included in this template. Reorder this list to control display order. At least one field is required.
       selected_list_title: Currently in template
     new_template_dialog:
@@ -1981,7 +1975,6 @@ en:
             description: 'The sample metadata import completed with the following errors:'
             ok_button: OK
           form_fields:
-            available: Available
             available_description: Metadata columns from your file that will not be imported into sample metadata.
             available_list_title: Not imported
             description: Importing a metadata spreadsheet allows multiple metadata fields to multiple samples be added, updated or removed at once.
@@ -1999,7 +1992,6 @@ en:
             no_valid_metadata: The uploaded spreadsheet contains no viable metadata
             sample_id_column: Sample Identifier Column
             select_sample_id_column: Select a Sample Identifier Column
-            selected: Selected
             selected_description: Metadata columns that will be imported into sample metadata.
             selected_list_title: Will be imported
             submit_button: Import Metadata
@@ -2020,7 +2012,6 @@ en:
         tooltip: Metadata display settings
       spreadsheet_imports:
         dialog:
-          available: Available
           available_description: Metadata fields from your file that will not be imported into sample metadata.
           available_list_title: Not imported
           description: Importing a sample spreadsheet allows multiple samples with or without metadata fields to be added at once.
@@ -2045,7 +2036,6 @@ en:
           select_sample_description_column: Select a Sample Description Column
           select_sample_name_column: Select a Sample Name Column
           select_static_project: Select Static Project
-          selected: Selected
           selected_description: Metadata fields that will be imported into sample metadata.
           selected_list_title: Will be imported
           static_project: Static Project

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -542,7 +542,7 @@ en:
       title: Analysis Export
     new_linelist_export_dialog:
       available_description: Metadata fields that will not be included in the export.
-      available_list_title: Not in export
+      available_list_title: Available metadata
       close_progress: Close export progress
       created_records: Created %{current} of %{total} records
       csv: ".csv"
@@ -557,7 +557,7 @@ en:
       preparing_rows: Preparing %{count} rows
       selected_count: 'Selected samples: %{count}'
       selected_description: Metadata fields included in the export. Reorder this list to control column order.
-      selected_list_title: In export
+      selected_list_title: Selected metadata
       start_error: 'Unable to start export: %{message}'
       title: Linelist Export
       unexpected_error: 'Unexpected error while generating export: %{message}'
@@ -565,14 +565,14 @@ en:
       xlsx_load_error: Unable to load the XLSX export library. Please retry or export as CSV.
     new_sample_export_dialog:
       available_description: File formats not included in this export. By default, all formats are included.
-      available_list_title: Not in export
+      available_list_title: Available metadata
       fields_instructions: Select file formats to restrict which files are included in the export. Move formats to the selected list to include only those formats.
       fields_instructions_title: How the lists work
       keyboard_help: Keyboard shortcuts are available on the list action buttons.
       samples: Samples
       select_formats: Select File Formats
       selected_description: File formats included in the export. Only files matching these formats will be exported.
-      selected_list_title: In export
+      selected_list_title: Selected metadata
       title: Sample Export
     new_single_analysis_export_dialog:
       single_selection: Workflow Executions (1 selected)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -565,14 +565,14 @@ en:
       xlsx_load_error: Unable to load the XLSX export library. Please retry or export as CSV.
     new_sample_export_dialog:
       available_description: File formats not included in this export. By default, all formats are included.
-      available_list_title: Available metadata
+      available_list_title: Available file formats
       fields_instructions: Select file formats to restrict which files are included in the export. Move formats to the selected list to include only those formats.
       fields_instructions_title: How the lists work
       keyboard_help: Keyboard shortcuts are available on the list action buttons.
       samples: Samples
       select_formats: Select File Formats
       selected_description: File formats included in the export. Only files matching these formats will be exported.
-      selected_list_title: Selected metadata
+      selected_list_title: Selected file formats
       title: Sample Export
     new_single_analysis_export_dialog:
       single_selection: Workflow Executions (1 selected)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1980,7 +1980,7 @@ fr:
             ok_button: OK
           form_fields:
             available_description: Colonnes de métadonnées de votre fichier qui ne seront pas importées dans les métadonnées d’échantillon.
-            available_list_title: Non importé
+            available_list_title: Métadonnées disponibles
             description: L’importation d’une feuille de calcul de métadonnées permet d’ajouter, de mettre à jour ou de supprimer plusieurs champs de métadonnées dans plusieurs échantillons à la fois.
             fields_instructions: Sélectionnez les colonnes de métadonnées à importer en les déplaçant vers la liste sélectionnée. L’ordre de la liste sélectionnée détermine l’ordre d’importation.
             fields_instructions_title: Fonctionnement des listes
@@ -1997,7 +1997,7 @@ fr:
             sample_id_column: Colonne identificateur de l’échantillon
             select_sample_id_column: Sélectionner une colonne identificateur de l’échantillon
             selected_description: Colonnes de métadonnées qui seront importées dans les métadonnées d’échantillon.
-            selected_list_title: Sera importé
+            selected_list_title: Métadonnées sélectionnées
             submit_button: Importer des métadonnées
           success:
             description: Les métadonnées ont été importées avec succès!
@@ -2017,7 +2017,7 @@ fr:
       spreadsheet_imports:
         dialog:
           available_description: Champs de métadonnées de votre fichier qui ne seront pas importés dans les métadonnées d’échantillon.
-          available_list_title: Non importé
+          available_list_title: Métadonnées disponibles
           description: Importer un tableur d’échantillons permet d’ajouter plusieurs échantillons, avec ou sans champs de métadonnées, en même temps.
           fields_instructions: Sélectionnez les champs de métadonnées à importer en les déplaçant vers la liste sélectionnée. L’ordre de la liste sélectionnée détermine l’ordre d’importation.
           fields_instructions_title: Fonctionnement des listes
@@ -2041,7 +2041,7 @@ fr:
           select_sample_name_column: Sélectionner une colonne de nom d’échantillon
           select_static_project: Sélectionner un projet statique
           selected_description: Champs de métadonnées qui seront importés dans les métadonnées d'échantillon.
-          selected_list_title: Sera importé
+          selected_list_title: Métadonnées sélectionnées
           static_project: Projet statique
           static_project_description: Attribue chaque échantillon au projet statique si la colonne d’identifiant du projet n’est pas attribuée, ou si la colonne d’identifiant du projet est attribuée mais que la valeur du projet dans le tableur est vide ou non valide.
           static_project_empty_state: Aucun projet n’est associé à ce nom ou à cet identifiant

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -565,14 +565,14 @@ fr:
       xlsx_load_error: Impossible de charger la bibliothèque d’exportation XLSX. Veuillez réessayer ou exporter en CSV.
     new_sample_export_dialog:
       available_description: Formats de fichiers non inclus dans cette exportation. Par défaut, tous les formats sont inclus.
-      available_list_title: Métadonnées disponibles
+      available_list_title: Formats de fichiers disponibles
       fields_instructions: Sélectionnez les formats de fichiers à inclure dans l’exportation. Déplacez les formats vers la liste sélectionnée pour n’inclure que ces formats.
       fields_instructions_title: Fonctionnement des listes
       keyboard_help: Des raccourcis clavier sont disponibles sur les boutons d’action des listes.
       samples: Échantillons
       select_formats: Sélectionner les formats de fichiers
       selected_description: Formats de fichiers inclus dans l’exportation. Seuls les fichiers correspondant à ces formats seront exportés.
-      selected_list_title: Métadonnées sélectionnées
+      selected_list_title: Formats de fichiers sélectionnés
       title: Exportation d’échantillons
     new_single_analysis_export_dialog:
       single_selection: Exécutions de flux de travail (1 sélectionné)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -541,7 +541,6 @@ fr:
         zero: Exécutions de flux de travail (0 sélectionné)
       title: Analyser les exportations
     new_linelist_export_dialog:
-      available: Disponible
       available_description: Champs de métadonnées qui ne seront pas inclus dans l’exportation.
       available_list_title: Non inclus dans l’exportation
       close_progress: Fermer la progression de l’exportation
@@ -556,7 +555,6 @@ fr:
       no_selection: Veuillez sélectionner au moins 1 échantillon avant d'exporter.
       preparing_export: Préparation de l’exportation pour %{count} lignes...
       preparing_rows: Préparation de %{count} lignes
-      selected: Sélectionné
       selected_count: 'Échantillons sélectionnés : %{count}'
       selected_description: Champs de métadonnées inclus dans l’exportation. Réorganisez cette liste pour contrôler l’ordre des colonnes.
       selected_list_title: Inclus dans l’exportation
@@ -566,7 +564,6 @@ fr:
       xlsx: ".xlsx"
       xlsx_load_error: Impossible de charger la bibliothèque d’exportation XLSX. Veuillez réessayer ou exporter en CSV.
     new_sample_export_dialog:
-      available: Disponible
       available_description: Formats de fichiers non inclus dans cette exportation. Par défaut, tous les formats sont inclus.
       available_list_title: Non inclus dans l’exportation
       fields_instructions: Sélectionnez les formats de fichiers à inclure dans l’exportation. Déplacez les formats vers la liste sélectionnée pour n’inclure que ces formats.
@@ -574,7 +571,6 @@ fr:
       keyboard_help: Des raccourcis clavier sont disponibles sur les boutons d’action des listes.
       samples: Échantillons
       select_formats: Sélectionner les formats de fichiers
-      selected: Sélectionné
       selected_description: Formats de fichiers inclus dans l’exportation. Seuls les fichiers correspondant à ces formats seront exportés.
       selected_list_title: Inclus dans l’exportation
       title: Exportation d’échantillons
@@ -1166,7 +1162,6 @@ fr:
     edit_template_dialog:
       title: Modifier le modèle de métadonnées
     form:
-      available: Disponible
       available_description: Champs qui ne sont pas encore inclus dans ce modèle. Déplacez les champs vers la liste sélectionnée pour les rendre disponibles dans ce modèle.
       available_list_title: Non inclus dans le modèle
       description_hint: Facultatif. Décrivez quand ce modèle devrait être utilisé.
@@ -1177,7 +1172,6 @@ fr:
       keyboard_help: Des raccourcis clavier sont disponibles sur les boutons d’action des listes.
       metadata: Champs de métadonnées
       name_hint: Requis. Choisissez un nom de modèle descriptif.
-      selected: Sélectionné
       selected_description: Champs inclus dans ce modèle. Réorganisez cette liste pour contrôler l’ordre d’affichage. Au moins un champ est requis.
       selected_list_title: Inclus dans le modèle
     new_template_dialog:
@@ -1985,7 +1979,6 @@ fr:
             description: 'L’importation des échantillons de métadonnées s’est terminée avec les erreurs suivantes:'
             ok_button: OK
           form_fields:
-            available: Disponible
             available_description: Colonnes de métadonnées de votre fichier qui ne seront pas importées dans les métadonnées d’échantillon.
             available_list_title: Non importé
             description: L’importation d’une feuille de calcul de métadonnées permet d’ajouter, de mettre à jour ou de supprimer plusieurs champs de métadonnées dans plusieurs échantillons à la fois.
@@ -2003,7 +1996,6 @@ fr:
             no_valid_metadata: Le chiffrier téléchargé ne contient aucune métadonnée viable.
             sample_id_column: Colonne identificateur de l’échantillon
             select_sample_id_column: Sélectionner une colonne identificateur de l’échantillon
-            selected: Sélectionné
             selected_description: Colonnes de métadonnées qui seront importées dans les métadonnées d’échantillon.
             selected_list_title: Sera importé
             submit_button: Importer des métadonnées
@@ -2024,7 +2016,6 @@ fr:
         tooltip: Paramètres d’affichage des métadonnées
       spreadsheet_imports:
         dialog:
-          available: Disponible
           available_description: Champs de métadonnées de votre fichier qui ne seront pas importés dans les métadonnées d’échantillon.
           available_list_title: Non importé
           description: Importer un tableur d’échantillons permet d’ajouter plusieurs échantillons, avec ou sans champs de métadonnées, en même temps.
@@ -2049,7 +2040,6 @@ fr:
           select_sample_description_column: Sélectionner une colonne de description de l’échantillon
           select_sample_name_column: Sélectionner une colonne de nom d’échantillon
           select_static_project: Sélectionner un projet statique
-          selected: Sélectionné
           selected_description: Champs de métadonnées qui seront importés dans les métadonnées d'échantillon.
           selected_list_title: Sera importé
           static_project: Projet statique

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -542,7 +542,7 @@ fr:
       title: Analyser les exportations
     new_linelist_export_dialog:
       available_description: Champs de métadonnées qui ne seront pas inclus dans l’exportation.
-      available_list_title: Non inclus dans l’exportation
+      available_list_title: Métadonnées disponibles
       close_progress: Fermer la progression de l’exportation
       created_records: Créé %{current} sur %{total} enregistrements
       csv: ".csv"
@@ -557,7 +557,7 @@ fr:
       preparing_rows: Préparation de %{count} lignes
       selected_count: 'Échantillons sélectionnés : %{count}'
       selected_description: Champs de métadonnées inclus dans l’exportation. Réorganisez cette liste pour contrôler l’ordre des colonnes.
-      selected_list_title: Inclus dans l’exportation
+      selected_list_title: Métadonnées sélectionnées
       start_error: 'Impossible de démarrer l’exportation : %{message}'
       title: Exportation de liste détaillée
       unexpected_error: 'Erreur inattendue lors de la génération de l’exportation : %{message}'
@@ -565,14 +565,14 @@ fr:
       xlsx_load_error: Impossible de charger la bibliothèque d’exportation XLSX. Veuillez réessayer ou exporter en CSV.
     new_sample_export_dialog:
       available_description: Formats de fichiers non inclus dans cette exportation. Par défaut, tous les formats sont inclus.
-      available_list_title: Non inclus dans l’exportation
+      available_list_title: Métadonnées disponibles
       fields_instructions: Sélectionnez les formats de fichiers à inclure dans l’exportation. Déplacez les formats vers la liste sélectionnée pour n’inclure que ces formats.
       fields_instructions_title: Fonctionnement des listes
       keyboard_help: Des raccourcis clavier sont disponibles sur les boutons d’action des listes.
       samples: Échantillons
       select_formats: Sélectionner les formats de fichiers
       selected_description: Formats de fichiers inclus dans l’exportation. Seuls les fichiers correspondant à ces formats seront exportés.
-      selected_list_title: Inclus dans l’exportation
+      selected_list_title: Métadonnées sélectionnées
       title: Exportation d’échantillons
     new_single_analysis_export_dialog:
       single_selection: Exécutions de flux de travail (1 sélectionné)

--- a/test/components/sortable_lists_component_test.rb
+++ b/test/components/sortable_lists_component_test.rb
@@ -36,6 +36,32 @@ class SortableListsComponentTest < ViewComponentTestCase
     assert_no_selector 'li[role="option"] a, li[role="option"] button, li[role="option"] input'
   end
 
+  test 'renders contextual list labels and describedby references' do
+    component = SortableListsComponent.new(required: true)
+    component.with_list(
+      id: 'available-list',
+      title: 'Not imported',
+      list_items: ['One'],
+      describedby: 'metadata-guidance-available-description'
+    )
+    component.with_list(
+      id: 'selected-list',
+      title: 'Will be imported',
+      list_items: ['Two'],
+      required: true,
+      describedby: 'metadata-guidance-selected-description metadata_fields_error'
+    )
+
+    render_inline(component)
+
+    assert_selector '#available-list-list-label', text: 'Not imported'
+    assert_selector '#selected-list-list-label', text: 'Will be imported'
+    assert_selector 'ul#available-list[aria-describedby*="metadata-guidance-available-description"]'
+    assert_selector 'ul#selected-list[aria-describedby*="metadata-guidance-selected-description"]'
+    assert_selector 'ul#selected-list[aria-describedby*="metadata_fields_error"]'
+    assert_selector 'ul#selected-list[aria-describedby*="selected-list-required"]'
+  end
+
   test 'renders required state only on the selected listbox' do
     component = SortableListsComponent.new(required: true)
     component.with_list(id: 'available-list', title: 'Available', list_items: ['One'])

--- a/test/components/viral/sortable_lists_guidance_component_test.rb
+++ b/test/components/viral/sortable_lists_guidance_component_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Viral
+  class SortableListsGuidanceComponentTest < ViewComponent::TestCase
+    test 'renders stable description ids for list aria-describedby references' do
+      render_inline(
+        Viral::SortableListsGuidanceComponent.new(
+          title: 'How the lists work',
+          instructions: 'Move fields between lists.',
+          keyboard_help: 'Keyboard shortcuts are available.',
+          id_prefix: 'metadata-guidance',
+          available: {
+            title: 'Not imported',
+            description: 'Fields that will not be imported.'
+          },
+          selected: {
+            title: 'Will be imported',
+            description: 'Fields that will be imported.'
+          }
+        )
+      )
+
+      assert_selector '#metadata-guidance-available-description', text: 'Not imported'
+      assert_selector '#metadata-guidance-available-description', text: 'Fields that will not be imported.'
+      assert_selector '#metadata-guidance-selected-description', text: 'Will be imported'
+      assert_selector '#metadata-guidance-selected-description', text: 'Fields that will be imported.'
+    end
+
+    test 'generates valid description ids when no id_prefix is provided' do
+      component = Viral::SortableListsGuidanceComponent.new(
+        title: 'How the lists work',
+        instructions: 'Move fields between lists.',
+        keyboard_help: 'Keyboard shortcuts are available.',
+        available: { title: 'Not imported', description: 'Fields that will not be imported.' },
+        selected: { title: 'Will be imported', description: 'Fields that will be imported.' }
+      )
+
+      assert_match(/\Asortable-lists-guidance-[0-9a-f]{8}-available-description\z/, component.available_description_id)
+      assert_match(/\Asortable-lists-guidance-[0-9a-f]{8}-selected-description\z/, component.selected_description_id)
+
+      render_inline(component)
+
+      assert_selector "[id='#{component.available_description_id}']", text: 'Not imported'
+      assert_selector "[id='#{component.selected_description_id}']", text: 'Will be imported'
+    end
+  end
+end

--- a/test/system/data_exports_test.rb
+++ b/test/system/data_exports_test.rb
@@ -943,8 +943,8 @@ class DataExportsTest < ApplicationSystemTestCase
       assert_text I18n.t('data_exports.new.samples_count.non_zero').gsub! 'COUNT_PLACEHOLDER', '1'
       assert_text I18n.t('data_exports.new_linelist_export_dialog.metadata')
       assert_text I18n.t('data_exports.new_linelist_export_dialog.fields_instructions')
-      assert_text I18n.t('data_exports.new_linelist_export_dialog.available')
-      assert_text I18n.t('data_exports.new_linelist_export_dialog.selected')
+      assert_text I18n.t('data_exports.new_linelist_export_dialog.available_list_title')
+      assert_text I18n.t('data_exports.new_linelist_export_dialog.selected_list_title')
       assert_selector 'button[aria-disabled="true"]',
                       text: I18n.t('common.actions.remove')
       assert_selector 'button[aria-disabled="true"]',

--- a/test/system/groups/metadata_templates_test.rb
+++ b/test/system/groups/metadata_templates_test.rb
@@ -83,8 +83,8 @@ module Groups
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: group.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -123,8 +123,8 @@ module Groups
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: group.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -150,8 +150,8 @@ module Groups
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: group.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -186,8 +186,8 @@ module Groups
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: group.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -227,8 +227,8 @@ module Groups
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: group.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -280,8 +280,8 @@ module Groups
 
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li",
                       count: group.metadata_fields.count - metadata_template.fields.count

--- a/test/system/groups/samples_test.rb
+++ b/test/system/groups/samples_test.rb
@@ -698,8 +698,8 @@ module Groups
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/invalid.txt')
       select 'invalid file extension', from: I18n.t('shared.samples.metadata.file_imports.form_fields.sample_id_column')
 
-      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.selected_list_title')
       click_button I18n.t('shared.samples.metadata.file_imports.form_fields.submit_button')
       ### ACTIONS END ###
 

--- a/test/system/projects/metadata_templates_test.rb
+++ b/test/system/projects/metadata_templates_test.rb
@@ -91,8 +91,8 @@ module Projects
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: project.namespace.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -135,8 +135,8 @@ module Projects
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: project.namespace.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -161,8 +161,8 @@ module Projects
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: project.namespace.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -226,8 +226,8 @@ module Projects
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: project.namespace.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -267,8 +267,8 @@ module Projects
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.new_template_dialog.title')
       assert_text I18n.t('metadata_templates.form.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: project.namespace.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0
@@ -318,8 +318,8 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t('metadata_templates.edit_template_dialog.title')
 
-      available_label_id = find('p', text: I18n.t(:'metadata_templates.form.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'metadata_templates.form.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li",
                       count: project.namespace.metadata_fields.count - metadata_template.fields.count

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -990,11 +990,11 @@ module Projects
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/valid.csv')
 
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 3
@@ -1063,11 +1063,11 @@ module Projects
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/valid.xlsx')
 
       assert_field I18n.t(:'shared.samples.metadata.file_imports.form_fields.sample_id_column')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 5
@@ -1139,11 +1139,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/valid.xlsx')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 5
@@ -1250,8 +1250,8 @@ module Projects
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/invalid.txt')
 
       select 'invalid file extension', from: I18n.t('shared.samples.metadata.file_imports.form_fields.sample_id_column')
-      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t('shared.samples.metadata.file_imports.form_fields.selected_list_title')
       click_button I18n.t('shared.samples.metadata.file_imports.form_fields.submit_button')
       ### ACTIONS END ###
 
@@ -1289,11 +1289,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/contains_empty_values.csv')
-      assert_selector 'p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_selector 'p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_selector 'p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_selector 'p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 3
@@ -1347,11 +1347,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/contains_empty_values.csv')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 3
@@ -1404,11 +1404,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/valid_with_whitespaces.csv')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 4
@@ -1467,11 +1467,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/duplicate_headers.csv')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 4
@@ -1508,11 +1508,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/missing_metadata_rows.csv')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 3
@@ -1585,11 +1585,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/mixed_project_samples.csv')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 3
@@ -1650,11 +1650,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/contains_analysis_values.csv')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 2
@@ -1720,11 +1720,11 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.metadata.file_imports.dialog.title')
       attach_file 'file_import[file]', Rails.root.join('test/fixtures/files/metadata/contains_ignored_headers.csv')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available')
-      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.available_list_title')
+      assert_text I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 3
@@ -1871,11 +1871,11 @@ module Projects
       assert_selector 'dialog h1', text: I18n.t(:'shared.samples.spreadsheet_imports.dialog.title')
       attach_file('spreadsheet_import[file]',
                   Rails.root.join('test/fixtures/files/batch_sample_import/project/valid_with_whitespaces.csv'))
-      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.available')
-      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.selected')
+      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.available_list_title')
+      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.spreadsheet_imports.dialog.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.spreadsheet_imports.dialog.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 3
@@ -2027,11 +2027,11 @@ module Projects
       # metadata sortable lists no longer hidden
       assert_selector 'dialog div', text: I18n.t('shared.samples.spreadsheet_imports.dialog.metadata')
 
-      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.available')
-      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.selected')
+      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.available_list_title')
+      assert_text I18n.t(:'shared.samples.spreadsheet_imports.dialog.selected_list_title')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.spreadsheet_imports.dialog.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.spreadsheet_imports.dialog.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 2
@@ -2111,8 +2111,8 @@ module Projects
       # metadata sortable lists renders now that description header is available
       assert_selector 'dialog div', text: I18n.t('shared.samples.spreadsheet_imports.dialog.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.metadata.file_imports.form_fields.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", text: 'description'
@@ -2144,8 +2144,8 @@ module Projects
                   Rails.root.join('test/fixtures/files/batch_sample_import/project/with_metadata_valid.csv'))
       assert_selector 'dialog div', text: I18n.t('shared.samples.spreadsheet_imports.dialog.metadata')
 
-      available_label_id = find('p', text: I18n.t(:'shared.samples.spreadsheet_imports.dialog.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'shared.samples.spreadsheet_imports.dialog.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: 0
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 2
@@ -3610,8 +3610,8 @@ module Projects
 
       assert_selector 'dialog h1', text: I18n.t(:'data_exports.new_linelist_export_dialog.title')
 
-      available_label_id = find('p', text: I18n.t(:'data_exports.new_linelist_export_dialog.available'))[:id]
-      selected_label_id = find('p', text: I18n.t(:'data_exports.new_linelist_export_dialog.selected'))[:id]
+      available_label_id = 'available-list-list-label'
+      selected_label_id = 'selected-list-list-label'
 
       assert_selector "ul[aria-labelledby='#{available_label_id}'] li", count: @project.namespace.metadata_fields.count
       assert_selector "ul[aria-labelledby='#{selected_label_id}'] li", count: 0


### PR DESCRIPTION
## What does this PR do and why?

- Adds stable IDs to the "available" and "selected" description sections in `SortableListsGuidanceComponent` via new `available_description_id` / `selected_description_id` helpers and an optional `id_prefix` parameter.
- Wires those IDs into `aria-describedby` on each sortable list across all six call sites, so screen readers announce the guidance text when a list receives focus.

## Screenshots or screen recordings

### Sample Metadata Import
<img width="2561" height="1284" alt="image" src="https://github.com/user-attachments/assets/d2da797b-cda1-4a73-b222-09f4227da2a1" />

### Linelist Export
<img width="2561" height="1284" alt="image" src="https://github.com/user-attachments/assets/468b4afa-984c-4d15-9f44-7a3b001be037" />

### Sample Export
<img width="1874" height="778" alt="image" src="https://github.com/user-attachments/assets/60f74efe-4973-40b5-a2f0-01586d14f5ae" />

## How to set up and validate locally

1. `bin/dev`
2. Open any page with a dual-list selector (e.g. metadata templates form, linelist export dialog, sample export dialog, spreadsheet import dialog, metadata file import).
3. Tab into the "Available" or "Selected" list and confirm a screen reader announces the matching guidance description.
4. `PARALLEL_WORKERS=4 bin/rails test test/components/sortable_lists_component_test.rb test/components/viral/sortable_lists_guidance_component_test.rb`

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.