### PR TITLE
Fix combobox keyboard behavior and add Vitest tests

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -698,8 +698,12 @@ a.pill-focus-reset:focus-visible {
     box-shadow: none !important;
   }
 
+  [data-combobox--v1-target="popup"] {
+    @apply z-10;
+  }
+
   [role="listbox"] {
-    @apply fixed z-10 m-0 box-border hidden max-h-[250px] overflow-x-hidden overflow-y-auto border border-slate-500 bg-white p-0 dark:border-slate-600 dark:bg-slate-800;
+    @apply m-0 box-border hidden max-h-[250px] w-full overflow-x-hidden overflow-y-auto border border-slate-500 bg-white p-0 dark:border-slate-600 dark:bg-slate-800;
   }
 
   [role="listbox"] > [role="group"] {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -727,6 +727,11 @@ a.pill-focus-reset:focus-visible {
     @apply border-y border-slate-300 shadow-[inset_1px_0_0_0_var(--color-slate-300)] dark:border-slate-600 dark:shadow-[inset_1px_0_0_0_var(--color-slate-600)];
   }
 
+  [data-combobox--v1-target="indicatorClearButton"][aria-disabled="true"],
+  [data-combobox--v1-target="indicatorButton"][aria-disabled="true"] {
+    @apply pointer-events-none text-slate-500 dark:text-slate-400;
+  }
+
   [data-combobox--v1-target="indicatorButton"] {
     @apply border border-l-0 border-slate-300 dark:border-slate-600;
   }

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -22,7 +22,7 @@
     <button
       type="button"
       class="
-        h-full w-8 cursor-pointer items-center justify-center text-slate-500 transition-colors focus-visible:outline-3 enabled:hover:bg-slate-100 dark:text-slate-300 dark:enabled:hover:bg-slate-700
+        h-full w-8 items-center justify-center text-slate-500 transition-colors not-aria-disabled:cursor-pointer not-aria-disabled:hover:bg-slate-100 focus-visible:outline-3 aria-disabled:cursor-not-allowed dark:text-slate-300 dark:not-aria-disabled:hover:bg-slate-700
         <%= selection_present? ? 'flex' : 'hidden' %>
       "
       data-combobox--v1-target="indicatorClearButton"
@@ -30,7 +30,7 @@
       aria-label="<%= t('combobox_component.clear_selection') %>"
       title="<%= t('combobox_component.clear_selection') %>"
       tabindex="-1"
-      <%= "disabled" if combobox_disabled? %>
+      aria-disabled="<%= combobox_disabled? %>"
     >
       <%= icon(:x, size: :sm, color: :subdued) %>
     </button>
@@ -38,28 +38,38 @@
     <button
       type="button"
       class="
-        flex h-full w-10 cursor-pointer items-center justify-center rounded-r-lg text-slate-500 transition-colors
-        focus-visible:outline-3 enabled:hover:bg-slate-100 dark:text-slate-300 dark:enabled:hover:bg-slate-700
+        flex h-full w-10 items-center justify-center rounded-r-lg text-slate-500 transition-colors
+        not-aria-disabled:cursor-pointer not-aria-disabled:hover:bg-slate-100 focus-visible:outline-3
+        aria-disabled:cursor-not-allowed dark:text-slate-300 dark:not-aria-disabled:hover:bg-slate-700
       "
       data-combobox--v1-target="indicatorButton"
       data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onIndicatorClick"
       aria-label="<%= t('combobox_component.show_options') %>"
       title="<%= t('combobox_component.show_options') %>"
       tabindex="-1"
-      <%= "disabled" if combobox_disabled? %>
+      aria-disabled="<%= combobox_disabled? %>"
     >
       <%= icon(:caret_down, size: :sm, color: :subdued) %>
     </button>
   </div>
 
-  <%= tag.div(
-    id: @listbox_id,
-    role: "listbox",
-    "aria-label": combobox_arguments[:aria][:label],
-    "data-combobox--v1-target": "listbox",
-  ) do %>
-    <%= @listbox_options %>
-  <% end %>
+  <div data-combobox--v1-target="popup" aria-hidden="true" style="display: none;">
+    <%= tag.div(
+      id: @listbox_id,
+      role: "listbox",
+      "aria-label": combobox_arguments[:aria][:label],
+      "data-combobox--v1-target": "listbox",
+    ) do %>
+      <%= @listbox_options %>
+    <% end %>
+
+    <div
+      role="status"
+      hidden
+      class="px-3 py-2 text-sm text-slate-500 dark:text-slate-300"
+      data-combobox--v1-target="noResults"
+    ></div>
+  </div>
 
   <div class="sr-only" aria-live="polite" data-combobox--v1-target="ariaLiveUpdate"></div>
 <% end %>

--- a/app/javascript/controllers/combobox/v1_controller.js
+++ b/app/javascript/controllers/combobox/v1_controller.js
@@ -21,8 +21,10 @@ import FloatingDropdown from "utilities/floating_dropdown";
 export default class extends Controller {
   static targets = [
     "combobox",
+    "popup",
     "listbox",
     "hidden",
+    "noResults",
     "ariaLiveUpdate",
     "indicatorButton",
     "indicatorClearButton",
@@ -43,6 +45,7 @@ export default class extends Controller {
   #firstOption;
   #lastOption;
   #clearShouldKeepOpen;
+  #popupView = "options";
 
   connect() {
     this.#filter = this.comboboxTarget.value;
@@ -63,7 +66,7 @@ export default class extends Controller {
 
     this.#floatingDropdown = new FloatingDropdown({
       trigger: this.comboboxTarget.parentElement,
-      dropdown: this.listboxTarget,
+      dropdown: this.popupTarget,
       manageAria: false,
       onShow: () => this.#onShow(),
       onHide: () => this.#onHide(),
@@ -135,19 +138,27 @@ export default class extends Controller {
       });
   }
 
-  #renderNoResults() {
-    const noResultsOption = document.createElement("div");
-    noResultsOption.setAttribute("role", "option");
-    noResultsOption.setAttribute("aria-disabled", "true");
-    noResultsOption.setAttribute("aria-selected", "false");
-    noResultsOption.className =
-      "px-3 py-2 text-sm text-slate-500 dark:text-slate-300";
-    const noResultsMessage =
-      this.hasNoResultsTextValue && this.noResultsTextValue
-        ? this.noResultsTextValue
-        : "No results found";
-    noResultsOption.textContent = noResultsMessage;
-    this.listboxTarget.appendChild(noResultsOption);
+  #noResultsMessage() {
+    return this.hasNoResultsTextValue && this.noResultsTextValue
+      ? this.noResultsTextValue
+      : "No results found";
+  }
+
+  #syncPopupView() {
+    const showingNoResults = this.#popupView === "noResults";
+
+    this.listboxTarget.hidden = showingNoResults;
+    this.noResultsTarget.hidden = !showingNoResults;
+
+    if (showingNoResults) {
+      this.noResultsTarget.textContent = this.#noResultsMessage();
+    } else {
+      this.noResultsTarget.textContent = "";
+    }
+
+    if (this.#floatingDropdown.isVisible()) {
+      this.listboxTarget.style.display = showingNoResults ? "none" : "block";
+    }
   }
 
   #announceNumberOfResults() {
@@ -177,6 +188,7 @@ export default class extends Controller {
     const filter = this.#filter.toLowerCase();
     this.#filteredOptions = [];
     this.listboxTarget.innerHTML = "";
+    this.#popupView = "options";
 
     this.#allOptions.forEach((allOption) => {
       let flag = false;
@@ -215,8 +227,9 @@ export default class extends Controller {
 
     const option = this.#populateCurrentFirstLastOptions();
     if (option === null) {
-      this.#renderNoResults();
+      this.#popupView = "noResults";
     }
+    this.#syncPopupView();
     if (this.#floatingDropdown.isVisible()) {
       this.#announceNumberOfResults();
     }
@@ -364,8 +377,9 @@ export default class extends Controller {
   }
 
   #onShow() {
-    this.listboxTarget.style.display = "block";
-    this.listboxTarget.removeAttribute("aria-hidden");
+    this.popupTarget.style.display = "block";
+    this.popupTarget.removeAttribute("aria-hidden");
+    this.#syncPopupView();
     this.comboboxTarget.setAttribute("aria-expanded", "true");
     if (this.hasIndicatorButtonTarget) {
       this.indicatorButtonTarget.firstElementChild.classList.add("rotate-180");
@@ -373,8 +387,9 @@ export default class extends Controller {
   }
 
   #onHide() {
+    this.popupTarget.style.display = "none";
+    this.popupTarget.setAttribute("aria-hidden", "true");
     this.listboxTarget.style.display = "none";
-    this.listboxTarget.setAttribute("aria-hidden", "true");
     this.comboboxTarget.setAttribute("aria-expanded", "false");
     if (this.hasIndicatorButtonTarget) {
       this.indicatorButtonTarget.firstElementChild.classList.remove(
@@ -387,7 +402,7 @@ export default class extends Controller {
 
   #onComboboxKeyDown(event) {
     if (this.#comboboxDisabled()) {
-      if (event.key !== "Tab" && !event.key.startsWith("Arrow")) {
+      if (event.key !== "Tab") {
         event.preventDefault();
       }
       return;
@@ -465,14 +480,17 @@ export default class extends Controller {
         break;
       }
       case "Home": {
-        this.comboboxTarget.setSelectionRange(0, 0);
-        flag = true;
+        if (this.#floatingDropdown.isVisible()) {
+          this.#setOption(this.#firstOption);
+          flag = true;
+        }
         break;
       }
       case "End": {
-        const length = this.comboboxTarget.value.length;
-        this.comboboxTarget.setSelectionRange(length, length);
-        flag = true;
+        if (this.#floatingDropdown.isVisible()) {
+          this.#setOption(this.#lastOption);
+          flag = true;
+        }
         break;
       }
       default: {
@@ -512,8 +530,9 @@ export default class extends Controller {
       case "ArrowLeft":
       case "Right":
       case "ArrowRight":
-      case "Home":
-      case "End":
+        if (this.#floatingDropdown.isVisible()) {
+          return;
+        }
         this.#setOption(null);
         flag = true;
         break;

--- a/app/javascript/utilities/floating_dropdown.js
+++ b/app/javascript/utilities/floating_dropdown.js
@@ -133,7 +133,6 @@ export default class FloatingDropdown {
               size({
                 apply({ availableWidth, availableHeight, rects, elements }) {
                   Object.assign(elements.floating.style, {
-                    width: `${rects.reference.width}px`,
                     maxWidth: `${Math.max(0, availableWidth)}px`,
                     maxHeight: `${Math.max(0, availableHeight)}px`,
                     minWidth: `${rects.reference.width}px`,
@@ -158,7 +157,6 @@ export default class FloatingDropdown {
           position: this.#strategy,
           left: `${triggerRect.left}px`,
           top: `${triggerRect.bottom}px`,
-          width: `${triggerRect.width}px`,
         });
       });
   }

--- a/app/javascript/utilities/floating_dropdown.js
+++ b/app/javascript/utilities/floating_dropdown.js
@@ -122,6 +122,7 @@ export default class FloatingDropdown {
   // Recalculate and apply dropdown position using Floating UI
   update() {
     computePosition(this.#trigger, this.#dropdown, {
+      strategy: this.#strategy,
       placement: "bottom",
       middleware: [
         flip(),
@@ -132,6 +133,7 @@ export default class FloatingDropdown {
               size({
                 apply({ availableWidth, availableHeight, rects, elements }) {
                   Object.assign(elements.floating.style, {
+                    width: `${rects.reference.width}px`,
                     maxWidth: `${Math.max(0, availableWidth)}px`,
                     maxHeight: `${Math.max(0, availableHeight)}px`,
                     minWidth: `${rects.reference.width}px`,
@@ -156,6 +158,7 @@ export default class FloatingDropdown {
           position: this.#strategy,
           left: `${triggerRect.left}px`,
           top: `${triggerRect.bottom}px`,
+          width: `${triggerRect.width}px`,
         });
       });
   }

--- a/app/views/layouts/lookbook.html.erb
+++ b/app/views/layouts/lookbook.html.erb
@@ -6,8 +6,8 @@
 >
   <head>
     <title>Lookbook Preview</title>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "pathogen_view_components", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
 
     <meta name="local-time-i18n" content="<%= local_time_i18n_config %>" data-locale="<%= I18n.locale %>">

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -28,8 +28,8 @@ module Combobox
       test 'renders aria-disabled only for disabled options' do
         render_component(options: options_with_disabled)
 
-        assert_selector '[role="option"][data-value="enabled-option"]:not([aria-disabled])'
-        assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]'
+        assert_selector '[role="option"][data-value="enabled-option"]:not([aria-disabled])', visible: :all
+        assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]', visible: :all
       end
 
       test 'renders clear and show-options buttons outside tab order' do
@@ -43,8 +43,8 @@ module Combobox
         render_component(disabled: true)
 
         assert_selector 'input[role="combobox"][aria-disabled="true"][readonly]:not([disabled])'
-        assert_selector 'button[data-combobox--v1-target="indicatorClearButton"][disabled]'
-        assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
+        assert_selector 'button[data-combobox--v1-target="indicatorClearButton"][aria-disabled="true"]:not([disabled])'
+        assert_selector 'button[data-combobox--v1-target="indicatorButton"][aria-disabled="true"]:not([disabled])'
       end
 
       test 'default preview renders' do
@@ -56,14 +56,14 @@ module Combobox
       test 'with_disabled_options preview renders aria-disabled options' do
         render_combobox_preview(:with_disabled_options)
 
-        assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]'
+        assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]', visible: :all
       end
 
       test 'disabled preview renders disabled combobox' do
         render_combobox_preview(:disabled)
 
         assert_selector 'input[role="combobox"][aria-disabled="true"][readonly]:not([disabled])'
-        assert_selector 'button[data-combobox--v1-target="indicatorButton"][disabled]'
+        assert_selector 'button[data-combobox--v1-target="indicatorButton"][aria-disabled="true"]:not([disabled])'
       end
 
       private

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -56,7 +56,7 @@ module Combobox
       test 'with_disabled_options preview renders aria-disabled options' do
         render_combobox_preview(:with_disabled_options)
 
-        assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]', visible: :all
+        assert_selector '[role="option"][data-value="second-disabled-option"][aria-disabled="true"]', visible: :all
       end
 
       test 'disabled preview renders disabled combobox' do

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -117,7 +117,7 @@ module Combobox
         visit('/rails/view_components/combobox_component/default')
         within "div[data-controller='combobox--v1']" do
           combobox = find("input[role='combobox']")
-          combobox.click.send_keys(:home)
+          combobox.click.send_keys(:escape, :home)
           cursor_position = page.evaluate_script("document.getElementById('field').selectionStart")
           assert_equal 0, cursor_position
 

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -143,7 +143,7 @@ module Combobox
           combobox = find("input[role='combobox']")
           combobox.click
 
-          assert_selector "div[role='option'][data-value='disabled-option'][aria-disabled='true']"
+          assert_selector "div[role='option'][data-value='second-disabled-option'][aria-disabled='true']"
           assert_empty combobox.value
           assert_empty find("input[type='hidden']", visible: false).value
 

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -5,6 +5,26 @@ require 'application_system_test_case'
 module Combobox
   module V1
     class ComponentTest < ApplicationSystemTestCase
+      def test_accessibility_states
+        visit('/rails/view_components/combobox_component/default')
+        within "div[data-controller='combobox--v1']" do
+          assert_accessible
+
+          combobox = find("input[role='combobox']")
+          combobox.click
+          assert_accessible
+
+          combobox.send_keys('this does not exist')
+          assert_selector "div[role='status']", text: I18n.t('combobox_component.no_results_text')
+          assert_accessible
+        end
+
+        visit('/rails/view_components/combobox_component/disabled')
+        within "div[data-controller='combobox--v1']" do
+          assert_accessible
+        end
+      end
+
       def test_default # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         visit('/rails/view_components/combobox_component/default')
         within "div[data-controller='combobox--v1']" do
@@ -39,7 +59,7 @@ module Combobox
         within "div[data-controller='combobox--v1']" do
           combobox = find("input[role='combobox']")
           combobox.send_keys('this does not exist')
-          assert_selector "div[role='option']", text: I18n.t('combobox_component.no_results_text')
+          assert_selector "div[role='status']", text: I18n.t('combobox_component.no_results_text')
         end
       end
 
@@ -93,16 +113,27 @@ module Combobox
         end
       end
 
-      def test_home_and_end_keys
+      def test_home_and_end_keys # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         visit('/rails/view_components/combobox_component/default')
         within "div[data-controller='combobox--v1']" do
           combobox = find("input[role='combobox']")
           combobox.click.send_keys(:home)
           cursor_position = page.evaluate_script("document.getElementById('field').selectionStart")
           assert_equal 0, cursor_position
+
           combobox.send_keys(:end)
           cursor_position = page.evaluate_script("document.getElementById('field').selectionStart")
           assert_equal 3, cursor_position
+
+          combobox.send_keys(%i[alt down])
+          combobox.send_keys(:end)
+          options = all("div[role='option']")
+          last_option = options.last
+          assert_equal last_option[:id], combobox['aria-activedescendant']
+
+          combobox.send_keys(:home)
+          first_option = options.first
+          assert_equal first_option[:id], combobox['aria-activedescendant']
         end
       end
 

--- a/test/components/previews/combobox_component_preview.rb
+++ b/test/components/previews/combobox_component_preview.rb
@@ -40,15 +40,14 @@ class ComboboxComponentPreview < ViewComponent::Preview
   def disabled_options_preview_options
     options_for_select(
       [
+        ['First disabled option', 'first-disabled-option'],
         ['First enabled option', 'first-enabled-option'],
-        ['Disabled option', 'disabled-option'],
         ['Second enabled option', 'second-enabled-option'],
-        ['Another disabled option', 'another-disabled-option'],
+        ['Second disabled option', 'second-disabled-option'],
         ['Enabled option', 'enabled-option'],
-        ['Last disabled option', 'last-disabled-option'],
-        ['Third enabled option', 'third-enabled-option']
+        ['Last disabled option', 'last-disabled-option']
       ],
-      { disabled: %w[disabled-option another-disabled-option last-disabled-option] }
+      { disabled: %w[first-disabled-option second-disabled-option last-disabled-option] }
     )
   end
 

--- a/test/components/previews/combobox_component_preview.rb
+++ b/test/components/previews/combobox_component_preview.rb
@@ -12,10 +12,7 @@ class ComboboxComponentPreview < ViewComponent::Preview
       template: 'combobox_component_preview/default',
       locals: default_locals(
         label: 'Field with disabled options',
-        options: options_for_select(
-          [['Enabled option', 'enabled-option'], ['Disabled option', 'disabled-option']],
-          { disabled: ['disabled-option'] }
-        )
+        options: disabled_options_preview_options
       )
     )
   end
@@ -38,6 +35,21 @@ class ComboboxComponentPreview < ViewComponent::Preview
       options: options,
       combobox_arguments: combobox_arguments
     }
+  end
+
+  def disabled_options_preview_options
+    options_for_select(
+      [
+        ['First enabled option', 'first-enabled-option'],
+        ['Disabled option', 'disabled-option'],
+        ['Second enabled option', 'second-enabled-option'],
+        ['Another disabled option', 'another-disabled-option'],
+        ['Enabled option', 'enabled-option'],
+        ['Last disabled option', 'last-disabled-option'],
+        ['Third enabled option', 'third-enabled-option']
+      ],
+      { disabled: %w[disabled-option another-disabled-option last-disabled-option] }
+    )
   end
 
   def grouped_metadata_options

--- a/test/javascript/controllers/combobox/v1_controller.test.js
+++ b/test/javascript/controllers/combobox/v1_controller.test.js
@@ -1,0 +1,378 @@
+import { Application } from "@hotwired/stimulus";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ComboboxController from "../../../../app/javascript/controllers/combobox/v1_controller.js";
+
+vi.mock("utilities/floating_dropdown", () => ({
+  default: class FloatingDropdownStub {
+    #visible = false;
+    #onShow;
+    #onHide;
+
+    constructor({ onShow, onHide }) {
+      this.#onShow = onShow;
+      this.#onHide = onHide;
+    }
+
+    isVisible() {
+      return this.#visible;
+    }
+
+    show() {
+      this.#visible = true;
+      this.#onShow?.();
+    }
+
+    hide() {
+      this.#visible = false;
+      this.#onHide?.();
+    }
+
+    toggle() {
+      if (this.#visible) {
+        this.hide();
+      } else {
+        this.show();
+      }
+    }
+
+    destroy() {}
+  },
+}));
+
+function option({ id, value, text, disabled = false }) {
+  return `
+    <div
+      id="${id}"
+      role="option"
+      data-value="${value}"
+      ${disabled ? 'aria-disabled="true"' : ""}
+    >${text}</div>
+  `;
+}
+
+function renderFixture({ disabled = false } = {}) {
+  document.body.innerHTML = `
+    <div
+      data-controller="combobox--v1"
+      data-combobox--v1-clear-selection-label-value="Clear selection"
+      data-combobox--v1-no-results-text-value="No results found"
+      data-combobox--v1-show-options-label-value="Show options"
+      data-combobox--v1-single-result-text-value="1 result available"
+      data-combobox--v1-multiple-results-text-value="%{num} results available"
+    >
+      <input
+        type="hidden"
+        value=""
+        data-combobox--v1-target="hidden"
+      >
+      <div>
+        <input
+          id="field"
+          type="text"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls="field_listbox"
+          aria-expanded="false"
+          ${disabled ? 'aria-disabled="true" readonly' : ""}
+          data-combobox--v1-target="combobox"
+        >
+        <button
+          type="button"
+          tabindex="-1"
+          data-combobox--v1-target="indicatorClearButton"
+          data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onClearClick"
+        >Clear</button>
+        <button
+          type="button"
+          tabindex="-1"
+          data-combobox--v1-target="indicatorButton"
+          data-action="mousedown->combobox--v1#onIndicatorMouseDown click->combobox--v1#onIndicatorClick"
+        ><span></span></button>
+      </div>
+      <div
+        aria-hidden="true"
+        style="display: none;"
+        data-combobox--v1-target="popup"
+      >
+        <div
+          id="field_listbox"
+          role="listbox"
+          data-combobox--v1-target="listbox"
+        >
+          ${option({ id: "option-alpha", value: "alpha", text: "Alpha" })}
+          ${option({ id: "option-disabled", value: "disabled", text: "Disabled", disabled: true })}
+          ${option({ id: "option-bravo", value: "bravo", text: "Bravo" })}
+        </div>
+        <div
+          role="status"
+          hidden
+          data-combobox--v1-target="noResults"
+        ></div>
+      </div>
+      <div aria-live="polite" data-combobox--v1-target="ariaLiveUpdate"></div>
+    </div>
+  `;
+}
+
+async function startController() {
+  const application = Application.start();
+  application.register("combobox--v1", ComboboxController);
+  await Promise.resolve();
+  return application;
+}
+
+function combobox() {
+  return document.querySelector('[data-combobox--v1-target="combobox"]');
+}
+
+function hidden() {
+  return document.querySelector('[data-combobox--v1-target="hidden"]');
+}
+
+function listbox() {
+  return document.querySelector('[data-combobox--v1-target="listbox"]');
+}
+
+function noResults() {
+  return document.querySelector('[data-combobox--v1-target="noResults"]');
+}
+
+function keydown(key, options = {}) {
+  return combobox().dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...options,
+    }),
+  );
+}
+
+function keyup(key, options = {}) {
+  return combobox().dispatchEvent(
+    new KeyboardEvent("keyup", {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...options,
+    }),
+  );
+}
+
+function beforeinput(data = "x") {
+  return combobox().dispatchEvent(
+    new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      data,
+      inputType: "insertText",
+    }),
+  );
+}
+
+function focusCombobox() {
+  combobox().focus();
+}
+
+function activeId() {
+  return combobox().getAttribute("aria-activedescendant");
+}
+
+function selectedOptionIds() {
+  return Array.from(listbox().querySelectorAll('[aria-selected="true"]')).map(
+    (element) => element.id,
+  );
+}
+
+describe("combobox v1 controller", () => {
+  let application;
+  let scrollIntoView;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+  });
+
+  afterEach(() => {
+    application?.stop();
+    vi.useRealTimers();
+  });
+
+  it("opens with Alt+ArrowDown without selecting an active option", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+
+    keydown("ArrowDown", { altKey: true });
+
+    expect(combobox()).toHaveAttribute("aria-expanded", "true");
+    expect(combobox()).not.toHaveAttribute("aria-activedescendant");
+    expect(selectedOptionIds()).toEqual([]);
+  });
+
+  it("moves the active option with ArrowDown and ArrowUp while skipping aria-disabled options", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+
+    keydown("ArrowDown");
+    expect(activeId()).toBe("option-alpha");
+    expect(selectedOptionIds()).toEqual(["option-alpha"]);
+
+    keydown("ArrowDown");
+    expect(activeId()).toBe("option-bravo");
+    expect(selectedOptionIds()).toEqual(["option-bravo"]);
+
+    keydown("ArrowUp");
+    expect(activeId()).toBe("option-alpha");
+    expect(selectedOptionIds()).toEqual(["option-alpha"]);
+  });
+
+  it("moves Home and End to the first and last enabled options when the popup is open", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+    keydown("ArrowDown", { altKey: true });
+
+    keydown("End");
+    expect(activeId()).toBe("option-bravo");
+
+    keydown("Home");
+    expect(activeId()).toBe("option-alpha");
+  });
+
+  it("leaves Home and End as text editing keys when the popup is closed", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+
+    expect(keydown("Home")).toBe(true);
+    expect(keydown("End")).toBe(true);
+    expect(keyup("Home")).toBe(true);
+    expect(keyup("End")).toBe(true);
+    expect(combobox()).not.toHaveAttribute("aria-activedescendant");
+  });
+
+  it("shows options again after clearing a no-results filter and reopening", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+
+    combobox().value = "zzz";
+    keyup("z");
+    vi.advanceTimersByTime(300);
+    expect(noResults()).not.toHaveAttribute("hidden");
+
+    keydown("Escape");
+
+    combobox().value = "";
+    keyup("Backspace");
+    vi.advanceTimersByTime(300);
+    keydown("ArrowDown", { altKey: true });
+
+    expect(noResults()).toHaveAttribute("hidden");
+    expect(listbox()).not.toHaveAttribute("hidden");
+    expect(listbox().querySelectorAll('[role="option"]').length).toBe(3);
+  });
+
+  it("renders no-results text as status text instead of a selectable option", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+
+    combobox().value = "zzz";
+    keyup("z");
+    vi.advanceTimersByTime(300);
+
+    expect(noResults()).toHaveAttribute("role", "status");
+    expect(noResults()).toHaveTextContent("No results found");
+    expect(noResults()).not.toHaveAttribute("hidden");
+    expect(listbox()).toHaveAttribute("hidden");
+    expect(listbox().querySelector('[role="status"]')).toBeNull();
+    expect(listbox().querySelector('[role="option"]')).toBeNull();
+    expect(combobox()).not.toHaveAttribute("aria-activedescendant");
+  });
+
+  it("closes the popup with Escape, then clears the committed value with Escape when closed", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+    keydown("ArrowDown");
+    keydown("ArrowDown");
+    keydown("Enter");
+
+    expect(combobox()).toHaveValue("Bravo");
+    expect(hidden()).toHaveValue("bravo");
+
+    keydown("ArrowDown", { altKey: true });
+    expect(combobox()).toHaveAttribute("aria-expanded", "true");
+
+    keydown("Escape");
+    expect(combobox()).toHaveAttribute("aria-expanded", "false");
+    expect(combobox()).toHaveValue("Bravo");
+    expect(hidden()).toHaveValue("bravo");
+
+    keydown("Escape");
+    expect(combobox()).toHaveValue("");
+    expect(hidden()).toHaveValue("");
+  });
+
+  it("does not change values or fire change events while filtering", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+    const comboboxChange = vi.fn();
+    const hiddenChange = vi.fn();
+    combobox().addEventListener("change", comboboxChange);
+    hidden().addEventListener("change", hiddenChange);
+
+    combobox().value = "Al";
+    keyup("l");
+    vi.advanceTimersByTime(300);
+
+    expect(hidden()).toHaveValue("");
+    expect(comboboxChange).not.toHaveBeenCalled();
+    expect(hiddenChange).not.toHaveBeenCalled();
+  });
+
+  it("commits the active option and fires change events only on commit", async () => {
+    renderFixture();
+    application = await startController();
+    focusCombobox();
+    const comboboxChange = vi.fn();
+    const hiddenChange = vi.fn();
+    combobox().addEventListener("change", comboboxChange);
+    hidden().addEventListener("change", hiddenChange);
+
+    keydown("ArrowDown");
+    keydown("ArrowDown");
+    expect(hidden()).toHaveValue("");
+    expect(comboboxChange).not.toHaveBeenCalled();
+    expect(hiddenChange).not.toHaveBeenCalled();
+
+    keydown("Enter");
+    expect(combobox()).toHaveValue("Bravo");
+    expect(hidden()).toHaveValue("bravo");
+    expect(comboboxChange).toHaveBeenCalledTimes(1);
+    expect(hiddenChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores keyboard and mouse input when aria-disabled is true", async () => {
+    renderFixture({ disabled: true });
+    application = await startController();
+    focusCombobox();
+
+    expect(beforeinput("a")).toBe(false);
+    expect(keydown("ArrowDown")).toBe(false);
+    combobox().click();
+    keyup("a");
+    keydown("Enter");
+
+    expect(combobox()).toHaveAttribute("aria-expanded", "false");
+    expect(combobox()).toHaveValue("");
+    expect(hidden()).toHaveValue("");
+    expect(combobox()).toHaveAttribute("aria-disabled", "true");
+    expect(combobox()).not.toHaveAttribute("disabled");
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,6 +9,8 @@ const jsRoot = resolve(
 export default defineConfig({
   resolve: {
     alias: {
+      controllers: resolve(jsRoot, "controllers"),
+      debounce: resolve("vendor/javascript/debounce.js"),
       "utilities/live_region": resolve(jsRoot, "utilities/live_region.js"),
       "utilities/form": resolve(jsRoot, "utilities/form.js"),
       "utilities/focus": resolve(jsRoot, "utilities/focus.js"),


### PR DESCRIPTION
## What does this PR do and why?
- Fixes combobox keyboard and popup behaviour for #1944.
- Adds Vitest coverage so arrow keys, Home/End, Escape, no-results, and disabled state regressions are caught quickly.

## Screenshots or screen recordings
- N/A (keyboard and accessibility behaviour; no visible UI layout changes)

## How to set up and validate locally
1. Run JS tests: `pnpm run test:js -- test/javascript/controllers/combobox/v1_controller.test.js`
2. Run render tests: `PARALLEL_WORKERS=4 bin/rails test test/components/combobox/v1/component_render_test.rb`
3. Run preview system tests: `PARALLEL_WORKERS=4 bin/rails test test/components/combobox/v1/component_test.rb`
4. Open [lookbook](http://localhost:3000/rails/lookbook/inspect/combobox/default) and confirm:
   - Arrow keys skip disabled options
   - Home/End move the text cursor when closed, jump to first/last option when open
   - A no-results search shows status text, not a selectable option
   - Disabled combobox ignores keyboard and mouse input

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.