### PR TITLE
Added UI to change visibility of parent group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -135,6 +135,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
 
   def edit_view_authorizations
     @allowed_to = {
+      change_visibility: allowed_to?(:change_visibility?, @group),
       destroy: allowed_to?(:destroy?, @group),
       transfer: allowed_to?(:transfer?, @group)
     }

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -51,6 +51,13 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     false
   end
 
+  def change_visibility?
+    return true if effective_access_level == Member::AccessLevel::OWNER
+
+    details[:name] = record.name
+    false
+  end
+
   def destroy?
     return true if effective_access_level == Member::AccessLevel::OWNER
 

--- a/app/services/base_group_service.rb
+++ b/app/services/base_group_service.rb
@@ -13,12 +13,12 @@ class BaseGroupService < BaseService
     descendants_to_update = @group.self_and_descendants_of_type(
       [Group.sti_name,
        Namespaces::ProjectNamespace.sti_name]
-    ).where(public: false).sort_by { |ns| ns.full_path.length }
+    ).where(public: false).order('LENGTH(routes.path) ASC')
 
     descendants_to_update.each do |descendant|
       next if descendant.public == true
 
-      descendant.update(public: true)
+      descendant.update!(public: true)
 
       key = descendant.is_a?(Group) ? 'group.update' : 'namespaces_project_namespace.update'
 
@@ -31,7 +31,7 @@ class BaseGroupService < BaseService
     descendants_to_update = @group.self_and_descendants_of_type(
       [Group.sti_name,
        Namespaces::ProjectNamespace.sti_name]
-    ).where(public: true).sort_by { |ns| ns.full_path.length }
+    ).where(public: true).order('LENGTH(routes.path) ASC')
 
     descendants_to_update.each do |descendant|
       next if descendant.public == false

--- a/app/services/base_group_service.rb
+++ b/app/services/base_group_service.rb
@@ -13,12 +13,12 @@ class BaseGroupService < BaseService
     descendants_to_update = @group.self_and_descendants_of_type(
       [Group.sti_name,
        Namespaces::ProjectNamespace.sti_name]
-    ).where(public: false).order(type: :asc)
+    ).where(public: false).sort_by { |ns| ns.full_path.length }
 
     descendants_to_update.each do |descendant|
       next if descendant.public == true
 
-      descendant.update!(public: true)
+      descendant.update(public: true)
 
       key = descendant.is_a?(Group) ? 'group.update' : 'namespaces_project_namespace.update'
 
@@ -31,12 +31,12 @@ class BaseGroupService < BaseService
     descendants_to_update = @group.self_and_descendants_of_type(
       [Group.sti_name,
        Namespaces::ProjectNamespace.sti_name]
-    ).where(public: true).order(type: :asc)
+    ).where(public: true).sort_by { |ns| ns.full_path.length }
 
     descendants_to_update.each do |descendant|
       next if descendant.public == false
 
-      descendant.update(public: false)
+      descendant.update!(public: false)
 
       key = descendant.is_a?(Group) ? 'group.update' : 'namespaces_project_namespace.update'
 

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -17,27 +17,28 @@ module Groups
         group.public = true
       end
 
-      group.save
+      ActiveRecord::Base.transaction do
+        group.save
 
-      if group.persisted?
-        @group.create_activity key: 'group.create',
-                               owner: current_user
-        if group.parent.nil?
-          Members::CreateService.new(current_user, group, {
-                                       user: current_user,
-                                       access_level: Member::AccessLevel::OWNER
-                                     }).execute
+        if group.persisted?
+          @group.create_activity key: 'group.create',
+                                 owner: current_user
+          if group.parent.nil?
+            Members::CreateService.new(current_user, group, {
+                                         user: current_user,
+                                         access_level: Member::AccessLevel::OWNER
+                                       }).execute
 
-        else
-          @group.parent.create_activity key: 'group.subgroups.create',
-                                        owner: current_user,
-                                        parameters: {
-                                          created_group_id: @group.id,
-                                          created_group_puid: @group.puid,
-                                          action: 'group_subgroup_create'
-                                        }
+          else
+            @group.parent.create_activity key: 'group.subgroups.create',
+                                          owner: current_user,
+                                          parameters: {
+                                            created_group_id: @group.id,
+                                            created_group_puid: @group.puid,
+                                            action: 'group_subgroup_create'
+                                          }
+          end
         end
-
       end
 
       group

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -13,7 +13,9 @@ module Groups
     def execute # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       authorize! group.parent, to: :create_subgroup? if params[:parent_id].present?
 
-      group.public = true if params[:parent_id].present? && group.parent.public?
+      if Flipper.enabled?(:global_groups, current_user) && params[:parent_id].present? && group.parent.public?
+        group.public = true
+      end
 
       group.save
 

