### PR TITLE
Profile Experimental Features UI

### DIFF
--- a/app/controllers/profiles/experimental_features_controller.rb
+++ b/app/controllers/profiles/experimental_features_controller.rb
@@ -53,10 +53,10 @@ module Profiles
     end
 
     def status_message_for(form)
-      return t('.error') if form_error?(form, :base, :flipper_error)
-      return t('.not_eligible') if form_error?(form, :feature_key, :not_eligible)
+      return t(:'profiles.experimental_features.update.error') if form_error?(form, :base, :flipper_error)
+      return t(:'profiles.experimental_features.update.not_eligible') if form_error?(form, :feature_key, :not_eligible)
 
-      t('.validation_error')
+      t(:'profiles.experimental_features.update.validation_error')
     end
 
     def form_error?(form, field, error_key)
@@ -67,7 +67,7 @@ module Profiles
       respond_to do |format|
         format.turbo_stream { head :unprocessable_content }
         format.html do
-          flash[:error] = t('.validation_error')
+          flash[:error] = t(:'profiles.experimental_features.update.validation_error')
           redirect_back_or_to profile_experimental_features_path
         end
       end

--- a/app/controllers/profiles/experimental_features_controller.rb
+++ b/app/controllers/profiles/experimental_features_controller.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Profiles
+  # Controller for user opt-in controls on experimental Flipper features
+  class ExperimentalFeaturesController < Profiles::ApplicationController
+    before_action :page_title
+
+    def show
+      authorize! @user, to: :read?
+      @eligible_features = service.eligible_features
+    end
+
+    def update # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      authorize! @user, to: :update?
+
+      form = build_form
+      updated = Profiles::ExperimentalFeatures::OptInService.new(@user, form).execute
+      feature = service.feature(form.feature_key, include_ineligible: !updated)
+      status_message = updated ? t('.success') : status_message_for(form)
+      status_variant = updated ? :success : :error
+
+      respond_to do |format|
+        format.turbo_stream do
+          render :update,
+                 status: updated ? :ok : :unprocessable_content,
+                 locals: {
+                   feature: feature,
+                   user: @user,
+                   status_message: status_message,
+                   status_variant: status_variant
+                 }
+        end
+        format.html do
+          flash[updated ? :success : :error] = status_message
+          redirect_back_or_to profile_experimental_features_path
+        end
+      end
+    rescue ActionController::ParameterMissing
+      respond_invalid_submission
+    end
+
+    private
+
+    def service
+      @service ||= Profiles::ExperimentalFeatures::OptInService.new(@user)
+    end
+
+    def build_form
+      Profiles::ExperimentalFeatures::OptInForm.new(
+        user: @user,
+        **params.expect(opt_in_form: %i[feature_key enabled])
+      )
+    end
+
+    def status_message_for(form)
+      return t('.error') if form_error?(form, :base, :flipper_error)
+      return t('.not_eligible') if form_error?(form, :feature_key, :not_eligible)
+
+      t('.validation_error')
+    end
+
+    def form_error?(form, field, error_key)
+      form.errors.details[field].any? { |error| error[:error] == error_key }
+    end
+
+    def respond_invalid_submission
+      respond_to do |format|
+        format.turbo_stream { head :unprocessable_content }
+        format.html do
+          flash[:error] = t('.validation_error')
+          redirect_back_or_to profile_experimental_features_path
+        end
+      end
+    end
+
+    def current_page
+      @current_page = t(:'profiles.sidebar.experimental_features')
+    end
+
+    def page_title
+      @title = t(:'profiles.experimental_features.show.title')
+    end
+  end
+end

--- a/app/controllers/profiles/experimental_features_controller.rb
+++ b/app/controllers/profiles/experimental_features_controller.rb
@@ -7,16 +7,17 @@ module Profiles
 
     def show
       authorize! @user, to: :read?
-      @eligible_features = service.eligible_features
+      @eligible_features = Profiles::ExperimentalFeatures::OptInService.new(@user).eligible_features
     end
 
     def update # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       authorize! @user, to: :update?
 
-      form = build_form
-      updated = Profiles::ExperimentalFeatures::OptInService.new(@user, form).execute
-      feature = service.feature(form.feature_key, include_ineligible: !updated)
-      status_message = updated ? t('.success') : status_message_for(form)
+      form = Profiles::ExperimentalFeatures::OptInForm.new(user: @user, **opt_in_form_params)
+      opt_in_service = Profiles::ExperimentalFeatures::OptInService.new(@user, form)
+      updated = opt_in_service.execute
+      feature = opt_in_service.feature(form.feature_key, include_ineligible: !updated)
+      status_message = updated ? t('.success') : error_message_for(form)
       status_variant = updated ? :success : :error
 
       respond_to do |format|
@@ -40,18 +41,11 @@ module Profiles
 
     private
 
-    def service
-      @service ||= Profiles::ExperimentalFeatures::OptInService.new(@user)
+    def opt_in_form_params
+      params.expect(opt_in_form: %i[feature_key enabled])
     end
 
-    def build_form
-      Profiles::ExperimentalFeatures::OptInForm.new(
-        user: @user,
-        **params.expect(opt_in_form: %i[feature_key enabled])
-      )
-    end
-
-    def status_message_for(form)
+    def error_message_for(form)
       return t(:'profiles.experimental_features.update.error') if form_error?(form, :base, :flipper_error)
       return t(:'profiles.experimental_features.update.not_eligible') if form_error?(form, :feature_key, :not_eligible)
 
@@ -83,7 +77,7 @@ module Profiles
     end
 
     def render_feature_update(feature:, feature_key:, status_message:, status_variant:, http_status:)
-      display_feature = feature.presence || application_settings.opt_in_feature_payload(feature_key, @user)
+      display_feature = feature.presence || Irida::CurrentSettings.opt_in_feature_payload(feature_key, @user)
 
       if display_feature.present?
         render :update,
@@ -97,10 +91,6 @@ module Profiles
       else
         head http_status
       end
-    end
-
-    def application_settings
-      Irida::CurrentSettings.current_application_settings
     end
 
     def current_page

