### PR TITLE
Advanced search combobox: ARIA wiring and accessibility tests (#1945)

### DIFF
--- a/app/components/advanced_search/v1/component.html.erb
+++ b/app/components/advanced_search/v1/component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div(
   id: "advanced-search",
   data: {
-    action: "viral--dialog:close->advanced-search--v1#close",
+    action: "viral--dialog:close->advanced-search--v1#close turbo:morph-element->advanced-search--v1#completeApplyFilter",
     controller: "advanced-search--v1",
     "advanced-search--v1-open-value": @open,
     "advanced-search--v1-status-value": @status,
@@ -78,7 +78,7 @@
     </div>
 
     <% dialog.with_primary_action(
-      "data-action": "viral--dialog#close filters#submit",
+      "data-action": "advanced-search--v1#markApplyFilter filters#submit",
     ) { t("components.advanced_search_component.v1.apply_filter_button") } %>
 
     <% dialog.with_secondary_action do %>

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -45,6 +45,9 @@
             describedby: conditions_form.field_id(:field, "error"),
             labelledby: conditions_form.field_id(:field, :label),
           },
+          listbox_aria: {
+            labelledby: conditions_form.field_id(:field, :label),
+          },
         ) %>
       <% end %>
 

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -40,9 +40,10 @@
             action: "change->advanced-search--v1#handleFieldChange",
           },
           aria: {
-            label: field_label,
+            required: true,
             invalid: invalid_field,
-            describedby: conditions_form.field_id(:field, "error")
+            describedby: conditions_form.field_id(:field, "error"),
+            labelledby: conditions_form.field_id(:field, :label),
           },
         ) %>
       <% end %>

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -57,7 +57,7 @@
     <%= tag.div(
       id: @listbox_id,
       role: "listbox",
-      **listbox_aria_attributes,
+      aria: listbox_aria_attributes,
       "data-combobox--v1-target": "listbox",
     ) do %>
       <%= @listbox_options %>

--- a/app/components/combobox/v1/component.html.erb
+++ b/app/components/combobox/v1/component.html.erb
@@ -57,7 +57,7 @@
     <%= tag.div(
       id: @listbox_id,
       role: "listbox",
-      "aria-label": combobox_arguments[:aria][:label],
+      **listbox_aria_attributes,
       "data-combobox--v1-target": "listbox",
     ) do %>
       <%= @listbox_options %>

--- a/app/components/combobox/v1/component.rb
+++ b/app/components/combobox/v1/component.rb
@@ -4,7 +4,7 @@ module Combobox
   module V1
     # Component for rendering a drop down that filters dynamically
     class Component < ::Component
-      def initialize(form:, field:, options:, **combobox_arguments)
+      def initialize(form:, field:, options:, listbox_aria: nil, **combobox_arguments)
         @combobox_id = form.field_id(field)
         @listbox_id = "#{form.field_id(field)}_listbox"
         @form = form
@@ -12,7 +12,7 @@ module Combobox
         @listbox_options = create_listbox(options)
         @selected_option = selected_option(options)
         @combobox_arguments = combobox_arguments
-        @listbox_labelledby = combobox_arguments.dig(:aria, :labelledby)
+        @listbox_aria = listbox_aria
       end
 
       private
@@ -28,7 +28,6 @@ module Combobox
           args[:aria] ||= {}
           args[:aria][:disabled] = 'true' if disabled
           args[:readonly] = true if disabled
-          args[:aria].delete(:labelledby)
           args[:aria][:autocomplete] = 'list'
           args[:aria][:expanded] = 'false'
           args[:aria][:controls] = @listbox_id
@@ -46,11 +45,10 @@ module Combobox
       end
 
       def listbox_aria_attributes
-        attrs = {}
-        attrs[:'aria-labelledby'] = @listbox_labelledby if @listbox_labelledby.present?
-        label = combobox_arguments.dig(:aria, :label)
-        attrs[:'aria-label'] = label if label.present? && @listbox_labelledby.blank?
-        attrs
+        return @listbox_aria if @listbox_aria.present?
+
+        label = @combobox_arguments.dig(:aria, :label)
+        label.present? ? { label: } : {}
       end
 
       def selected_option(options)

