### PR TITLE
Fix: Private ip generation in tests

### DIFF
--- a/test/graphql/concerns/last_used_ip_concern_test.rb
+++ b/test/graphql/concerns/last_used_ip_concern_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'faker'
 
 class LastUsedIpConcernTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
@@ -15,7 +14,7 @@ class LastUsedIpConcernTest < ActionDispatch::IntegrationTest
   test 'update_last_used_ips adds new IP address to personal access token and sends email' do
     user = users(:john_doe)
 
-    ip_address = Faker::Internet.public_ip_v4_address
+    ip_address = public_ip_v4_address
 
     # Ensure the personal access token starts with no IP addresses
     assert_empty @personal_access_token.last_used_ips
@@ -49,7 +48,7 @@ class LastUsedIpConcernTest < ActionDispatch::IntegrationTest
   end
 
   test 'update_last_used_ips does not add IP address if it is already in the list of last used ips' do
-    ip_address = Faker::Internet.public_ip_v4_address
+    ip_address = public_ip_v4_address
     ip_addresses = @personal_access_token.last_used_ips
     ip_addresses << ip_address
     @personal_access_token.update(last_used_ips: ip_addresses)
@@ -69,7 +68,7 @@ class LastUsedIpConcernTest < ActionDispatch::IntegrationTest
   test 'update_last_used_ips returns early if personal access token is an integration token' do
     @personal_access_token.update(integration: true)
     post api_graphql_path, params: { query: '{ __schema }' },
-                           headers: { Authorization: @authorization_header, 'REMOTE_ADDR' => Faker::Internet.public_ip_v4_address }
+                           headers: { Authorization: @authorization_header, 'REMOTE_ADDR' => public_ip_v4_address }
 
     assert_enqueued_emails 0
     assert_empty @personal_access_token.reload.last_used_ips
@@ -87,19 +86,19 @@ class LastUsedIpConcernTest < ActionDispatch::IntegrationTest
 
   test 'update_last_used_ips returns early if personal access token is nil' do
     post api_graphql_path, params: { query: '{ __schema }' },
-                           headers: { Authorization: @authorization_header, 'REMOTE_ADDR' => Faker::Internet.public_ip_v4_address }
+                           headers: { Authorization: @authorization_header, 'REMOTE_ADDR' => public_ip_v4_address }
 
     assert_enqueued_emails 0
     assert_response :success
   end
 
   test 'update_last_used_ips only keeps track of the last 5 used ips' do
-    ip_addresses = Array.new(5) { Faker::Internet.public_ip_v4_address }
+    ip_addresses = Array.new(5) { public_ip_v4_address }
 
     @personal_access_token.update(last_used_ips: ip_addresses)
 
     first_ip_address = ip_addresses.first
-    new_ip_address = Faker::Internet.public_ip_v4_address
+    new_ip_address = public_ip_v4_address
 
     assert_equal 5, @personal_access_token.last_used_ips.length
 
@@ -117,7 +116,7 @@ class LastUsedIpConcernTest < ActionDispatch::IntegrationTest
   end
 
   test 'update_last_used_ips does not add IP address if it is in private ranges' do
-    ip_address = Faker::Internet.private_ip_v4_address
+    ip_address = private_ip_v4_address
 
     assert IPAddr.new(ip_address).private?, 'IP address should be private'
     assert_not_includes @personal_access_token.reload.last_used_ips, ip_address

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,7 @@ require 'test_helpers/dashboard_sorting_helper'
 require 'test_helpers/sorting_test_helper'
 require 'test_helpers/w3c_validation_helpers'
 require 'test_helpers/user_opt_in_features_test_helper'
+require 'test_helpers/ip_test_helpers'
 require 'turbo/broadcastable/test_helper'
 require 'minitest/retry'
 
@@ -70,6 +71,7 @@ module ActiveSupport
     include ActionPolicy::TestHelper
     include ArrayHelpers
     include WorkflowExecutionAdvancedSearchHelper
+    include IPTestHelpers
     include ActiveJob::TestHelper
     include ActionMailer::TestHelper
     include Turbo::Broadcastable::TestHelper

--- a/test/test_helpers/ip_test_helpers.rb
+++ b/test/test_helpers/ip_test_helpers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module IPTestHelpers
+  # Generate a random RFC1918 (private) IPv4 address.
+  # Covers: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+  def rfc1918_ip
+    case rand(3)
+    when 0
+      "10.#{rand(0..255)}.#{rand(0..255)}.#{rand(1..254)}"
+    when 1
+      "172.#{rand(16..31)}.#{rand(0..255)}.#{rand(1..254)}"
+    else
+      "192.168.#{rand(0..255)}.#{rand(1..254)}"
+    end
+  end
+
+  alias private_ip_v4_address rfc1918_ip
+
+  # Generate a random public IPv4 address (avoids RFC1918, loopback and link-local ranges).
+  def public_ip_v4_address # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    loop do
+      a = rand(1..223)
+      b = rand(0..255)
+      c = rand(0..255)
+      d = rand(1..254)
+
+      next if a == 10
+      next if a == 127
+      next if a == 169 && b == 254
+      next if a == 172 && (16..31).cover?(b)
+      next if a == 192 && b == 168
+
+      return "#{a}.#{b}.#{c}.#{d}"
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Adds in a new test helper which generates private ip addresses as defined by [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918), and public ip addresses instead of using faker.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
