### PR TITLE
Project transfer form object with form error summary 

### DIFF
--- a/app/components/select2/v1/component.html.erb
+++ b/app/components/select2/v1/component.html.erb
@@ -20,7 +20,7 @@
     },
   ) %>
 
-  <%= form.hidden_field name, data: { "select2--v1-target": "hidden" } %>
+  <%= form.hidden_field name, id: form.field_id(name, 'hidden'), data: { "select2--v1-target": "hidden" } %>
 
   <%= tag.div(
     data: { "select2--v1-target": "dropdown" },

--- a/app/components/select2/v1/component.html.erb
+++ b/app/components/select2/v1/component.html.erb
@@ -20,7 +20,7 @@
     },
   ) %>
 
-  <%= form.hidden_field name, id: "#{id}-hidden", data: { "select2--v1-target": "hidden" } %>
+  <%= form.hidden_field name, data: { "select2--v1-target": "hidden" } %>
 
   <%= tag.div(
     data: { "select2--v1-target": "dropdown" },

--- a/app/components/select2/v1/component.html.erb
+++ b/app/components/select2/v1/component.html.erb
@@ -20,7 +20,7 @@
     },
   ) %>
 
-  <%= form.hidden_field name, data: { "select2--v1-target": "hidden" } %>
+  <%= form.hidden_field name, id: "#{id}-hidden", data: { "select2--v1-target": "hidden" } %>
 
   <%= tag.div(
     data: { "select2--v1-target": "dropdown" },

--- a/app/components/select2/v2/component.html.erb
+++ b/app/components/select2/v2/component.html.erb
@@ -20,7 +20,7 @@
     },
   ) %>
 
-  <%= form.hidden_field name, id: "#{id}-hidden", data: { "select2--v2-target": "hidden" } %>
+  <%= form.hidden_field name, data: { "select2--v2-target": "hidden" } %>
 
   <%= tag.div(
     data: { "select2--v2-target": "dropdown" },

--- a/app/components/select2/v2/component.html.erb
+++ b/app/components/select2/v2/component.html.erb
@@ -20,7 +20,7 @@
     },
   ) %>
 
-  <%= form.hidden_field name, data: { "select2--v2-target": "hidden" } %>
+  <%= form.hidden_field name, id: "#{id}-hidden", data: { "select2--v2-target": "hidden" } %>
 
   <%= tag.div(
     data: { "select2--v2-target": "dropdown" },

--- a/app/components/select2/v2/component.html.erb
+++ b/app/components/select2/v2/component.html.erb
@@ -20,7 +20,7 @@
     },
   ) %>
 