--- a/app/components/combobox/v1/component.rb
+++ b/app/components/combobox/v1/component.rb
@@ -12,6 +12,7 @@ module Combobox
         @listbox_options = create_listbox(options)
         @selected_option = selected_option(options)
         @combobox_arguments = combobox_arguments
+        @listbox_labelledby = combobox_arguments.dig(:aria, :labelledby)
       end
 
       private
@@ -27,6 +28,7 @@ module Combobox
           args[:aria] ||= {}
           args[:aria][:disabled] = 'true' if disabled
           args[:readonly] = true if disabled
+          args[:aria].delete(:labelledby)
           args[:aria][:autocomplete] = 'list'
           args[:aria][:expanded] = 'false'
           args[:aria][:controls] = @listbox_id
@@ -41,6 +43,14 @@ module Combobox
 
       def combobox_disabled?
         @combobox_arguments[:disabled] == true
+      end
+
+      def listbox_aria_attributes
+        attrs = {}
+        attrs[:'aria-labelledby'] = @listbox_labelledby if @listbox_labelledby.present?
+        label = combobox_arguments.dig(:aria, :label)
+        attrs[:'aria-label'] = label if label.present? && @listbox_labelledby.blank?
+        attrs
       end
 
       def selected_option(options)

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import { closeDialog } from "utilities/dialog";
 
 export default class AdvancedSearchController extends Controller {
   static targets = [
@@ -25,6 +26,27 @@ export default class AdvancedSearchController extends Controller {
     status: Boolean,
   };
 
+  #dialogHost() {
+    return this.element.querySelector('[data-controller~="viral--dialog"]');
+  }
+
+  #completeApplyFilterIfNeeded() {
+    if (sessionStorage.getItem("advancedSearch:applyFilter") !== "1") {
+      return;
+    }
+
+    sessionStorage.removeItem("advancedSearch:applyFilter");
+
+    if (this.hasErrorsValue) {
+      this.#focusFirstInvalidField();
+      return;
+    }
+
+    if (this.openValue) {
+      closeDialog(this.element, this.application);
+    }
+  }
+
   #hiddenClasses = ["invisible", "@max-xl:hidden"];
   #groupSelector =
     "fieldset[data-advanced-search--v1-target='groupsContainer']";