--- a/app/services/groups/transfer_service.rb
+++ b/app/services/groups/transfer_service.rb
@@ -29,10 +29,12 @@ module Groups
 
       @group.update(parameters)
 
-      if parameters[:public] == true
-        update_descendants_to_public
-      elsif parameters[:public] == false
-        update_descendants_to_private
+      if Flipper.enabled?(:global_groups, current_user)
+        if parameters[:public] == true
+          update_descendants_to_public
+        elsif parameters[:public] == false
+          update_descendants_to_private
+        end
       end
 
       create_activities(old_namespace, new_namespace)
@@ -51,8 +53,10 @@ module Groups
     def update_params(new_namespace)
       params = { parent_id: new_namespace.id }
 
-      params[:public] = true if new_namespace.public? && !@group.public?
-      params[:public] = false if !new_namespace.public? && @group.public?
+      if Flipper.enabled?(:global_groups, current_user)
+        params[:public] = true if new_namespace.public? && !@group.public?
+        params[:public] = false if !new_namespace.public? && @group.public?
+      end
 
       params
     end

--- a/app/services/groups/transfer_service.rb
+++ b/app/services/groups/transfer_service.rb
@@ -2,7 +2,7 @@
 
 module Groups
   # Service used to Transfer Groups
-  class TransferService < BaseGroupService
+  class TransferService < BaseGroupService # rubocop:disable Metrics/ClassLength
     def initialize(group, user = nil, transfer_form = nil)
       super(group, user)
       @transfer_form = transfer_form
@@ -27,25 +27,28 @@ module Groups
 
       parameters = update_params(new_namespace)
 
-      @group.update(parameters)
+      ActiveRecord::Base.transaction do
+        @group.update(parameters)
 
-      if Flipper.enabled?(:global_groups, current_user)
-        if parameters[:public] == true
-          update_descendants_to_public
-        elsif parameters[:public] == false
-          update_descendants_to_private
+        if Flipper.enabled?(:global_groups, current_user)
+          if parameters[:public] == true
+            update_descendants_to_public
+          elsif parameters[:public] == false
+            update_descendants_to_private
+          end
         end
+
+        create_activities(old_namespace, new_namespace)
+
+        UpdateMembershipsJob.perform_later(new_namespace_member_ids)
+
+        update_samples_count(old_namespace, new_namespace)
+
+        new_namespace.update_metadata_summary_by_namespace_transfer(@group, old_namespace)
+
+        return true
       end
-
-      create_activities(old_namespace, new_namespace)
-
-      UpdateMembershipsJob.perform_later(new_namespace_member_ids)
-
-      update_samples_count(old_namespace, new_namespace)
-
-      new_namespace.update_metadata_summary_by_namespace_transfer(@group, old_namespace)
-
-      true
+      false
     end
 
     private

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -9,17 +9,19 @@ module Groups
       super
     end
 
-    def execute # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    def execute # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength
       authorize! @group, to: :update? unless params.key?(:public)
-      authorize! @group, to: :change_visibility? if (params.to_unsafe_h.size == 1) && params.key?(:public)
+      authorize! @group, to: :change_visibility? if params.key?(:public)
 
       updated = group.update(params)
 
       if updated
-        if group.parent.nil?
-          if params.key?(:public) && params[:public] == 'true'
+        if group.parent.nil? && params.key?(:public)
+          public_param_normalized = params[:public].to_s
+
+          if public_param_normalized == 'true'
             update_descendants_to_public
-          elsif params.key?(:public) && params[:public] == 'false'
+          elsif public_param_normalized == 'false'
             update_descendants_to_private
           end
         end

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -16,7 +16,7 @@ module Groups
       updated = group.update(params)
 
       if updated
-        if group.parent.nil? && params.key?(:public)
+        if Flipper.enabled?(:global_groups, current_user) && group.parent.nil? && params.key?(:public)
           public_param_normalized = params[:public].to_s
 
           if public_param_normalized == 'true'

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -13,12 +13,11 @@ module Groups
       authorize! @group, to: :update? unless params.key?(:public)
       authorize! @group, to: :change_visibility? if params.key?(:public)
 
-      updated = group.update(params)
+      ActiveRecord::Base.transaction do
+        updated = group.update(params)
 
-      if updated
-        if Flipper.enabled?(:global_groups, current_user) && group.parent.nil? && params.key?(:public)
+        if updated && Flipper.enabled?(:global_groups, current_user) && group.parent.nil? && params.key?(:public)
           public_param_normalized = params[:public].to_s
-
           if public_param_normalized == 'true'
             update_descendants_to_public
           elsif public_param_normalized == 'false'
@@ -29,9 +28,10 @@ module Groups
         @group.create_activity key: 'group.update',
                                owner: current_user
 