--- a/app/controllers/profiles/experimental_features_controller.rb
+++ b/app/controllers/profiles/experimental_features_controller.rb
@@ -21,14 +21,13 @@ module Profiles
 
       respond_to do |format|
         format.turbo_stream do
-          render :update,
-                 status: updated ? :ok : :unprocessable_content,
-                 locals: {
-                   feature: feature,
-                   user: @user,
-                   status_message: status_message,
-                   status_variant: status_variant
-                 }
+          render_feature_update(
+            feature: feature,
+            feature_key: form.feature_key,
+            status_message: status_message,
+            status_variant: status_variant,
+            http_status: updated ? :ok : :unprocessable_content
+          )
         end
         format.html do
           flash[updated ? :success : :error] = status_message
@@ -63,14 +62,45 @@ module Profiles
       form.errors.details[field].any? { |error| error[:error] == error_key }
     end
 
-    def respond_invalid_submission
+    def respond_invalid_submission # rubocop:disable Metrics/MethodLength
+      feature_key = params.dig(:opt_in_form, :feature_key)
+
       respond_to do |format|
-        format.turbo_stream { head :unprocessable_content }
+        format.turbo_stream do
+          render_feature_update(
+            feature: nil,
+            feature_key: feature_key,
+            status_message: t(:'profiles.experimental_features.update.validation_error'),
+            status_variant: :error,
+            http_status: :unprocessable_content
+          )
+        end
         format.html do
           flash[:error] = t(:'profiles.experimental_features.update.validation_error')
           redirect_back_or_to profile_experimental_features_path
         end
       end
+    end
+
+    def render_feature_update(feature:, feature_key:, status_message:, status_variant:, http_status:)
+      display_feature = feature.presence || application_settings.opt_in_feature_payload(feature_key, @user)
+
+      if display_feature.present?
+        render :update,
+               status: http_status,
+               locals: {
+                 feature: display_feature,
+                 user: @user,
+                 status_message: status_message,
+                 status_variant: status_variant
+               }
+      else
+        head http_status
+      end
+    end
+
+    def application_settings
+      Irida::CurrentSettings.current_application_settings
     end
 
     def current_page

