### PR TITLE
Chore(Deps): Devenv updates 2026 06 03

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "pnpm"
 
       - name: Install JavaScript dependencies
@@ -110,7 +110,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "pnpm"
 
       - name: Install JavaScript dependencies
@@ -160,7 +160,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "pnpm"
 
       - name: Install dependencies
@@ -217,7 +217,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "pnpm"
 
       - name: Install dependencies
@@ -293,7 +293,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "pnpm"
 
       - name: Install dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -202,6 +202,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'capybara-playwright-driver'
+  gem 'playwright-ruby-client', '1.59.1'
 
   gem 'minitest-retry', require: false
   gem 'mocha', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,7 @@ GEM
       racc
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
-    playwright-ruby-client (1.58.1)
+    playwright-ruby-client (1.59.1)
       base64
       concurrent-ruby (>= 1.1.6)
       mime-types (>= 3.0)
@@ -821,6 +821,7 @@ DEPENDENCIES
   paranoia
   pathogen_view_components!
   pg
+  playwright-ruby-client (= 1.59.1)
   propshaft
   public_activity
   puma (~> 8.0)

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1775040883,
-        "narHash": "sha256-o0Cmde4drfgbWXXo1ebKTrhSLQuL9Yrj1InonVyC7Nc=",
+        "lastModified": 1780459148,
+        "narHash": "sha256-oIpiel88r8zV/WqTFwcGAjWXKOASHNzq7wjXQ6ORTvg=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c277ffa27759cd230089700da568864446528e80",
+        "rev": "493ed7ef062ba3972c06e60970fe5ebe014f5c33",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1774287239,
-        "narHash": "sha256-W3krsWcDwYuA3gPWsFA24YAXxOFUL6iIlT6IknAoNSE=",
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774420888,
-        "narHash": "sha256-LknAwF4BtEWuPbJTFXooydwwrZt9/WX6hEnhpAWb1Zc=",
+        "lastModified": 1780482956,
+        "narHash": "sha256-MOm2av5eQrX78Zki1RdG2xDgtx5M+cEtq9bMbkvJXr4=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "b15239544340b2e9c75664c3cc3b14a5b57cd8fd",
+        "rev": "f40500672aedbf8d32a0f6938d80dba67bba863a",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773840656,
-        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,36 +6,6 @@ lib.mkMerge [
     env.PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright.passthru.browsers}";
     env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS="true";
 
-    # TODO: remove when pipelines are confirmed to work with 25.10.2
-    overlays = [
-      (final: super: {
-        # Override the 'nextflow' package to use a newer version
-        nextflow = super.nextflow.overrideAttrs (oldAttrs: {
-          version = "24.10.3";
-          src = super.fetchFromGitHub {
-            owner = "nextflow-io";
-            repo = "nextflow";
-            rev = "6183fdf9dbd9114f5ee86d11bc5e69cbd06501a6";
-            hash = "sha256-/5DhBtsoChHpYFlSo0PsrN5yHPn2LNSqKaczlYLuGa8=";
-          };
-          mitmCache = super.gradle.fetchDeps {
-            pname = "nextflow";
-            data = ./nextflow-deps.json;
-          };
-          postPatch = ''
-            # Nextflow invokes the constant "/bin/bash" (not as a shebang) at
-            # several locations so we fix that globally. However, when running inside
-            # a container, we actually *want* "/bin/bash". Thus the global fix needs
-            # to be reverted for this specific use case.
-            substituteInPlace modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy \
-              --replace-fail "['/bin/bash'," "['${super.bash}/bin/bash'," \
-              --replace-fail "if( containerBuilder ) {" "if( containerBuilder ) {
-                        launcher = launcher.replaceFirst(\"/nix/store/.*/bin/bash\", \"/bin/bash\")"
-          '';
-        });
-      })
-    ];
-
     # https://devenv.sh/packages/
     packages = with pkgs; [
       pkg-config

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "axe-core": "^4.11.4",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
-    "globals": "^17.5.0",
+    "globals": "^17.6.0",
     "jsdom": "^29.1.1",
-    "playwright": "1.58.2",
+    "playwright": "1.59.1",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "vitest": "^4.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,14 +49,14 @@ importers:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.4.0(jiti@2.7.0))
       globals:
-        specifier: ^17.5.0
-        version: 17.5.0
+        specifier: ^17.6.0
+        version: 17.6.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       playwright:
-        specifier: 1.58.2
-        version: 1.58.2
+        specifier: 1.59.1
+        version: 1.59.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -1081,8 +1081,8 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  globals@17.5.0:
-    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
@@ -1352,13 +1352,13 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2556,7 +2556,7 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  globals@17.5.0: {}
+  globals@17.6.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -2773,11 +2773,11 @@ snapshots:
 
   pify@2.3.0: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.59.1: {}
 
-  playwright@1.58.2:
+  playwright@1.59.1:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates devenv to 2.1.2 from 2.0.6, removes nextflow package overrides and updates playwright to 1.59.1,

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Temporarily disable direnv with `direnv deny`
2. Ensure all servers and services are stopped
3. Checkout branch
4. Update devenv with `nix profile upgrade devenv`
6. Run `devenv shell`
7. Confirm shell initialized
8. Re-enable direnv with `direnv allow`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