+        return updated
       end
 
-      updated
+      false
     end
   end
 end

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -9,21 +9,24 @@ module Groups
       super
     end
 
-    def execute # rubocop:disable Metrics/AbcSize
-      authorize! @group, to: :update?
+    def execute # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+      authorize! @group, to: :update? unless params.key?(:public)
+      authorize! @group, to: :change_visibility? if (params.to_unsafe_h.size == 1) && params.key?(:public)
+
       updated = group.update(params)
 
       if updated
         if group.parent.nil?
-          if params.key?(:public) && params[:public] == true
+          if params.key?(:public) && params[:public] == 'true'
             update_descendants_to_public
-          elsif params.key?(:public) && params[:public] == false
+          elsif params.key?(:public) && params[:public] == 'false'
             update_descendants_to_private
           end
         end
 
         @group.create_activity key: 'group.update',
                                owner: current_user
+
       end
 
       updated

--- a/app/services/projects/create_service.rb
+++ b/app/services/projects/create_service.rb
@@ -35,8 +35,10 @@ module Projects
       # We want to authorize that the user can create a project in the parent namespace
       authorize! project.namespace.parent, to: :create?
 
-      project.namespace.public = true if project.namespace.parent.group_namespace? && project.namespace.parent.public?
-      project.namespace.save
+      if Flipper.enabled?(:global_groups, current_user)
+        project.namespace.public = true if project.namespace.parent.group_namespace? && project.namespace.parent.public?
+        project.namespace.save
+      end
 
       project.save
 

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -85,11 +85,13 @@ module Projects
     def update_params(project) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
       params = { parent_id: @new_namespace.id }
 
-      if @new_namespace.group_namespace? && @new_namespace.public? && !project.namespace.public?
-        params[:public] = true
-      elsif (@new_namespace.user_namespace? || (@new_namespace.group_namespace? && !@new_namespace.public?)) &&
-            project.namespace.public?
-        params[:public] = false
+      if Flipper.enabled?(:global_groups, current_user)
+        if @new_namespace.group_namespace? && @new_namespace.public? && !project.namespace.public?
+          params[:public] = true
+        elsif (@new_namespace.user_namespace? || (@new_namespace.group_namespace? && !@new_namespace.public?)) &&
+              project.namespace.public?
+          params[:public] = false
+        end
       end
 
       params

--- a/app/views/groups/_edit_change_visibility.html.erb
+++ b/app/views/groups/_edit_change_visibility.html.erb
@@ -45,10 +45,10 @@
 
     <div class="mt-4 grid gap-4">
       <%= button_to t("groups.edit.advanced.change_visibility.submit"),