--- a/app/javascript/controllers/experimental_feature_toggle_controller.js
+++ b/app/javascript/controllers/experimental_feature_toggle_controller.js
@@ -35,8 +35,6 @@ export default class extends Controller {
 
     this.pending = true;
     this.lastSubmittedChecked = this.switchTarget.checked;
-    this.element.setAttribute("aria-busy", "true");
-    this.switchTarget.setAttribute("aria-disabled", "true");
     this.statusTarget.textContent = this.savingTextValue;
     this.announce(this.savingTextValue);
     sessionStorage.setItem(this.sessionStorageKey(), this.switchTarget.id);
@@ -62,8 +60,6 @@ export default class extends Controller {
     if (!this.pending) return;
 
     this.pending = false;
-    this.element.removeAttribute("aria-busy");
-    this.switchTarget.removeAttribute("aria-disabled");
 
     if (this.lastSubmittedChecked !== undefined) {
       this.switchTarget.checked = !this.lastSubmittedChecked;

--- a/app/javascript/controllers/experimental_feature_toggle_controller.js
+++ b/app/javascript/controllers/experimental_feature_toggle_controller.js
@@ -1,0 +1,79 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["form", "status", "switch"];
+  static values = {
+    savingText: String,
+    successText: String,
+    featureKey: String,
+    clearDelay: Number,
+    minimumSavingMs: Number,
+  };
+
+  connect() {
+    this.pending = false;
+    this.restoreFocus();
+    this.announceCurrentStatus();
+    this.clearSuccessAfterDelay();
+  }
+
+  submit() {
+    if (this.pending) {
+      this.switchTarget.checked = this.lastSubmittedChecked;
+      return;
+    }
+
+    this.pending = true;
+    this.lastSubmittedChecked = this.switchTarget.checked;
+    this.element.setAttribute("aria-busy", "true");
+    this.switchTarget.setAttribute("aria-disabled", "true");
+    this.statusTarget.textContent = this.savingTextValue;
+    this.announce(this.savingTextValue);
+    sessionStorage.setItem(this.sessionStorageKey(), this.switchTarget.id);
+
+    const minimumSavingMs = this.hasMinimumSavingMsValue
+      ? this.minimumSavingMsValue
+      : 900;
+    window.setTimeout(() => {
+      this.formTarget.requestSubmit();
+    }, minimumSavingMs);
+  }
+
+  sessionStorageKey() {
+    return `experimentalFeatureToggleFocus:${this.featureKeyValue}`;
+  }
+
+  restoreFocus() {
+    const restoreId = sessionStorage.getItem(this.sessionStorageKey());
+    if (restoreId && restoreId === this.switchTarget.id) {
+      this.switchTarget.focus();
+      sessionStorage.removeItem(this.sessionStorageKey());
+    }
+  }
+
+  clearSuccessAfterDelay() {
+    if (this.statusTarget.textContent.trim() !== this.successTextValue) return;
+
+    const delay = this.hasClearDelayValue ? this.clearDelayValue : 3000;
+    window.setTimeout(() => {
+      if (this.statusTarget.textContent.trim() === this.successTextValue) {
+        this.statusTarget.textContent = "";
+      }
+    }, delay);
+  }
+
+  announceCurrentStatus() {
+    const currentStatus = this.statusTarget.textContent.trim();
+    if (!currentStatus) return;
+    if (currentStatus === this.savingTextValue) return;
+
+    this.announce(currentStatus);
+  }
+
+  announce(message) {
+    const announcer = document.getElementById(
+      "experimental-features-live-announcer",
+    );
+    if (announcer) announcer.textContent = message;
+  }
+}

--- a/app/javascript/controllers/experimental_feature_toggle_controller.js
+++ b/app/javascript/controllers/experimental_feature_toggle_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
   static values = {
     savingText: String,
     successText: String,
+    validationErrorText: String,
     featureKey: String,
     clearDelay: Number,
     minimumSavingMs: Number,
@@ -12,9 +13,18 @@ export default class extends Controller {
 
   connect() {
     this.pending = false;
+    this.boundOnSubmitEnd = this.onSubmitEnd.bind(this);
+    this.formTarget.addEventListener("turbo:submit-end", this.boundOnSubmitEnd);
     this.restoreFocus();
     this.announceCurrentStatus();
     this.clearSuccessAfterDelay();
+  }
+
+  disconnect() {
+    this.formTarget.removeEventListener(
+      "turbo:submit-end",
+      this.boundOnSubmitEnd,
+    );
   }
 
   submit() {
@@ -37,6 +47,35 @@ export default class extends Controller {
     window.setTimeout(() => {
       this.formTarget.requestSubmit();
     }, minimumSavingMs);
+  }
+
+  onSubmitEnd(event) {
+    if (event.detail.success) return;
+
+    const responseHtml = event.detail.fetchResponse?.responseHTML;
+    if (responseHtml?.includes("turbo-stream")) return;
+
+    this.resetPendingState();
+  }
+
+  resetPendingState() {
+    if (!this.pending) return;
+
+    this.pending = false;
+    this.element.removeAttribute("aria-busy");
+    this.switchTarget.removeAttribute("aria-disabled");
+
+    if (this.lastSubmittedChecked !== undefined) {
+      this.switchTarget.checked = !this.lastSubmittedChecked;
+    }
+
+    if (this.statusTarget.textContent.trim() === this.savingTextValue) {
+      const errorMessage = this.hasValidationErrorTextValue
+        ? this.validationErrorTextValue
+        : "";
+      this.statusTarget.textContent = errorMessage;
+      if (errorMessage) this.announce(errorMessage);
+    }
   }
 
   sessionStorageKey() {

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -45,6 +45,16 @@ class ApplicationSetting < ApplicationRecord
     end
   end
 
+  def opt_in_feature_payload(feature_key, user)
+    normalized_feature_key = feature_key.to_s
+    return nil unless flipper_feature_available?(normalized_feature_key)
+
+    feature_config = (user_opt_in_features || {})[normalized_feature_key]
+    return nil if feature_config.blank?
+
+    user_opt_in_feature_payload(normalized_feature_key, feature_config, user)
+  end
+
   private
 
   def flipper_feature_available?(feature_key)

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -12,6 +12,21 @@ module Profiles
         @opt_in_form = opt_in_form
       end
 
+      def eligible_features
+        settings.eligible_user_opt_in_features(current_user)
+      end
+
+      def feature(feature_key, include_ineligible: false)
+        normalized_feature_key = feature_key.to_s
+        return nil if normalized_feature_key.blank?
+
+        feature = eligible_features.find { |item| item[:key] == normalized_feature_key.to_sym }
+        return feature if feature.present?
+        return nil unless include_ineligible
+
+        feature_payload(normalized_feature_key)
+      end
+
       def execute
         return false unless opt_in_form&.valid?
 
@@ -24,6 +39,28 @@ module Profiles
       end
 
       private
+
+      def settings
+        @settings ||= Irida::CurrentSettings.current_application_settings
+      end
+
+      def feature_payload(feature_key)
+        return nil unless FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
+
+        feature_config = (settings.user_opt_in_features || {})[feature_key]
+        return nil if feature_config.blank?
+
+        {
+          key: feature_key.to_sym,
+          name: localized_value(feature_config['name']),
+          description: localized_value(feature_config['description']),
+          enabled: Flipper[feature_key.to_sym].actors_value.include?(current_user.flipper_id)
+        }
+      end
+
+      def localized_value(translations)
+        translations[I18n.locale.to_s].presence || translations['en']
+      end
 
       def update_actor_gate
         if opt_in_form.enabled?

--- a/app/services/profiles/experimental_features/opt_in_service.rb
+++ b/app/services/profiles/experimental_features/opt_in_service.rb
@@ -45,21 +45,7 @@ module Profiles
       end
 
       def feature_payload(feature_key)
-        return nil unless FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
-
-        feature_config = (settings.user_opt_in_features || {})[feature_key]
-        return nil if feature_config.blank?
-
-        {
-          key: feature_key.to_sym,
-          name: localized_value(feature_config['name']),
-          description: localized_value(feature_config['description']),
-          enabled: Flipper[feature_key.to_sym].actors_value.include?(current_user.flipper_id)
-        }
-      end
-
-      def localized_value(translations)
-        translations[I18n.locale.to_s].presence || translations['en']
+        settings.opt_in_feature_payload(feature_key, current_user)
       end
 
       def update_actor_gate

--- a/app/views/layouts/profiles.html.erb
+++ b/app/views/layouts/profiles.html.erb
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
+
 <html class="light" lang="<%= locale %>">
   <%= render "layouts/partials/head" %>
+
   <body class="bg-white dark:bg-slate-900">
     <%= render LayoutComponent.new(user: current_user, fixed: true) do |layout| %>
       <% layout.with_sidebar(label: t(:'profiles.sidebar.header'), icon_name: User.icon, pipelines_enabled: @pipelines_enabled) do |navigation| %>
         <%= navigation.with_header(label: t(:"profiles.sidebar.header")) %>
+
         <%= navigation.with_section do |section| %>
           <%= render section.with_item(
             url: profile_path,
@@ -12,6 +15,7 @@
             label: t(:"profiles.sidebar.profile"),
             selected: @current_page == t(:"profiles.sidebar.profile"),
           ) %>
+
           <% if allowed_to?(:edit_password?, @user) %>
             <%= render section.with_item(
               url: edit_profile_password_path,
@@ -20,18 +24,28 @@
               selected: @current_page == t(:"profiles.sidebar.password"),
             ) %>
           <% end %>
+
           <%= render section.with_item(
             url: profile_personal_access_tokens_path,
             icon: PersonalAccessToken.icon,
             label: t(:"profiles.sidebar.access_tokens"),
             selected: @current_page == t(:"profiles.sidebar.access_tokens"),
           ) %>
+
           <%= render section.with_item(
             url: profile_preferences_path,
             icon: :sliders_horizontal,
             label: t(:"profiles.sidebar.preferences"),
             selected: @current_page == t(:"profiles.sidebar.preferences"),
           ) %>
+
+          <%= render section.with_item(
+            url: profile_experimental_features_path,
+            icon: :flask_conical,
+            label: t(:"profiles.sidebar.experimental_features"),
+            selected: @current_page == t(:"profiles.sidebar.experimental_features"),
+          ) %>
+
           <%= render section.with_item(
             url: profile_account_path,
             icon: :bank,
@@ -39,7 +53,9 @@
             selected: @current_page == t(:"profiles.sidebar.account"),
           ) %>
         <% end %>
+
         <% layout.with_language_selection %>
+
         <% layout.with_body do %>
           <%= yield %>
         <% end %>

--- a/app/views/profiles/experimental_features/_feature_row.html.erb
+++ b/app/views/profiles/experimental_features/_feature_row.html.erb
@@ -55,7 +55,7 @@
             },
             aria: {
               labelledby: label_id,
-              describedby: "#{description_id} #{status_id}"
+              describedby: description_id
             },
             data: {
               action: "change->experimental-feature-toggle#submit",

--- a/app/views/profiles/experimental_features/_feature_row.html.erb
+++ b/app/views/profiles/experimental_features/_feature_row.html.erb
@@ -1,0 +1,66 @@
+<% feature_key = feature[:key] %>
+<% form = Profiles::ExperimentalFeatures::OptInForm.new(user: user, feature_key: feature_key, enabled: feature[:enabled]) %>
+<% switch_id = "experimental-feature-#{feature_key}-switch" %>
+<% label_id = "experimental-feature-#{feature_key}-label" %>
+<% description_id = "experimental-feature-#{feature_key}-description" %>
+<% status_id = "experimental-feature-#{feature_key}-status" %>
+<% status_variant = local_assigns[:status_variant] %>
+
+<% status_classes = {
+  success: "text-green-700 dark:text-green-400",
+  error: "text-red-600 dark:text-red-400"
+}.fetch(status_variant, "text-slate-500 dark:text-slate-400") %>
+
+<div
+  id="experimental-feature-<%= feature_key %>"
+  class="flex flex-col gap-2 py-1 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
+  data-controller="experimental-feature-toggle"
+  data-experimental-feature-toggle-saving-text-value="<%= t("profiles.experimental_features.update.saving") %>"
+  data-experimental-feature-toggle-success-text-value="<%= t("profiles.experimental_features.update.success") %>"
+  data-experimental-feature-toggle-feature-key-value="<%= feature_key %>"
+  data-experimental-feature-toggle-minimum-saving-ms-value="900"
+  data-experimental-feature-toggle-clear-delay-value="3000"
+>
+  <div class="min-w-0 flex-1">
+    <%= label_tag switch_id, feature[:name], id: label_id, class: "cursor-pointer text-sm font-semibold text-slate-800 dark:text-white" %>
+
+    <p id="<%= description_id %>" class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+      <%= feature[:description] %>
+    </p>
+  </div>
+
+  <div class="pt-0.5 sm:shrink-0">
+    <%= form_with model: form,
+                  url: profile_experimental_features_path,
+                  method: :patch,
+                  data: { "experimental-feature-toggle-target": "form" } do |f| %>
+      <%= f.hidden_field :feature_key %>
+
+      <div class="flex items-center justify-end gap-2">
+        <p
+          id="<%= status_id %>"
+          class="max-w-56 text-right text-sm break-words <%= status_classes %>"
+          data-experimental-feature-toggle-target="status"
+        >
+          <%= local_assigns[:status_message] %>
+        </p>
+
+        <%# Pathogen::Form::Switch renders the internal .pathogen-switch-track element. %>
+        <%= f.switch :enabled,
+            id: switch_id,
+            state_text: {
+              on: t("profiles.experimental_features.toggle_state.on"),
+              off: t("profiles.experimental_features.toggle_state.off")
+            },
+            aria: {
+              labelledby: label_id,
+              describedby: "#{description_id} #{status_id}"
+            },
+            data: {
+              action: "change->experimental-feature-toggle#submit",
+              "experimental-feature-toggle-target": "switch"
+            } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/profiles/experimental_features/_feature_row.html.erb
+++ b/app/views/profiles/experimental_features/_feature_row.html.erb
@@ -17,6 +17,7 @@
   data-controller="experimental-feature-toggle"
   data-experimental-feature-toggle-saving-text-value="<%= t("profiles.experimental_features.update.saving") %>"
   data-experimental-feature-toggle-success-text-value="<%= t("profiles.experimental_features.update.success") %>"
+  data-experimental-feature-toggle-validation-error-text-value="<%= t("profiles.experimental_features.update.validation_error") %>"
   data-experimental-feature-toggle-feature-key-value="<%= feature_key %>"
   data-experimental-feature-toggle-minimum-saving-ms-value="900"
   data-experimental-feature-toggle-clear-delay-value="3000"

--- a/app/views/profiles/experimental_features/show.html.erb
+++ b/app/views/profiles/experimental_features/show.html.erb
@@ -1,0 +1,41 @@
+<%= render Viral::PageHeaderComponent.new(title: t(".title")) %>
+
+<div
+  id="experimental-features-live-announcer"
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"
+  class="sr-only"
+></div>
+
+<%= viral_card do |card| %>
+  <% card.with_section(border_bottom: true, border_top: true) do %>
+    <p class="text-sm text-slate-500 dark:text-slate-400"><%= t(".description") %></p>
+  <% end %>
+
+  <% if @eligible_features.empty? %>
+    <% card.with_section do %>
+      <div class="py-12 text-center">
+        <p class="mb-2 text-sm font-semibold text-slate-800 dark:text-white">
+          <%= t(".empty_state.title") %>
+        </p>
+
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          <%= t(".empty_state.description") %>
+        </p>
+      </div>
+    <% end %>
+  <% else %>
+    <% card.with_section(flush: true) do %>
+      <fieldset>
+        <legend class="sr-only"><%= t(".legend") %></legend>
+
+        <% @eligible_features.each do |feature| %>
+          <div class="border-b border-slate-200 p-4 last:border-b-0 dark:border-slate-700">
+            <%= render "feature_row", feature: feature, user: @user %>
+          </div>
+        <% end %>
+      </fieldset>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/profiles/experimental_features/update.turbo_stream.erb
+++ b/app/views/profiles/experimental_features/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<% if feature.present? %>
+  <%= turbo_stream.replace "experimental-feature-#{feature[:key]}" do %>
+    <%= render "feature_row",
+          feature: feature,
+          user: user,
+          status_message: status_message,
+          status_variant: status_variant %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1322,6 +1322,23 @@ en:
         - All projects and groups you are a member of will be left intact
       show:
         title: Delete account
+    experimental_features:
+      show:
+        description: These features are experimental and may change or be removed.
+        empty_state:
+          description: There are no experimental features available for your account right now.
+          title: No experimental features available
+        legend: Experimental feature controls
+        title: Experimental Features
+      toggle_state:
+        'off': 'Off'
+        'on': 'On'
+      update:
+        error: Something went wrong. Please try again.
+        not_eligible: This feature is not available for your account.
+        saving: Saving...
+        success: Saved
+        validation_error: The feature setting could not be updated. Please refresh the page and try again.
     passwords:
       update:
         forgot: Forgot your password?
@@ -1384,6 +1401,7 @@ en:
     sidebar:
       access_tokens: Access Tokens
       account: Account
+      experimental_features: Experimental Features
       header: User Settings
       password: Password
       preferences: Preferences

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1326,6 +1326,23 @@ fr:
         - Tous les projets et groupes dont vous êtes membre seront laissés intacts
       show:
         title: Supprimer le compte
+    experimental_features:
+      show:
+        description: Ces fonctionnalités sont expérimentales et peuvent changer ou être retirées.
+        empty_state:
+          description: Aucune fonctionnalité expérimentale n’est disponible pour votre compte en ce moment.
+          title: Aucune fonctionnalité expérimentale disponible
+        legend: Contrôles des fonctionnalités expérimentales
+        title: Fonctionnalités expérimentales
+      toggle_state:
+        'off': Désactivé
+        'on': Activé
+      update:
+        error: Une erreur est survenue. Veuillez réessayer.
+        not_eligible: Cette fonctionnalité n’est pas disponible pour votre compte.
+        saving: Enregistrement...
+        success: Enregistré
+        validation_error: Le paramètre de fonctionnalité n’a pas pu être mis à jour. Veuillez actualiser la page et réessayer.
     passwords:
       update:
         forgot: Vous avez oublié votre mot de passe?
@@ -1388,6 +1405,7 @@ fr:
     sidebar:
       access_tokens: Jetons d’accès
       account: Compte
+      experimental_features: Fonctionnalités expérimentales
       header: Paramètres de l’utilisateur
       password: Mot de passe
       preferences: Préférences

--- a/config/routes/profile.rb
+++ b/config/routes/profile.rb
@@ -5,6 +5,7 @@ resource :profile, only: %i[show update] do
     resource :password, only: %i[edit update]
     resource :account, only: %i[show destroy]
     resource :preferences, only: %i[show update]
+    resource :experimental_features, only: %i[show update]
     resources :personal_access_tokens, only: %i[index create new] do
       member do
         delete :revoke

--- a/test/controllers/profiles/experimental_features_controller_test.rb
+++ b/test/controllers/profiles/experimental_features_controller_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Profiles
+  class ExperimentalFeaturesControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @user = users(:john_doe)
+    end
+
+    test 'should get show' do
+      sign_in @user
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        get profile_experimental_features_url
+      end
+
+      assert_response :success
+      w3c_validate 'User Profile Experimental Features Page'
+    end
+
+    test 'show renders empty state when no features are eligible' do
+      sign_in @user
+
+      with_user_opt_in_features(user_opt_in_feature_config(allowlist: [users(:jane_doe).email])) do
+        get profile_experimental_features_path
+      end
+
+      assert_response :success
+      assert_includes response.body, I18n.t('profiles.experimental_features.show.empty_state.title')
+    end
+
+    test 'show renders eligible feature name and switch control' do
+      sign_in @user
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        get profile_experimental_features_path
+      end
+
+      assert_response :success
+      assert_includes response.body, 'Data Grid Samples Table'
+      assert_select 'fieldset input[type="checkbox"][role="switch"]'
+      assert_select '#experimental-feature-data_grid_samples_table-status[role="status"]', false
+      assert_select '#experimental-feature-data_grid_samples_table-status[aria-live]', false
+      assert_select '#experimental-feature-data_grid_samples_table-status.break-words'
+      assert_select '#experimental-feature-data_grid_samples_table-status.whitespace-nowrap', false
+    end
+
+    test 'turbo_stream update enables actor gate for eligible feature' do
+      sign_in @user
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'data_grid_samples_table', enabled: '1' } }
+
+        assert_response :ok
+        assert_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        assert_includes response.body, 'turbo-stream action="replace"'
+      end
+    ensure
+      Flipper.disable_actor(:data_grid_samples_table, @user)
+    end
+
+    test 'turbo_stream update disables actor gate for eligible feature' do
+      sign_in @user
+      Flipper.enable_actor(:data_grid_samples_table, @user)
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'data_grid_samples_table', enabled: '0' } }
+
+        assert_response :ok
+        assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+        assert_includes response.body, 'turbo-stream action="replace"'
+      end
+    end
+
+    test 'turbo_stream update rejects non-allowlisted feature requests' do
+      sign_in @user
+      Flipper.expects(:enable_actor).never
+
+      with_user_opt_in_features(user_opt_in_feature_config(allowlist: [users(:jane_doe).email])) do
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'data_grid_samples_table', enabled: '1' } }
+      end
+
+      assert_response :unprocessable_content
+      assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+    end
+
+    test 'should redirect unauthenticated users on update' do
+      patch profile_experimental_features_path(format: :turbo_stream),
+            params: { opt_in_form: { feature_key: 'data_grid_samples_table', enabled: '1' } }
+
+      assert_response :redirect
+    end
+  end
+end