@@ -36,6 +58,7 @@ export default class AdvancedSearchController extends Controller {
     this.boundOnMorph = this.onMorph.bind(this);
 
     document.addEventListener("turbo:morph", this.boundOnMorph);
+    this.#completeApplyFilterIfNeeded();
   }
 
   disconnect() {
@@ -64,6 +87,7 @@ export default class AdvancedSearchController extends Controller {
 
   onMorph() {
     this.renderSearchIfOpen();
+    this.#completeApplyFilterIfNeeded();
   }
 
   clear() {
@@ -168,6 +192,15 @@ export default class AdvancedSearchController extends Controller {
     this.clear();
     this.searchGroupsContainerTarget.innerHTML =
       this.emptySearchTemplateTarget.innerHTML;
+  }
+
+  completeApplyFilter() {
+    this.#completeApplyFilterIfNeeded();
+  }
+
+  markApplyFilter() {
+    this.#dialogHost()?.setAttribute("data-preserve-open-on-disconnect", "");
+    sessionStorage.setItem("advancedSearch:applyFilter", "1");
   }
 
   handleOperatorChange(event) {
@@ -426,11 +459,13 @@ export default class AdvancedSearchController extends Controller {
   }
 
   #focusFirstInvalidField() {
-    const invalidField = Array.from(
-      this.element.querySelectorAll("[aria-invalid='true']"),
-    ).find((field) => !field.disabled && field.offsetParent !== null);
+    requestAnimationFrame(() => {
+      const invalidField = Array.from(
+        this.element.querySelectorAll("[aria-invalid='true']"),
+      ).find((field) => !field.disabled && field.offsetParent !== null);
 
-    invalidField?.focus();
+      invalidField?.focus();
+    });
   }
 
   #selectedConditionField(condition) {

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -43,7 +43,7 @@ export default class AdvancedSearchController extends Controller {
     }
 
     if (this.openValue) {
-      closeDialog(this.element, this.application);
+      closeDialog(this.#dialogHost(), this.application);
     }
   }
 

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -42,9 +42,7 @@ export default class AdvancedSearchController extends Controller {
       return;
     }
 
-    if (this.openValue) {
-      closeDialog(this.#dialogHost(), this.application);
-    }
+    closeDialog(this.#dialogHost(), this.application);
   }
 
   #hiddenClasses = ["invisible", "@max-xl:hidden"];
@@ -199,7 +197,9 @@ export default class AdvancedSearchController extends Controller {
   }
 
   markApplyFilter() {
-    this.#dialogHost()?.setAttribute("data-preserve-open-on-disconnect", "");
+    const dialogHost = this.#dialogHost();
+    dialogHost?.removeAttribute("data-turbo-permanent");
+    dialogHost?.setAttribute("data-preserve-open-on-disconnect", "");
     sessionStorage.setItem("advancedSearch:applyFilter", "1");
   }
 

--- a/app/javascript/controllers/viral/dialog_controller.js
+++ b/app/javascript/controllers/viral/dialog_controller.js
@@ -39,11 +39,15 @@ export default class extends Controller {
       this.#focusTrap.deactivate();
     }
     if (this.openValue) {
-      this.close();
-      if (this.#trigger) {
-        // re-add refocusTrigger on save
-        // (this is so that turbo page loads that replace the open dialog with a closed one will refocus the trigger)
-        savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: true });
+      if (this.element.hasAttribute("data-preserve-open-on-disconnect")) {
+        this.element.removeAttribute("data-preserve-open-on-disconnect");
+      } else {
+        this.close();
+        if (this.#trigger) {
+          // re-add refocusTrigger on save
+          // (this is so that turbo page loads that replace the open dialog with a closed one will refocus the trigger)
+          savedDialogStates.set(this.dialogTarget.id, { refocusTrigger: true });
+        }
       }
     }
   }

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'test_helpers/advanced_search_combobox_test_helper'
 require 'test_helpers/axe_helpers'
 require 'test_helpers/better_rails_system_tests'
 require 'test_helpers/capybara_setup'
@@ -12,6 +13,7 @@ require 'action_dispatch/system_test_case'
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :irida_next_playwright
 
+  include AdvancedSearchComboboxTestHelper
   include AxeHelpers
   include BetterRailsSystemTests
   include HTML5Helpers

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'test_helpers/advanced_search_combobox_test_helper'
 require 'test_helpers/axe_helpers'
 require 'test_helpers/better_rails_system_tests'
 require 'test_helpers/capybara_setup'
@@ -13,7 +12,6 @@ require 'action_dispatch/system_test_case'
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :irida_next_playwright
 
-  include AdvancedSearchComboboxTestHelper
   include AxeHelpers
   include BetterRailsSystemTests
   include HTML5Helpers

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'application_system_test_case'
+require 'test_helpers/advanced_search_combobox_test_helper'
 
 class AdvancedSearchComponentTest < ApplicationSystemTestCase
+  include AdvancedSearchComboboxTestHelper
+
   def setup
     Flipper.enable(:advanced_search_with_auto_complete)
   end

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -196,6 +196,27 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
     end
   end
 
+  test 'field combobox passes axe in collapsed, open, filtered, and selected states' do
+    visit('rails/view_components/advanced_search_component/default')
+    within 'div[data-controller-connected="true"]' do
+      open_advanced_search_dialog
+
+      within 'dialog' do
+        within first("div[data-controller='combobox--v1']") do
+          combobox = find("input[role='combobox']")
+          assert_no_selector 'input[role="combobox"][aria-label]'
+          assert_selector 'input[role="combobox"][aria-required="true"]'
+          assert_selector "div[role='listbox'][aria-labelledby]", visible: :all
+
+          assert_combobox_passes_axe_in_required_states(
+            combobox: combobox,
+            filter_text: I18n.t('samples.table_component.puid')
+          )
+        end
+      end
+    end
+  end
+
   test 'workflow preview keeps enum operators available with native field selects' do
     Flipper.disable(:advanced_search_with_auto_complete)
 

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -32,13 +32,17 @@ module Combobox
         assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]', visible: :all
       end
 
-      test 'labels listbox with aria-labelledby when labelledby is passed' do
+      test 'passes through input aria-labelledby and labels listbox explicitly' do
         render_component(
           aria: {
+            labelledby: 'field-label'
+          },
+          listbox_aria: {
             labelledby: 'field-label'
           }
         )
 
+        assert_selector 'input[role="combobox"][aria-labelledby="field-label"]'
         assert_selector 'div[role="listbox"][aria-labelledby="field-label"]', visible: :all
         assert_no_selector 'div[role="listbox"][aria-label]', visible: :all
       end

--- a/test/components/combobox/v1/component_render_test.rb
+++ b/test/components/combobox/v1/component_render_test.rb
@@ -32,6 +32,17 @@ module Combobox
         assert_selector '[role="option"][data-value="disabled-option"][aria-disabled="true"]', visible: :all
       end
 
+      test 'labels listbox with aria-labelledby when labelledby is passed' do
+        render_component(
+          aria: {
+            labelledby: 'field-label'
+          }
+        )
+
+        assert_selector 'div[role="listbox"][aria-labelledby="field-label"]', visible: :all
+        assert_no_selector 'div[role="listbox"][aria-label]', visible: :all
+      end
+
       test 'renders clear and show-options buttons outside tab order' do
         render_component
 

--- a/test/components/combobox/v1/component_test.rb
+++ b/test/components/combobox/v1/component_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 module Combobox
   module V1
     class ComponentTest < ApplicationSystemTestCase
-      def test_accessibility_states
+      def test_accessibility_states # rubocop:disable Metrics/MethodLength
         visit('/rails/view_components/combobox_component/default')
         within "div[data-controller='combobox--v1']" do
           assert_accessible
@@ -16,6 +16,9 @@ module Combobox
 
           combobox.send_keys('this does not exist')
           assert_selector "div[role='status']", text: I18n.t('combobox_component.no_results_text')
+          assert_accessible
+
+          combobox.send_keys(:escape, 'patient', :enter)
           assert_accessible
         end
 

--- a/test/components/previews/combobox_component_preview/default.html.erb
+++ b/test/components/previews/combobox_component_preview/default.html.erb
@@ -8,6 +8,9 @@
     aria: {
       labelledby: form.field_id(:field, :label),
     },
+    listbox_aria: {
+      labelledby: form.field_id(:field, :label),
+    },
     **combobox_arguments
   ) %>
 <% end %>