-  <%= form.hidden_field name, data: { "select2--v2-target": "hidden" } %>
+  <%= form.hidden_field name, id: form.field_id(name, 'hidden'), data: { "select2--v2-target": "hidden" } %>
 
   <%= tag.div(
     data: { "select2--v2-target": "dropdown" },

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -92,7 +92,9 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
         flash[:success] = t('.success', project_name: @project.name)
         format.turbo_stream { redirect_to namespace_project_path(@project.namespace.parent, @project) }
       else
-        render status: :unprocessable_content
+        format.turbo_stream do
+          render status: :unprocessable_content
+        end
       end
     end
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,6 +34,7 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
     authorize! @project
     @samples_count = @project.samples.size
     @automated_workflows_count = WorkflowExecution.where(submitter: @project.namespace.automation_bot).size
+    @transfer_form = ::Projects::TransferForm.new
   end
 
   def create
@@ -84,14 +85,14 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
     end
   end
 
-  def transfer # rubocop:disable Metrics/AbcSize
-    if Projects::TransferService.new(@project, current_user).execute(new_namespace)
+  def transfer
+    @transfer_form = ::Projects::TransferForm.new(project_transfer_params.merge(project: @project))
+    if Projects::TransferService.new(@project, current_user, @transfer_form).execute
       flash[:success] = t('.success', project_name: @project.name)
       respond_to do |format|
         format.turbo_stream { redirect_to namespace_project_path(@project.namespace.parent, @project) }
       end
     else
-      @error = @project.errors.messages.values.flatten.first
       respond_to do |format|
         format.turbo_stream
       end
@@ -122,6 +123,10 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
     params.expect(project: project_params_attributes)
   end
 
+  def project_transfer_params
+    params.expect(projects_transfer_form: [:new_namespace_id])
+  end
+
   def namespace_attributes
     %i[
       name
@@ -142,10 +147,6 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
     return unless @project
 
     @authorized_namespaces = @authorized_namespaces.where.not(id: @project.namespace.parent.id)
-  end
-
-  def new_namespace
-    Namespace.find_by(id: params.expect(:new_namespace_id))
   end
 
   def resolve_layout

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -87,14 +87,12 @@ class ProjectsController < Projects::ApplicationController # rubocop:disable Met
 
   def transfer
     @transfer_form = ::Projects::TransferForm.new(project_transfer_params.merge(project: @project))
-    if Projects::TransferService.new(@project, current_user, @transfer_form).execute
-      flash[:success] = t('.success', project_name: @project.name)
-      respond_to do |format|
+    respond_to do |format|
+      if Projects::TransferService.new(@project, current_user, @transfer_form).execute
+        flash[:success] = t('.success', project_name: @project.name)
         format.turbo_stream { redirect_to namespace_project_path(@project.namespace.parent, @project) }
-      end
-    else
-      respond_to do |format|
-        format.turbo_stream
+      else
+        render status: :unprocessable_content
       end
     end
   end

--- a/app/forms/projects/transfer_form.rb
+++ b/app/forms/projects/transfer_form.rb
@@ -36,7 +36,7 @@ module Projects
         return
       end
 
-      return unless Namespaces::ProjectNamespace.where(parent_id: new_namespace.id)
+      return unless Namespaces::ProjectNamespace.where(parent_id: new_namespace_id)
                                                 .exists?(['path = ? or name = ?', project.path, project.name])
 
       errors.add(:new_namespace_id, :project_exists)

--- a/app/forms/projects/transfer_form.rb
+++ b/app/forms/projects/transfer_form.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Projects
+  # Form object for transferring projects
+  class TransferForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations::Callbacks
+
+    attribute :new_namespace_id, :string
+    attribute :project
+
+    validates :new_namespace_id, presence: true
+    validate :new_namespace_exists, if: -> { new_namespace_id.present? }
+    validate :project_does_not_conflict_with_new_namespace, if: -> { new_namespace_id.present? && project.present? }
+
+    def initialize(attributes = {})
+      super
+    end
+
+    def new_namespace
+      Namespace.find_by(id: new_namespace_id)
+    end
+
+    private
+
+    def new_namespace_exists
+      return unless new_namespace.nil?
+
+      errors.add(:new_namespace_id, :not_found)
+    end
+
+    def project_does_not_conflict_with_new_namespace
+      if new_namespace_id == project.namespace.parent_id
+        errors.add(:new_namespace_id, :cannot_be_same)
+        return
+      end
+
+      return unless Namespaces::ProjectNamespace.where(parent_id: new_namespace.id)
+                                                .exists?(['path = ? or name = ?', project.path, project.name])
+
+      errors.add(:new_namespace_id, :project_exists)
+    end
+  end
+end

--- a/app/forms/projects/transfer_form.rb
+++ b/app/forms/projects/transfer_form.rb
@@ -31,7 +31,7 @@ module Projects
     end
 
     def project_does_not_conflict_with_new_namespace
-      if new_namespace_id == project.namespace.parent_id
+      if new_namespace_id.to_s == project.namespace.parent_id.to_s
         errors.add(:new_namespace_id, :cannot_be_same)
         return
       end

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -42,7 +42,7 @@ export default class extends Controller {
       this.#blankValues["spreadsheet_import_project_puid_column"] =
         this.selectProjectValue;
       this.staticProjectInput = document.getElementById(
-        "static-project-select-hidden",
+        "spreadsheet_import_static_project_id",
       );
     }
   }

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -42,7 +42,7 @@ export default class extends Controller {
       this.#blankValues["spreadsheet_import_project_puid_column"] =
         this.selectProjectValue;
       this.staticProjectInput = document.getElementById(
-        "spreadsheet_import_static_project_id",
+        "spreadsheet_import_static_project_id_hidden",
       );
     }
   }