--- a/test/controllers/profiles/experimental_features_controller_test.rb
+++ b/test/controllers/profiles/experimental_features_controller_test.rb
@@ -90,6 +90,78 @@ module Profiles
 
       assert_response :unprocessable_content
       assert_not_includes Flipper[:data_grid_samples_table].actors_value, @user.flipper_id
+      assert_includes response.body, 'turbo-stream action="replace"'
+      assert_includes response.body, I18n.t('profiles.experimental_features.update.not_eligible')
+    end
+
+    test 'turbo_stream update returns validation error for invalid enabled value' do
+      sign_in @user
+      Flipper.expects(:enable_actor).never
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'data_grid_samples_table', enabled: 'yes' } }
+      end
+
+      assert_response :unprocessable_content
+      assert_includes response.body, 'turbo-stream action="replace"'
+      assert_includes response.body, I18n.t('profiles.experimental_features.update.validation_error')
+    end
+
+    test 'turbo_stream update returns empty response for unknown feature key' do
+      sign_in @user
+      Flipper.expects(:enable_actor).never
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'unknown_feature', enabled: '1' } }
+      end
+
+      assert_response :unprocessable_content
+      assert_not_includes response.body, 'turbo-stream'
+    end
+
+    test 'turbo_stream update returns validation error when params are incomplete' do
+      sign_in @user
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'data_grid_samples_table' } }
+      end
+
+      assert_response :unprocessable_content
+      assert_includes response.body, 'turbo-stream action="replace"'
+      assert_includes response.body, I18n.t('profiles.experimental_features.update.validation_error')
+    end
+
+    test 'turbo_stream update returns flipper error message when toggle fails' do
+      sign_in @user
+      Flipper.expects(:enable_actor).raises(Flipper::Error, 'adapter failed')
+      Rails.logger.expects(:error).with(regexp_matches(/adapter failed/))
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'data_grid_samples_table', enabled: '1' } }
+      end
+
+      assert_response :unprocessable_content
+      assert_includes response.body, 'turbo-stream action="replace"'
+      assert_includes response.body, I18n.t('profiles.experimental_features.update.error')
+    ensure
+      Flipper.disable_actor(:data_grid_samples_table, @user)
+    end
+
+    test 'turbo_stream update includes success message when enabled' do
+      sign_in @user
+
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        patch profile_experimental_features_path(format: :turbo_stream),
+              params: { opt_in_form: { feature_key: 'data_grid_samples_table', enabled: '1' } }
+
+        assert_includes response.body, I18n.t('profiles.experimental_features.update.success')
+      end
+    ensure
+      Flipper.disable_actor(:data_grid_samples_table, @user)
     end
 
     test 'should redirect unauthenticated users on update' do