--- a/test/components/previews/combobox_component_preview/default.html.erb
+++ b/test/components/previews/combobox_component_preview/default.html.erb
@@ -1,10 +1,13 @@
 <%= form_with(url: "#") do |form| %>
-  <label for="<%= form.field_id(:field) %>"><%= label %></label>
+  <label id="<%= form.field_id(:field, :label) %>" for="<%= form.field_id(:field) %>"><%= label %></label>
 
   <%= render ComboboxComponent.new(
     form: form,
     field: :field,
     options: options,
+    aria: {
+      labelledby: form.field_id(:field, :label),
+    },
     **combobox_arguments
   ) %>
 <% end %>

--- a/test/javascript/controllers/advanced_search/v1_controller.test.js
+++ b/test/javascript/controllers/advanced_search/v1_controller.test.js
@@ -65,11 +65,49 @@ describe("advanced search v1 controller", () => {
     expect(sessionStorage.getItem("advancedSearch:applyFilter")).toBeNull();
   });
 
+  it("closes the dialog host after a successful pending apply when open is false", async () => {
+    renderFixture({ open: false });
+    application = await startController();
+
+    const dialogHost = document.querySelector(
+      '[data-controller="viral--dialog"]',
+    );
+
+    expect(closeDialogMock).toHaveBeenCalledWith(dialogHost, application);
+    expect(sessionStorage.getItem("advancedSearch:applyFilter")).toBeNull();
+  });
+
   it("keeps the dialog open when a pending apply returns errors", async () => {
     renderFixture({ hasErrors: true });
     application = await startController();
 
     expect(closeDialogMock).not.toHaveBeenCalled();
     expect(sessionStorage.getItem("advancedSearch:applyFilter")).toBeNull();
+  });
+
+  it("removes turbo-permanent before submitting an apply filter", async () => {
+    sessionStorage.removeItem("advancedSearch:applyFilter");
+    renderFixture();
+    const dialogHost = document.querySelector(
+      '[data-controller="viral--dialog"]',
+    );
+    dialogHost?.setAttribute("data-turbo-permanent", "");
+
+    application = await startController();
+
+    const controller = application.getControllerForElementAndIdentifier(
+      document.getElementById("advanced-search"),
+      "advanced-search--v1",
+    );
+
+    expect(dialogHost?.hasAttribute("data-turbo-permanent")).toBe(true);
+
+    controller.markApplyFilter();
+
+    expect(dialogHost?.hasAttribute("data-turbo-permanent")).toBe(false);
+    expect(dialogHost?.hasAttribute("data-preserve-open-on-disconnect")).toBe(
+      true,
+    );
+    expect(sessionStorage.getItem("advancedSearch:applyFilter")).toBe("1");
   });
 });

