### PR TITLE
refactor(ally): enhance accessibility of PAT token visibility toggle

### DIFF
--- a/app/components/token_component.html.erb
+++ b/app/components/token_component.html.erb
@@ -1,8 +1,6 @@
 <%= render Viral::BaseComponent.new(tag: 'div', **system_arguments, data: {
   controller: "token",
-  "token-item-value": value,
-  "token-show-mask-button-value": t(:'components.token.show'),
-  "token-hide-mask-button-value": t(:'components.token.hide') }) do %>
+  "token-item-value": value }) do %>
   <div class="relative mr-2 grow">
     <input
       type="text"
@@ -20,13 +18,19 @@
     <button
       type="button"
       data-token-target="maskButton"
-      class="absolute inset-y-0 right-0 bottom-0 rounded-r-lg p-2"
+      class="
+        absolute inset-y-0 right-0 bottom-0 rounded-r-lg p-2 focus-visible:outline focus-visible:outline-2
+        focus-visible:outline-offset-2 focus-visible:outline-neutral-600 dark:focus-visible:outline-neutral-300
+      "
       data-action="click->token#toggleVisibility"
       aria-label="<%= t(:'components.token.toggle_visible') %>"
+      aria-pressed="false"
     >
-      <span data-token-target="hide"><%= icon(:eye, color: :subdued, size: :sm, class: "cursor-pointer") %></span>
+      <span data-token-target="hide" aria-hidden="true">
+        <%= icon(:eye, color: :subdued, size: :sm, class: "cursor-pointer") %>
+      </span>
 
-      <span data-token-target="view" class="flex hidden items-center">
+      <span data-token-target="view" class="flex hidden items-center" aria-hidden="true">
         <%= icon(:eye_slash, color: :subdued, size: :sm, class: "cursor-pointer") %>
       </span>
     </button>

--- a/app/components/token_component.html.erb
+++ b/app/components/token_component.html.erb
@@ -7,8 +7,8 @@
       autocomplete="off"
       data-token-target="input"
       class="
-        w-full rounded-lg border border-slate-300 bg-slate-50 font-mono text-sm text-slate-900 dark:border-slate-600
-        dark:bg-slate-700 dark:text-white dark:placeholder-slate-400
+        w-full rounded-lg border border-slate-300 bg-slate-50 pr-11 font-mono text-sm text-slate-900
+        dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400
       "
       value="<%= '*' * value.length %>"
       readonly
@@ -19,8 +19,14 @@
       type="button"
       data-token-target="maskButton"
       class="
-        absolute inset-y-0 right-0 bottom-0 rounded-r-lg p-2 focus-visible:outline focus-visible:outline-2
-        focus-visible:outline-offset-2 focus-visible:outline-neutral-600 dark:focus-visible:outline-neutral-300
+        pointer-events-auto absolute inset-y-0 right-0 flex w-11 cursor-pointer items-center justify-center
+        rounded-r-lg border border-l-0 border-slate-300 bg-slate-50 shadow-[inset_1px_0_0_0_var(--color-slate-300)]
+        transition-[color,box-shadow] hover:bg-slate-100 focus-visible:outline focus-visible:outline-2
+        focus-visible:outline-offset-2 focus-visible:outline-neutral-600 aria-pressed:bg-slate-200
+        aria-pressed:shadow-[inset_1px_0_0_0_var(--color-slate-300),inset_0_2px_4px_0_rgb(0_0_0/0.06)]
+        dark:border-slate-600 dark:bg-slate-700 dark:shadow-[inset_1px_0_0_0_var(--color-slate-600)]
+        dark:hover:bg-slate-600 dark:focus-visible:outline-neutral-300 dark:aria-pressed:bg-slate-600
+        dark:aria-pressed:shadow-[inset_1px_0_0_0_var(--color-slate-600),inset_0_2px_4px_0_rgb(0_0_0/0.2)]
       "
       data-action="click->token#toggleVisibility"
       aria-label="<%= t(:'components.token.toggle_visible') %>"

