### PR TITLE
feat(workflows): disable out-of-limit pipeline launch

### DIFF
--- a/app/javascript/controllers/workflow_selection_controller.js
+++ b/app/javascript/controllers/workflow_selection_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
   static values = {
     fieldName: String,
     featureFlag: { type: Boolean },
+    unavailableLabel: String,
   };
 
   #sampleCount;
@@ -32,9 +33,10 @@ export default class extends Controller {
 
     document.addEventListener("turbo:submit-end", preventEscapeListener);
 
-    if (this.featureFlagValue) {
-      this.#sampleCount = this.selectionOutlet.getStoredItemsCount();
-    }
+    this.#sampleCount = this.hasSelectionOutlet
+      ? this.selectionOutlet.getStoredItemsCount()
+      : 0;
+    this.updateWorkflowAvailability();
   }
 
   disconnect() {
@@ -74,7 +76,12 @@ export default class extends Controller {
     document.addEventListener("keydown", preventEscapeListener, true);
   }
 
-  selectWorkflow({ params }) {
+  selectWorkflow(event) {
+    if (event.currentTarget.getAttribute("aria-disabled") === "true") {
+      return;
+    }
+
+    const { params } = event;
     this.preventClosingDialog();
     this.pipelineIdTarget.value = params.pipelineid;
     this.workflowVersionTarget.value = params.workflowversion;
@@ -116,6 +123,124 @@ export default class extends Controller {
       );
     }
     this.formTarget.requestSubmit();
+  }
+
+  updateWorkflowAvailability() {
+    const workflowsByState = [];
+
+    this.workflowTargets.forEach((workflow) => {
+      const disabledMessage = this.disabledMessage(workflow);
+      const isDisabled = disabledMessage.length > 0;
+      const limitMessage = workflow.querySelector(
+        "[data-workflow-selection-limit-message]",
+      );
+
+      this.setDisabledState(workflow, isDisabled);
+
+      if (limitMessage) {
+        limitMessage.classList.toggle("hidden", !isDisabled);
+        limitMessage.textContent = disabledMessage;
+      }
+
+      workflowsByState.push({ workflow, isDisabled });
+    });
+
+    this.reorderWorkflows(workflowsByState);
+  }
+
+  disabledMessage(workflow) {
+    const minSamplesConfigured =
+      workflow.dataset.workflowSelectionMinSamplesConfigured === "true";
+    const maxSamplesConfigured =
+      workflow.dataset.workflowSelectionMaxSamplesConfigured === "true";
+    const minimumSamples = Number.parseInt(
+      workflow.dataset.workflowSelectionMinSamples ?? "0",
+      10,
+    );
+    const maximumSamples = Number.parseInt(
+      workflow.dataset.workflowSelectionMaxSamples ?? "-1",
+      10,
+    );
+
+    if (minSamplesConfigured && this.#sampleCount < minimumSamples) {
+      return workflow.dataset.workflowSelectionMinSamplesMessage;
+    }
+
+    if (
+      maxSamplesConfigured &&
+      maximumSamples > 0 &&
+      this.#sampleCount > maximumSamples
+    ) {
+      return workflow.dataset.workflowSelectionMaxSamplesMessage;
+    }
+
+    return "";
+  }
+
+  setDisabledState(workflow, disabled) {
+    workflow.setAttribute("aria-disabled", disabled.toString());
+  }
+
+  reorderWorkflows(workflowsByState) {
+    if (workflowsByState.length === 0) {
+      return;
+    }
+
+    const list = workflowsByState[0].workflow.closest("ul");
+    if (!list) {
+      return;
+    }
+
+    const enabledRows = [];
+    const disabledRows = [];
+
+    workflowsByState.forEach(({ workflow, isDisabled }) => {
+      const row = workflow.closest("li");
+      if (!row) {
+        return;
+      }
+
+      if (isDisabled) {
+        disabledRows.push(row);
+      } else {
+        enabledRows.push(row);
+      }
+    });
+
+    list
+      .querySelectorAll("[data-workflow-selection-divider]")
+      .forEach((divider) => divider.remove());
+
+    enabledRows.forEach((row) => list.appendChild(row));
+
+    if (disabledRows.length > 0) {
+      list.appendChild(this.createUnavailableDivider());
+      disabledRows.forEach((row) => list.appendChild(row));
+    }
+  }
+
+  createUnavailableDivider() {
+    const divider = document.createElement("li");
+    divider.dataset.workflowSelectionDivider = "true";
+    divider.className = "pt-2";
+
+    const container = document.createElement("div");
+    container.className =
+      "flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400";
+
+    const leadingRule = document.createElement("span");
+    leadingRule.className = "h-px flex-1 bg-slate-200 dark:bg-slate-700";
+
+    const label = document.createElement("span");
+    label.textContent = this.unavailableLabelValue;
+
+    const trailingRule = document.createElement("span");
+    trailingRule.className = "h-px flex-1 bg-slate-200 dark:bg-slate-700";
+
+    container.append(leadingRule, label, trailingRule);
+    divider.appendChild(container);
+
+    return divider;
   }
 
   #toJson(formData) {

--- a/app/services/workflow_executions/create_service.rb
+++ b/app/services/workflow_executions/create_service.rb
@@ -140,13 +140,13 @@ module WorkflowExecutions
       max_samples = workflow_execution.workflow.maximum_samples
       if @samples_count < min_samples
         workflow_execution.errors.add(:base,
-                                      I18n.t('services.workflow_executions.create.min_samples_required',
+                                      I18n.t('shared.workflow_executions.sample_limits.min_samples_required',
                                              min_samples: min_samples))
       end
       return unless max_samples.positive? && (@samples_count > max_samples)
 
       workflow_execution.errors.add(:base,
-                                    I18n.t('services.workflow_executions.create.max_samples_exceeded',
+                                    I18n.t('shared.workflow_executions.sample_limits.max_samples_exceeded',
                                            max_samples: max_samples))
     end
 

--- a/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
+++ b/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
@@ -38,8 +38,8 @@
               data-workflow-selection-max-samples-configured="<%= max_samples_configured %>"
               data-workflow-selection-min-samples="<%= workflow.minimum_samples if min_samples_configured %>"
               data-workflow-selection-max-samples="<%= workflow.maximum_samples if max_samples_configured %>"
-              data-workflow-selection-min-samples-message="<%= t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: workflow.minimum_samples) %>"
-              data-workflow-selection-max-samples-message="<%= t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: workflow.maximum_samples) %>"
+              data-workflow-selection-min-samples-message="<%= t('shared.workflow_executions.sample_limits.min_samples_required', min_samples: workflow.minimum_samples) %>"
+              data-workflow-selection-max-samples-message="<%= t('shared.workflow_executions.sample_limits.max_samples_exceeded', max_samples: workflow.maximum_samples) %>"
               data-action="click->workflow-selection#selectWorkflow"
             >
               <span class="mr-2 shrink-0">

--- a/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
+++ b/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
@@ -6,7 +6,7 @@
   <% field_name =
     Flipper.enabled?(:v2_samplesheet, current_user) ? "sample_count" : "sample_ids[]" %>
 
-  <%= render Viral::BaseComponent.new(tag: 'div', data: { controller: "workflow-selection", "workflow-selection-selection-outlet": "#samples-table", "workflow-selection-field-name-value": field_name, "workflow-selection-feature-flag-value": Flipper.enabled?(:v2_samplesheet, current_user).to_s}) do %>
+  <%= render Viral::BaseComponent.new(tag: 'div', data: { controller: "workflow-selection", "workflow-selection-selection-outlet": "#samples-table", "workflow-selection-field-name-value": field_name, "workflow-selection-feature-flag-value": Flipper.enabled?(:v2_samplesheet, current_user).to_s, "workflow-selection-unavailable-label-value": t("workflow_executions.submissions.pipeline_selection.unavailable") }) do %>
     <%= form_with url: workflow_executions_submissions_path, data: { turbo_stream: true, "workflow-selection-target": "form" } do |form| %>
       <%= form.hidden_field :pipeline_id,
                         data: {
@@ -22,6 +22,9 @@
 
       <ul class="space-y-2">
         <% workflows.each do |key, workflow| %>
+          <% min_samples_configured = workflow.min_samples_limit_configured? %>
+          <% max_samples_configured = workflow.max_samples_limit_configured? %>
+
           <li>
             <button
               type="button"
@@ -31,6 +34,12 @@
               data-workflow-selection-workflowName-param="<%= workflow.name %>"
               data-workflow-selection-workflowVersion-param="<%= workflow.version %>"
               data-workflow-selection-namespaceId-param="<%= @namespace_id %>"
+              data-workflow-selection-min-samples-configured="<%= min_samples_configured %>"
+              data-workflow-selection-max-samples-configured="<%= max_samples_configured %>"
+              data-workflow-selection-min-samples="<%= workflow.minimum_samples if min_samples_configured %>"
+              data-workflow-selection-max-samples="<%= workflow.maximum_samples if max_samples_configured %>"
+              data-workflow-selection-min-samples-message="<%= t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: workflow.minimum_samples) %>"
+              data-workflow-selection-max-samples-message="<%= t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: workflow.maximum_samples) %>"
               data-action="click->workflow-selection#selectWorkflow"
             >
               <span class="mr-2 shrink-0">
@@ -51,6 +60,14 @@
                 <span class="text-sm font-normal text-wrap text-slate-500 dark:text-slate-400">
                   <%= workflow.description %>
                 </span>
+
+                <span
+                  class="
+                    mt-2 block hidden w-fit rounded-md bg-red-100 px-2 py-1 text-sm font-medium text-red-700
+                    dark:bg-red-900/40 dark:text-red-300
+                  "
+                  data-workflow-selection-limit-message
+                ></span>
               </span>
             </button>
           </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1944,10 +1944,6 @@ en:
       missing_data_row: The file does not have any data rows. Please add some rows of data to the file and retry uploading.
       missing_field: Row with index '%{index}' is missing required fields
       missing_header: File is missing the header(s) '%{header_title}'
-    workflow_executions:
-      create:
-        max_samples_exceeded: Maximum number of samples for pipeline (%{max_samples}) exceeded
-        min_samples_required: Minimum number of samples that the pipeline requires for analysis (%{min_samples})
   shared:
     alert:
       list:
@@ -2120,6 +2116,9 @@ en:
         name: 'Name:'
         run_id: 'Run ID:'
         workflow: 'Workflow:'
+      sample_limits:
+        max_samples_exceeded: Maximum number of samples for pipeline (%{max_samples}) exceeded
+        min_samples_required: Minimum number of samples that the pipeline requires for analysis (%{min_samples})
   spreadsheet_helper:
     failed_parsing: 'Failed to parse spreadsheet file: %{error}'
     no_file: No file provided
@@ -2216,8 +2215,6 @@ en:
         title: "%{workflow} parameters"
       pipeline_selection:
         loading_html: "<span class='flex items-center space-x-2'><span class='font-medium truncate text-slate-900 dark:text-white group-hover:text-slate-100'>WORKFLOW_NAME_PLACEHOLDER</span><span class='bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-400 text-xs font-medium px-2.5 py-0.5 rounded-full'>WORKFLOW_VERSION_PLACEHOLDER</span></span>Preparing workflow execution arguments for COUNT_PLACEHOLDER samples, this may take a bit of time."
-        max_samples_exceeded: Maximum number of samples for pipeline (%{max_samples}) exceeded
-        min_samples_required: Minimum number of samples that the pipeline requires for analysis (%{min_samples})
         title: Workflow Selection
         unavailable: Unavailable
     summary:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2216,7 +2216,10 @@ en:
         title: "%{workflow} parameters"
       pipeline_selection:
         loading_html: "<span class='flex items-center space-x-2'><span class='font-medium truncate text-slate-900 dark:text-white group-hover:text-slate-100'>WORKFLOW_NAME_PLACEHOLDER</span><span class='bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-400 text-xs font-medium px-2.5 py-0.5 rounded-full'>WORKFLOW_VERSION_PLACEHOLDER</span></span>Preparing workflow execution arguments for COUNT_PLACEHOLDER samples, this may take a bit of time."
+        max_samples_exceeded: Maximum number of samples for pipeline (%{max_samples}) exceeded
+        min_samples_required: Minimum number of samples that the pipeline requires for analysis (%{min_samples})
         title: Workflow Selection
+        unavailable: Unavailable
     summary:
       created_at: Created
       deleted: Deleted

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2220,7 +2220,10 @@ fr:
         title: Paramètres %{workflow}
       pipeline_selection:
         loading_html: "<span class='flex items-center space-x-2'><span class='font-medium truncate text-slate-900 dark:text-white group-hover:text-slate-100'>WORKFLOW_NAME_PLACEHOLDER</span><span class='bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-400 text-xs font-medium px-2.5 py-0.5 rounded-full'>WORKFLOW_VERSION_PLACEHOLDER</span></span>La préparation des arguments d’exécution du flux de travail pour les échantillons COUNT_PLACEHOLDER peut prendre un certain temps."
+        max_samples_exceeded: Le nombre maximal d'échantillons autorisé pour le pipeline (%{max_samples}) a été dépassé
+        min_samples_required: Le nombre minimum d'échantillons requis pour que le pipeline puisse effectuer l’analyse (%{min_samples})
         title: Sélection du flux de travail
+        unavailable: Non disponible
     summary:
       created_at: Créé
       deleted: Supprimé

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1948,10 +1948,6 @@ fr:
       missing_data_row: Le fichier ne comporte aucune ligne de données. Veuillez ajouter des lignes de données au fichier et réessayer le téléchargement.
       missing_field: La ligne avec l’index '%{index}' ne contient pas de champs obligatoires
       missing_header: Le fichier ne contient pas d’en-têtes '%{header_title}'
-    workflow_executions:
-      create:
-        max_samples_exceeded: Le nombre maximal d'échantillons autorisé pour le pipeline (%{max_samples}) a été dépassé
-        min_samples_required: Le nombre minimum d'échantillons requis pour que le pipeline puisse effectuer l’analyse (%{min_samples})
   shared:
     alert:
       list:
@@ -2124,6 +2120,9 @@ fr:
         name: 'Nom :'
         run_id: 'Exécuter l’identifiant :'
         workflow: 'Flux de travail :'
+      sample_limits:
+        max_samples_exceeded: Le nombre maximal d'échantillons autorisé pour le pipeline (%{max_samples}) a été dépassé
+        min_samples_required: Le nombre minimum d'échantillons requis pour que le pipeline puisse effectuer l’analyse (%{min_samples})
   spreadsheet_helper:
     failed_parsing: 'Échec d’analyse du fichier tableur : %{error}'
     no_file: Aucun fichier fourni
@@ -2220,8 +2219,6 @@ fr:
         title: Paramètres %{workflow}
       pipeline_selection:
         loading_html: "<span class='flex items-center space-x-2'><span class='font-medium truncate text-slate-900 dark:text-white group-hover:text-slate-100'>WORKFLOW_NAME_PLACEHOLDER</span><span class='bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-400 text-xs font-medium px-2.5 py-0.5 rounded-full'>WORKFLOW_VERSION_PLACEHOLDER</span></span>La préparation des arguments d’exécution du flux de travail pour les échantillons COUNT_PLACEHOLDER peut prendre un certain temps."
-        max_samples_exceeded: Le nombre maximal d'échantillons autorisé pour le pipeline (%{max_samples}) a été dépassé
-        min_samples_required: Le nombre minimum d'échantillons requis pour que le pipeline puisse effectuer l’analyse (%{min_samples})
         title: Sélection du flux de travail
         unavailable: Non disponible
     summary:

--- a/config/pipelines/pipelines.json
+++ b/config/pipelines/pipelines.json
@@ -5,7 +5,11 @@
     "description": "IRIDA Next Example Pipeline",
     "versions": [
       {
-        "name": "1.0.3"
+        "name": "1.0.3",
+        "settings": {
+          "min_samples": 2,
+          "max_samples": 5
+        }
       },
       {
         "name": "1.0.2",

--- a/lib/irida/pipeline.rb
+++ b/lib/irida/pipeline.rb
@@ -18,6 +18,8 @@ module Irida
 
     def initialize(pipeline_id, entry, version, schema_loc, schema_input_loc, unknown: false) # rubocop:disable Metrics/MethodLength,Metrics/ParameterLists,Metrics/AbcSize
       @pipeline_id = pipeline_id
+      @entry = entry
+      @version_entry = version
       @name = entry['name']
       @description = entry['description']
       @type = 'NFL'
@@ -131,6 +133,14 @@ module Irida
       @settings.fetch('max_samples', -1).to_i
     end
 
+    def min_samples_limit_configured?
+      settings_key_configured?('min_samples')
+    end
+
+    def max_samples_limit_configured?
+      settings_key_configured?('max_samples')
+    end
+
     def maximum_run_time(sample_count = 0)
       max_run_time = @settings.fetch('max_runtime', nil)
 
@@ -233,6 +243,10 @@ module Irida
         )
 
       settings
+    end
+
+    def settings_key_configured?(key)
+      @entry['settings']&.key?(key) || @version_entry['settings']&.key?(key)
     end
 
     def samplesheet_schema_overrides_for_entry(entry, version)

--- a/test/graphql/submit_workflow_execution_mutation_test.rb
+++ b/test/graphql/submit_workflow_execution_mutation_test.rb
@@ -114,7 +114,7 @@ class SubmitWorkflowExecutionMutationTest < ActiveSupport::TestCase
 
     assert_not_empty errors, 'should have errors which prevented creation of workflow execution.'
     assert(errors.any? do |e|
-      e['message'] == I18n.t('services.workflow_executions.create.min_samples_required',
+      e['message'] == I18n.t('shared.workflow_executions.sample_limits.min_samples_required',
                              min_samples: 2)
     end)
   end
@@ -171,7 +171,7 @@ class SubmitWorkflowExecutionMutationTest < ActiveSupport::TestCase
 
     assert_not_empty errors, 'should have errors which prevented creation of workflow execution.'
     assert(errors.any? do |e|
-      e['message'] == I18n.t('services.workflow_executions.create.max_samples_exceeded',
+      e['message'] == I18n.t('shared.workflow_executions.sample_limits.max_samples_exceeded',
                              max_samples: 2)
     end)
   end

--- a/test/lib/irida/pipeline_test.rb
+++ b/test/lib/irida/pipeline_test.rb
@@ -407,4 +407,52 @@ class PipelinesTest < ActiveSupport::TestCase
 
     assert_equal(-1, pipeline.maximum_samples)
   end
+
+  test 'min samples limit configured at version level' do
+    entry = {
+      url: 'https://github.com/phac-nml/iridanextexample',
+      name: 'phac-nml/iridanextexample',
+      description: 'IRIDA Next Example Pipeline'
+    }.with_indifferent_access
+
+    pipeline = Irida::Pipeline.new('phac-nml/iridanextexample', entry, { 'name' => '1.0.3', 'settings' => {
+                                     'min_samples' => 2
+                                   } },
+                                   Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json'),
+                                   Rails.root.join('test/fixtures/files/nextflow/samplesheet_schema.json'))
+
+    assert pipeline.min_samples_limit_configured?
+  end
+
+  test 'max samples limit configured at entry level' do
+    entry = {
+      url: 'https://github.com/phac-nml/iridanextexample',
+      name: 'phac-nml/iridanextexample',
+      description: 'IRIDA Next Example Pipeline',
+      settings: {
+        max_samples: 5
+      }
+    }.with_indifferent_access
+
+    pipeline = Irida::Pipeline.new('phac-nml/iridanextexample', entry, { 'name' => '1.0.3' },
+                                   Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json'),
+                                   Rails.root.join('test/fixtures/files/nextflow/samplesheet_schema.json'))
+
+    assert pipeline.max_samples_limit_configured?
+  end
+
+  test 'sample limit configured helpers return false when limits are not configured' do
+    entry = {
+      url: 'https://github.com/phac-nml/iridanextexample',
+      name: 'phac-nml/iridanextexample',
+      description: 'IRIDA Next Example Pipeline'
+    }.with_indifferent_access
+
+    pipeline = Irida::Pipeline.new('phac-nml/iridanextexample', entry, { 'name' => '1.0.3' },
+                                   Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json'),
+                                   Rails.root.join('test/fixtures/files/nextflow/samplesheet_schema.json'))
+
+    assert_not pipeline.min_samples_limit_configured?
+    assert_not pipeline.max_samples_limit_configured?
+  end
 end

--- a/test/lib/irida/pipeline_test.rb
+++ b/test/lib/irida/pipeline_test.rb
@@ -424,6 +424,39 @@ class PipelinesTest < ActiveSupport::TestCase
     assert pipeline.min_samples_limit_configured?
   end
 
+  test 'min samples limit configured at entry level' do
+    entry = {
+      url: 'https://github.com/phac-nml/iridanextexample',
+      name: 'phac-nml/iridanextexample',
+      description: 'IRIDA Next Example Pipeline',
+      settings: {
+        min_samples: 3
+      }
+    }.with_indifferent_access
+
+    pipeline = Irida::Pipeline.new('phac-nml/iridanextexample', entry, { 'name' => '1.0.3' },
+                                   Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json'),
+                                   Rails.root.join('test/fixtures/files/nextflow/samplesheet_schema.json'))
+
+    assert pipeline.min_samples_limit_configured?
+  end
+
+  test 'max samples limit configured at version level' do
+    entry = {
+      url: 'https://github.com/phac-nml/iridanextexample',
+      name: 'phac-nml/iridanextexample',
+      description: 'IRIDA Next Example Pipeline'
+    }.with_indifferent_access
+
+    pipeline = Irida::Pipeline.new('phac-nml/iridanextexample', entry, { 'name' => '1.0.3', 'settings' => {
+                                     'max_samples' => 5
+                                   } },
+                                   Rails.root.join('test/fixtures/files/nextflow/nextflow_schema.json'),
+                                   Rails.root.join('test/fixtures/files/nextflow/samplesheet_schema.json'))
+
+    assert pipeline.max_samples_limit_configured?
+  end
+
   test 'max samples limit configured at entry level' do
     entry = {
       url: 'https://github.com/phac-nml/iridanextexample',

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -98,7 +98,7 @@ module WorkflowExecutions
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params1).execute
 
       assert @workflow_execution.errors[:base].include?(
-        I18n.t('services.workflow_executions.create.min_samples_required',
+        I18n.t('shared.workflow_executions.sample_limits.min_samples_required',
                min_samples: @workflow_execution.workflow.minimum_samples)
       )
     end
@@ -144,7 +144,7 @@ module WorkflowExecutions
       @workflow_execution = WorkflowExecutions::CreateService.new(@user, workflow_params1).execute
 
       assert @workflow_execution.errors[:base].include?(
-        I18n.t('services.workflow_executions.create.max_samples_exceeded',
+        I18n.t('shared.workflow_executions.sample_limits.max_samples_exceeded',
                max_samples: @workflow_execution.workflow.maximum_samples)
       )
     end

--- a/test/system/workflow_executions/submissions_v1_test.rb
+++ b/test/system/workflow_executions/submissions_v1_test.rb
@@ -111,7 +111,7 @@ module WorkflowExecutions
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
-      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: 2)
+      assert_text I18n.t('shared.workflow_executions.sample_limits.min_samples_required', min_samples: 2)
 
       find('button[data-workflow-selection-workflowversion-param="1.0.2"]').click
 
@@ -132,7 +132,7 @@ module WorkflowExecutions
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
-      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 2)
+      assert_text I18n.t('shared.workflow_executions.sample_limits.max_samples_exceeded', max_samples: 2)
     end
 
     test 'should display a pipeline selection modal for project samples as analyst' do

--- a/test/system/workflow_executions/submissions_v1_test.rb
+++ b/test/system/workflow_executions/submissions_v1_test.rb
@@ -109,11 +109,11 @@ module WorkflowExecutions
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
       assert_text I18n.t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: 2)
 
-      find('button[data-workflow-selection-workflow-version-param="1.0.2"]').click
+      find('button[data-workflow-selection-workflowversion-param="1.0.2"]').click
 
       assert_selector 'h1.dialog--title',
                       text: I18n.t('workflow_executions.submissions.create.title',
@@ -130,9 +130,9 @@ module WorkflowExecutions
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
-      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 5)
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
+      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 2)
     end
 
     test 'should display a pipeline selection modal for project samples as analyst' do

--- a/test/system/workflow_executions/submissions_v1_test.rb
+++ b/test/system/workflow_executions/submissions_v1_test.rb
@@ -99,6 +99,42 @@ module WorkflowExecutions
       assert_text I18n.t(:"components.nextflow.shared_with.#{@project.namespace.type.downcase}", locale: user.locale)
     end
 
+    test 'pipeline selection marks workflow versions outside configured minimum sample limits unavailable' do
+      user = users(:john_doe)
+      login_as user
+
+      visit namespace_project_samples_url(namespace_id: @namespace.path, project_id: @project.path)
+
+      check "checkbox_sample_#{@sample43.id}"
+      click_on I18n.t(:'projects.samples.index.workflows.button_sr')
+
+      assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
+      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: 2)
+
+      find('button[data-workflow-selection-workflow-version-param="1.0.2"]').click
+
+      assert_selector 'h1.dialog--title',
+                      text: I18n.t('workflow_executions.submissions.create.title',
+                                   workflow: 'phac-nml/iridanextexample')
+    end
+
+    test 'pipeline selection marks workflow versions outside configured maximum sample limits unavailable' do
+      user = users(:john_doe)
+      login_as user
+
+      visit namespace_project_samples_url(@group1, @project2)
+
+      click_button I18n.t('common.controls.select_all')
+      click_on I18n.t(:'projects.samples.index.workflows.button_sr')
+
+      assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
+      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 5)
+    end
+
     test 'should display a pipeline selection modal for project samples as analyst' do
       user = users(:james_doe)
       login_as user

--- a/test/system/workflow_executions/submissions_v2_test.rb
+++ b/test/system/workflow_executions/submissions_v2_test.rb
@@ -124,6 +124,42 @@ module WorkflowExecutions
       assert_text I18n.t(:"components.nextflow.shared_with.#{@project.namespace.type.downcase}", locale: user.locale)
     end
 
+    test 'pipeline selection marks workflow versions outside configured minimum sample limits unavailable' do
+      user = users(:john_doe)
+      login_as user
+
+      visit namespace_project_samples_url(namespace_id: @namespace.path, project_id: @project.path)
+
+      check "checkbox_sample_#{@sample43.id}"
+      click_on I18n.t(:'projects.samples.index.workflows.button_sr')
+
+      assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
+      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: 2)
+
+      find('button[data-workflow-selection-workflow-version-param="1.0.2"]').click
+
+      assert_selector 'h1.dialog--title',
+                      text: I18n.t('workflow_executions.submissions.create.title',
+                                   workflow: 'phac-nml/iridanextexample')
+    end
+
+    test 'pipeline selection marks workflow versions outside configured maximum sample limits unavailable' do
+      user = users(:john_doe)
+      login_as user
+
+      visit namespace_project_samples_url(@group1, @project2)
+
+      click_button I18n.t('common.controls.select_all')
+      click_on I18n.t(:'projects.samples.index.workflows.button_sr')
+
+      assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
+      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 5)
+    end
+
     test 'should display a pipeline selection modal for project samples as analyst' do
       user = users(:james_doe)
       login_as user

--- a/test/system/workflow_executions/submissions_v2_test.rb
+++ b/test/system/workflow_executions/submissions_v2_test.rb
@@ -136,7 +136,7 @@ module WorkflowExecutions
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
-      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: 2)
+      assert_text I18n.t('shared.workflow_executions.sample_limits.min_samples_required', min_samples: 2)
 
       find('button[data-workflow-selection-workflowversion-param="1.0.2"]').click
 