--- a/test/javascript/controllers/advanced_search/v1_controller.test.js
+++ b/test/javascript/controllers/advanced_search/v1_controller.test.js
@@ -1,0 +1,75 @@
+import { Application } from "@hotwired/stimulus";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdvancedSearchController from "../../../../app/javascript/controllers/advanced_search/v1_controller.js";
+const closeDialogMock = vi.hoisted(() => vi.fn());
+
+vi.mock("utilities/dialog", () => ({
+  closeDialog: closeDialogMock,
+}));
+
+function renderFixture({ hasErrors = false, open = true } = {}) {
+  document.body.innerHTML = `
+    <div
+      id="advanced-search"
+      data-controller="advanced-search--v1"
+      data-advanced-search--v1-has-errors-value="${hasErrors}"
+      data-advanced-search--v1-open-value="${open}"
+      data-advanced-search--v1-status-value="true"
+    >
+      <div data-controller="viral--dialog">
+        <dialog open>
+          <input aria-invalid="true">
+        </dialog>
+      </div>
+      <template data-advanced-search--v1-target="searchGroupsTemplate"></template>
+      <div data-advanced-search--v1-target="searchGroupsContainer"></div>
+      <template data-advanced-search--v1-target="groupTemplate"></template>
+      <template data-advanced-search--v1-target="conditionTemplate"></template>
+      <template data-advanced-search--v1-target="emptySearchTemplate"></template>
+      <template data-advanced-search--v1-target="listValueTemplate"></template>
+      <template data-advanced-search--v1-target="listSelectValueTemplate"></template>
+      <template data-advanced-search--v1-target="selectValueTemplate"></template>
+      <template data-advanced-search--v1-target="valueTemplate"></template>
+    </div>
+  `;
+}
+
+async function startController() {
+  const application = Application.start();
+  application.register("advanced-search--v1", AdvancedSearchController);
+  await Promise.resolve();
+  return application;
+}
+
+describe("advanced search v1 controller", () => {
+  let application;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.setItem("advancedSearch:applyFilter", "1");
+  });
+
+  afterEach(() => {
+    application?.stop();
+  });
+
+  it("closes the dialog host after a successful pending apply", async () => {
+    renderFixture();
+    application = await startController();
+
+    const dialogHost = document.querySelector(
+      '[data-controller="viral--dialog"]',
+    );
+
+    expect(closeDialogMock).toHaveBeenCalledWith(dialogHost, application);
+    expect(sessionStorage.getItem("advancedSearch:applyFilter")).toBeNull();
+  });
+
+  it("keeps the dialog open when a pending apply returns errors", async () => {
+    renderFixture({ hasErrors: true });
+    application = await startController();
+
+    expect(closeDialogMock).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem("advancedSearch:applyFilter")).toBeNull();
+  });
+});

--- a/test/system/advanced_search/combobox_accessibility_test.rb
+++ b/test/system/advanced_search/combobox_accessibility_test.rb
@@ -14,7 +14,7 @@ module AdvancedSearch
     end
 
     test 'group samples field combobox passes axe and updates operator options' do
-      visit group_samples_url(groups(:group_one))
+      visit_for_advanced_search_combobox_test group_samples_url(groups(:group_one))
       open_advanced_search_dialog
 
       within_first_field_combobox do
@@ -37,7 +37,7 @@ module AdvancedSearch
     end
 
     test 'group samples invalid field combobox passes axe' do
-      visit group_samples_url(groups(:group_one))
+      visit_for_advanced_search_combobox_test group_samples_url(groups(:group_one))
       open_advanced_search_dialog
       assert_invalid_field_combobox_passes_axe
     end