--- a/app/javascript/controllers/token_controller.js
+++ b/app/javascript/controllers/token_controller.js
@@ -12,12 +12,11 @@ export default class extends Controller {
   ];
   static values = {
     item: String,
-    hideMaskButton: String,
-    showMaskButton: String,
   };
 
   connect() {
     this.visible = false;
+    this.maskButtonTarget.setAttribute("aria-pressed", "false");
     this.element.setAttribute("data-controller-connected", "true");
   }
 
@@ -36,10 +35,6 @@ export default class extends Controller {
     if (this.visible) {
       this.hideTarget.classList.remove("hidden");
       this.viewTarget.classList.add("hidden");
-      this.maskButtonTarget.setAttribute(
-        "aria-label",
-        this.hideMaskButtonValue,
-      );
       this.inputTarget.value = Array.prototype.join.call(
         { length: this.itemValue.length },
         "*",
@@ -47,13 +42,13 @@ export default class extends Controller {
     } else {
       this.hideTarget.classList.add("hidden");
       this.viewTarget.classList.remove("hidden");
-      this.maskButtonTarget.setAttribute(
-        "aria-label",
-        this.showMaskButtonValue,
-      );
       this.inputTarget.value = this.itemValue;
     }
     this.visible = !this.visible;
+    this.maskButtonTarget.setAttribute(
+      "aria-pressed",
+      this.visible ? "true" : "false",
+    );
   }
 
   removeTokenPanel() {

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -394,7 +394,7 @@ en:
     token:
       copied: Copied!
       copy: Copy to clipboard
-      toggle_visible: Toggle visibility
+      toggle_visible: Show token
     treegrid:
       row:
         collapse: Collapse

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -394,8 +394,6 @@ en:
     token:
       copied: Copied!
       copy: Copy to clipboard
-      hide: Hide token
-      show: Show token
       toggle_visible: Toggle visibility
     treegrid:
       row:

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -394,7 +394,7 @@ fr:
     token:
       copied: Copié!
       copy: Copier dans le presse-papiers
-      toggle_visible: Basculer la visibilité
+      toggle_visible: Afficher le jeton
     treegrid:
       row:
         collapse: Développer

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -394,8 +394,6 @@ fr:
     token:
       copied: Copié!
       copy: Copier dans le presse-papiers
-      hide: Cacher le jeton
-      show: Montrer le jeton
       toggle_visible: Basculer la visibilité
     treegrid:
       row:

--- a/test/components/viral/system/token_component_test.rb
+++ b/test/components/viral/system/token_component_test.rb
@@ -7,6 +7,14 @@ module System
     test 'token component' do
       visit('/rails/view_components/token_component/default')
       within('.Viral-Preview > [data-controller-connected="true"]') do
+        assert_selector %(button[data-token-target="maskButton"][aria-pressed="false"])
+
+        find(%(button[data-token-target="maskButton"])).click
+        assert_selector %(button[data-token-target="maskButton"][aria-pressed="true"])
+
+        find(%(button[data-token-target="maskButton"])).click
+        assert_selector %(button[data-token-target="maskButton"][aria-pressed="false"])
+
         click_button 'Copy to clipboard'
         assert_no_text 'Copy to clipboard'
         assert_text 'Copied!'


### PR DESCRIPTION
## What does this PR do and why?
- Implements APG toggle-button semantics for PAT visibility control.
- Keeps a stable accessible name and uses `aria-pressed` to announce masked/unmasked state.
- Adds keyboard-focus styling and a system test for `aria-pressed` toggling behavior.
- Reference: [WAI-ARIA APG Button Toggle Example](https://www.w3.org/WAI/ARIA/apg/patterns/button/examples/button/)

## Screenshots or screen recordings

<img width="1614" height="674" alt="image" src="https://github.com/user-attachments/assets/ac5f2eb0-7ccd-405c-b4ec-9cff231e7de0" />

## How to set up and validate locally
- `PARALLEL_WORKERS=1 bin/rails test:system test/components/viral/system/token_component_test.rb`
- On a windows machine, use NVDA to ensure button state is properly read out.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
