### PR TITLE
Fix form error summaries within group settings

### DIFF
--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -4,7 +4,7 @@
   <% card.with_section do %>
     <%= form_with(model: @group, url: group_path, method: :patch, html: { novalidate: true }) do |form| %>
       <div class="grid gap-4">
-        <%= form_error_summary(form) %>
+        <%= form_error_summary(form,  include: %i[path]) %>
 
         <p class="text-slate-600 dark:text-slate-400">
           <%= t(:"groups.edit.advanced.path.description") %>

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,4 +1,4 @@
-<%= form_error_summary(form, target_overrides: { parent_id: "namespace-select" }) %>
+<%= form_error_summary(form, target_overrides: { parent_id: "namespace-select" }, include: %i[name description]) %>
 
 <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,4 +1,5 @@
-<%= form_error_summary(form, target_overrides: { parent_id: "namespace-select" }, include: %i[name description]) %>
+<%= form_error_summary(form, target_overrides: { parent_id: "namespace-select" },
+include: %i[name description] + (group.new_record? ? [:path] : [])) %>
 
 <%= render partial: "shared/form/required_field_legend" %>
 

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <%= form_error_summary(form, target_overrides: { parent_id: "namespace-select" },
-include: %i[name description] + (group.new_record? ? [:path] : [])) %>
+include: group.new_record? ? %i[name description path parent_id] : %i[name description]) %>
 
 <%= render partial: "shared/form/required_field_legend" %>
 


### PR DESCRIPTION
## What does this PR do and why?
Fixes displaying form error summaries for relevant forms within the group settings page.

## Screenshots or screen recordings
BEFORE:
<img width="2497" height="1985" alt="image" src="https://github.com/user-attachments/assets/3f1d9a67-5a5d-49e4-b252-77fe1d987aa1" />
<img width="2497" height="1985" alt="image" src="https://github.com/user-attachments/assets/df3b08cd-573a-4a90-90b6-db9855fab1b8" />

AFTER:
<img width="2811" height="1985" alt="image" src="https://github.com/user-attachments/assets/8c875b8c-00f6-4f9b-9e09-767acee2c472" />
<img width="2823" height="1985" alt="image" src="https://github.com/user-attachments/assets/80114b0f-887f-498e-ad00-a6febf826d18" />

## How to set up and validate locally
1. Navigate to a new group or edit an existing one.
1. Try submitting an empty name or path.
1. Verify only one form error summary is displayed.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
