### PR TITLE
Remove unnecessary turbo: false from links and forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'faraday-net_http_persistent', '~> 2.1'
 gem 'openssl', '~> 4.0'
 
 gem 'heroicon-rails', '>= 0.2.9'
-gem 'pathogen_view_components', github: 'phac-nml/pathogen-view-components', tag: 'v1.1.3'
+gem 'pathogen_view_components', github: 'phac-nml/pathogen-view-components', tag: 'v1.1.4'
 gem 'reactionview', '~> 0.3.0'
 gem 'view_component', ['>= 4.0', '< 5.0']
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/phac-nml/pathogen-view-components.git
-  revision: 8ee6165d23e3c57f4470c2eb5dd53e364a9ef7b1
-  tag: v1.1.3
+  revision: e9fa67c216ad2f3d98973fb60119a7a8f2de4344
+  tag: v1.1.4
   specs:
     pathogen_view_components (1.0.0)
       actionview (>= 5.0.0)

--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -2,19 +2,11 @@
   <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
     <%= render Viral::BaseComponent.new(**system_arguments) do %>
       <table
-        class="
-          w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
-          whitespace-nowrap
-        "
+        class="w-full text-left text-sm whitespace-nowrap text-slate-500 rtl:text-right dark:text-slate-400"
         data-controller="table"
         data-action="focusin->table#handleCellFocus"
       >
-        <thead
-          class="
-            sticky top-0 z-10 text-xs uppercase text-slate-700 bg-slate-50 dark:bg-slate-700
-            dark:text-slate-300
-          "
-        >
+        <thead class="sticky top-0 z-10 bg-slate-50 text-xs text-slate-700 uppercase dark:bg-slate-700 dark:text-slate-300">
           <tr>
             <% @columns.each_with_index do |column, index| %>
               <%= render_cell(
@@ -34,6 +26,7 @@
                 ) %>
               <% end %>
             <% end %>