--- a/app/javascript/controllers/spreadsheet_import_controller.js
+++ b/app/javascript/controllers/spreadsheet_import_controller.js
@@ -42,7 +42,7 @@ export default class extends Controller {
       this.#blankValues["spreadsheet_import_project_puid_column"] =
         this.selectProjectValue;
       this.staticProjectInput = document.getElementById(
-        "spreadsheet_import_static_project_id",
+        "static-project-select-hidden",
       );
     }
   }

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -8,7 +8,7 @@ module Projects
       @transfer_form = transfer_form
     end
 
-    def execute
+    def execute # rubocop:disable Naming/PredicateMethod
       return false unless @transfer_form.valid?
 
       @new_namespace = @transfer_form.new_namespace
@@ -25,6 +25,8 @@ module Projects
       @new_namespace.update_metadata_summary_by_namespace_transfer(@project.namespace, @old_namespace)
 
       update_samples_count
+
+      true
     end
 
     private

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -3,20 +3,16 @@
 module Projects
   # Service used to Transfer Projects
   class TransferService < BaseProjectService
-    class TransferError < StandardError
+    def initialize(project, user = nil, transfer_form = nil)
+      super(project, user)
+      @transfer_form = transfer_form
     end
-    attr_reader :new_namespace, :old_namespace
 
-    def execute(new_namespace) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      @new_namespace = new_namespace
+    def execute
+      return false unless @transfer_form.valid?
+
+      @new_namespace = @transfer_form.new_namespace
       @old_namespace = @project.parent
-
-      raise TransferError, I18n.t('services.projects.transfer.namespace_empty') if @new_namespace.blank?
-
-      if @new_namespace.id == project.namespace.parent_id
-        raise TransferError,
-              I18n.t('services.projects.transfer.project_in_namespace')
-      end
 
       # Authorize if user can transfer project
       authorize! @project, to: :transfer?
@@ -29,26 +25,16 @@ module Projects
       @new_namespace.update_metadata_summary_by_namespace_transfer(@project.namespace, @old_namespace)
 
       update_samples_count
-
-      true
-    rescue Projects::TransferService::TransferError => e
-      project.errors.add(:new_namespace, e.message)
-      false
     end
 
     private
 
-    def transfer(project) # rubocop:disable Metrics/AbcSize
-      if Namespaces::ProjectNamespace.where(parent_id: new_namespace.id).exists?(['path = ? or name = ?',
-                                                                                  project.path, project.name])
-        raise TransferError, I18n.t('services.projects.transfer.namespace_project_exists')
-      end
-
+    def transfer(project)
       project_ancestor_member_user_ids = Member.for_namespace_and_ancestors(project.namespace).select(:user_id)
-      new_namespace_member_ids = Member.for_namespace_and_ancestors(new_namespace)
+      new_namespace_member_ids = Member.for_namespace_and_ancestors(@new_namespace)
                                        .where(user_id: project_ancestor_member_user_ids).select(&:id)
 
-      project.namespace.update(parent_id: new_namespace.id)
+      project.namespace.update(parent_id: @new_namespace.id)
 
       create_activities(project)
 

--- a/app/views/projects/_transfer_form.html.erb
+++ b/app/views/projects/_transfer_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: namespace_project_transfer_path, method: :post, class: "grid gap-4", id: "edit_advanced_transfer",
+<%= form_with(model: @transfer_form, url: namespace_project_transfer_path, method: :post, class: "grid gap-4", id: "edit_advanced_transfer",
               data:
               if Flipper.enabled?(:v2_select2, Current.user)
                 { turbo_confirm: "", controller: "select2--v2" }
@@ -7,11 +7,12 @@
               end) do |form| %>
   <div class="mb-2"><%= render partial: "shared/form/required_field_legend" %></div>
 