@@ -45,7 +45,7 @@ module AdvancedSearch
     test 'workflow executions field combobox passes axe and updates operator options' do
       Flipper.enable(:workflow_execution_advanced_search)
 
-      visit workflow_executions_path
+      visit_for_advanced_search_combobox_test workflow_executions_path
       open_advanced_search_dialog
 
       within_first_field_combobox do
@@ -72,7 +72,7 @@ module AdvancedSearch
     test 'advanced search uses native field select when autocomplete flag is disabled' do
       Flipper.disable(:advanced_search_with_auto_complete, @user)
 
-      visit group_samples_url(groups(:group_one))
+      visit_for_advanced_search_combobox_test group_samples_url(groups(:group_one))
       open_advanced_search_dialog
 
       within 'dialog' do

--- a/test/system/advanced_search/combobox_accessibility_test.rb
+++ b/test/system/advanced_search/combobox_accessibility_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require 'application_system_test_case'
+require 'test_helpers/advanced_search_combobox_test_helper'
 
 module AdvancedSearch
   class ComboboxAccessibilityTest < ApplicationSystemTestCase
+    include AdvancedSearchComboboxTestHelper
+
     setup do
       @user = users(:john_doe)
       login_as @user

--- a/test/system/advanced_search/combobox_accessibility_test.rb
+++ b/test/system/advanced_search/combobox_accessibility_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module AdvancedSearch
+  class ComboboxAccessibilityTest < ApplicationSystemTestCase
+    setup do
+      @user = users(:john_doe)
+      login_as @user
+      Flipper.enable(:advanced_search_with_auto_complete, @user)
+    end
+
+    test 'group samples field combobox passes axe and updates operator options' do
+      visit group_samples_url(groups(:group_one))
+      open_advanced_search_dialog
+
+      within_first_field_combobox do
+        combobox = find("input[role='combobox']")
+        assert_no_selector 'input[role="combobox"][aria-label]'
+        assert_selector 'input[role="combobox"][aria-required="true"]'
+
+        assert_combobox_passes_axe_in_required_states(
+          combobox: combobox,
+          filter_text: I18n.t('samples.table_component.puid')
+        )
+      end
+
+      within 'dialog' do
+        within first("select[name$='[operator]']") do
+          assert_text I18n.t('components.advanced_search_component.v1.operation.in')
+          assert_text I18n.t('components.advanced_search_component.v1.operation.not_in')
+        end
+      end
+    end
+
+    test 'group samples invalid field combobox passes axe' do
+      visit group_samples_url(groups(:group_one))
+      open_advanced_search_dialog
+      assert_invalid_field_combobox_passes_axe
+    end
+
+    test 'workflow executions field combobox passes axe and updates operator options' do
+      Flipper.enable(:workflow_execution_advanced_search)
+
+      visit workflow_executions_path
+      open_advanced_search_dialog
+
+      within_first_field_combobox do
+        combobox = find("input[role='combobox']")
+        assert_combobox_passes_axe_in_required_states(
+          combobox: combobox,
+          filter_text: I18n.t('workflow_executions.table_component.state')
+        )
+      end
+
+      within 'dialog' do
+        within first("select[name$='[operator]']") do
+          allowed_operators = all("option:not([hidden]):not([value=''])").map(&:value)
+          assert_equal %w[= != in not_in], allowed_operators
+        end
+
+        first("select[name$='[operator]']").find("option[value='=']").select_option
+        assert_selector "select[name$='[value]']"
+      end
+    ensure
+      Flipper.disable(:workflow_execution_advanced_search)
+    end
+
+    test 'advanced search uses native field select when autocomplete flag is disabled' do
+      Flipper.disable(:advanced_search_with_auto_complete, @user)
+
+      visit group_samples_url(groups(:group_one))
+      open_advanced_search_dialog
+
+      within 'dialog' do
+        assert_selector "select[name$='[field]']"
+        assert_no_selector "input[role='combobox']"
+      end
+    ensure
+      Flipper.enable(:advanced_search_with_auto_complete, @user)
+    end
+  end
+end

