### PR TITLE
Add aria attributes for disabled options in the combobox

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -723,8 +723,32 @@ a.pill-focus-reset:focus-visible {
     @apply bg-blue-800/80 text-white dark:bg-blue-600/50;
   }
 
+  [data-combobox--v1-target="indicatorClearButton"] {
+    @apply border-y border-slate-300 shadow-[inset_1px_0_0_0_var(--color-slate-300)] dark:border-slate-600 dark:shadow-[inset_1px_0_0_0_var(--color-slate-600)];
+  }
+
+  [data-combobox--v1-target="indicatorButton"] {
+    @apply border border-l-0 border-slate-300 dark:border-slate-600;
+  }
+
+  input[aria-invalid="true"]
+    ~ div
+    [data-combobox--v1-target="indicatorClearButton"] {
+    @apply border-y-red-700 shadow-[inset_1px_0_0_0_var(--color-red-700)] dark:border-y-red-600 dark:shadow-[inset_1px_0_0_0_var(--color-red-600)];
+  }
+
+  input[aria-invalid="true"]
+    ~ div
+    [data-combobox--v1-target="indicatorButton"] {
+    @apply border-red-700 dark:border-red-600;
+  }
+
   button:disabled {
     @apply cursor-not-allowed text-slate-500 dark:text-slate-400;
+  }
+
+  button:disabled:hover {
+    @apply bg-transparent;
   }
 }
 

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -715,10 +715,10 @@ a.pill-focus-reset:focus-visible {
   }
 
   [role="option"][aria-disabled="true"] {
-    @apply cursor-not-allowed text-slate-500 dark:text-slate-300;
+    @apply pointer-events-none cursor-not-allowed bg-slate-100 text-slate-400 opacity-70 dark:bg-slate-700/50 dark:text-slate-500;
   }
 
-  [role="option"][aria-selected="true"],
+  [role="option"][aria-selected="true"]:not([aria-disabled="true"]),
   [role="option"]:not([aria-disabled="true"]):hover {
     @apply bg-blue-800/80 text-white dark:bg-blue-600/50;
   }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -684,7 +684,7 @@ a.pill-focus-reset:focus-visible {
     @apply border-red-700 text-red-900 dark:border-red-600 dark:text-red-400;
   }
 