-  <div class="form-field">
-    <% form_id = "transfer-form-select2" %>
+  <% invalid_new_namespace_id = @transfer_form.errors.include?(:new_namespace_id) %>
+
+  <div class="form-field <%= 'invalid' if invalid_new_namespace_id %>">
+    <%= form_error_summary(form) %>
 
     <%= form.label :new_namespace_id, t(:"projects.edit.advanced.transfer.new_namespace_id"),
-                   for: form_id,
                    class: "mb-1 block text-sm font-medium text-slate-900 dark:text-white",
                    data: { required: true } %>
 
@@ -27,7 +28,7 @@
         autocomplete="off"
       >
     <% else %>
-      <%= render Select2Component.new(form:, name: :new_namespace_id, id: form_id, placeholder: t(:"projects.edit.advanced.transfer.select_namespace")) do |select| %>
+      <%= render Select2Component.new(form:, name: :new_namespace_id, id: form.field_id(:new_namespace_id), placeholder: t(:"projects.edit.advanced.transfer.select_namespace")) do |select| %>
         <% @authorized_namespaces.each do |namespace| %>
           <% select.with_option(
                       value: namespace.id,
@@ -48,8 +49,10 @@
       <% end %>
     <% end %>
 
-    <% if @error.present? %>
-      <p class="text-sm text-red-500 dark:text-red-400"><%= @error %></p>
+    <% if invalid_new_namespace_id %>
+      <%= render "shared/form/field_errors",
+              id: form.field_id(:new_namespace_id, "error"),
+              errors: @transfer_form.errors.full_messages_for(:new_namespace_id) %>
     <% end %>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1773,7 +1773,7 @@ en:
       samples: Samples
       workflow_executions: Workflow Executions
     transfer:
-      success: Success
+      success: Project %{project_name} was successfully transferred
     update:
       success: Project %{project_name} was successfully updated
     workflow_executions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,21 @@ en:
               cannot_be_same_as_old_parent: must be different from the current parent group
               namespace_group_exists: already has a group with the same name/path
               namespace_not_found: does not exist
+        projects/transfer_form:
+          attributes:
+            new_namespace_id:
+              blank: is empty
+              cannot_be_same: must be different from the current namespace
+              not_found: does not exist
+              project_exists: already has a project with the same name/path
+        sample/search_condition:
+          attributes:
+            field:
+              not_a_metadata: is an invalid metadata field
+            operator:
+              not_a_date_operator: cannot be used on dates
+            value:
+              not_a_date: must be formatted YYYY-MM-DD
   activerecord:
     attributes:
       attachment:
@@ -1882,10 +1897,6 @@ en:
     projects:
       create:
         namespace_required: Namespace required
-      transfer:
-        namespace_empty: Namespace empty
-        namespace_project_exists: Project with the same name or path already exists in the target namespace.
-        project_in_namespace: Project in namespace
     samples:
       batch_import:
         duplicate_sample_name: Duplicate sample name on index '%{index}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
         field: Group %{group_index} Condition %{condition_index} Field
         operator: Group %{group_index} Condition %{condition_index} Operator
         value: Group %{group_index} Condition %{condition_index} Value
+      projects/transfer_form:
+        new_namespace_id: New namespace
       sample/query:
         group: Group
       sample/search_condition:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,14 +64,6 @@ en:
               cannot_be_same: must be different from the current namespace
               not_found: does not exist
               project_exists: already has a project with the same name/path
-        sample/search_condition:
-          attributes:
-            field:
-              not_a_metadata: is an invalid metadata field
-            operator:
-              not_a_date_operator: cannot be used on dates
-            value:
-              not_a_date: must be formatted YYYY-MM-DD
   activerecord:
     attributes:
       attachment:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -12,6 +12,8 @@ fr:
         field: Groupe %{group_index} Condition %{condition_index} Champ
         operator: Groupe %{group_index} Condition %{condition_index} Opérateur
         value: Groupe %{group_index} Condition %{condition_index} Valeur
+      projects/transfer_form:
+        new_namespace_id: Nouvel espace de noms
       sample/query:
         group: Groupe
       sample/search_condition:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1777,7 +1777,7 @@ fr:
       samples: Échantillons
       workflow_executions: Exécutions de flux de travail
     transfer:
-      success: Réussite
+      success: Le projet %{project_name} a été transféré avec succès
     update:
       success: Le projet %{project_name} a été mis à jour avec succès
     workflow_executions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -55,6 +55,21 @@ fr:
               cannot_be_same_as_old_parent: doit être différent du groupe parent actuel
               namespace_group_exists: existe déjà un groupe portant le même nom/chemin
               namespace_not_found: n'existe pas
+        projects/transfer_form:
+          attributes:
+            new_namespace_id:
+              blank: est vide
+              cannot_be_same: doit être différent de l'espace de noms actuel
+              not_found: n'existe pas
+              project_exists: a déjà un projet avec le même nom/chemin
+        sample/search_condition:
+          attributes:
+            field:
+              not_a_metadata: est un champ de métadonnées non valide
+            operator:
+              not_a_date_operator: ne peut pas être utilisé sur les dates
+            value:
+              not_a_date: doit être formaté AAAA-MM-JJ
   activerecord:
     attributes:
       attachment:
@@ -1886,10 +1901,6 @@ fr:
     projects:
       create:
         namespace_required: Espace de noms requis
-      transfer:
-        namespace_empty: Espace de noms vide
-        namespace_project_exists: Un projet portant le même nom ou le même chemin existe déjà dans l’espace de noms cible.
-        project_in_namespace: Projet dans l’espace de noms
     samples:
       batch_import:
         duplicate_sample_name: Nom de l’échantillon en double sur l’index '%{index}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -64,14 +64,6 @@ fr:
               cannot_be_same: doit être différent de l'espace de noms actuel
               not_found: n'existe pas
               project_exists: a déjà un projet avec le même nom/chemin
-        sample/search_condition:
-          attributes:
-            field:
-              not_a_metadata: est un champ de métadonnées non valide
-            operator:
-              not_a_date_operator: ne peut pas être utilisé sur les dates
-            value:
-              not_a_date: doit être formaté AAAA-MM-JJ
   activerecord:
     attributes:
       attachment:

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -221,7 +221,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     old_namespace = groups(:group_one)
 
     post namespace_project_transfer_path(old_namespace, project),
-         params: { new_namespace_id: namespace.id }, as: :turbo_stream
+         params: { projects_transfer_form: { new_namespace_id: namespace.id } }, as: :turbo_stream
 
     assert_response :redirect
   end
@@ -231,8 +231,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     project = projects(:project1)
     old_namespace = groups(:group_one)
     post namespace_project_transfer_path(old_namespace, project),
-         params: { new_namespace_id: groups(:david_doe_group_four).id },
-         as: :turbo_stream
+         params: { projects_transfer_form: { new_namespace_id: groups(:david_doe_group_four).id } }, as: :turbo_stream
 
     assert_response :unauthorized
   end

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -18,31 +18,35 @@ module Projects
 
     test 'transfer project with permission' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project))
 
       assert_changes -> { @project.namespace.parent }, to: new_namespace do
