### PR TITLE
Fix FASTQ pairing when file suffixes differ

### DIFF
--- a/app/components/attachments/dialogs/new_attachment_component.html.erb
+++ b/app/components/attachments/dialogs/new_attachment_component.html.erb
@@ -14,6 +14,7 @@
       data-attachment-upload-uploading-text-value="<%= t('components.attachments.dialogs.new_attachment_component.uploading') %>"
       data-attachment-upload-success-text-value="<%= t('common.upload.uploaded_successfully') %>"
       data-attachment-upload-error-fallback-text-value="<%= t('common.upload.failed') %>"
+      data-attachment-upload-fastq-pairing-patterns-value="<%= helpers.attachment_upload_fastq_pairing_data_attributes[:attachment_upload_fastq_pairing_patterns_value].to_json %>"
     >
       <%= viral_alert(
         message: t("common.upload.upload_failed_retry"),

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# View helpers for attachment upload Stimulus data attributes.
+module AttachmentsHelper
+  def attachment_upload_fastq_pairing_data_attributes
+    { attachment_upload_fastq_pairing_patterns_value: Attachment.fastq_pairing_filename_patterns }
+  end
+end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -18,6 +18,26 @@ class Attachment < ApplicationRecord # rubocop:disable Metrics/ClassLength
     'unknown' => nil
   }.freeze
 