+
             <%= render_cell(
               tag: 'th',
               scope: 'col',
@@ -43,54 +36,51 @@
             <% end %>
           </tr>
         </thead>
-        <tbody
-          class="
-            overflow-y-auto bg-white divide-y divide-slate-200 dark:bg-slate-800
-            dark:divide-slate-700
-          "
-        >
+
+        <tbody class="divide-y divide-slate-200 overflow-y-auto bg-white dark:divide-slate-700 dark:bg-slate-800">
           <% @data_exports.each do |data_export| %>
             <%= render Viral::BaseComponent.new(**row_arguments(data_export)) do %>
               <td class="px-3 py-3">
                 <%= link_to data_export.id,
                 data_export_path(data_export),
-                data: {
-                  turbo: false,
-                },
                 class:
                   "text-slate-900 dark:text-slate-100 font-semibold underline hover:decoration-2" %>
               </td>
+
               <td class="px-3 py-3">
                 <% unless data_export.name.nil? %>
                   <%= link_to data_export.name,
                   data_export_path(data_export),
-                  data: {
-                    turbo: false,
-                  },
                   class:
                     "text-slate-900 dark:text-slate-100 font-semibold underline hover:decoration-2" %>
                 <% end %>
               </td>
+
               <td class="px-3 py-3">
                 <%= t(:"data_exports.types.#{data_export.export_type}") %>
               </td>
+
               <td class="px-3 py-3">
                 <% status_text = t("common.statuses.#{data_export.status}").upcase %>
+
                 <% if data_export.status == 'ready' %>
                   <%= viral_pill(text: status_text, color: :green) %>
                 <% else %>
                   <%= viral_pill(text: status_text, color: :slate) %>
                 <% end %>
               </td>
+
               <td class="px-3 py-3">
                 <%= helpers.local_date(data_export.created_at, :long) %>
               </td>
+
               <td class="px-3 py-3">
                 <% unless data_export.expires_at.nil? %>
                   <%= helpers.local_date(data_export.expires_at, :long) %>
                 <% end %>
               </td>
-              <td class="px-3 py-3 space-x-2">
+
+              <td class="space-x-2 px-3 py-3">
                 <% if data_export.status == 'ready' %>
                   <%= button_to t('common.actions.download'),
                   rails_blob_path(data_export.file),
@@ -110,6 +100,7 @@
                   class:
                     "font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer" %>
                 <% end %>
+
                 <%= button_to t('common.actions.delete'),
                 data_export_path(data_export),
                 data: {
@@ -140,6 +131,7 @@
         </tbody>
       </table>
     <% end %>
+
     <%= render Viral::Pagy::FullComponent.new(
       @pagy,
       item: t("data_exports.index.limit.item"),

--- a/app/components/namespace_row/contents_component.html.erb
+++ b/app/components/namespace_row/contents_component.html.erb
@@ -5,7 +5,6 @@
     name: @namespace.name,
     size: @icon_size,
     colour_string: "#{@namespace.name}-#{@namespace.id}",
-    data: non_turbo_link_data,
   ) %>
 
   <% if @full_name && @namespace.parent %>
@@ -14,7 +13,7 @@
 
   <%= link_to(
     namespace_path(@namespace),
-    data: non_turbo_link_data,
+    data: top_frame_link_data,
     class: "underline hover:decoration-2 font-semibold dark:text-white wrap-anywhere min-w-0",
     aria: {label: I18n.t(:"components.namespace_row.contents_component.namespace_link.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_name: @namespace.name, namespace_puid: @namespace.puid) }
   ) do %>
@@ -42,7 +41,7 @@
   <div class="mr-2 ml-auto flex flex-col items-end">
     <div class="flex flex-row flex-wrap gap-2 text-slate-500 dark:text-slate-400">
       <% if @namespace.group_namespace? %>
-        <%= pathogen_link(href: namespace_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.subnamespaces.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: namespace_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.subnamespaces.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -62,7 +61,7 @@
             <%= @namespace.children.count %>
           </span>
         <% end %>
-        <%= pathogen_link(href: namespace_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.projects.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: namespace_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.projects.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -82,7 +81,7 @@
             <%= @namespace.project_namespaces.count %>
           </span>
         <% end %>
-        <%= pathogen_link(href: group_samples_path(@namespace), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: group_samples_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -105,7 +104,7 @@
       <% end %>
 
       <% if @namespace.project_namespace? %>
-        <%= pathogen_link(href: namespace_project_samples_path(@namespace.parent, @namespace.project), data: non_turbo_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: namespace_project_samples_path(@namespace.parent, @namespace.project), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(

--- a/app/components/namespace_row/contents_component.rb
+++ b/app/components/namespace_row/contents_component.rb
@@ -29,7 +29,7 @@ module NamespaceRow
     }.freeze
 
     EMPTY_ARRAY = [].freeze
-    NON_TURBO_LINK_DATA = { turbo: false }.freeze
+    TOP_FRAME_LINK_DATA = { turbo_frame: '_top' }.freeze
 
     def avatar_icon
       if @namespace.group_namespace?
@@ -48,8 +48,8 @@ module NamespaceRow
       (BASE_COUNT_PILL_CLASSES + variant_classes).join(' ')
     end
 
-    def non_turbo_link_data
-      NON_TURBO_LINK_DATA.dup
+    def top_frame_link_data
+      TOP_FRAME_LINK_DATA.dup
     end
   end
 end

--- a/app/components/samples/table/v1/component.html.erb
+++ b/app/components/samples/table/v1/component.html.erb
@@ -127,10 +127,9 @@
                       </span>
                     <% elsif column == :name %>
                       <%= link_to(
-                    sample_path(sample),
-                    data: { turbo: false },
-                    class: "text-slate-700 dark:text-slate-300 font-sans font-semibold underline hover:decoration-2"
-                  ) do %>
+                        sample_path(sample),
+                        class: "text-slate-700 dark:text-slate-300 font-sans font-semibold underline hover:decoration-2"
+                      ) do %>
                         <%= highlight(
                           sample[column],
                           defined?(@search_params[:name_or_puid_cont]) &&
@@ -142,9 +141,6 @@
                     <% elsif column == "namespaces.puid" %>
                       <%= link_to sample.project.puid,
                       namespace_project_samples_path(sample.project.namespace.parent, sample.project),
-                      data: {
-                        turbo: false,
-                      },
                       class: "font-semibold underline hover:decoration-2" %>
                     <% elsif column == :created_at %>
                       <%= helpers.local_date(sample[column], :long) %>

--- a/app/components/samples/table/v2/component.rb
+++ b/app/components/samples/table/v2/component.rb
@@ -124,7 +124,6 @@ module Samples
         def render_name_column(_column, sample)
           helpers.link_to(
             helpers.sample_path(sample),
-            data: { turbo: false },
             class: 'pathogen-data-grid__link pathogen-data-grid__link--sample'
           ) do
             helpers.highlight(
@@ -141,7 +140,6 @@ module Samples
           helpers.link_to(
             sample.project.puid,
             helpers.namespace_project_samples_path(sample.project.namespace.parent, sample.project),
-            data: { turbo: false },
             class: 'pathogen-data-grid__link pathogen-data-grid__link--project'
           )
         end

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -131,9 +131,6 @@
                     <% if column == :id %>
                       <%= link_to(
                     individual_path(workflow_execution),
-                    data: {
-                      turbo: false,
-                    },
                     class: "text-slate-900 dark:text-slate-100 font-mono underline hover:decoration-2",
                   ) do %>
                         <%= highlight(

--- a/app/views/data_exports/_preview.html.erb
+++ b/app/views/data_exports/_preview.html.erb
@@ -21,7 +21,7 @@
                   <%= link_to project["name"],
                   redirect_data_export_path(identifier: project["name"]),
                   data: {
-                    turbo: false,
+                    turbo_frame: "_top",
                   },
                   class: "underline hover:decoration-2 text-sm" %>
                 </span>
@@ -37,7 +37,7 @@
                         <%= link_to sample["name"],
                         redirect_data_export_path(identifier: sample["name"]),
                         data: {
-                          turbo: false,
+                          turbo_frame: "_top",
                         },
                         class: "underline hover:decoration-2 text-sm" %>
                       </span>
@@ -79,7 +79,7 @@
                   <%= link_to workflow_execution_id["name"],
                   redirect_data_export_path(identifier: workflow_execution_id["name"]),
                   data: {
-                    turbo: false,
+                    turbo_frame: "_top",
                   },
                   class: "underline hover:decoration-2 text-sm" %>
                 </span>
@@ -95,7 +95,7 @@
                           <%= link_to child["name"],
                           redirect_data_export_path(identifier: child["name"]),
                           data: {
-                            turbo: false,
+                            turbo_frame: "_top",
                           },
                           class: "underline hover:decoration-2 text-sm" %>
                         </span>

--- a/app/views/projects/samples/edit.html.erb
+++ b/app/views/projects/samples/edit.html.erb
@@ -2,27 +2,27 @@
   title: t("projects.samples.edit.title"),
   subtitle: t("projects.samples.edit.subtitle"),
 ) %>
+
 <div class="p-4">
   <div class="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
     <div
       class="
-        p-4 bg-white border border-slate-200 rounded-lg shadow-sm 2xl:col-span-2
-        dark:border-slate-700 sm:p-6 dark:bg-slate-800
+        rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6 2xl:col-span-2 dark:border-slate-700
+        dark:bg-slate-800
       "
     >
-      <h2
-        class="
-          mb-4 text-xl font-semibold leading-tight text-slate-900 dark:text-white
-        "
-      >
+      <h2 class="mb-4 text-xl leading-tight font-semibold text-slate-900 dark:text-white">
         <%= t("projects.samples.edit.form.title") %>
       </h2>
-      <%= form_with(model: @sample, url: namespace_project_sample_path(id: @sample.id), data: {turbo: false}, method: :patch, html: { novalidate: true}) do |form| %>
+
+      <%= form_with(model: @sample, url: namespace_project_sample_path(id: @sample.id), method: :patch, html: { novalidate: true}) do |form| %>
         <div class="grid gap-4">
           <%= render partial: "form_fields", locals: { form: form, sample: @sample } %>
+
           <div>
             <%= form.submit t("projects.samples.edit.submit_button"),
                         class: "button button-primary mr-1" %>
+
             <%= link_to t('common.actions.cancel'),
             namespace_project_sample_path(id: @sample.id),
             class: "button button-default" %>

--- a/app/views/projects/samples/new.html.erb
+++ b/app/views/projects/samples/new.html.erb
@@ -2,20 +2,22 @@
   title: t("projects.samples.new.title"),
   subtitle: t("projects.samples.new.subtitle"),
 ) %>
+
 <div class="p-4">
   <div class="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
     <div
       class="
-        p-4 bg-white border border-slate-200 rounded-lg shadow-sm 2xl:col-span-2
-        dark:border-slate-700 sm:p-6 dark:bg-slate-800
+        rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6 2xl:col-span-2 dark:border-slate-700
+        dark:bg-slate-800
       "
     >
-      <%= form_with(model: @sample, url: namespace_project_samples_path, data: {turbo: false}, method: :post, html: { novalidate: true}) do |form| %>
+      <%= form_with(model: @sample, url: namespace_project_samples_path, method: :post, html: { novalidate: true}) do |form| %>
         <div class="grid gap-4">
           <%= render partial: "form_fields", locals: { form: form, sample: @sample } %>
 
           <div class="flex">
             <%= form.submit class: "button button-primary mr-2" %>
+
             <%= link_to t('common.actions.cancel'),
             namespace_project_samples_path,
             class: "button button-default" %>

--- a/app/views/workflow_executions/_summary.html.erb
+++ b/app/views/workflow_executions/_summary.html.erb
@@ -59,7 +59,7 @@
               <%= link_to namespace.name,
               @namespace_path,
               data: {
-                turbo: false,
+                turbo_frame: "_top",
               },
               class: "underline hover:decoration-2" %>
               <%= render PuidComponent.new(puid: namespace.puid, show_clipboard: false) %>

--- a/test/components/namespace_row/contents_component_test.rb
+++ b/test/components/namespace_row/contents_component_test.rb
@@ -20,7 +20,7 @@ module NamespaceRow
         assert_selector 'div[data-placement="left"]', count: 3
         # Verify tooltip controller is present
         assert_selector 'div[data-controller="pathogen--tooltip"]', minimum: 3
-        assert_selector 'a[data-turbo="false"]', minimum: 4
+        assert_selector 'a[data-turbo-frame="_top"]', minimum: 4
       end
     end
 
@@ -41,7 +41,7 @@ module NamespaceRow
         assert_selector 'div[data-placement="left"]', count: 1
         # Verify tooltip controller is present
         assert_selector 'div[data-controller="pathogen--tooltip"]', minimum: 1
-        assert_selector 'a[data-turbo="false"]', minimum: 2
+        assert_selector 'a[data-turbo-frame="_top"]', minimum: 2
       end
     end
 

--- a/test/controllers/projects/samples_controller_test.rb
+++ b/test/controllers/projects/samples_controller_test.rb
@@ -151,6 +151,15 @@ module Projects
       assert_response :unprocessable_content
     end
 
+    test 'should not update a sample with wrong parameters via turbo stream' do
+      patch namespace_project_sample_url(@namespace, @project, @sample1),
+            params: { sample: { description: @sample1.description, name: '?',
+                                project_id: @sample1.project_id } },
+            as: :turbo_stream
+
+      assert_response :unprocessable_content
+    end
+
     test 'show sample history listing' do
       @sample1.create_logidze_snapshot!
 


### PR DESCRIPTION
## What does this PR do and why?

- Removes `turbo: false` from sample, data export, and workflow execution links and forms so they use default Turbo navigation.
- Where the link sits inside a nested Turbo Frame, replaces `turbo: false` with `turbo_frame: "_top"` so it breaks out instead of disabling Turbo.

## Screenshots or screen recordings

- N/A (no visible UI change; Turbo navigation behaviour only).

### Light Mode
https://github.com/user-attachments/assets/8dbfb0cf-82b2-4a64-8fb8-e0cfea905e08

### Dark Mode

https://github.com/user-attachments/assets/c9331c82-b39c-4dc7-9cfb-db90e1666033

## How to set up and validate locally

1. Visit a group listing, and click namespace / project / sample pill links — confirm they navigate top-level and do not stay trapped in a nested frame.
3. Visit `/data_exports`, open an export, and click the sample and workflow links in the preview — confirm they navigate correctly.
4. Create and edit a sample with invalid data — confirm inline validation errors still render (turbo_stream response path).
5. Use the new client side linelist export with a large number of samples.  During the export naviate around the application and ensure the dialog window does not disappear.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.