-        Projects::TransferService.new(@project, @john_doe).execute(new_namespace)
+        Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       end
 
       assert_enqueued_with(job: UpdateMembershipsJob)
     end
 
     test 'transfer project without specifying new namespace' do
-      assert_not Projects::TransferService.new(@project, @john_doe).execute(nil)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: nil }.merge(project: @project))
+      assert_not Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       assert_no_enqueued_jobs(except: Turbo::Streams::BroadcastStreamJob)
     end
 
     test 'transfer project to namespace containing project' do
       group_one = groups(:group_one)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: group_one.id }.merge(project: @project))
 
-      assert_not Projects::TransferService.new(@project, @john_doe).execute(group_one)
+      assert_not Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       assert_no_enqueued_jobs(except: Turbo::Streams::BroadcastStreamJob)
     end
 
     test 'transfer project without project permission' do
       new_namespace = namespaces_user_namespaces(:jane_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project))
 
       exception = assert_raises(ActionPolicy::Unauthorized) do
-        Projects::TransferService.new(@project, @jane_doe).execute(new_namespace)
+        Projects::TransferService.new(@project, @jane_doe, transfer_form).execute
       end
 
       assert_equal ProjectPolicy, exception.policy
@@ -56,9 +60,10 @@ module Projects
 
     test 'transfer project without target namespace permission' do
       new_namespace = namespaces_user_namespaces(:jane_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project))
 
       assert_raises(ActionPolicy::Unauthorized) do