+  FASTQ_PAIRING_FILENAME_REGEX = {
+    'illumina_pe' => /^(?<sample_name>.+_[^_]+(?:_L[0-9]{3})?)_R(?<region>[1-2])_(?<set>[0-9]{3})\.(?<suffix>.+)$/,
+    'pe' => /^(?<sample_name>.+_)(?<region>R?[1-2]|[FfRr])\.(?<suffix>.+)$/
+  }.freeze
+
+  FASTQ_PAIRING_TYPES = %w[illumina_pe pe].freeze
+
+  FASTQ_PE_REGION_PAIRING = {
+    '1' => { direction: 'forward', pair_key_suffix: '1-2' },
+    '2' => { direction: 'reverse', pair_key_suffix: '1-2' },
+    'R1' => { direction: 'forward', pair_key_suffix: 'R1-R2' },
+    'R2' => { direction: 'reverse', pair_key_suffix: 'R1-R2' },
+    'F' => { direction: 'forward', pair_key_suffix: 'F-R' },
+    'R' => { direction: 'reverse', pair_key_suffix: 'F-R' },
+    'f' => { direction: 'forward', pair_key_suffix: 'f-r' },
+    'r' => { direction: 'reverse', pair_key_suffix: 'f-r' }
+  }.freeze
+
+  FastqPairingInfo = Data.define(:type, :direction, :pair_key)
+
   PREVIEWABLE_TYPES = {
     'image' => :image,
     'text' => :text,
@@ -91,6 +111,44 @@ class Attachment < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def self.icon
     :file_text
+  end
+
+  def self.fastq_pairing_filename_patterns
+    FASTQ_PAIRING_FILENAME_REGEX.transform_values(&:source)
+  end
+
+  def self.fastq_illumina_pe_pairing_info(filename)
+    match = FASTQ_PAIRING_FILENAME_REGEX['illumina_pe'].match(filename.to_s)
+    return unless match
+
+    FastqPairingInfo.new(
+      type: 'illumina_pe',
+      direction: match[:region] == '1' ? 'forward' : 'reverse',
+      pair_key: "#{match[:sample_name]}_#{match[:set]}_#{match[:suffix]}"
+    )
+  end
+
+  def self.fastq_pe_pairing_info(filename)
+    match = FASTQ_PAIRING_FILENAME_REGEX['pe'].match(filename.to_s)
+    return unless match
+
+    config = FASTQ_PE_REGION_PAIRING[match[:region]]
+    return unless config
+
+    FastqPairingInfo.new(
+      type: 'pe',
+      direction: config[:direction],
+      pair_key: "#{match[:sample_name]}_#{config[:pair_key_suffix]}_#{match[:suffix]}"
+    )
+  end
+
+  def self.fastq_pairing_info(filename, type:)
+    case type
+    when 'illumina_pe'
+      fastq_illumina_pe_pairing_info(filename)
+    when 'pe'
+      fastq_pe_pairing_info(filename)
+    end
   end
 
   def self.metadata_arel_node(key)

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -105,51 +105,26 @@ module Attachments
       # identify illumina pe attachments based on illumina fastq filename convention
       # https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/NamingConvention_FASTQ-files-swBS.htm
       attachments.each do |att|
-        illumina_regex = /^(?<sample_name>.+_[^_]+(?:_L[0-9]{3})?)_R(?<region>[1-2])_(?<set>[0-9]{3})\.(?<suffix>.+)$/
-        match = illumina_regex.match(att.filename.to_s)
+        pairing_info = Attachment.fastq_illumina_pe_pairing_info(att.filename.to_s)
+        next unless pairing_info
 
-        next unless match
-
-        pair_key = "#{match[:sample_name]}_#{match[:set]}_#{match[:suffix]}"
-
-        case match[:region]
-        when '1'
-          illumina_pe[pair_key]['forward'] = att
-        when '2'
-          illumina_pe[pair_key]['reverse'] = att
-        end
+        illumina_pe[pairing_info.pair_key][pairing_info.direction] = att
       end
 
       # assign metadata to detected illumina pe files that contain fwd and rev
       assign_metadata(illumina_pe, 'illumina_pe')
     end
 
-    def identify_paired_end_files(attachments) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
+    def identify_paired_end_files(attachments)
       # auto-vivify hash, as found on stack overflow http://stackoverflow.com/questions/5878529/how-to-assign-hashab-c-if-hasha-doesnt-exist
       pe = Hash.new { |h, k| h[k] = {} }
 
       # identify pe attachments based on fastq filename convention
       attachments.each do |att|
-        next unless /^(?<sample_name>.+_)(?<region>R?[1-2]|[FfRr])\.(?<suffix>.+)$/ =~ att.filename.to_s
+        pairing_info = Attachment.fastq_pe_pairing_info(att.filename.to_s)
+        next unless pairing_info
 
-        case region
-        when '1'
-          pe["#{sample_name}_1-2_#{suffix}"]['forward'] = att
-        when 'R1'
-          pe["#{sample_name}_R1-R2_#{suffix}"]['forward'] = att
-        when 'F'
-          pe["#{sample_name}_F-R_#{suffix}"]['forward'] = att
-        when 'f'
-          pe["#{sample_name}_f-r_#{suffix}"]['forward'] = att
-        when '2'
-          pe["#{sample_name}_1-2_#{suffix}"]['reverse'] = att
-        when 'R2'
-          pe["#{sample_name}_R1-R2_#{suffix}"]['reverse'] = att
-        when 'R'
-          pe["#{sample_name}_F-R_#{suffix}"]['reverse'] = att
-        when 'r'
-          pe["#{sample_name}_f-r_#{suffix}"]['reverse'] = att
-        end
+        pe[pairing_info.pair_key][pairing_info.direction] = att
       end
 
       # assign metadata to detected pe files that contain fwd and rev

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -105,15 +105,18 @@ module Attachments
       # identify illumina pe attachments based on illumina fastq filename convention
       # https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/NamingConvention_FASTQ-files-swBS.htm
       attachments.each do |att|
-        unless /^(?<sample_name>.+_[^_]+(?:_L[0-9]{3})?)_R(?<region>[1-2])_(?<set>[0-9]{3})\./ =~ att.filename.to_s
-          next
-        end
+        illumina_regex = /^(?<sample_name>.+_[^_]+(?:_L[0-9]{3})?)_R(?<region>[1-2])_(?<set>[0-9]{3})\.(?<suffix>.+)$/
+        match = illumina_regex.match(att.filename.to_s)
 
-        case region
+        next unless match
+
+        pair_key = "#{match[:sample_name]}_#{match[:set]}_#{match[:suffix]}"
+
+        case match[:region]
         when '1'
-          illumina_pe["#{sample_name}_#{set}"]['forward'] = att
+          illumina_pe[pair_key]['forward'] = att
         when '2'
-          illumina_pe["#{sample_name}_#{set}"]['reverse'] = att
+          illumina_pe[pair_key]['reverse'] = att
         end
       end
 
@@ -127,25 +130,25 @@ module Attachments
 
       # identify pe attachments based on fastq filename convention
       attachments.each do |att|
-        next unless /^(?<sample_name>.+_)(?<region>R?[1-2]|[FfRr])\./ =~ att.filename.to_s
+        next unless /^(?<sample_name>.+_)(?<region>R?[1-2]|[FfRr])\.(?<suffix>.+)$/ =~ att.filename.to_s
 
         case region
         when '1'
-          pe["#{sample_name}_1-2"]['forward'] = att
+          pe["#{sample_name}_1-2_#{suffix}"]['forward'] = att
         when 'R1'
-          pe["#{sample_name}_R1-R2"]['forward'] = att
+          pe["#{sample_name}_R1-R2_#{suffix}"]['forward'] = att
         when 'F'
-          pe["#{sample_name}_F-R"]['forward'] = att
+          pe["#{sample_name}_F-R_#{suffix}"]['forward'] = att
         when 'f'
-          pe["#{sample_name}_f-r"]['forward'] = att
+          pe["#{sample_name}_f-r_#{suffix}"]['forward'] = att
         when '2'
-          pe["#{sample_name}_1-2"]['reverse'] = att
+          pe["#{sample_name}_1-2_#{suffix}"]['reverse'] = att
         when 'R2'
-          pe["#{sample_name}_R1-R2"]['reverse'] = att
+          pe["#{sample_name}_R1-R2_#{suffix}"]['reverse'] = att
         when 'R'
-          pe["#{sample_name}_F-R"]['reverse'] = att
+          pe["#{sample_name}_F-R_#{suffix}"]['reverse'] = att
         when 'r'
-          pe["#{sample_name}_f-r"]['reverse'] = att
+          pe["#{sample_name}_f-r_#{suffix}"]['reverse'] = att
         end
       end
 

--- a/app/views/projects/samples/attachments/_form.html.erb
+++ b/app/views/projects/samples/attachments/_form.html.erb
@@ -8,6 +8,7 @@
     data-attachment-upload-uploading-text-value="<%= t('components.attachments.dialogs.new_attachment_component.uploading') %>"
     data-attachment-upload-success-text-value="<%= t('common.upload.uploaded_successfully') %>"
     data-attachment-upload-error-fallback-text-value="<%= t('common.upload.failed') %>"
+    data-attachment-upload-fastq-pairing-patterns-value="<%= attachment_upload_fastq_pairing_data_attributes[:attachment_upload_fastq_pairing_patterns_value].to_json %>"
   >
     <%= viral_alert(
       message: t("common.upload.upload_failed_retry"),

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -274,6 +274,80 @@ class AttachmentTest < ActiveSupport::TestCase
     assert_not unknown_attachment.fastq?
   end
 
+  test '.fastq_pairing_filename_patterns returns pattern sources' do
+    patterns = Attachment.fastq_pairing_filename_patterns
+
+    assert_equal Attachment::FASTQ_PAIRING_TYPES, patterns.keys
+    assert_equal Attachment::FASTQ_PAIRING_FILENAME_REGEX['illumina_pe'].source, patterns['illumina_pe']
+    assert_equal Attachment::FASTQ_PAIRING_FILENAME_REGEX['pe'].source, patterns['pe']
+  end
+
+  test '.fastq_illumina_pe_pairing_info returns pairing details' do
+    test_cases = [
+      {
+        filename: 'TestSample_S1_L001_R1_001.fastq',
+        direction: 'forward',
+        pair_key: 'TestSample_S1_L001_001_fastq'
+      },
+      {
+        filename: 'TestSample_S1_L001_R2_001.fastq',
+        direction: 'reverse',
+        pair_key: 'TestSample_S1_L001_001_fastq'
+      },
+      {
+        filename: 'TestSample_S1_R1_001.fastq',
+        direction: 'forward',
+        pair_key: 'TestSample_S1_001_fastq'
+      },
+      {
+        filename: 'samplename_S1_L001_R2_001.instrument_b.fastq.gz',
+        direction: 'reverse',
+        pair_key: 'samplename_S1_L001_001_instrument_b.fastq.gz'
+      }
+    ]
+
+    test_cases.each do |test_case|
+      pairing_info = Attachment.fastq_illumina_pe_pairing_info(test_case[:filename])
+
+      assert_equal 'illumina_pe', pairing_info.type
+      assert_equal test_case[:direction], pairing_info.direction
+      assert_equal test_case[:pair_key], pairing_info.pair_key
+    end
+  end
+
+  test '.fastq_pe_pairing_info returns pairing details' do
+    test_cases = [
+      { filename: 'file_1.fastq', direction: 'forward', pair_key: 'file__1-2_fastq' },
+      { filename: 'file_2.fastq', direction: 'reverse', pair_key: 'file__1-2_fastq' },
+      { filename: 'seq_R1.fastq', direction: 'forward', pair_key: 'seq__R1-R2_fastq' },
+      { filename: 'seq_R2.fastq', direction: 'reverse', pair_key: 'seq__R1-R2_fastq' },
+      { filename: 'samp_F.fastq', direction: 'forward', pair_key: 'samp__F-R_fastq' },
+      { filename: 'samp_R.fastq', direction: 'reverse', pair_key: 'samp__F-R_fastq' },
+      { filename: 'germ_f.fastq', direction: 'forward', pair_key: 'germ__f-r_fastq' },
+      { filename: 'germ_r.fastq', direction: 'reverse', pair_key: 'germ__f-r_fastq' },
+      {
+        filename: 'samplename_R1.instrument_a.fastq.gz',
+        direction: 'forward',
+        pair_key: 'samplename__R1-R2_instrument_a.fastq.gz'
+      }
+    ]
+
+    test_cases.each do |test_case|
+      pairing_info = Attachment.fastq_pe_pairing_info(test_case[:filename])
+
+      assert_equal 'pe', pairing_info.type
+      assert_equal test_case[:direction], pairing_info.direction
+      assert_equal test_case[:pair_key], pairing_info.pair_key
+    end
+  end
+
+  test '.fastq_pairing_info returns nil for non-matching filename' do
+    assert_nil Attachment.fastq_illumina_pe_pairing_info('not_fastq_name.txt')
+    assert_nil Attachment.fastq_pe_pairing_info('sample.fastq.gz')
+    assert_nil Attachment.fastq_pairing_info('sample.fastq.gz', type: 'illumina_pe')
+    assert_nil Attachment.fastq_pairing_info('sample.fastq.gz', type: 'pe')
+  end
+
   test 'associated_attachment' do
     attachment_fwd = attachments(:attachmentPEFWD1)
     attachment_rev = attachments(:attachmentPEREV1)

--- a/test/services/attachments/create_service_test.rb
+++ b/test/services/attachments/create_service_test.rb
@@ -88,6 +88,108 @@ module Attachments
       assert_equal @sample.id, activity.parameters[:sample_id]
     end
 
+    test 'create attachments pairs illumina pe files separately when suffixes differ' do
+      filenames = [
+        'samplename_S1_L001_R1_001.instrument_a.fastq.gz',
+        'samplename_S1_L001_R2_001.instrument_a.fastq.gz',
+        'samplename_S1_L001_R1_001.instrument_b.fastq.gz',
+        'samplename_S1_L001_R2_001.instrument_b.fastq.gz'
+      ]
+      blobs = filenames.map.with_index do |filename, index|
+        ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("fastq content #{index}"),
+          filename: filename,
+          content_type: 'application/octet-stream'
+        )
+      end
+
+      assert_difference -> { Attachment.count } => 4 do
+        Attachments::CreateService.new(@user, @sample, { files: blobs }).execute
+      end
+
+      created_attachments = Attachment.last(4)
+      paired_attachments = created_attachments.select { |attachment| attachment.metadata['type'] == 'illumina_pe' }
+
+      assert_equal 4, paired_attachments.size
+
+      instrument_a_attachments = paired_attachments.select do |attachment|
+        attachment.filename.to_s.include?('.instrument_a.')
+      end
+      instrument_b_attachments = paired_attachments.select do |attachment|
+        attachment.filename.to_s.include?('.instrument_b.')
+      end
+
+      assert_equal 2, instrument_a_attachments.size
+      assert_equal 2, instrument_b_attachments.size
+
+      instrument_a_forward = instrument_a_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'forward'
+      end
+      instrument_a_reverse = instrument_a_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'reverse'
+      end
+      instrument_b_forward = instrument_b_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'forward'
+      end
+      instrument_b_reverse = instrument_b_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'reverse'
+      end
+
+      assert_equal instrument_a_reverse.id, instrument_a_forward.metadata['associated_attachment_id']
+      assert_equal instrument_b_reverse.id, instrument_b_forward.metadata['associated_attachment_id']
+    end
+
+    test 'create attachments pairs pe files separately when suffixes differ' do
+      filenames = [
+        'samplename_R1.instrument_a.fastq.gz',
+        'samplename_R2.instrument_a.fastq.gz',
+        'samplename_R1.instrument_b.fastq.gz',
+        'samplename_R2.instrument_b.fastq.gz'
+      ]
+      blobs = filenames.map.with_index do |filename, index|
+        ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("fastq content #{index}"),
+          filename: filename,
+          content_type: 'application/octet-stream'
+        )
+      end
+
+      assert_difference -> { Attachment.count } => 4 do
+        Attachments::CreateService.new(@user, @sample, { files: blobs }).execute
+      end
+
+      created_attachments = Attachment.last(4)
+      paired_attachments = created_attachments.select { |attachment| attachment.metadata['type'] == 'pe' }
+
+      assert_equal 4, paired_attachments.size
+
+      instrument_a_attachments = paired_attachments.select do |attachment|
+        attachment.filename.to_s.include?('.instrument_a.')
+      end
+      instrument_b_attachments = paired_attachments.select do |attachment|
+        attachment.filename.to_s.include?('.instrument_b.')
+      end
+
+      assert_equal 2, instrument_a_attachments.size
+      assert_equal 2, instrument_b_attachments.size
+
+      instrument_a_forward = instrument_a_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'forward'
+      end
+      instrument_a_reverse = instrument_a_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'reverse'
+      end
+      instrument_b_forward = instrument_b_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'forward'
+      end
+      instrument_b_reverse = instrument_b_attachments.find do |attachment|
+        attachment.metadata['direction'] == 'reverse'
+      end
+
+      assert_equal instrument_a_reverse.id, instrument_a_forward.metadata['associated_attachment_id']
+      assert_equal instrument_b_reverse.id, instrument_b_forward.metadata['associated_attachment_id']
+    end
+
     test 'create attachments with valid paired end forward and reverse fastq filenames' do
       paired_blobs_list = [
         [active_storage_blobs(:attachmentK_file_test_file_fastq_blob),


### PR DESCRIPTION
## What does this PR do and why?
- Fixes FASTQ auto-pairing when forward/reverse files share a sample prefix but have different suffixes (e.g. `.instrument_a.fastq.gz` vs `.instrument_b.fastq.gz`).
- Centralizes Illumina PE and generic PE pairing regex on `Attachment` and passes the same patterns to the upload UI for upcoming client-side pairing.

## Screenshots or screen recordings
- N/A (no visible UI change; upload forms only gain a data attribute for pairing patterns).

## How to set up and validate locally
1. Open a sample and upload paired FASTQ files with distinct suffixes (e.g. `sample_R1.instrument_a.fastq.gz` and `sample_R2.instrument_a.fastq.gz`, plus a second pair with `instrument_b`).
3. Confirm each pair is linked separately in attachment metadata (forward/reverse `associated_attachment_id`).
4. Run `PARALLEL_WORKERS=4 bin/rails test test/models/attachment_test.rb test/services/attachments/create_service_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.