--- a/test/test_helpers/advanced_search_combobox_test_helper.rb
+++ b/test/test_helpers/advanced_search_combobox_test_helper.rb
@@ -28,8 +28,11 @@ module AdvancedSearchComboboxTestHelper
   def assert_invalid_field_combobox_passes_axe
     click_button I18n.t(:'components.advanced_search_component.v1.apply_filter_button')
 
-    within_first_field_combobox do
+    within page.find('dialog') do
       assert_selector 'input[role="combobox"][aria-invalid="true"]'
+    end
+
+    within_first_field_combobox do
       assert_accessible
     end
   end

--- a/test/test_helpers/advanced_search_combobox_test_helper.rb
+++ b/test/test_helpers/advanced_search_combobox_test_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module AdvancedSearchComboboxTestHelper
+  ADVANCED_SEARCH_DIALOG_SELECTOR = '#advanced-search-dialog'
+
+  def visit_for_advanced_search_combobox_test(path)
+    page.visit(path)
+  end
+
   def open_advanced_search_dialog
     click_button I18n.t(:'components.advanced_search_component.v1.title')
     assert_selector 'dialog h1', text: I18n.t(:'components.advanced_search_component.v1.title')
@@ -13,16 +19,16 @@ module AdvancedSearchComboboxTestHelper
   end
 
   def assert_combobox_passes_axe_in_required_states(combobox:, filter_text:)
-    assert_accessible
+    assert_accessible(within: ADVANCED_SEARCH_DIALOG_SELECTOR)
 
     combobox.click
-    assert_accessible
+    assert_accessible(within: ADVANCED_SEARCH_DIALOG_SELECTOR)
 
     combobox.send_keys([:ctrl, 'a'], :delete, filter_text)
-    assert_accessible
+    assert_accessible(within: ADVANCED_SEARCH_DIALOG_SELECTOR)
 
     combobox.send_keys(:enter)
-    assert_accessible
+    assert_accessible(within: ADVANCED_SEARCH_DIALOG_SELECTOR)
   end
 
   def assert_invalid_field_combobox_passes_axe
@@ -32,8 +38,6 @@ module AdvancedSearchComboboxTestHelper
       assert_selector 'input[role="combobox"][aria-invalid="true"]'
     end
 
-    within_first_field_combobox do
-      assert_accessible
-    end
+    assert_accessible(within: ADVANCED_SEARCH_DIALOG_SELECTOR)
   end
 end

--- a/test/test_helpers/advanced_search_combobox_test_helper.rb
+++ b/test/test_helpers/advanced_search_combobox_test_helper.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module AdvancedSearchComboboxTestHelper
+  def open_advanced_search_dialog
+    click_button I18n.t(:'components.advanced_search_component.v1.title')
+    assert_selector 'dialog h1', text: I18n.t(:'components.advanced_search_component.v1.title')
+  end
+
+  def within_first_field_combobox(&)
+    within page.find('dialog') do
+      within first("div[data-controller='combobox--v1']", &)
+    end
+  end
+
+  def assert_combobox_passes_axe_in_required_states(combobox:, filter_text:)
+    assert_accessible
+
+    combobox.click
+    assert_accessible
+
+    combobox.send_keys([:ctrl, 'a'], :delete, filter_text)
+    assert_accessible
+
+    combobox.send_keys(:enter)
+    assert_accessible
+  end
+
+  def assert_invalid_field_combobox_passes_axe
+    click_button I18n.t(:'components.advanced_search_component.v1.apply_filter_button')
+
+    within_first_field_combobox do
+      assert_selector 'input[role="combobox"][aria-invalid="true"]'
+      assert_accessible
+    end
+  end
+end

--- a/test/test_helpers/axe_helpers.rb
+++ b/test/test_helpers/axe_helpers.rb
@@ -54,15 +54,28 @@ module AxeHelpers
 
     WCAG_AA_RUN_TAGS = %w[wcag2a wcag2aa wcag21a wcag22a wcag21aa wcag22aa best-practice].freeze
 