-        Projects::TransferService.new(@project, @john_doe).execute(new_namespace)
+        Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       end
 
       assert_no_enqueued_jobs(except: Turbo::Streams::BroadcastStreamJob)
@@ -67,31 +72,32 @@ module Projects
     test 'transfer project to namespace containing project with same name' do
       project = projects(:john_doe_project2)
       group_one = groups(:group_one)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: group_one.id }.merge(project: project))
 
-      assert_not Projects::TransferService.new(project, @john_doe).execute(group_one)
+      assert_not Projects::TransferService.new(project, @john_doe, transfer_form).execute
       assert_no_enqueued_jobs(except: Turbo::Streams::BroadcastStreamJob)
     end
 
     test 'authorize allowed to transfer project with permission' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project))
 
       assert_authorized_to(:transfer?, @project,
                            with: ProjectPolicy,
                            context: { user: @john_doe }) do
-        Projects::TransferService.new(@project,
-                                      @john_doe).execute(new_namespace)
+        Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       end
       assert_enqueued_with(job: UpdateMembershipsJob)
     end
 
     test 'authorize allowed to transfer to namespace' do
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project))
 
       assert_authorized_to(:transfer_into_namespace?, new_namespace,
                            with: Namespaces::UserNamespacePolicy,
                            context: { user: @john_doe }) do
-        Projects::TransferService.new(@project,
-                                      @john_doe).execute(new_namespace)
+        Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       end
       assert_enqueued_with(job: UpdateMembershipsJob)
     end
@@ -101,12 +107,13 @@ module Projects
       project_namespace.create_logidze_snapshot!
 
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project))
 
       assert_equal 1, project_namespace.log_data.version
       assert_equal 1, project_namespace.log_data.size
 
       assert_changes -> { project_namespace.parent }, to: new_namespace do
-        Projects::TransferService.new(@project, @john_doe).execute(new_namespace)
+        Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       end
 
       project_namespace.create_logidze_snapshot!
@@ -126,12 +133,13 @@ module Projects
       project_namespace.create_logidze_snapshot!
 
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project))
 
       assert_equal 1, project_namespace.log_data.version
       assert_equal 1, project_namespace.log_data.size
 
       assert_changes -> { project_namespace.parent }, to: new_namespace do
-        Projects::TransferService.new(@project, @john_doe).execute(new_namespace)
+        Projects::TransferService.new(@project, @john_doe, transfer_form).execute
       end
 
       project_namespace.create_logidze_snapshot!
@@ -163,7 +171,9 @@ module Projects
 
       assert_no_changes -> { @group12.reload.metadata_summary } do
         assert_no_changes -> { @project31.namespace.reload.metadata_summary } do
-          Projects::TransferService.new(@project31, @john_doe).execute(@subgroup12b)
+          transfer_form = ::Projects::TransferForm.new({ new_namespace_id: @subgroup12b.id }.merge(project: @project31))
+
+          Projects::TransferService.new(@project31, @john_doe, transfer_form).execute
         end
       end
 
@@ -176,8 +186,9 @@ module Projects
       @project31 = projects(:project31)
 
       new_namespace = namespaces_user_namespaces(:john_doe_namespace)
+      transfer_form = ::Projects::TransferForm.new({ new_namespace_id: new_namespace.id }.merge(project: @project31))
 
-      Projects::TransferService.new(@project31, @john_doe).execute(new_namespace)
+      Projects::TransferService.new(@project31, @john_doe, transfer_form).execute
 
       new_namespace.reload
       assert_equal({}, new_namespace.metadata_summary)
@@ -195,7 +206,9 @@ module Projects
 
       assert_no_changes -> { @group12.reload.samples_count } do
         assert_no_changes -> { @project31.reload.samples.size } do
