### PR TITLE
chore(deps): Upgrade playwright from 1.59.1 to 1.60.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'capybara-playwright-driver'
-  gem 'playwright-ruby-client', '1.59.1'
+  gem 'playwright-ruby-client', '1.60.0'
 
   gem 'minitest-retry', require: false
   gem 'mocha', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,7 +514,7 @@ GEM
       racc
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
-    playwright-ruby-client (1.59.1)
+    playwright-ruby-client (1.60.0)
       base64
       concurrent-ruby (>= 1.1.6)
       mime-types (>= 3.0)
@@ -826,7 +826,7 @@ DEPENDENCIES
   paranoia
   pathogen_view_components!
   pg
-  playwright-ruby-client (= 1.59.1)
+  playwright-ruby-client (= 1.60.0)
   propshaft
   public_activity
   puma (~> 8.0)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,7 +2,7 @@
 @source "../../components/**/*.{rb,erb}";
 @source "../../javascript/**/*.js";
 @source "../../views/**/*.erb";
-@source "../../../node_modules/flowbite/**/*.js";
+@source "../../../node_modules/flowbite/dist";
 @source "../../helpers/**/*.rb";
 
 @plugin "flowbite/plugin";

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1780459148,
-        "narHash": "sha256-oIpiel88r8zV/WqTFwcGAjWXKOASHNzq7wjXQ6ORTvg=",
+        "lastModified": 1781456191,
+        "narHash": "sha256-aZb6/djq1Msd1oi9L2BEHx7rnRRJEtvWUy2A59zaZVQ=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "493ed7ef062ba3972c06e60970fe5ebe014f5c33",
+        "rev": "48a93d1fd74ca3fb4f3f64e942cfcb19a1d9f7e0",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780482956,
-        "narHash": "sha256-MOm2av5eQrX78Zki1RdG2xDgtx5M+cEtq9bMbkvJXr4=",
+        "lastModified": 1781519518,
+        "narHash": "sha256-5f9Yix1MUsjX+pgsJNNvfoaOUwQEp+MaDttVMLU+bcg=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "f40500672aedbf8d32a0f6938d80dba67bba863a",
+        "rev": "b217e4bf517b5437d2ffab5faa4432f1f8a0b26f",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1781359544,
+        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-ruby": "nixpkgs-ruby"
+        "nixpkgs-ruby": "nixpkgs-ruby",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,6 +6,14 @@ lib.mkMerge [
     env.PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright.passthru.browsers}";
     env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS="true";
 
+    overlays = [
+      (final: prev: {
+        playwright-test = (import inputs.nixpkgs-unstable {
+          system = prev.stdenv.system;
+        }).playwright-test;
+      })
+    ];
+
     # https://devenv.sh/packages/
     packages = with pkgs; [
       pkg-config

--- a/devenv.nix
+++ b/devenv.nix
@@ -11,6 +11,9 @@ lib.mkMerge [
         playwright-test = (import inputs.nixpkgs-unstable {
           system = prev.stdenv.system;
         }).playwright-test;
+        playwright = (import inputs.nixpkgs-unstable {
+          system = prev.stdenv.system;
+        }).playwright;
       })
     ];
 

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,4 +6,6 @@ inputs:
       nixpkgs:
         follows: nixpkgs
     url: github:bobvanderlinden/nixpkgs-ruby
+  nixpkgs-unstable:
+    url: github:nixos/nixpkgs/nixpkgs-unstable
 strictPorts: true

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
-    "playwright": "1.59.1",
+    "playwright": "1.60.0",
     "prettier": "^3.8.4",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "vitest": "^4.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       playwright:
-        specifier: 1.59.1
-        version: 1.59.1
+        specifier: 1.60.0
+        version: 1.60.0
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -1349,13 +1349,13 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2772,11 +2772,11 @@ snapshots:
 
   pify@2.3.0: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR upgrades playwright dependencies from 1.59.1 to 1.60.0.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. **Before checkout** stop server and services if running
2. Run `devenv up` and confirm no issues
3. Run `bin/setup` and confirm that server starts up and no changes to package.json and pnpm-lock.yaml
4. Run `env HEADLESS=0 SKIP_W3C_VALIDATE=1 bin/rails test test/system/sign_in_display_test.rb` to confirm that system tests still work as expected.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