-    AXE_COMMAND = <<~COMMAND.freeze
-      axe.run({ runOnly: { type: 'tag', values: #{WCAG_AA_RUN_TAGS.to_json} } })
-    COMMAND
+    AXE_CORE_JS = Rails.root.join('node_modules/axe-core/axe.js').read.freeze
 
-    AXE_JS = <<~JS.freeze
-      #{Rails.root.join('node_modules/axe-core/axe.js').read}
+    def self.axe_command(context_selector: nil)
+      context =
+        if context_selector
+          "document.querySelector(#{context_selector.to_json})"
+        else
+          'document'
+        end
 
-      #{AXE_COMMAND}.then(results => console.log(JSON.stringify({ testRunner: results.testRunner, violations: results.violations })));
-    JS
+      <<~COMMAND
+        axe.run(#{context} || document, { runOnly: { type: 'tag', values: #{WCAG_AA_RUN_TAGS.to_json} } })
+      COMMAND
+    end
+
+    def self.axe_js(context_selector: nil)
+      <<~JS
+        #{AXE_CORE_JS}
+
+        #{axe_command(context_selector:)}.then(results => console.log(JSON.stringify({ testRunner: results.testRunner, violations: results.violations })));
+      JS
+    end
 
     class << self
       def format_target(target)
@@ -126,7 +139,7 @@ module AxeHelpers
       end
     end
 
-    def initialize(page, exclusions: [])
+    def initialize(page, exclusions: [], context_selector: nil)
       unless page.driver.is_a?(Capybara::Playwright::Driver)
         raise ArgumentError,
               'make sure to use the playwright driver with this matcher'
@@ -134,6 +147,7 @@ module AxeHelpers
 
       @page = page
       @exclusions = exclusions
+      @context_selector = context_selector
     end
 
     def violations
@@ -182,7 +196,7 @@ module AxeHelpers
             page.driver.with_playwright_page do |playwright_page|
               playwright_page.expect_console_message(
                 predicate: method(:console_message_contains_axe_results?)
-              ) { playwright_page.add_script_tag(content: AXE_JS) }
+              ) { playwright_page.add_script_tag(content: self.class.axe_js(context_selector: @context_selector)) }
             end
           JSON.parse(axe_results_console_message.text)
         end
@@ -196,8 +210,8 @@ module AxeHelpers
     end
   end
 
-  def assert_accessible(exclusions: nil)
-    actual = AxeResults.new(page, exclusions: axe_exclusions(exclusions))
+  def assert_accessible(exclusions: nil, within: nil)
+    actual = AxeResults.new(page, exclusions: axe_exclusions(exclusions), context_selector: within)
 
     assert actual.violations.empty?, <<~MSG
       Expected no axe violations, found #{actual.violations.count}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
       controllers: resolve(jsRoot, "controllers"),
       debounce: resolve("vendor/javascript/debounce.js"),
       "utilities/live_region": resolve(jsRoot, "utilities/live_region.js"),
+      "utilities/dialog": resolve(jsRoot, "utilities/dialog.js"),
       "utilities/form": resolve(jsRoot, "utilities/form.js"),
       "utilities/focus": resolve(jsRoot, "utilities/focus.js"),
       "utilities/refresh": resolve(jsRoot, "utilities/refresh.js"),


### PR DESCRIPTION
## What does this PR do and why?
- Wires the advanced-search field combobox to use the visible label, pass validation ARIA on the input, and label the listbox correctly.
- Adds axe and system test coverage on sample and workflow pages so we can trust the rollout behind `advanced_search_with_auto_complete`.

Closes #1945. Closes #1942.

## Screenshots or screen recordings
- N/A (accessibility wiring and test coverage only; no visual layout changes)

## How to set up and validate locally
1. Enable `advanced_search_with_auto_complete` for your user (or globally in development).
2. Run the focused test suite:
   - `PARALLEL_WORKERS=1 bin/rails test test/components/combobox/v1/component_render_test.rb`
   - `PARALLEL_WORKERS=1 bin/rails test test/components/combobox/v1/component_test.rb`
   - `PARALLEL_WORKERS=1 bin/rails test test/components/advanced_search_component_test.rb`
   - `PARALLEL_WORKERS=1 bin/rails test test/system/advanced_search/combobox_accessibility_test.rb`
   - `pnpm run test:js -- test/javascript/controllers/combobox/v1_controller.test.js`
3. On a group samples page, open advanced search and confirm field selection still updates operator/value controls.
4. On workflow executions (with `workflow_execution_advanced_search` enabled), repeat the field selection check.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.