--- a/test/javascript/controllers/experimental_feature_toggle_controller.test.js
+++ b/test/javascript/controllers/experimental_feature_toggle_controller.test.js
@@ -18,6 +18,7 @@ function renderFixture({
       data-controller="experimental-feature-toggle"
       data-experimental-feature-toggle-saving-text-value="Saving..."
       data-experimental-feature-toggle-success-text-value="Saved"
+      data-experimental-feature-toggle-validation-error-text-value="The feature setting could not be updated. Please refresh the page and try again."
       data-experimental-feature-toggle-feature-key-value="${featureKey}"
       data-experimental-feature-toggle-minimum-saving-ms-value="900"
       data-experimental-feature-toggle-clear-delay-value="3000"
@@ -149,5 +150,70 @@ describe("experimental feature toggle controller", () => {
     vi.advanceTimersByTime(3000);
 
     expect(status()).toHaveTextContent("");
+  });
+
+  it("recovers pending state when turbo submit fails without a stream response", async () => {
+    vi.useFakeTimers();
+    renderFixture();
+    application = await startController();
+    const form = document.querySelector("form");
+    form.requestSubmit = vi.fn();
+
+    switchControl().checked = true;
+    switchControl().dispatchEvent(new Event("change", { bubbles: true }));
+    vi.advanceTimersByTime(900);
+
+    form.dispatchEvent(
+      new CustomEvent("turbo:submit-end", {
+        bubbles: true,
+        detail: {
+          success: false,
+          fetchResponse: { responseHTML: "" },
+        },
+      }),
+    );
+
+    expect(
+      document.getElementById("experimental-feature-data_grid_samples_table"),
+    ).not.toHaveAttribute("aria-busy");
+    expect(switchControl()).not.toHaveAttribute("aria-disabled");
+    expect(switchControl().checked).toBe(false);
+    expect(status()).toHaveTextContent(
+      "The feature setting could not be updated. Please refresh the page and try again.",
+    );
+    expect(announcer()).toHaveTextContent(
+      "The feature setting could not be updated. Please refresh the page and try again.",
+    );
+  });
+
+  it("does not reset pending state when turbo submit returns a stream response", async () => {
+    vi.useFakeTimers();
+    renderFixture();
+    application = await startController();
+    const form = document.querySelector("form");
+    form.requestSubmit = vi.fn();
+
+    switchControl().checked = true;
+    switchControl().dispatchEvent(new Event("change", { bubbles: true }));
+    vi.advanceTimersByTime(900);
+
+    form.dispatchEvent(
+      new CustomEvent("turbo:submit-end", {
+        bubbles: true,
+        detail: {
+          success: false,
+          fetchResponse: {
+            responseHTML: '<turbo-stream action="replace"></turbo-stream>',
+          },
+        },
+      }),
+    );
+
+    expect(
+      document.getElementById("experimental-feature-data_grid_samples_table"),
+    ).toHaveAttribute("aria-busy", "true");
+    expect(switchControl()).toHaveAttribute("aria-disabled", "true");
+    expect(switchControl().checked).toBe(true);
+    expect(status()).toHaveTextContent("Saving...");
   });
 });