@@ -157,7 +157,7 @@ module WorkflowExecutions
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
       assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
-      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 2)
+      assert_text I18n.t('shared.workflow_executions.sample_limits.max_samples_exceeded', max_samples: 2)
     end
 
     test 'should display a pipeline selection modal for project samples as analyst' do

--- a/test/system/workflow_executions/submissions_v2_test.rb
+++ b/test/system/workflow_executions/submissions_v2_test.rb
@@ -134,11 +134,11 @@ module WorkflowExecutions
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
       assert_text I18n.t('workflow_executions.submissions.pipeline_selection.min_samples_required', min_samples: 2)
 
-      find('button[data-workflow-selection-workflow-version-param="1.0.2"]').click
+      find('button[data-workflow-selection-workflowversion-param="1.0.2"]').click
 
       assert_selector 'h1.dialog--title',
                       text: I18n.t('workflow_executions.submissions.create.title',
@@ -155,9 +155,9 @@ module WorkflowExecutions
       click_on I18n.t(:'projects.samples.index.workflows.button_sr')
 
       assert_selector 'h1.dialog--title', text: I18n.t(:'workflow_executions.submissions.pipeline_selection.title')
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.3"][aria-disabled="true"]'
-      assert_selector 'button[data-workflow-selection-workflow-version-param="1.0.2"][aria-disabled="false"]'
-      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 5)
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.3"][aria-disabled="true"]'
+      assert_selector 'button[data-workflow-selection-workflowversion-param="1.0.2"][aria-disabled="false"]'
+      assert_text I18n.t('workflow_executions.submissions.pipeline_selection.max_samples_exceeded', max_samples: 2)
     end
 
     test 'should display a pipeline selection modal for project samples as analyst' do


### PR DESCRIPTION
## What does this PR do and why?
- Disables workflow versions in the pipeline selection dialog when the selected sample count is outside configured `min_samples` or `max_samples` limits.
- Unavailable versions show an inline reason, cannot be selected, and are grouped below an "Unavailable" divider so users can still launch a valid version.

## Screenshots or screen recordings

<img width="1150" height="759" alt="image" src="https://github.com/user-attachments/assets/552b37a8-ea40-4474-9719-d64f4ec46215" />

<img width="1794" height="759" alt="image" src="https://github.com/user-attachments/assets/f40cd63d-e6c9-4978-ae2d-c476e4820034" />

## How to set up and validate locally
1. Start the app with `bin/dev`.
2. Open a project samples page and select one sample.
3. Open the workflow selection dialog and confirm `phac-nml/iridanextexample` version 1.0.3 is unavailable with the minimum samples message; version 1.0.2 remains selectable.
4. Select six or more samples and confirm 1.0.3 is unavailable with the maximum samples exceeded message.
5. Run `PARALLEL_WORKERS=4 bin/rails test test/lib/irida/pipeline_test.rb test/system/workflow_executions/submissions_v1_test.rb test/system/workflow_executions/submissions_v2_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.