-  input:disabled {
+  input[aria-disabled="true"] {
     @apply cursor-not-allowed bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-300;
   }
 

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -684,6 +684,10 @@ a.pill-focus-reset:focus-visible {
     @apply border-red-700 text-red-900 dark:border-red-600 dark:text-red-400;
   }
 
+  input:disabled {
+    @apply cursor-not-allowed bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-300;
+  }
+
   input:focus-visible {
     @apply outline-3 outline-offset-2 outline-black outline-solid dark:outline-white;
     box-shadow: none !important;
@@ -710,9 +714,17 @@ a.pill-focus-reset:focus-visible {
     @apply m-0 block cursor-pointer px-2.5 py-[3px];
   }
 
+  [role="option"][aria-disabled="true"] {
+    @apply cursor-not-allowed text-slate-500 dark:text-slate-300;
+  }
+
   [role="option"][aria-selected="true"],
-  [role="option"]:hover {
+  [role="option"]:not([aria-disabled="true"]):hover {
     @apply bg-blue-800/80 text-white dark:bg-blue-600/50;
+  }
+
+  button:disabled {
+    @apply cursor-not-allowed text-slate-500 dark:text-slate-400;
   }
 }
 

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -22,7 +22,7 @@
     <button
       type="button"
       class="
-        h-full w-8 cursor-pointer items-center justify-center text-slate-500 transition-colors hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
+        h-full w-8 cursor-pointer items-center justify-center text-slate-500 transition-colors focus-visible:outline-3 enabled:hover:bg-slate-100 dark:text-slate-300 dark:enabled:hover:bg-slate-700
         <%= selection_present? ? 'flex' : 'hidden' %>
       "
       data-combobox--v1-target="indicatorClearButton"
@@ -39,7 +39,7 @@
       type="button"
       class="
         flex h-full w-10 cursor-pointer items-center justify-center rounded-r-lg text-slate-500 transition-colors
-        hover:bg-slate-100 focus-visible:outline-3 dark:text-slate-300 dark:hover:bg-slate-700
+        focus-visible:outline-3 enabled:hover:bg-slate-100 dark:text-slate-300 dark:enabled:hover:bg-slate-700
       "
       data-combobox--v1-target="indicatorButton"
       data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onIndicatorClick"

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -29,6 +29,8 @@
       data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onClearClick"
       aria-label="<%= t('combobox_component.clear_selection') %>"
       title="<%= t('combobox_component.clear_selection') %>"
+      tabindex="-1"
+      <%= "disabled" if combobox_disabled? %>
     >
       <%= icon(:x, size: :sm, color: :subdued) %>
     </button>
@@ -44,6 +46,7 @@
       aria-label="<%= t('combobox_component.show_options') %>"
       title="<%= t('combobox_component.show_options') %>"
       tabindex="-1"
+      <%= "disabled" if combobox_disabled? %>
     >
       <%= icon(:caret_down, size: :sm, color: :subdued) %>
     </button>

--- a/app/components/combobox/v1/component.rb
+++ b/app/components/combobox/v1/component.rb
@@ -16,15 +16,17 @@ module Combobox
 
       private
 
-      def combobox_arguments # rubocop:disable Metrics/AbcSize
+      def combobox_arguments # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
         { tag: 'input' }.deep_merge(@combobox_arguments).tap do |args|
           args[:autocomplete] = 'off'
           args[:id] = @combobox_id
           args[:type] = 'text'
           args[:value] = @selected_option[:name]
           args[:role] = 'combobox'
+          disabled = args.delete(:disabled) == true
           args[:aria] ||= {}
-          args[:aria][:disabled] = 'true' if args.delete(:disabled) == true
+          args[:aria][:disabled] = 'true' if disabled
+          args[:readonly] = true if disabled
           args[:aria][:autocomplete] = 'list'
           args[:aria][:expanded] = 'false'
           args[:aria][:controls] = @listbox_id

--- a/app/components/combobox/v1/component.rb
+++ b/app/components/combobox/v1/component.rb
@@ -24,6 +24,7 @@ module Combobox
           args[:value] = @selected_option[:name]
           args[:role] = 'combobox'
           args[:aria] ||= {}
+          args[:aria][:disabled] = 'true' if args.delete(:disabled) == true
           args[:aria][:autocomplete] = 'list'
           args[:aria][:expanded] = 'false'
           args[:aria][:controls] = @listbox_id

--- a/app/components/combobox/v1/component.rb
+++ b/app/components/combobox/v1/component.rb
@@ -36,6 +36,10 @@ module Combobox
         @selected_option[:value].present?
       end
 
+      def combobox_disabled?
+        @combobox_arguments[:disabled] == true
+      end
+
       def selected_option(options)
         fragment = Nokogiri::HTML.fragment(options)
         fragment.search('option').each do |option|
@@ -76,6 +80,7 @@ module Combobox
           listbox_group_option['id'] = "#{@listbox_id}_option#{option_index}"
           listbox_group_option['role'] = 'option'
           listbox_group_option['data-value'] = option['value']
+          listbox_group_option['aria-disabled'] = 'true' if option.key?('disabled')
           listbox_group_option.content = option.text
           option.replace(listbox_group_option)
         end

--- a/app/javascript/controllers/combobox/utils.js
+++ b/app/javascript/controllers/combobox/utils.js
@@ -6,6 +6,10 @@ export function isOptionDisabled(option) {
   return option?.getAttribute("aria-disabled") === "true";
 }
 
+export function isComboboxDisabled(combobox) {
+  return combobox?.getAttribute("aria-disabled") === "true";
+}
+
 export function getLowercaseContent(node) {
   return node.textContent.toLowerCase();
 }

--- a/app/javascript/controllers/combobox/utils.js
+++ b/app/javascript/controllers/combobox/utils.js
@@ -2,6 +2,10 @@ export function isPrintableCharacter(str) {
   return str.length === 1 && str.match(/\S| /);
 }
 
+export function isOptionDisabled(option) {
+  return option?.getAttribute("aria-disabled") === "true";
+}
+
 export function getLowercaseContent(node) {
   return node.textContent.toLowerCase();
 }

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -3,6 +3,7 @@ import debounce from "debounce";
 import { announce } from "utilities/live_region";
 import {
   isPrintableCharacter,
+  isOptionDisabled,
   getLowercaseContent,
   highlightOption,
   setActiveDescendant,
@@ -223,14 +224,15 @@ export default class extends Controller {
 
   #populateCurrentFirstLastOptions() {
     const currentOption = this.#option;
-    const numItems = this.#filteredOptions.length;
+    const selectableOptions = this.#selectableOptions();
+    const numItems = selectableOptions.length;
     let option;
 
     if (numItems > 0) {
-      this.#firstOption = this.#filteredOptions[0];
-      this.#lastOption = this.#filteredOptions[numItems - 1];
+      this.#firstOption = selectableOptions[0];
+      this.#lastOption = selectableOptions[numItems - 1];
 
-      if (currentOption && this.#filteredOptions.indexOf(currentOption) >= 0) {
+      if (currentOption && selectableOptions.includes(currentOption)) {
         option = currentOption;
       } else {
         option = this.#firstOption;
@@ -243,7 +245,15 @@ export default class extends Controller {
     return option;
   }
 
+  #selectableOptions() {
+    return this.#filteredOptions.filter((option) => !isOptionDisabled(option));
+  }
+
   #setValue(option) {
+    if (isOptionDisabled(option)) {
+      return;
+    }
+
     this.hiddenTarget.value = option ? option.getAttribute("data-value") : "";
     this.#filter = option ? option.textContent : "";
     this.comboboxTarget.value = this.#filter;
@@ -271,26 +281,40 @@ export default class extends Controller {
   }
 
   #getPreviousOption(currentOption) {
+    const selectableOptions = this.#selectableOptions();
+    if (selectableOptions.length === 0) {
+      return null;
+    }
+
+    if (!currentOption || isOptionDisabled(currentOption)) {
+      return selectableOptions[selectableOptions.length - 1];
+    }
+
     if (currentOption !== this.#firstOption) {
-      const index = this.#filteredOptions.indexOf(currentOption);
-      return this.#filteredOptions[index - 1];
+      const index = selectableOptions.indexOf(currentOption);
+      return selectableOptions[index - 1];
     }
     return this.#lastOption;
   }
 
   #getNextOption(currentOption) {
+    const selectableOptions = this.#selectableOptions();
+    if (selectableOptions.length === 0) {
+      return null;
+    }
+
+    if (!currentOption || isOptionDisabled(currentOption)) {
+      return selectableOptions[0];
+    }
+
     if (currentOption !== this.#lastOption) {
-      const index = this.#filteredOptions.indexOf(currentOption);
-      return this.#filteredOptions[index + 1];
+      const index = selectableOptions.indexOf(currentOption);
+      return selectableOptions[index + 1];
     }
     return this.#firstOption;
   }
 
   // Menu display methods
-
-  #hasOptions() {
-    return this.#filteredOptions.length;
-  }
 
   #hasSelection() {
     return this.hiddenTarget.value.length > 0;
@@ -370,7 +394,9 @@ export default class extends Controller {
     switch (event.key) {
       case "Enter": {
         this.debouncedFilterAndUpdate.flush();
-        this.#setValue(this.#option);
+        if (this.#option && !isOptionDisabled(this.#option)) {
+          this.#setValue(this.#option);
+        }
         this.#setOption(this.#filterOptions());
         this.#floatingDropdown.hide();
         flag = true;
@@ -378,11 +404,11 @@ export default class extends Controller {
       }
       case "Down":
       case "ArrowDown":
-        if (this.#filteredOptions.length > 0) {
+        if (this.#selectableOptions().length > 0) {
           if (altKey) {
             this.#setOption(null);
           } else {
-            if (this.#filteredOptions.length > 1) {
+            if (this.#selectableOptions().length > 1) {
               this.#setOption(this.#getNextOption(this.#option));
             } else {
               this.#setOption(this.#firstOption);
@@ -397,7 +423,7 @@ export default class extends Controller {
 
       case "Up":
       case "ArrowUp":
-        if (this.#hasOptions()) {
+        if (this.#selectableOptions().length > 0) {
           if (this.#floatingDropdown.isVisible()) {
             this.#setOption(this.#getPreviousOption(this.#option));
           } else {
@@ -423,7 +449,9 @@ export default class extends Controller {
 
       case "Tab": {
         this.debouncedFilterAndUpdate.flush();
-        this.#setValue(this.#option);
+        if (this.#option && !isOptionDisabled(this.#option)) {
+          this.#setValue(this.#option);
+        }
         this.#floatingDropdown.hide();
         break;
       }
@@ -509,7 +537,9 @@ export default class extends Controller {
         !this.indicatorClearButtonTarget.contains(event.target))
     ) {
       this.debouncedFilterAndUpdate.flush();
-      this.#setValue(this.#option);
+      if (this.#option && !isOptionDisabled(this.#option)) {
+        this.#setValue(this.#option);
+      }
       this.#floatingDropdown.hide();
     }
   }
@@ -539,7 +569,7 @@ export default class extends Controller {
 
   #onOptionClick(event) {
     const option = event.target.closest('[role="option"]');
-    if (option) {
+    if (option && !isOptionDisabled(option)) {
       this.#setValue(option);
       this.#setOption(option);
       this.#floatingDropdown.hide();

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -4,6 +4,7 @@ import { announce } from "utilities/live_region";
 import {
   isPrintableCharacter,
   isOptionDisabled,
+  isComboboxDisabled,
   getLowercaseContent,
   highlightOption,
   setActiveDescendant,
@@ -55,6 +56,7 @@ export default class extends Controller {
     this.boundOnBackgroundMouseDown = this.#onBackgroundMouseDown.bind(this);
     this.boundOnComboboxKeyDown = this.#onComboboxKeyDown.bind(this);
     this.boundOnComboboxKeyUp = this.#onComboboxKeyUp.bind(this);
+    this.boundOnComboboxBeforeInput = this.#onComboboxBeforeInput.bind(this);
     this.boundOnComboboxClick = this.#onComboboxClick.bind(this);
     this.boundOnOptionClick = this.#onOptionClick.bind(this);
     this.boundOnComboboxFocus = this.#onComboboxFocus.bind(this);
@@ -384,6 +386,13 @@ export default class extends Controller {
   // Combobox events
 
   #onComboboxKeyDown(event) {
+    if (this.#comboboxDisabled()) {
+      if (event.key !== "Tab" && !event.key.startsWith("Arrow")) {
+        event.preventDefault();
+      }
+      return;
+    }
+
     let flag = false;
     const altKey = event.altKey;
 
@@ -478,6 +487,10 @@ export default class extends Controller {
   }
 
   #onComboboxKeyUp(event) {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     let flag = false;
     const char = event.key;
 
@@ -520,15 +533,33 @@ export default class extends Controller {
     }
   }
 
+  #onComboboxBeforeInput(event) {
+    if (this.#comboboxDisabled()) {
+      event.preventDefault();
+    }
+  }
+
   #onComboboxClick() {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     this.#floatingDropdown.toggle();
   }
 
   #onComboboxFocus() {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     this.#filterOptions();
   }
 
   #onBackgroundMouseDown(event) {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     if (
       !this.comboboxTarget.contains(event.target) &&
       !this.listboxTarget.contains(event.target) &&
@@ -545,11 +576,19 @@ export default class extends Controller {
   }
 
   onIndicatorMouseDown(event) {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     event.preventDefault();
     this.#clearShouldKeepOpen = this.#floatingDropdown.isVisible();
   }
 
   onIndicatorClick(event) {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 
@@ -558,6 +597,10 @@ export default class extends Controller {
   }
 
   onClearClick(event) {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 
@@ -568,6 +611,10 @@ export default class extends Controller {
   // Listbox Option events
 
   #onOptionClick(event) {
+    if (this.#comboboxDisabled()) {
+      return;
+    }
+
     const option = event.target.closest('[role="option"]');
     if (option && !isOptionDisabled(option)) {
       this.#setValue(option);
@@ -590,9 +637,14 @@ export default class extends Controller {
 
   // Event handlers
 
+  #comboboxDisabled() {
+    return isComboboxDisabled(this.comboboxTarget);
+  }
+
   #addComboboxEventListeners(combobox) {
     combobox.addEventListener("keydown", this.boundOnComboboxKeyDown);
     combobox.addEventListener("keyup", this.boundOnComboboxKeyUp);
+    combobox.addEventListener("beforeinput", this.boundOnComboboxBeforeInput);
     combobox.addEventListener("click", this.boundOnComboboxClick);
     combobox.addEventListener("focus", this.boundOnComboboxFocus);
   }
@@ -600,6 +652,10 @@ export default class extends Controller {
   #removeComboboxEventListeners(combobox) {
     combobox.removeEventListener("keydown", this.boundOnComboboxKeyDown);
     combobox.removeEventListener("keyup", this.boundOnComboboxKeyUp);
+    combobox.removeEventListener(
+      "beforeinput",
+      this.boundOnComboboxBeforeInput,
+    );
     combobox.removeEventListener("click", this.boundOnComboboxClick);
     combobox.removeEventListener("focus", this.boundOnComboboxFocus);
   }

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -82,10 +82,10 @@ module Combobox
       end
 
       def options_with_disabled
-        <<~HTML
-          <option value="enabled-option">Enabled option</option>
-          <option value="disabled-option" disabled="disabled">Disabled option</option>
-        HTML
+        options_for_select(
+          [['Enabled option', 'enabled-option'], ['Disabled option', 'disabled-option']],
+          { disabled: ['disabled-option'] }
+        )
       end
     end
   end

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'view_component_test_case'
+
+module Combobox
+  module V1
+    class ComponentRenderTest < ViewComponentTestCase
+      include ActionView::Helpers::FormOptionsHelper
+
+      test 'renders default combobox role and aria state' do
+        render_component
+
+        assert_selector 'input[role="combobox"][aria-autocomplete="list"][aria-expanded="false"]'
+      end
+
+      test 'passes through aria attributes' do
+        render_component(
+          aria: {
+            required: true,
+            invalid: true,
+            describedby: 'field-error'
+          }
+        )
+
+        assert_selector 'input[aria-required="true"][aria-invalid="true"][aria-describedby="field-error"]'
+      end
+
+      test 'renders aria-disabled only for disabled options' do
+        render_component(options: options_with_disabled)
+
+        assert_selector '[role="option"][data-value="enabled-option"]:not([aria-disabled])'
+        assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]'
+      end
+
+      test 'renders clear and show-options buttons outside tab order' do
+        render_component
+
+        assert_selector 'button[data-combobox--v1-target="indicatorClearButton"][tabindex="-1"]'
+        assert_selector 'button[data-combobox--v1-target="indicatorButton"][tabindex="-1"]'
+      end
+
+      test 'disables combobox input and indicator buttons when disabled is true' do
+        render_component(disabled: true)
+
+        assert_selector 'input[role="combobox"][disabled]'
+        assert_selector 'button[data-combobox--v1-target="indicatorClearButton"][disabled]'
+        assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
+      end
+
+      test 'preview renders' do
+        ViewComponent::TestCase.instance_method(:render_preview).bind_call(
+          self,
+          :default,
+          from: ComboboxComponentPreview,
+          params: {}
+        )
+
+        assert_selector 'input[role="combobox"]'
+      end
+
+      private
+
+      def render_component(options: default_options, **)
+        render_inline(
+          ComboboxComponent.new(
+            form: build_form_builder,
+            field: :field,
+            options: options,
+            **
+          )
+        )
+      end
+
+      def build_form_builder
+        template = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
+        object = Struct.new(:field).new(nil)
+        ActionView::Helpers::FormBuilder.new(:search, object, template, {})
+      end
+
+      def default_options
+        options_for_select([['Enabled option', 'enabled-option']])
+      end
+
+      def options_with_disabled
+        <<~HTML
+          <option value="enabled-option">Enabled option</option>
+          <option value="disabled-option" disabled="disabled">Disabled option</option>
+        HTML
+      end
+    end
+  end
+end

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -47,15 +47,23 @@ module Combobox
         assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
       end
 
-      test 'preview renders' do
-        ViewComponent::TestCase.instance_method(:render_preview).bind_call(
-          self,
-          :default,
-          from: ComboboxComponentPreview,
-          params: {}
-        )
+      test 'default preview renders' do
+        render_combobox_preview(:default)
 
         assert_selector 'input[role="combobox"]'
+      end
+
+      test 'with_disabled_options preview renders aria-disabled options' do
+        render_combobox_preview(:with_disabled_options)
+
+        assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]'
+      end
+
+      test 'disabled preview renders disabled combobox' do
+        render_combobox_preview(:disabled)
+
+        assert_selector 'input[role="combobox"][disabled]'
+        assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
       end
 
       private
@@ -85,6 +93,15 @@ module Combobox
         options_for_select(
           [['Enabled option', 'enabled-option'], ['Disabled option', 'disabled-option']],
           { disabled: ['disabled-option'] }
+        )
+      end
+
+      def render_combobox_preview(name)
+        ViewComponent::TestCase.instance_method(:render_preview).bind_call(
+          self,
+          name,
+          from: ComboboxComponentPreview,
+          params: {}
         )
       end
     end

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -39,10 +39,10 @@ module Combobox
         assert_selector 'button[data-combobox--v1-target="indicatorButton"][tabindex="-1"]'
       end
 
-      test 'disables combobox input and indicator buttons when disabled is true' do
+      test 'renders combobox input with aria-disabled and indicator buttons disabled when disabled is true' do
         render_component(disabled: true)
 
-        assert_selector 'input[role="combobox"][disabled]'
+        assert_selector 'input[role="combobox"][aria-disabled="true"]:not([disabled])'
         assert_selector 'button[data-combobox--v1-target="indicatorClearButton"][disabled]'
         assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
       end
@@ -62,7 +62,7 @@ module Combobox
       test 'disabled preview renders disabled combobox' do
         render_combobox_preview(:disabled)
 
-        assert_selector 'input[role="combobox"][disabled]'
+        assert_selector 'input[role="combobox"][aria-disabled="true"]:not([disabled])'
         assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
       end
 

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -42,7 +42,7 @@ module Combobox
       test 'renders combobox input with aria-disabled and indicator buttons disabled when disabled is true' do
         render_component(disabled: true)
 
-        assert_selector 'input[role="combobox"][aria-disabled="true"]:not([disabled])'
+        assert_selector 'input[role="combobox"][aria-disabled="true"][readonly]:not([disabled])'
         assert_selector 'button[data-combobox--v1-target="indicatorClearButton"][disabled]'
         assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
       end
@@ -62,7 +62,7 @@ module Combobox
       test 'disabled preview renders disabled combobox' do
         render_combobox_preview(:disabled)
 
-        assert_selector 'input[role="combobox"][aria-disabled="true"]:not([disabled])'
+        assert_selector 'input[role="combobox"][aria-disabled="true"][readonly]:not([disabled])'
         assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
       end
 

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -137,6 +137,47 @@ module Combobox
           assert_empty hidden.value
         end
       end
+
+      def test_disabled_combobox_does_not_open_or_change # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        visit('/rails/view_components/combobox_component/disabled')
+        within "div[data-controller='combobox--v1']" do
+          combobox = find("input[role='combobox']")
+          hidden = find("input[type='hidden']", visible: false)
+
+          assert_equal 'age', combobox.value
+          assert_equal 'metadata.age', hidden.value
+          assert_equal 'true', combobox['aria-disabled']
+          assert_equal 'readonly', combobox['readonly']
+
+          beforeinput_prevented = page.evaluate_script(<<~JS)
+            (() => {
+              const combobox = document.querySelector('input[role="combobox"]');
+              return !combobox.dispatchEvent(new InputEvent('beforeinput', {
+                bubbles: true,
+                cancelable: true,
+                data: 'country',
+                inputType: 'insertText',
+              }));
+            })();
+          JS
+          assert beforeinput_prevented
+
+          page.execute_script(<<~JS)
+            const combobox = document.querySelector('input[role="combobox"]');
+            combobox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            combobox.dispatchEvent(
+              new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+            );
+            combobox.dispatchEvent(new KeyboardEvent('keyup', { key: 'c', bubbles: true }));
+            combobox.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+          JS
+
+          assert_equal 'age', combobox.value
+          assert_equal 'metadata.age', hidden.value
+          assert_equal 'false', combobox['aria-expanded']
+          assert_selector "div[role='listbox']", visible: false
+        end
+      end
     end
   end
 end

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -106,6 +106,22 @@ module Combobox
         end
       end
 
+      def test_disabled_option_is_not_selectable
+        visit('/rails/view_components/combobox_component/with_disabled_options')
+        within "div[data-controller='combobox--v1']" do
+          combobox = find("input[role='combobox']")
+          combobox.click
+
+          find("div[role='option'][data-value='disabled-option']").click
+          assert_empty combobox.value
+          assert_empty find("input[type='hidden']", visible: false).value
+
+          find("div[role='option'][data-value='enabled-option']").click
+          assert_equal 'Enabled option', combobox.value
+          assert_equal 'enabled-option', find("input[type='hidden']", visible: false).value
+        end
+      end
+
       def test_escape_key
         visit('/rails/view_components/combobox_component/default')
         within "div[data-controller='combobox--v1']" do

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -112,7 +112,7 @@ module Combobox
           combobox = find("input[role='combobox']")
           combobox.click
 
-          find("div[role='option'][data-value='disabled-option']").click
+          assert_selector "div[role='option'][data-value='disabled-option'][aria-disabled='true']"
           assert_empty combobox.value
           assert_empty find("input[type='hidden']", visible: false).value
 

--- a/test/components/previews/combobox_component_preview.rb
+++ b/test/components/previews/combobox_component_preview.rb
@@ -3,7 +3,44 @@
 class ComboboxComponentPreview < ViewComponent::Preview
   include ActionView::Helpers::FormOptionsHelper
 
-  def default # rubocop:disable Metrics/MethodLength
+  def default
+    render_with_template(locals: default_locals)
+  end
+
+  def with_disabled_options
+    render_with_template(
+      template: 'combobox_component_preview/default',
+      locals: default_locals(
+        label: 'Field with disabled options',
+        options: options_for_select(
+          [['Enabled option', 'enabled-option'], ['Disabled option', 'disabled-option']],
+          { disabled: ['disabled-option'] }
+        )
+      )
+    )
+  end
+
+  def disabled
+    render_with_template(
+      template: 'combobox_component_preview/default',
+      locals: default_locals(
+        label: 'Disabled combobox',
+        combobox_arguments: { disabled: true }
+      )
+    )
+  end
+
+  private
+
+  def default_locals(label: 'Metadata field', options: grouped_metadata_options, combobox_arguments: {})
+    {
+      label: label,
+      options: options,
+      combobox_arguments: combobox_arguments
+    }
+  end
+
+  def grouped_metadata_options
     sample_fields = %w[name puid created_at updated_at attachments_updated_at]
     metadata_fields = { 'Metadata fields': [['age', 'metadata.age'],
                                             ['country', 'metadata.country'],
@@ -17,12 +54,8 @@ class ComboboxComponentPreview < ViewComponent::Preview
                                             ['patient_sex', 'metadata.patient_sex'],
                                             ['wgs_id', 'metadata.wgs_id']] }
 
-    options = options_for_select(sample_fields).concat(
+    options_for_select(sample_fields).concat(
       grouped_options_for_select(metadata_fields, selected_key = 'metadata.age') # rubocop:disable Lint/UselessAssignment
     )
-
-    render_with_template(locals: {
-                           options: options
-                         })
   end
 end

--- a/test/components/previews/combobox_component_preview/default.html.erb
+++ b/test/components/previews/combobox_component_preview/default.html.erb
@@ -1,9 +1,10 @@
 <%= form_with(url: "#") do |form| %>
-  <label for="<%= form.field_id(:field) %>">Metadata field</label>
+  <label for="<%= form.field_id(:field) %>"><%= label %></label>
 
   <%= render ComboboxComponent.new(
     form: form,
     field: :field,
     options: options,
+    **combobox_arguments
   ) %>
 <% end %>

--- a/test/javascript/controllers/combobox/utils.test.js
+++ b/test/javascript/controllers/combobox/utils.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { isOptionDisabled } from "../../../../app/javascript/controllers/combobox/utils.js";
+import {
+  isComboboxDisabled,
+  isOptionDisabled,
+} from "../../../../app/javascript/controllers/combobox/utils.js";
 
 describe("combobox utils", () => {
   describe("isOptionDisabled", () => {
@@ -18,6 +21,25 @@ describe("combobox utils", () => {
       expect(isOptionDisabled(enabledOption)).toBe(false);
       expect(isOptionDisabled(falseOption)).toBe(false);
       expect(isOptionDisabled(null)).toBe(false);
+    });
+  });
+
+  describe("isComboboxDisabled", () => {
+    it("returns true when aria-disabled is true", () => {
+      const combobox = document.createElement("input");
+      combobox.setAttribute("aria-disabled", "true");
+
+      expect(isComboboxDisabled(combobox)).toBe(true);
+    });
+
+    it("returns false when aria-disabled is absent or false", () => {
+      const enabledCombobox = document.createElement("input");
+      const falseCombobox = document.createElement("input");
+      falseCombobox.setAttribute("aria-disabled", "false");
+
+      expect(isComboboxDisabled(enabledCombobox)).toBe(false);
+      expect(isComboboxDisabled(falseCombobox)).toBe(false);
+      expect(isComboboxDisabled(null)).toBe(false);
     });
   });
 });

--- a/test/javascript/controllers/combobox/utils.test.js
+++ b/test/javascript/controllers/combobox/utils.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { isOptionDisabled } from "../../../../app/javascript/controllers/combobox/utils.js";
+
+describe("combobox utils", () => {
+  describe("isOptionDisabled", () => {
+    it("returns true when aria-disabled is true", () => {
+      const option = document.createElement("div");
+      option.setAttribute("aria-disabled", "true");
+
+      expect(isOptionDisabled(option)).toBe(true);
+    });
+
+    it("returns false when aria-disabled is absent or false", () => {
+      const enabledOption = document.createElement("div");
+      const falseOption = document.createElement("div");
+      falseOption.setAttribute("aria-disabled", "false");
+
+      expect(isOptionDisabled(enabledOption)).toBe(false);
+      expect(isOptionDisabled(falseOption)).toBe(false);
+      expect(isOptionDisabled(null)).toBe(false);
+    });
+  });
+});

--- a/test/system/projects/members_test.rb
+++ b/test/system/projects/members_test.rb
@@ -252,7 +252,11 @@ module Projects
       assert_selector '[role="tab"]#members-tab[aria-selected="true"]'
       assert_selector '[role="tabpanel"]#members-panel:not([hidden])'
 
-      assert_button I18n.t(:'projects.members.index.add'), disabled: false
+      # Wait for lazy turbo frames and dialog re-render to settle before clicking Add
+      assert_selector 'turbo-frame#members table'
+      within('turbo-frame#new_member_dialog') do
+        assert_selector '[data-controller="viral--dialog"][data-controller-connected="true"]'
+      end
 
       click_button I18n.t(:'projects.members.index.add')
 


### PR DESCRIPTION
## What does this PR do and why?
Adds missing `aria-disabled` and other aria attributes to the combobox component so disabled options work correctly for screen readers. Closes #1943.

## Screenshots or screen recordings

<img width="1301" height="187" alt="image" src="https://github.com/user-attachments/assets/6290de7f-b826-42e1-8100-bfa12fb30175" />

## How to set up and validate locally
1. Run `PARALLEL_WORKERS=4 bin/rails test test/components/combobox/v1/component_render_test.rb`
2. Open `http://localhost:3000/rails/view_components/combobox_component/default` and check the combobox looks right.
3. Check that advanced search still works.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
