### PR TITLE
fix(dialog_controller): add type check for KeyboardEvent in handleEsc

### DIFF
--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -72,6 +72,10 @@ export default class extends Controller {
 
   handleEsc(event) {
     event.preventDefault();
+
+    if (!(event instanceof KeyboardEvent)) {
+      return;
+    }
     if (this.#closable) this.close();
   }
 


### PR DESCRIPTION
## What does this PR do and why?
- Adds a `KeyboardEvent` guard in `handleEsc` so the dialog only closes on a real Escape keydown.
- Avoids closing when `handleEsc` is invoked with a non-keyboard event.

## Screenshots or screen recordings
- N/A (no visual UI change; JavaScript behaviour only)

## How to set up and validate locally
1. Check out `fix/dialog-controller-handle-esc-keyboard-event` and start the app (`bin/dev`).
2. Go to a project samples page and open the Advanced Search Dialog
3. Selecting a value from the auto-suggested list should not close the dialog.
4. Press Escape and confirm the dialog closes as before.
5. Optional: `pnpm run test:js`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.