--- a/test/javascript/controllers/experimental_feature_toggle_controller.test.js
+++ b/test/javascript/controllers/experimental_feature_toggle_controller.test.js
@@ -1,0 +1,153 @@
+import { Application } from "@hotwired/stimulus";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ExperimentalFeatureToggleController from "../../../app/javascript/controllers/experimental_feature_toggle_controller.js";
+
+function renderFixture({
+  status = "",
+  featureKey = "data_grid_samples_table",
+} = {}) {
+  document.body.innerHTML = `
+    <div
+      id="experimental-features-live-announcer"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    ></div>
+    <div
+      id="experimental-feature-${featureKey}"
+      data-controller="experimental-feature-toggle"
+      data-experimental-feature-toggle-saving-text-value="Saving..."
+      data-experimental-feature-toggle-success-text-value="Saved"
+      data-experimental-feature-toggle-feature-key-value="${featureKey}"
+      data-experimental-feature-toggle-minimum-saving-ms-value="900"
+      data-experimental-feature-toggle-clear-delay-value="3000"
+    >
+      <form data-experimental-feature-toggle-target="form">
+        <p
+          id="experimental-feature-${featureKey}-status"
+          data-experimental-feature-toggle-target="status"
+        >${status}</p>
+        <input
+          id="experimental-feature-${featureKey}-switch"
+          type="checkbox"
+          role="switch"
+          data-experimental-feature-toggle-target="switch"
+          data-action="change->experimental-feature-toggle#submit"
+        />
+      </form>
+    </div>
+  `;
+}
+
+async function startController() {
+  const application = Application.start();
+  application.register(
+    "experimental-feature-toggle",
+    ExperimentalFeatureToggleController,
+  );
+  await Promise.resolve();
+  return application;
+}
+
+function switchControl() {
+  return document.getElementById(
+    "experimental-feature-data_grid_samples_table-switch",
+  );
+}
+
+function status() {
+  return document.getElementById(
+    "experimental-feature-data_grid_samples_table-status",
+  );
+}
+
+function announcer() {
+  return document.getElementById("experimental-features-live-announcer");
+}
+
+describe("experimental feature toggle controller", () => {
+  let application;
+
+  afterEach(() => {
+    application?.stop();
+    vi.useRealTimers();
+  });
+
+  it("sets pending state, announces saving, and submits after the minimum delay", async () => {
+    vi.useFakeTimers();
+    renderFixture();
+    application = await startController();
+    const form = document.querySelector("form");
+    form.requestSubmit = vi.fn();
+
+    switchControl().checked = true;
+    switchControl().dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(
+      document.getElementById("experimental-feature-data_grid_samples_table"),
+    ).toHaveAttribute("aria-busy", "true");
+    expect(switchControl()).toHaveAttribute("aria-disabled", "true");
+    expect(status()).toHaveTextContent("Saving...");
+    expect(announcer()).toHaveTextContent("Saving...");
+    expect(
+      sessionStorage.getItem(
+        "experimentalFeatureToggleFocus:data_grid_samples_table",
+      ),
+    ).toBe("experimental-feature-data_grid_samples_table-switch");
+    expect(form.requestSubmit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(900);
+    expect(form.requestSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("reverts duplicate changes while a submission is pending", async () => {
+    vi.useFakeTimers();
+    renderFixture();
+    application = await startController();
+    document.querySelector("form").requestSubmit = vi.fn();
+
+    switchControl().checked = true;
+    switchControl().dispatchEvent(new Event("change", { bubbles: true }));
+    switchControl().checked = false;
+    switchControl().dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(switchControl().checked).toBe(true);
+    vi.advanceTimersByTime(900);
+    expect(document.querySelector("form").requestSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("restores focus from the per-feature session storage key", async () => {
+    renderFixture();
+    sessionStorage.setItem(
+      "experimentalFeatureToggleFocus:data_grid_samples_table",
+      "experimental-feature-data_grid_samples_table-switch",
+    );
+
+    application = await startController();
+
+    expect(document.activeElement).toBe(switchControl());
+    expect(
+      sessionStorage.getItem(
+        "experimentalFeatureToggleFocus:data_grid_samples_table",
+      ),
+    ).toBeNull();
+  });
+
+  it("announces rendered non-saving statuses through the page announcer", async () => {
+    renderFixture({ status: "Saved" });
+
+    application = await startController();
+
+    expect(announcer()).toHaveTextContent("Saved");
+  });
+
+  it("clears rendered success text after the delay", async () => {
+    vi.useFakeTimers();
+    renderFixture({ status: "Saved" });
+    application = await startController();
+
+    vi.advanceTimersByTime(3000);
+
+    expect(status()).toHaveTextContent("");
+  });
+});

--- a/test/javascript/controllers/experimental_feature_toggle_controller.test.js
+++ b/test/javascript/controllers/experimental_feature_toggle_controller.test.js
@@ -84,10 +84,6 @@ describe("experimental feature toggle controller", () => {
     switchControl().checked = true;
     switchControl().dispatchEvent(new Event("change", { bubbles: true }));
 
-    expect(
-      document.getElementById("experimental-feature-data_grid_samples_table"),
-    ).toHaveAttribute("aria-busy", "true");
-    expect(switchControl()).toHaveAttribute("aria-disabled", "true");
     expect(status()).toHaveTextContent("Saving...");
     expect(announcer()).toHaveTextContent("Saving...");
     expect(
@@ -173,10 +169,6 @@ describe("experimental feature toggle controller", () => {
       }),
     );
 
-    expect(
-      document.getElementById("experimental-feature-data_grid_samples_table"),
-    ).not.toHaveAttribute("aria-busy");
-    expect(switchControl()).not.toHaveAttribute("aria-disabled");
     expect(switchControl().checked).toBe(false);
     expect(status()).toHaveTextContent(
       "The feature setting could not be updated. Please refresh the page and try again.",
@@ -209,10 +201,6 @@ describe("experimental feature toggle controller", () => {
       }),
     );
 
-    expect(
-      document.getElementById("experimental-feature-data_grid_samples_table"),
-    ).toHaveAttribute("aria-busy", "true");
-    expect(switchControl()).toHaveAttribute("aria-disabled", "true");
     expect(switchControl().checked).toBe(true);
     expect(status()).toHaveTextContent("Saving...");
   });

--- a/test/models/application_setting_test.rb
+++ b/test/models/application_setting_test.rb
@@ -233,4 +233,23 @@ class ApplicationSettingTest < ActiveSupport::TestCase
                    feature[:description]
     end
   end
+
+  test 'opt_in_feature_payload returns configured feature metadata regardless of allowlist' do
+    user = users(:john_doe)
+    config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: config)
+
+    feature = settings.opt_in_feature_payload(:data_grid_samples_table, user)
+
+    assert_equal :data_grid_samples_table, feature[:key]
+    assert_equal 'Data Grid Samples Table', feature[:name]
+    assert_equal false, feature[:enabled]
+  end
+
+  test 'opt_in_feature_payload returns nil for unknown feature key' do
+    user = users(:john_doe)
+    settings = ApplicationSetting.build_from_defaults(user_opt_in_features: user_opt_in_feature_config)
+
+    assert_nil settings.opt_in_feature_payload(:unknown_feature, user)
+  end
 end

--- a/test/services/profiles/experimental_features/opt_in_service_test.rb
+++ b/test/services/profiles/experimental_features/opt_in_service_test.rb
@@ -57,6 +57,48 @@ module Profiles
         end
       end
 
+      test 'eligible_features returns configured eligible payloads' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          feature = OptInService.new(@user).eligible_features.first
+
+          assert_equal :data_grid_samples_table, feature[:key]
+          assert_equal 'Data Grid Samples Table', feature[:name]
+          assert_equal 'Enable the new data grid for the samples table.', feature[:description]
+          assert_equal false, feature[:enabled]
+        end
+      end
+
+      test 'feature returns nil for unknown feature key' do
+        with_user_opt_in_features(user_opt_in_feature_config) do
+          feature = OptInService.new(@user).feature('unknown_feature')
+
+          assert_nil feature
+        end
+      end
+
+      test 'feature returns nil for ineligible user by default' do
+        config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
+
+        with_user_opt_in_features(config) do
+          feature = OptInService.new(@user).feature('data_grid_samples_table')
+
+          assert_nil feature
+        end
+      end
+
+      test 'feature returns payload for configured ineligible feature when include_ineligible is true' do
+        config = user_opt_in_feature_config(allowlist: [users(:jane_doe).email])
+
+        with_user_opt_in_features(config) do
+          feature = OptInService.new(@user).feature('data_grid_samples_table', include_ineligible: true)
+
+          assert_equal :data_grid_samples_table, feature[:key]
+          assert_equal 'Data Grid Samples Table', feature[:name]
+          assert_equal 'Enable the new data grid for the samples table.', feature[:description]
+          assert_equal false, feature[:enabled]
+        end
+      end
+
       private
 
       def build_form(**attributes)

--- a/test/system/profiles/experimental_features_test.rb
+++ b/test/system/profiles/experimental_features_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module Profiles
+  class ExperimentalFeaturesTest < ApplicationSystemTestCase
+    include UserOptInFeaturesTestHelper
+
+    setup do
+      @user = users(:john_doe)
+      login_as @user
+    end
+
+    test 'toggle shows pending state, restores focus, and clears success text' do
+      with_user_opt_in_features(user_opt_in_feature_config) do
+        visit profile_experimental_features_path
+
+        page.execute_script <<~JS
+          const form = document.querySelector("#experimental-feature-data_grid_samples_table form");
+          const originalRequestSubmit = form.requestSubmit.bind(form);
+          form.requestSubmit = function() {
+            setTimeout(() => originalRequestSubmit(), 300);
+          };
+        JS
+
+        within '#experimental-feature-data_grid_samples_table' do
+          find("label.group[for='experimental-feature-data_grid_samples_table-switch']").click
+        end
+
+        assert_selector '#experimental-feature-data_grid_samples_table[aria-busy="true"]'
+        assert_selector '#experimental-feature-data_grid_samples_table-switch[aria-disabled="true"]', visible: :all
+        assert_selector '#experimental-feature-data_grid_samples_table-status',
+                        text: I18n.t('profiles.experimental_features.update.saving')
+
+        assert_selector '#experimental-feature-data_grid_samples_table-status',
+                        text: I18n.t('profiles.experimental_features.update.success')
+        assert_equal 'experimental-feature-data_grid_samples_table-switch',
+                     page.evaluate_script('document.activeElement.id')
+
+        assert_no_selector '#experimental-feature-data_grid_samples_table-status',
+                           text: I18n.t('profiles.experimental_features.update.success'),
+                           wait: 5
+      end
+    ensure
+      Flipper.disable_actor(:data_grid_samples_table, @user)
+    end
+  end
+end

--- a/test/system/profiles/experimental_features_test.rb
+++ b/test/system/profiles/experimental_features_test.rb
@@ -27,8 +27,6 @@ module Profiles
           find("label.group[for='experimental-feature-data_grid_samples_table-switch']").click
         end
 
-        assert_selector '#experimental-feature-data_grid_samples_table[aria-busy="true"]'
-        assert_selector '#experimental-feature-data_grid_samples_table-switch[aria-disabled="true"]', visible: :all
         assert_selector '#experimental-feature-data_grid_samples_table-status',
                         text: I18n.t('profiles.experimental_features.update.saving')
 


### PR DESCRIPTION
## What does this PR do and why?
- Adds a profile **Experimental Features** page so users can opt in or out of eligible Flipper features.
- Bumps `pathogen_view_components` to v1.1.8 for `Pathogen::Form::Switch` on the toggle UI.

## Screenshots or screen recordings

https://github.com/user-attachments/assets/c5ff78c9-60df-45f5-a434-f1605167a7dd

### NVDA
<img width="1762" height="731" alt="image" src="https://github.com/user-attachments/assets/a5dd8d74-cc6d-4778-aac5-89bbc66b1c6d" />

## How to set up and validate locally
1. Sign in as `user5@email.com`
2. Go to a project samples page, ensure the normal table is visible
3. Go to profile &gt; experimental features, toggle on "Data Grid Samples Table".
4. Ensure that it says "Saving..." followed by "Saved" next to the toggle.
5. Go back to the same samples table and ensure the new table is rendered.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.