### PR TITLE
Form error summaries for edit workflow

### DIFF
--- a/app/models/workflow_execution.rb
+++ b/app/models/workflow_execution.rb
@@ -28,7 +28,7 @@ class WorkflowExecution < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   validates :metadata, presence: true, json: { message: ->(errors) { errors }, schema: METADATA_JSON_SCHEMA }
   validate :validate_namespace, on: :create
   validate :validate_workflow_available, if: :initial?
-  validates :name, presence: true, if: -> { !submitter&.automation_bot? }
+  validates :name, presence: true
 
   enum :state,
        { initial: 0, prepared: 1, submitted: 2, running: 3, completing: 4, completed: 5, error: 6, canceling: 7,

--- a/app/views/groups/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/groups/workflow_executions/_edit_dialog.html.erb
@@ -27,14 +27,15 @@
       <%= form.label :name, data: { required: true } %>
 
       <%= form.text_field :name,
-                      autofocus: true,
                       value: @workflow_execution.name,
                       placeholder:
                         t("groups.workflow_executions.edit_dialog.name_placeholder") %>
 
-      <%= render "shared/form/field_errors",
+      <% if invalid_name %>
+        <%= render "shared/form/field_errors",
               id: form.field_id(:name, "error"),
               errors: @workflow_execution.errors.full_messages_for(:name) %>
+      <% end %>
     </div>
 
     <div class="mt-4">

--- a/app/views/groups/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/groups/workflow_executions/_edit_dialog.html.erb
@@ -17,12 +17,14 @@
   </div>
 
   <%= form_with(model: workflow_execution, url: group_workflow_execution_path, method: :patch, class: "grid gap-4") do |form| %>
+    <%= render partial: "shared/form/required_field_legend" %>
+
     <%= form_error_summary(form) %>
 
     <% invalid_name = @workflow_execution.errors.include?(:name) %>
 
     <div class="form-field <%= 'invalid' if invalid_name %>">
-      <%= form.label :name %>
+      <%= form.label :name, data: { required: true } %>
 
       <%= form.text_field :name,
                       autofocus: true,

--- a/app/views/groups/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/groups/workflow_executions/_edit_dialog.html.erb
@@ -6,6 +6,7 @@
         workflow_execution_id: @workflow_execution.id,
       ),
   ) %>
+
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= t(
@@ -15,19 +16,23 @@
     </p>
   </div>
 
-  <div class="mb-4">
-    <%= turbo_frame_tag("edit_workflow_execution_error_alert") %>
-  </div>
-
   <%= form_with(model: workflow_execution, url: group_workflow_execution_path, method: :patch, class: "grid gap-4") do |form| %>
-    <div class="form-field">
+    <%= form_error_summary(form) %>
+
+    <% invalid_name = @workflow_execution.errors.include?(:name) %>
+
+    <div class="form-field <%= 'invalid' if invalid_name %>">
       <%= form.label :name %>
+
       <%= form.text_field :name,
                       autofocus: true,
                       value: @workflow_execution.name,
                       placeholder:
                         t("groups.workflow_executions.edit_dialog.name_placeholder") %>
 
+      <%= render "shared/form/field_errors",
+              id: form.field_id(:name, "error"),
+              errors: @workflow_execution.errors.full_messages_for(:name) %>
     </div>
 
     <div class="mt-4">
@@ -38,9 +43,8 @@
       <button
         type="button"
         class="
-          text-sm text-slate-900 border border-slate-200 bg-white hover:bg-slate-100
-          hover:text-slate-950 rounded-lg p-2 dark:text-white dark:bg-slate-600
-          dark:hover:bg-slate-700
+          rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-900 hover:bg-slate-100
+          hover:text-slate-950 dark:bg-slate-600 dark:text-white dark:hover:bg-slate-700
         "
         data-action="click->viral--dialog#close"
       >

--- a/app/views/groups/workflow_executions/update.turbo_stream.erb
+++ b/app/views/groups/workflow_executions/update.turbo_stream.erb
@@ -4,18 +4,15 @@
   <% end %>
 <% end %>
 
-<% if @workflow_execution.errors.empty? %>
-  <%= turbo_stream.update "edit_dialog",
+<%= turbo_stream.update "edit_dialog",
                       partial: "edit_dialog",
                       locals: {
                         open: @workflow_execution.errors.any?,
                         workflow_execution: @workflow_execution,
                       } %>
 
+<% if @workflow_execution.errors.empty? %>
   <%= turbo_stream.replace "workflow_execution_summary" do %>
     <%= render partial: "workflow_executions/summary" %>
   <% end %>
-<% else %>
-  <%= turbo_stream.update "edit_workflow_execution_error_alert",
-                      viral_alert(type:, message:, classes: "mb-4") %>
 <% end %>

--- a/app/views/projects/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/projects/workflow_executions/_edit_dialog.html.erb
@@ -6,6 +6,7 @@
         workflow_execution_id: @workflow_execution.id,
       ),
   ) %>