-      @group,
+      group_path,
+      method: :patch,
       params: { group: { public: !@group.public}},
       data: {
-        method: :patch,
         turbo_confirm: "",
         turbo_content: ".confirm-change-visibility",
         confirm_value: @group.path,

--- a/app/views/groups/_edit_change_visibility.html.erb
+++ b/app/views/groups/_edit_change_visibility.html.erb
@@ -1,0 +1,59 @@
+<%= viral_card do |card| %>
+  <% card.with_header(title: t("groups.edit.advanced.change_visibility.title")) %>
+
+  <% card.with_section do %>
+    <div>
+      <div class="confirm-change-visibility hidden">
+        <div class="mb-4 flex rounded-lg bg-red-50 p-4 text-red-800 dark:bg-slate-800 dark:text-red-400">
+          <%= icon(:warning_circle) %>
+
+          <span class="ml-4 flex-1">
+            <%= t(
+              "groups.edit.advanced.change_visibility.confirm.#{!group.public? ? 'public' : 'private' }.warning_html",
+              group_name: group.human_name,
+            ) %>
+          </span>
+        </div>
+
+        <div class="mb-4">
+          <% t("groups.edit.advanced.change_visibility.confirm.points_html", group: group.path).each do |item| %>
+            <p class="mb-2 text-base text-slate-900 dark:text-white"><%= item %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <p class="mb-2 text-base text-slate-900 dark:text-white">
+      <% if @group.public? %>
+        <%= t("groups.edit.advanced.change_visibility.description.public") %>
+      <% else %>
+        <%= t("groups.edit.advanced.change_visibility.description.private") %>
+      <% end %>
+    </p>
+
+    <ul class="mb-4 ml-4 list-inside list-disc space-y-1 text-slate-500 dark:text-slate-400">
+      <% if @group.public? %>
+        <% t("groups.edit.advanced.change_visibility.private.points_html").each do |item| %>
+          <li><%= item %></li>
+        <% end %>
+      <% else %>
+        <% t("groups.edit.advanced.change_visibility.public.points_html").each do |item| %>
+          <li><%= item %></li>
+        <% end %>
+      <% end %>
+    </ul>
+
+    <div class="mt-4 grid gap-4">
+      <%= button_to t("groups.edit.advanced.change_visibility.submit"),
+      @group,
+      params: { group: { public: !@group.public}},
+      data: {
+        method: :patch,
+        turbo_confirm: "",
+        turbo_content: ".confirm-change-visibility",
+        confirm_value: @group.path,
+      },
+      class: "button button-primary inline-block" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/groups/_edit_change_visibility.html.erb
+++ b/app/views/groups/_edit_change_visibility.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <p class="mb-2 text-base text-slate-900 dark:text-white">
-      <% if @group.public? %>
+      <% if group.public? %>
         <%= t("groups.edit.advanced.change_visibility.description.public") %>
       <% else %>
         <%= t("groups.edit.advanced.change_visibility.description.private") %>
@@ -32,7 +32,7 @@
     </p>
 
     <ul class="mb-4 ml-4 list-inside list-disc space-y-1 text-slate-500 dark:text-slate-400">
-      <% if @group.public? %>
+      <% if group.public? %>
         <% t("groups.edit.advanced.change_visibility.private.points_html").each do |item| %>
           <li><%= item %></li>
         <% end %>

--- a/app/views/groups/_edit_change_visibility.html.erb
+++ b/app/views/groups/_edit_change_visibility.html.erb
@@ -47,11 +47,11 @@
       <%= button_to t("groups.edit.advanced.change_visibility.submit"),
       group_path,
       method: :patch,
-      params: { group: { public: !@group.public}},
+      params: { group: { public: !group.public}},
       data: {
         turbo_confirm: "",
         turbo_content: ".confirm-change-visibility",
-        confirm_value: @group.path,
+        confirm_value: group.path,
       },
       class: "button button-primary inline-block" %>
     </div>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -4,6 +4,7 @@
 
     <%= viral_card do |card| %>
       <% card.with_header(title: t(:"groups.edit.details.subtitle")) %>
+
       <% card.with_section do %>
         <%= turbo_frame_tag("group_name_and_description_form") do %>
           <%= render partial: "edit_name_and_description_form",
@@ -25,6 +26,12 @@
 
     <% if @allowed_to[:transfer] %>
       <%= render "edit_advanced_transfer", group: @group %>
+    <% end %>
+
+    <% if @group.parent.nil? && @allowed_to[:change_visibility] %>
+      <%= turbo_frame_tag("group_change_visibility_form") do %>
+        <%= render "edit_change_visibility", group: @group %>
+      <% end %>
     <% end %>
 
     <% if @allowed_to[:destroy] %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -28,9 +28,11 @@
       <%= render "edit_advanced_transfer", group: @group %>
     <% end %>
 
-    <% if @group.parent.nil? && @allowed_to[:change_visibility] %>
-      <%= turbo_frame_tag("group_change_visibility_form") do %>
-        <%= render "edit_change_visibility", group: @group %>
+    <% if Flipper.enabled?(:global_groups, current_user) %>
+      <% if @group.parent.nil? && @allowed_to[:change_visibility] %>
+        <%= turbo_frame_tag("group_change_visibility_form") do %>
+          <%= render "edit_change_visibility", group: @group %>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/app/views/groups/update.turbo_stream.erb
+++ b/app/views/groups/update.turbo_stream.erb
@@ -8,7 +8,6 @@
   <%= turbo_stream.update "namespace_name" do %>
     <%= @group.name %>
   <% end %>
-
   <%= turbo_stream.update "breadcrumb" do %>
     <%= render Layout::BreadcrumbComponent.new(links: @context_crumbs) %>
   <% end %>
@@ -23,6 +22,12 @@
 
 <%= turbo_stream.update "group_path_form",
                     partial: "edit_advanced_path",
+                    locals: {
+                      group: @group,
+                    } %>
+
+<%= turbo_stream.update "group_change_visibility_form",
+                    partial: "edit_change_visibility",
                     locals: {
                       group: @group,
                     } %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2,11 +2,9 @@ features:
   advanced_search_with_auto_complete:
     admin_manageable: true
     description:
-      en:
-        "Enable auto-complete suggestions for the field dropdown within the advanced\
+      en: "Enable auto-complete suggestions for the field dropdown within the advanced\
         \ search dialog."
-      fr:
-        "Activer les suggestions de saisie semi-automatique dans la liste des champs\
+      fr: "Activer les suggestions de saisie semi-automatique dans la liste des champs\
         \ de la recherche avancée."
     enable_in_development: true
     name:
@@ -16,8 +14,7 @@ features:
     admin_manageable: true
     description:
       en: "Allow users to select and cancel multiple workflow executions at once."
-      fr:
-        "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
+      fr: "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
         \ de flux de travail à la fois."
     enable_in_development: true
     name:
@@ -42,8 +39,7 @@ features:
       en: "Client-Side Linelist Imports"
       fr: "Importations de listes linéaires côté client"
   compose_with_retry:
-    description:
-      "Exponentially backoff and retry failed compose operations. This\
+    description: "Exponentially backoff and retry failed compose operations. This\
       \ is intended to mitigate transient errors in the compose process."
     enable_in_development: true
   data_grid_samples_table:
@@ -55,6 +51,16 @@ features:
     name:
       en: "Data Grid Samples Table"
       fr: "Tableau de données des échantillons"
+  global_groups:
+    admin_manageable: true
+    description:
+      en: "Enable groups to be marked as public so that all users have access"
+      fr: "Permettre de marquer les groupes comme publics afin que tous les utilisateurs\
+        \ y aient accès"
+    enable_in_development: true
+    name:
+      en: "Global groups"
+      fr: "Groupes globaux"
   integration_access_token_generation:
     description: "Allow users to generate access tokens for API access."
     enable_in_development: true
@@ -70,11 +76,9 @@ features:
   samples_refresh_notice:
     admin_manageable: true
     description:
-      en:
-        "Show a notice on the samples table when samples table is out of date due\
+      en: "Show a notice on the samples table when samples table is out of date due\
         \ to additions, deletions, or updates."
-      fr:
-        "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
+      fr: "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
         \ après un ajout, une suppression ou une modification."
     enable_in_development: true
     name:
@@ -101,8 +105,7 @@ features:
     admin_manageable: true
     description:
       en: "Enable the new v2 nextflow samplesheet display and submission process."
-      fr:
-        "Activer le nouvel affichage et le nouveau processus de soumission de la\
+      fr: "Activer le nouvel affichage et le nouveau processus de soumission de la\
         \ feuille d'échantillons Nextflow version 2."
     enable_in_development: true
     name:
@@ -118,16 +121,14 @@ features:
       en: "Version 2 Select"
       fr: "Sélecteur version 2"
   wes_extended_metadata:
-    description:
-      "Include additional metadata in WES submission, such as namespaceId\
+    description: "Include additional metadata in WES submission, such as namespaceId\
       \ and samplesCount."
     enable_in_development: true
   workflow_execution_advanced_search:
     admin_manageable: true
     description:
       en: "Enable the advanced search dialog for workflow executions."
-      fr:
-        "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
+      fr: "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
         \ flux de travail."
     enable_in_development: true
     name:
@@ -137,8 +138,7 @@ features:
     admin_manageable: true
     description:
       en: "Enable searching within the workflow execution attachments table."
-      fr:
-        "Activer la recherche dans le tableau des pièces jointes des exécutions\
+      fr: "Activer la recherche dans le tableau des pièces jointes des exécutions\
         \ de flux de travail."
     enable_in_development: true
     name:

--- a/config/features.yml
+++ b/config/features.yml
@@ -2,9 +2,11 @@ features:
   advanced_search_with_auto_complete:
     admin_manageable: true
     description:
-      en: "Enable auto-complete suggestions for the field dropdown within the advanced\
+      en:
+        "Enable auto-complete suggestions for the field dropdown within the advanced\
         \ search dialog."
-      fr: "Activer les suggestions de saisie semi-automatique dans la liste des champs\
+      fr:
+        "Activer les suggestions de saisie semi-automatique dans la liste des champs\
         \ de la recherche avancée."
     enable_in_development: true
     name:
@@ -14,7 +16,8 @@ features:
     admin_manageable: true
     description:
       en: "Allow users to select and cancel multiple workflow executions at once."
-      fr: "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
+      fr:
+        "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
         \ de flux de travail à la fois."
     enable_in_development: true
     name:
@@ -39,7 +42,8 @@ features:
       en: "Client-Side Linelist Imports"
       fr: "Importations de listes linéaires côté client"
   compose_with_retry:
-    description: "Exponentially backoff and retry failed compose operations. This\
+    description:
+      "Exponentially backoff and retry failed compose operations. This\
       \ is intended to mitigate transient errors in the compose process."
     enable_in_development: true
   data_grid_samples_table:
@@ -66,9 +70,11 @@ features:
   samples_refresh_notice:
     admin_manageable: true
     description:
-      en: "Show a notice on the samples table when samples table is out of date due\
+      en:
+        "Show a notice on the samples table when samples table is out of date due\
         \ to additions, deletions, or updates."
-      fr: "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
+      fr:
+        "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
         \ après un ajout, une suppression ou une modification."
     enable_in_development: true
     name:
@@ -95,7 +101,8 @@ features:
     admin_manageable: true
     description:
       en: "Enable the new v2 nextflow samplesheet display and submission process."
-      fr: "Activer le nouvel affichage et le nouveau processus de soumission de la\
+      fr:
+        "Activer le nouvel affichage et le nouveau processus de soumission de la\
         \ feuille d'échantillons Nextflow version 2."
     enable_in_development: true
     name:
@@ -111,14 +118,16 @@ features:
       en: "Version 2 Select"
       fr: "Sélecteur version 2"
   wes_extended_metadata:
-    description: "Include additional metadata in WES submission, such as namespaceId\
+    description:
+      "Include additional metadata in WES submission, such as namespaceId\
       \ and samplesCount."
     enable_in_development: true
   workflow_execution_advanced_search:
     admin_manageable: true
     description:
       en: "Enable the advanced search dialog for workflow executions."
-      fr: "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
+      fr:
+        "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
         \ flux de travail."
     enable_in_development: true
     name:
@@ -128,7 +137,8 @@ features:
     admin_manageable: true
     description:
       en: "Enable searching within the workflow execution attachments table."
-      fr: "Activer la recherche dans le tableau des pièces jointes des exécutions\
+      fr:
+        "Activer la recherche dans le tableau des pièces jointes des exécutions\
         \ de flux de travail."
     enable_in_development: true
     name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -863,6 +863,26 @@ en:
       success: Group %{group_name} was deleted
     edit:
       advanced:
+        change_visibility:
+          confirm:
+            points_html:
+            - To prevent accidental actions we ask you to confirm your intention.
+            - Please type <kbd>%{group}</kbd> to proceed or close this dialog to cancel.
+            private:
+              warning_html: You are going to change the visibility of <strong>%{group_name}</strong> to <strong>private</strong>. Once you confirm, all subgroups and projects under this group will only be accessible by explicit membership.
+            public:
+              warning_html: You are going to change the visibility of <strong>%{group_name}</strong> to <strong>public</strong>. Once you confirm, all subgroups and projects under this group will also be publicly visible to all users of the application.
+          description:
+            private: This group is currently private
+            public: This group is currently public
+          private:
+            points_html:
+            - Changing a group to private will change all descendants (groups and projects) to private. Only users with explicit membership will be able to access.
+          public:
+            points_html:
+            - Changing a group to public will change of all descendants (groups and projects) to public. All users with and without explicit membership will be able to access.
+          submit: Change visibility
+          title: Change group visibility
         delete:
           confirm:
             points_html:
@@ -897,6 +917,8 @@ en:
           - Be careful. Changing a group's parent can have unintended side effects.
           - You can only transfer groups where you have sufficient permissions.
           - If the parent group's visibility is lower than the group's current visibility, visibility levels for subgroups and projects will be changed to match the new parent group's visibility.
+          - If the parent group is public, this group and all its descendants will be set to public.
+          - If the parent group is private, this group and all its descendants will be set to private
           select_group: Select Group
           submit: Transfer group
           title: Transfer group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -880,7 +880,7 @@ en:
             - Changing a group to private will change all descendants (groups and projects) to private. Only users with explicit membership will be able to access.
           public:
             points_html:
-            - Changing a group to public will change of all descendants (groups and projects) to public. All users with and without explicit membership will be able to access.
+            - Changing a group to public will change all descendants (groups and projects) to public. All users with and without explicit membership will be able to access.
           submit: Change visibility
           title: Change group visibility
         delete:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -865,6 +865,26 @@ fr:
       success: Le groupe %{group_name} a été supprimé
     edit:
       advanced:
+        change_visibility:
+          confirm:
+            points_html:
+            - Pour éviter les actions accidentelles, nous vous demandons de confirmer votre intention.
+            - Veuillez taper <kbd>%{group}</kbd> pour continuer ou fermer cette boîte de dialogue pour annuler.
+            private:
+              warning_html: Vous êtes sur le point de changer la visibilité de <strong>%{group_name}</strong> en <strong>privée</strong>. Une fois confirmé, tous les sous-groupes et projets sous ce groupe ne seront accessibles que par adhésion explicite.
+            public:
+              warning_html: Vous êtes sur le point de changer la visibilité de <strong>%{group_name}</strong> en <strong>publique</strong>. Une fois confirmé, tous les sous-groupes et projets sous ce groupe seront également visibles publiquement à tous les utilisateurs de l'application.
+          description:
+            private: Ce groupe est actuellement privé
+            public: Ce groupe est actuellement public
+          private:
+            points_html:
+            - Le changement d'un groupe en privé changera tous les descendants (groupes et projets) en privés. Seuls les utilisateurs ayant une adhésion explicite pourront y accéder.
+          public:
+            points_html:
+            - Le changement d'un groupe en public changera tous les descendants (groupes et projets) en publics. Tous les utilisateurs, avec ou sans adhésion explicite, pourront y accéder.
+          submit: Modifier la visibilité
+          title: Modifier la visibilité du groupe
         delete:
           confirm:
             points_html:
@@ -899,6 +919,8 @@ fr:
           - Soyez prudent. Changer le parent d’un groupe peut avoir des effets secondaires involontaires.
           - Vous ne pouvez transférer des groupes que si vous avez suffisamment d’autorisations.
           - Si la visibilité du groupe parent est inférieure à la visibilité actuelle du groupe, les niveaux de visibilité des sous-groupes et des projets seront modifiés pour correspondre à la visibilité du nouveau groupe parent.
+          - Si le groupe parent est public, ce groupe et tous ses descendants seront définis comme publics.
+          - Si le groupe parent est privé, ce groupe et tous ses descendants seront définis comme privés
           select_group: Sélectionner un groupe
           submit: Groupe de transfert
           title: Groupe de transfert

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -946,7 +946,7 @@ CREATE TABLE public.site_banners (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT site_banners_singleton_guard_check CHECK (((singleton_guard)::text = 'global'::text)),
-    CONSTRAINT site_banners_style_check CHECK (((style)::text = ANY (ARRAY[('info'::character varying)::text, ('warning'::character varying)::text, ('danger'::character varying)::text, ('success'::character varying)::text])))
+    CONSTRAINT site_banners_style_check CHECK (((style)::text = ANY ((ARRAY['info'::character varying, 'warning'::character varying, 'danger'::character varying, 'success'::character varying])::text[])))
 );
 
 

--- a/test/lib/irida/experimental_feature_catalog_test.rb
+++ b/test/lib/irida/experimental_feature_catalog_test.rb
@@ -13,6 +13,7 @@ module Irida
         client_linelist_exports_v1
         client_linelist_imports_v1
         data_grid_samples_table
+        global_groups
         sample_attachments_searching
         samples_refresh_notice
         v2_dropdown

--- a/test/services/groups/transfer_service_test.rb
+++ b/test/services/groups/transfer_service_test.rb
@@ -13,6 +13,12 @@ module Groups
       @subgroup12a = groups(:subgroup_twelve_a)
       @subgroup12b = groups(:subgroup_twelve_b)
       @subgroup12aa = groups(:subgroup_twelve_a_a)
+
+      Flipper.enable(:global_groups)
+    end
+
+    def teardown
+      Flipper.disable(:global_groups)
     end
 
     test 'transfer group with permission' do

--- a/test/services/groups/update_service_test.rb
+++ b/test/services/groups/update_service_test.rb
@@ -7,6 +7,11 @@ module Groups
     def setup
       @user = users(:john_doe)
       @group = groups(:group_one)
+      Flipper.enable(:global_groups)
+    end
+
+    def teardown
+      Flipper.disable(:global_groups)
     end
 
     test 'update group with valid params' do

--- a/test/services/projects/create_service_test.rb
+++ b/test/services/projects/create_service_test.rb
@@ -8,6 +8,11 @@ module Projects
       @user = users(:john_doe)
       @parent_namespace = namespaces_user_namespaces(:john_doe_namespace)
       @parent_group_namespace = groups(:group_one)
+      Flipper.enable(:global_groups)
+    end
+
+    def teardown
+      Flipper.disable(:global_groups)
     end
 
     test 'create project with valid params under user namespace' do

--- a/test/services/projects/transfer_service_test.rb
+++ b/test/services/projects/transfer_service_test.rb
@@ -14,6 +14,11 @@ module Projects
       @subgroup12a = groups(:subgroup_twelve_a)
       @subgroup12b = groups(:subgroup_twelve_b)
       @subgroup12aa = groups(:subgroup_twelve_a_a)
+      Flipper.enable(:global_groups)
+    end
+
+    def teardown
+      Flipper.disable(:global_groups)
     end
 
     test 'transfer project with permission' do

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -16,6 +16,11 @@ class GroupsTest < ApplicationSystemTestCase
     @project30 = projects(:project30)
     @sample34 = samples(:sample34)
     login_as @user
+    Flipper.enable(:global_groups)
+  end
+
+  def teardown
+    Flipper.disable(:global_groups)
   end
 
   test 'can create a group' do

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -252,6 +252,68 @@ class GroupsTest < ApplicationSystemTestCase
     assert_current_path '/-/groups/group-1-edited/-/edit'
   end
 
+  test 'can update visibility of parent group to public' do
+    private_group = groups(:group_one)
+
+    visit group_url(private_group)
+
+    click_on I18n.t('common.labels.settings')
+    click_link I18n.t('common.labels.general')
+
+    assert_selector 'h2', text: I18n.t('groups.edit.advanced.change_visibility.title')
+    assert_selector 'p', text: I18n.t('groups.edit.advanced.change_visibility.description.private')
+
+    assert_selector 'button', text: I18n.t('groups.edit.advanced.change_visibility.submit')
+    click_on I18n.t('groups.edit.advanced.change_visibility.submit')
+
+    within('#turbo-confirm') do
+      assert_text I18n.t('components.confirmation.title')
+      fill_in I18n.t('components.confirmation.confirm_label'), with: private_group.path
+      click_on I18n.t('common.controls.confirm')
+    end
+
+    assert_text I18n.t('groups.update.success', group_name: private_group.name)
+    assert_selector 'p', text: I18n.t('groups.edit.advanced.change_visibility.description.public')
+  end
+
+  test 'can update visibility of parent group to private' do
+    public_group = groups(:public_group1)
+
+    visit group_url(public_group)
+
+    click_on I18n.t('common.labels.settings')
+    click_link I18n.t('common.labels.general')
+
+    assert_selector 'h2', text: I18n.t('groups.edit.advanced.change_visibility.title')
+    assert_selector 'p', text: I18n.t('groups.edit.advanced.change_visibility.description.public')
+
+    assert_selector 'button', text: I18n.t('groups.edit.advanced.change_visibility.submit')
+    click_on I18n.t('groups.edit.advanced.change_visibility.submit')
+
+    within('#turbo-confirm') do
+      assert_text I18n.t('components.confirmation.title')
+      fill_in I18n.t('components.confirmation.confirm_label'), with: public_group.path
+      click_on I18n.t('common.controls.confirm')
+    end
+
+    assert_text I18n.t('groups.update.success', group_name: public_group.name)
+    assert_selector 'p', text: I18n.t('groups.edit.advanced.change_visibility.description.private')
+  end
+
+  test 'cannot update visibility of a subgroup' do
+    subgroup = groups(:subgroup1)
+
+    visit group_url(subgroup)
+
+    click_on I18n.t('common.labels.settings')
+    click_link I18n.t('common.labels.general')
+
+    assert_no_selector 'h2', text: I18n.t('groups.edit.advanced.change_visibility.title')
+    assert_no_selector 'p', text: I18n.t('groups.edit.advanced.change_visibility.description.private')
+    assert_no_selector 'p', text: I18n.t('groups.edit.advanced.change_visibility.description.public')
+    assert_no_selector 'button', text: I18n.t('groups.edit.advanced.change_visibility.submit')
+  end
+
   test 'show error when editing a group path and leaving it blank' do
     group1 = groups(:group_one)
     visit group_url(group1)

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -227,6 +227,17 @@ class ProjectsTest < ApplicationSystemTestCase
     assert_selector 'h2', text: I18n.t(:'projects.edit.advanced.title')
   end
 
+  test 'cannot update visibility of a project' do
+    group = groups(:group_one)
+    project = projects(:project1)
+    visit namespace_project_url(group, project)
+
+    click_on I18n.t('common.labels.settings')
+    click_link I18n.t('common.labels.general')
+
+    assert_no_selector 'button', text: I18n.t('groups.edit.advanced.change_visibility.submit')
+  end
+
   test 'cannot access edit project' do
     login_as users(:david_doe)
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR adds in the UI to change a parent group's visibility between private and public.
- New card added for `Change group visibility` on the parent group General Settings page
- Descriptions and points added for changing from private to public, and vice versa
- Button added to launch confirmation window which has the user type the group path to confirm that they intended to make these changes

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="2543" height="1148" alt="image" src="https://github.com/user-attachments/assets/cd261c59-2517-4191-8cc3-13e106dc7f3b" />

<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/eb6215f8-fd97-4589-a912-eed9b396ba33" />


<img width="2552" height="1048" alt="image" src="https://github.com/user-attachments/assets/0cbf0b53-472f-4892-840f-bd3a6db4b638" />

<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/c5dd1900-f598-443c-ba81-aae9fe681be4" />



Subgroups and Projects don't have Change visibility action as it can only be done at the parent group level

<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/62d32e2a-7a3f-4fbf-9487-b0a4560eafa9" />

<img width="2560" height="1167" alt="image" src="https://github.com/user-attachments/assets/b946577a-ca8b-4305-b4ec-badb3466bf14" />


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Verify tests pass
2.  Log in as user0@email.com
3. Update the Bacillus group to `public` from the Bacillus -> General Settings page by clicking the `Change visibility` button and confirming
4. Log in as a user which doesn't have access to the group. Verify that you can see all the subgroups and projects with `GUEST` access level
5. Verify that you cannot update the visibility at the subgroup and project level
6. Logout and log in as user0@email.com
7. Update the Bacillus group back to `private` from the Bacillus -> General Settings page by clicking the `Change visibility` button and confirming
8. Log in as a user from step 4. Verify that you cannot see any of the subgroups and projects under Bacillus


## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