-          Projects::TransferService.new(@project31, @john_doe).execute(@subgroup12b)
+          transfer_form = ::Projects::TransferForm.new({ new_namespace_id: @subgroup12b.id }.merge(project: @project31))
+
+          Projects::TransferService.new(@project31, @john_doe, transfer_form).execute
         end
       end
 
@@ -219,7 +232,10 @@ module Projects
       assert_no_changes -> { @subgroup12a.reload.samples_count } do
         assert_no_changes -> { @subgroup12aa.reload.samples_count } do
           assert_no_changes -> { john_doe_project.reload.samples.size } do
-            Projects::TransferService.new(john_doe_project, @john_doe).execute(@subgroup12b)
+            transfer_form = ::Projects::TransferForm.new({ new_namespace_id: @subgroup12b.id }
+            .merge(project: @project31))
+
+            Projects::TransferService.new(john_doe_project, @john_doe, transfer_form).execute
           end
         end
       end
@@ -242,7 +258,10 @@ module Projects
 
       assert_no_changes -> { @subgroup12b.reload.samples_count } do
         assert_no_changes -> { @project31.reload.samples.size } do
-          Projects::TransferService.new(@project31, @john_doe).execute(john_doe_namespace)
+          transfer_form = ::Projects::TransferForm.new({ new_namespace_id: john_doe_namespace.id }
+          .merge(project: @project31))
+
+          Projects::TransferService.new(@project31, @john_doe, transfer_form).execute
         end
       end
 

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -233,7 +233,7 @@ module Projects
         assert_no_changes -> { @subgroup12aa.reload.samples_count } do
           assert_no_changes -> { john_doe_project.reload.samples.size } do
             transfer_form = ::Projects::TransferForm.new({ new_namespace_id: @subgroup12b.id }
-            .merge(project: @project31))
+            .merge(project: john_doe_project))
 
             Projects::TransferService.new(john_doe_project, @john_doe, transfer_form).execute
           end

--- a/test/system/projects/transfer_test.rb
+++ b/test/system/projects/transfer_test.rb
@@ -51,7 +51,7 @@ module Projects
         click_on I18n.t('common.controls.confirm')
       end
 
-      assert_text I18n.t(:'services.projects.transfer.namespace_project_exists', project_name: project2.name)
+      assert_text I18n.t(:'activemodel.errors.models.projects/transfer_form.attributes.new_namespace_id.project_exists')
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR adds a `form_error_summary` to the transfer section of the project general settings page. A transfer form object was also created to be used by the`form_error_summary`. 

Summary of changes:
* `app/forms/projects/transfer_form.rb` is a form object used to encapsulate a project transfer request, it includes validation for transfer params
* `app/controllers/projects_controller.rb` has been updated to use this new form object for `edit` and `transfer` endpoints
* `app/views/projects/` views have been updated to use the new form object and to use the `form_error_summary` helper
* `app/services/projects/transfer_service.rb` has been updated to require a project transfer_form. In addition validations have been moved out of the service and into the form object

## Screenshots or screen recordings
<img width="3084" height="1279" alt="image" src="https://github.com/user-attachments/assets/01c9a8ce-916f-49c6-b9e4-29bdc1a733e0" />

## How to set up and validate locally
To test the following error messages:
  - **blank** 
    Replace the following line within the `transfer` action of the groups_controller.rb:
  `@transfer_form = ::Projects::TransferForm.new(project_transfer_params.merge(project: @project))`
  with
  `@transfer_form = ::Projects::TransferForm.new({ new_namespace_id: nil}.merge(project: @project))`
  - **not_found**
    Create new groups `Group1` & `Group2`. Then create a new project `Project 1` within `Group1`. Try transferring `Project1` to `Group2`, but before submitting delete `Group2`. 
  - **project_exists**
    Create `Group1` -> `Project1` and `Group2`->`Project1`. Try transferring `Project1` to the other group. 
  - **cannot_be_same** 
    Comment out the following line from the `authorized_namespaces` method of the projects_controller.rb:
  `@authorized_namespaces = @authorized_namespaces.where.not(id: @project.namespace.parent.id)`
    Try transferring a project to the same group.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