+
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= t(
@@ -15,30 +16,30 @@
     </p>
   </div>
 
-  <div class="mb-4">
-    <%= turbo_frame_tag("edit_workflow_execution_error_alert") %>
-  </div>
-
   <%= form_with(model: workflow_execution, url: namespace_project_workflow_execution_path, method: :patch, class: "grid gap-4") do |form| %>
-    <div class="form-field">
+    <%= form_error_summary(form) %>
+
+    <% invalid_name = @workflow_execution.errors.include?(:name) %>
+
+    <div class="form-field <%= 'invalid' if invalid_name %>">
       <%= form.label :name %>
+
       <%= form.text_field :name,
                       autofocus: true,
                       value: @workflow_execution.name,
                       placeholder:
                         t("projects.workflow_executions.edit_dialog.name_placeholder") %>
 
+      <%= render "shared/form/field_errors",
+              id: form.field_id(:name, "error"),
+              errors: @workflow_execution.errors.full_messages_for(:name) %>
     </div>
 
     <div class="mt-4">
       <%= form.submit t("projects.workflow_executions.edit_dialog.submit_button"),
                   class: "button button-primary" %>
 
-      <button
-        type="button"
-        class="button button-default"
-        data-action="click->viral--dialog#close"
-      >
+      <button type="button" class="button button-default" data-action="click->viral--dialog#close">
         <%= t('common.actions.cancel') %>
       </button>
     </div>

--- a/app/views/projects/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/projects/workflow_executions/_edit_dialog.html.erb
@@ -27,14 +27,15 @@
       <%= form.label :name, data: { required: true } %>
 
       <%= form.text_field :name,
-                      autofocus: true,
                       value: @workflow_execution.name,
                       placeholder:
                         t("projects.workflow_executions.edit_dialog.name_placeholder") %>
 
-      <%= render "shared/form/field_errors",
+      <% if invalid_name %>
+        <%= render "shared/form/field_errors",
               id: form.field_id(:name, "error"),
               errors: @workflow_execution.errors.full_messages_for(:name) %>
+      <% end %>
     </div>
 
     <div class="mt-4">

--- a/app/views/projects/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/projects/workflow_executions/_edit_dialog.html.erb
@@ -17,12 +17,14 @@
   </div>
 
   <%= form_with(model: workflow_execution, url: namespace_project_workflow_execution_path, method: :patch, class: "grid gap-4") do |form| %>
+    <%= render partial: "shared/form/required_field_legend" %>
+
     <%= form_error_summary(form) %>
 
     <% invalid_name = @workflow_execution.errors.include?(:name) %>
 
     <div class="form-field <%= 'invalid' if invalid_name %>">
-      <%= form.label :name %>
+      <%= form.label :name, data: { required: true } %>
 
       <%= form.text_field :name,
                       autofocus: true,

--- a/app/views/projects/workflow_executions/update.turbo_stream.erb
+++ b/app/views/projects/workflow_executions/update.turbo_stream.erb
@@ -4,18 +4,15 @@
   <% end %>
 <% end %>
 
-<% if @workflow_execution.errors.empty? %>
-  <%= turbo_stream.update "edit_dialog",
+<%= turbo_stream.update "edit_dialog",
                       partial: "edit_dialog",
                       locals: {
                         open: @workflow_execution.errors.any?,
                         workflow_execution: @workflow_execution,
                       } %>
 
+<% if @workflow_execution.errors.empty? %>
   <%= turbo_stream.replace "workflow_execution_summary" do %>
     <%= render partial: "workflow_executions/summary" %>
   <% end %>
-<% else %>
-  <%= turbo_stream.update "edit_workflow_execution_error_alert",
-                      viral_alert(type:, message:, classes: "mb-4") %>
 <% end %>

--- a/app/views/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/workflow_executions/_edit_dialog.html.erb
@@ -11,12 +11,14 @@
   </div>
 
   <%= form_with(model: workflow_execution, url: workflow_execution_path, method: :patch, class: "grid gap-4") do |form| %>
+    <%= render partial: "shared/form/required_field_legend" %>
+
     <%= form_error_summary(form) %>
 
     <% invalid_name = @workflow_execution.errors.include?(:name) %>
 
     <div class="form-field <%= 'invalid' if invalid_name %>">
-      <%= form.label :name %>
+      <%= form.label :name, data: { required: true } %>
 
       <%= form.text_field :name,
                       autofocus: true,

--- a/app/views/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/workflow_executions/_edit_dialog.html.erb
@@ -21,14 +21,15 @@
       <%= form.label :name, data: { required: true } %>
 
       <%= form.text_field :name,
-                      autofocus: true,
                       value: @workflow_execution.name,
                       placeholder:
                         t("workflow_executions.edit_dialog.name_placeholder") %>
 
-      <%= render "shared/form/field_errors",
+      <% if invalid_name %>
+        <%= render "shared/form/field_errors",
               id: form.field_id(:name, "error"),
               errors: @workflow_execution.errors.full_messages_for(:name) %>
+      <% end %>
     </div>
 
     <div class="flex h-5 items-center">

--- a/app/views/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/workflow_executions/_edit_dialog.html.erb
@@ -1,5 +1,6 @@
 <%= viral_dialog(open: open) do |dialog| %>
   <% dialog.with_header(title: t("workflow_executions.edit_dialog.title")) %>
+
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
     <p class="dark:text-slate-400">
       <%= t(
@@ -9,24 +10,29 @@
     </p>
   </div>
 
-  <div class="mb-4">
-    <%= turbo_frame_tag("edit_workflow_execution_error_alert") %>
-  </div>
-
   <%= form_with(model: workflow_execution, url: workflow_execution_path, method: :patch, class: "grid gap-4") do |form| %>
-    <div class="form-field">
+    <%= form_error_summary(form) %>
+
+    <% invalid_name = @workflow_execution.errors.include?(:name) %>
+
+    <div class="form-field <%= 'invalid' if invalid_name %>">
       <%= form.label :name %>
+
       <%= form.text_field :name,
                       autofocus: true,
                       value: @workflow_execution.name,
                       placeholder:
                         t("workflow_executions.edit_dialog.name_placeholder") %>
 
+      <%= render "shared/form/field_errors",
+              id: form.field_id(:name, "error"),
+              errors: @workflow_execution.errors.full_messages_for(:name) %>
     </div>
 
-    <div class="flex items-center h-5">
+    <div class="flex h-5 items-center">
       <%= form.check_box :shared_with_namespace,
                      { checked: @workflow_execution["shared_with_namespace"] } %>
+
       <%= form.label :shared_with_namespace,
                  t(
                    :"workflow_executions.edit_dialog.shared_with_namespace.#{@workflow_execution.namespace.type.downcase}",
@@ -38,11 +44,7 @@
       <%= form.submit t("workflow_executions.edit_dialog.submit_button"),
                   class: "button button-primary" %>
 
-      <button
-        type="button"
-        class="button button-default"
-        data-action="click->viral--dialog#close"
-      >
+      <button type="button" class="button button-default" data-action="click->viral--dialog#close">
         <%= t("common.actions.cancel") %>
       </button>
     </div>

--- a/app/views/workflow_executions/update.turbo_stream.erb
+++ b/app/views/workflow_executions/update.turbo_stream.erb
@@ -4,18 +4,17 @@
   <% end %>
 <% end %>
 
-<% if @workflow_execution.errors.empty? %>
-  <%= turbo_stream.update "edit_dialog",
+<%= turbo_stream.update "edit_dialog",
                       partial: "edit_dialog",
                       locals: {
                         open: @workflow_execution.errors.any?,
                         workflow_execution: @workflow_execution,
                       } %>
 
+<% if @workflow_execution.errors.empty? %>
   <%= turbo_stream.replace "workflow_execution_summary" do %>
     <%= render partial: "summary" %>
   <% end %>
-
   <%= turbo_stream.update "we_name_header" do %>
     <% if @workflow_execution.name.blank? %>
       <%= @workflow_execution.workflow&.name %>
@@ -23,7 +22,4 @@
       <%= @workflow_execution.name %>
     <% end %>
   <% end %>
-<% else %>
-  <%= turbo_stream.update "edit_workflow_execution_error_alert",
-                      viral_alert(type:, message:, classes: "mb-4") %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1040,7 +1040,7 @@ en:
     workflow_executions:
       edit_dialog:
         description: You are editing workflow execution '%{workflow_execution_id}'
-        name_placeholder: Enter workflow execution name (optional)
+        name_placeholder: Enter workflow execution name
         submit_button: Submit
         title: Edit workflow execution
       index:
@@ -1764,7 +1764,7 @@ en:
     workflow_executions:
       edit_dialog:
         description: You are editing automated workflow execution '%{workflow_execution_id}'
-        name_placeholder: Enter workflow execution name (optional)
+        name_placeholder: Enter workflow execution name
         submit_button: Submit
         title: Edit automated workflow execution
       index:
@@ -2156,7 +2156,7 @@ en:
       error_message: 'The following errors prevented the Workflow Execution from being created:'
     edit_dialog:
       description: You are editing workflow execution '%{workflow_execution_id}'
-      name_placeholder: Enter workflow execution name (optional)
+      name_placeholder: Enter workflow execution name
       shared_with_namespace:
         group: Share results with group members?
         project: Share results with project members?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1042,7 +1042,7 @@ fr:
     workflow_executions:
       edit_dialog:
         description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'
-        name_placeholder: Entrez le nom d’exécution du flux de travail (facultatif)
+        name_placeholder: Entrez le nom d’exécution du flux de travail
         submit_button: Envoyer
         title: Modifier l’exécution du flux de travail
       index:
@@ -1768,7 +1768,7 @@ fr:
     workflow_executions:
       edit_dialog:
         description: Vous modifiez l’exécution automatisée du flux de travail '%{workflow_execution_id}'
-        name_placeholder: Entrez le nom d’exécution du flux de travail (facultatif)
+        name_placeholder: Entrez le nom d’exécution du flux de travail
         submit_button: Envoyer
         title: Modifier l’exécution automatisée du flux de travail
       index:
@@ -2160,7 +2160,7 @@ fr:
       error_message: 'Les erreurs suivantes ont empêché la création de l’exécution du flux de travail :'
     edit_dialog:
       description: Vous modifiez l’exécution du flux de travail '%{workflow_execution_id}'
-      name_placeholder: Entrez le nom d’exécution du flux de travail (facultatif)
+      name_placeholder: Entrez le nom d’exécution du flux de travail
       shared_with_namespace:
         group: Partager les résultats avec les membres du groupe?
         project: Partager les résultats avec les membres du projet?


### PR DESCRIPTION
## What does this PR do and why?
This PR adds a `form_error_summary` to the edit workflow execution dialogs.

## Screenshots or screen recordings
<img width="1084" height="1017" alt="image" src="https://github.com/user-attachments/assets/729075b9-0091-4ff0-a408-41b688b30419" />

## How to set up and validate locally
1. Navigate to edit a workflow exection.
2. Enter a blank name.
3. Verify a form error summary is displayed.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
