### PR TITLE
Fix: Workflow execution search when advanced search is enabled

### DIFF
--- a/app/components/search_field_component.rb
+++ b/app/components/search_field_component.rb
@@ -18,8 +18,6 @@ class SearchFieldComponent < Component
     @system_arguments[:data][:controller] = 'search-field'
     return unless include_advanced_search_outlet
 
-    @system_arguments[:data][:'search-field-advanced-search-outlet'] =
-      '#advanced-search'
     @system_arguments[:data][:'search-field-advanced-search--v1-outlet'] =
       '#advanced-search'
   end

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -48,17 +48,18 @@ export default class AdvancedSearchController extends Controller {
     }
   }
 
-  renderSearch(addGroupIfEmpty = true) {
-    if (
-      addGroupIfEmpty === true &&
-      this.searchGroupsTemplateTarget.innerHTML.trim() === ""
-    ) {
+  renderSearch() {
+    if (this.searchGroupsTemplateTarget.innerHTML.trim() === "") {
       this.searchGroupsContainerTarget.innerHTML = "";
       this.addGroup();
     } else {
-      this.searchGroupsContainerTarget.innerHTML =
-        this.searchGroupsTemplateTarget.innerHTML;
+      this.renderExistingSearch();
     }
+  }
+
+  renderExistingSearch() {
+    this.searchGroupsContainerTarget.innerHTML =
+      this.searchGroupsTemplateTarget.innerHTML;
   }
 
   onMorph() {

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -48,8 +48,11 @@ export default class AdvancedSearchController extends Controller {
     }
   }
 
-  renderSearch() {
-    if (this.searchGroupsTemplateTarget.innerHTML.trim() === "") {
+  renderSearch(addGroupIfEmpty = true) {
+    if (
+      addGroupIfEmpty === true &&
+      this.searchGroupsTemplateTarget.innerHTML.trim() === ""
+    ) {
       this.searchGroupsContainerTarget.innerHTML = "";
       this.addGroup();
     } else {

--- a/app/javascript/controllers/search_field_controller.js
+++ b/app/javascript/controllers/search_field_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static outlets = ["advanced-search", "advanced-search--v1", "selection"];
+  static outlets = ["advanced-search--v1", "selection"];
   static targets = ["input", "clearButton", "submitButton"];
 
   /**
@@ -161,9 +161,7 @@ export default class extends Controller {
 
   beforeSubmit(event) {
     if (this.hasAdvancedSearchV1Outlet) {
-      this.advancedSearchV1Outlet.renderSearch();
-    } else if (this.hasAdvancedSearchOutlet) {
-      this.advancedSearchOutlet.renderSearch();
+      this.advancedSearchV1Outlet.renderSearch(false);
     }
   }
 }

--- a/app/javascript/controllers/search_field_controller.js
+++ b/app/javascript/controllers/search_field_controller.js
@@ -161,7 +161,7 @@ export default class extends Controller {
 
   beforeSubmit(event) {
     if (this.hasAdvancedSearchV1Outlet) {
-      this.advancedSearchV1Outlet.renderSearch(false);
+      this.advancedSearchV1Outlet.renderExistingSearch();
     }
   }
 }

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -536,6 +536,64 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'can filter by ID and name on workflow execution index page when workflow advanced-search flag is enabled' do
+    Flipper.enable(:workflow_execution_advanced_search)
+    visit workflow_executions_path
+
+    assert_text "Displaying items 1-#{PAGE_SIZE} of #{WORKFLOW_EXECUTION_COUNT} in total"
+    assert_selector 'table tbody tr', count: PAGE_SIZE
+
+    within('table tbody') do
+      assert_text @workflow_execution2.id
+      assert_text @workflow_execution2.name
+      assert_text @workflow_execution3.id
+      assert_text @workflow_execution3.name
+    end
+
+    fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
+            with: @workflow_execution2.id
+    find('input.t-search-component').send_keys(:return)
+
+    assert_text 'Displaying 1 item'
+    assert_selector 'table tbody tr', count: 1
+
+    within('table tbody') do
+      assert_text @workflow_execution2.id
+      assert_text @workflow_execution2.name
+      assert_no_text @workflow_execution3.id
+      assert_no_text @workflow_execution3.name
+    end
+
+    fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
+            with: ''
+    find('input.t-search-component').send_keys(:return)
+
+    assert_button I18n.t(:'components.search_field_component.clear_button')
+    assert_no_selector 'dialog[open] h1', text: I18n.t(:'components.advanced_search_component.v1.title')
+
+    assert_text "Displaying items 1-#{PAGE_SIZE} of #{WORKFLOW_EXECUTION_COUNT} in total"
+    assert_selector 'table tbody tr', count: PAGE_SIZE
+
+    fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
+            with: @workflow_execution3.name
+    find('input.t-search-component').send_keys(:return)
+
+    assert_button I18n.t(:'components.search_field_component.clear_button')
+    assert_no_selector 'dialog[open] h1', text: I18n.t(:'components.advanced_search_component.v1.title')
+
+    assert_text 'Displaying 1 item'
+    assert_selector 'table tbody tr', count: 1
+
+    within('table tbody') do
+      assert_no_text @workflow_execution2.id
+      assert_no_text @workflow_execution2.name
+      assert_text @workflow_execution3.id
+      assert_text @workflow_execution3.name
+    end
+  ensure
+    Flipper.disable(:workflow_execution_advanced_search)
+  end
+
   test 'workflow advanced search is hidden when workflow advanced-search feature flag is disabled' do
     Flipper.disable(:workflow_execution_advanced_search)
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes a bug where applying a search on the workflow executions page when no advanced search is present would cause the advanced search dialog to appear with errors.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch the server with `bin/setup`
2. Navigate to Workflow Executions page
3. Type a search term into the search box and hit enter
4. Confirm that search returns normally and results are rendered (on main this would popup the advanced search dialog with search errors)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
