### PR TITLE
Advanced Search: Add metadata operator logic to backend

### DIFF
--- a/app/models/concerns/advanced_search/filtering.rb
+++ b/app/models/concerns/advanced_search/filtering.rb
@@ -153,7 +153,7 @@ module AdvancedSearch
       condition_greater_than_or_equal(scope, node, value)
     end
 
-    ##############################
+    ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
     def apply_less_than_or_equal_v1(scope, node, value, field:, metadata_field:)
       metadata_key = field.delete_prefix('metadata.')
@@ -180,5 +180,7 @@ module AdvancedSearch
     def apply_not_in_operator_v1(scope, node, value, metadata_field:, field_name:)
       condition_not_in_v1(scope, node, value, metadata_field:, field_name:)
     end
+
+    ### END feature flag :advanced_search_metadata_operators ###
   end
 end

--- a/app/models/concerns/advanced_search/filtering.rb
+++ b/app/models/concerns/advanced_search/filtering.rb
@@ -22,9 +22,9 @@ module AdvancedSearch
       value = normalize_condition_value(condition)
       metadata_field = field_name.starts_with?('metadata.')
       operator = condition.operator
-      placeholder = false
+      feature_flag_enabled = Flipper.enabled?(:advanced_search_metadata_operators)
 
-      if metadata_field && placeholder
+      if metadata_field && feature_flag_enabled
         if operator.starts_with?('TEXT_')
           apply_metadata_text_operator(scope, node, value, operator, model_class:, field_name:)
         elsif operator.starts_with?('NUMERIC_')
@@ -34,7 +34,7 @@ module AdvancedSearch
         else
           apply_metadata_exists_operator(scope, node, operator)
         end
-      elsif placeholder
+      elsif feature_flag_enabled
         case condition.operator
         when '='
           condition_equals(scope, node, value, field_name:)
@@ -45,9 +45,9 @@ module AdvancedSearch
         when 'not_in'
           condition_not_in(scope, node, value, field_name:)
         when '<='
-          scope.where(node.lteq(value))
+          apply_less_than_or_equal(scope, node, value)
         when '>='
-          scope.where(node.gteq(value))
+          apply_greater_than_or_equal(scope, node, value)
         when 'contains'
           condition_contains(scope, node, value, model_class:, field_name:)
         when 'not_contains'
@@ -115,13 +115,9 @@ module AdvancedSearch
       when 'TEXT_NOT_CONTAINS'
         condition_not_contains(scope, node, value, model_class:, field_name:)
       when 'TEXT_IN'
-        scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).in(downcase_values(value)))
+        metadata_condition_in(scope, node, value)
       when 'TEXT_NOT_IN'
-        lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
-        # Include NULL metadata values in negative set operations: NULL is not in the provided set.
-        # This maintains consistency with metadata_condition_not_equals, where "not X" includes records without the
-        # field.
-        scope.where(node.eq(nil).or(lower_function.not_in(downcase_values(value))))
+        metadata_condition_not_in(scope, node, value)
       end
     end
 
@@ -132,8 +128,6 @@ module AdvancedSearch
       when 'NUMERIC_NOT_EQUALS'
         metadata_condition_not_equals(scope, node, value, field_name:)
       when 'NUMERIC_LESS_THAN_EQUALS', 'NUMERIC_GREATER_THAN_EQUALS'
-        return scope.none unless valid_numeric_format?(value)
-
         metadata_condition_numeric_comparison(scope, node, value,
                                               operator == 'NUMERIC_LESS_THAN_EQUALS' ? :lteq : :gteq)
       end
@@ -146,21 +140,17 @@ module AdvancedSearch
       when 'DATE_NOT_EQUALS'
         metadata_condition_not_equals(scope, node, value, field_name:)
       when 'DATE_LESS_THAN_EQUALS', 'DATE_GREATER_THAN_EQUALS'
-        return scope.none unless valid_date_format?(value)
 
         metadata_condition_date_comparison(scope, node, value, operator == 'DATE_LESS_THAN_EQUALS' ? :lteq : :gteq)
       end
     end
 
-    def valid_date_format?(value)
-      Date.iso8601(value.to_s)
-      true
-    rescue ArgumentError
-      false
+    def apply_less_than_or_equal(scope, node, value)
+      condition_less_than_or_equal(scope, node, value)
     end
 
-    def valid_numeric_format?(value)
-      value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
+    def apply_greater_than_or_equal(scope, node, value)
+      condition_greater_than_or_equal(scope, node, value)
     end
 
     ##############################

--- a/app/models/concerns/advanced_search/filtering.rb
+++ b/app/models/concerns/advanced_search/filtering.rb
@@ -16,6 +16,7 @@ module AdvancedSearch
 
     private
 
+    ### TODO: This file contains both new and old logic dependent on feature flag :advanced_search_metadata_operators
     def add_condition(scope, condition) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       field_name = normalize_condition_field(condition)
       node = build_arel_node(field_name, model_class)
@@ -153,7 +154,7 @@ module AdvancedSearch
       condition_greater_than_or_equal(scope, node, value)
     end
 
-    ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+    ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
     def apply_less_than_or_equal_v1(scope, node, value, field:, metadata_field:)
       metadata_key = field.delete_prefix('metadata.')

--- a/app/models/concerns/advanced_search/filtering.rb
+++ b/app/models/concerns/advanced_search/filtering.rb
@@ -11,40 +11,53 @@
 # - `apply_*_operator` methods for special-case fields (e.g., upcasing PUID)
 module AdvancedSearch
   # Applies search conditions to build filtered ActiveRecord scopes.
-  module Filtering
+  module Filtering # rubocop:disable Metrics/ModuleLength
     extend ActiveSupport::Concern
 
     private
 
-    def add_condition(scope, condition) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+    def add_condition(scope, condition) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       field_name = normalize_condition_field(condition)
       node = build_arel_node(field_name, model_class)
       value = normalize_condition_value(condition)
       metadata_field = field_name.starts_with?('metadata.')
+      placeholder = false
 
-      case condition.operator
-      when '='
-        apply_equals_operator(scope, node, value, metadata_field:, field_name:)
-      when 'in'
-        apply_in_operator(scope, node, value, metadata_field:, field_name:)
-      when '!='
-        apply_not_equals_operator(scope, node, value, metadata_field:, field_name:)
-      when 'not_in'
-        apply_not_in_operator(scope, node, value, metadata_field:, field_name:)
-      when '<='
-        apply_less_than_or_equal(scope, node, value, field: field_name, metadata_field:)
-      when '>='
-        apply_greater_than_or_equal(scope, node, value, field: field_name, metadata_field:)
-      when 'contains'
-        condition_contains(scope, node, value, model_class:, field_name:)
-      when 'not_contains'
-        condition_not_contains(scope, node, value, model_class:, field_name:)
-      when 'exists'
-        condition_exists(scope, node)
-      when 'not_exists'
-        condition_not_exists(scope, node)
+      if metadata_field && placeholder
+        if operator.starts_with?('TEXT_')
+          apply_metadata_text_operator(scope, node, value, operator, model_class:, field_name:)
+        elsif operator.starts_with?('NUMERIC_')
+          apply_metadata_numeric_operator(scope, node, value, operator, field_name:)
+        elsif operator.starts_with?('DATE_')
+          apply_metadata_date_operator(scope, node, value, operator, field_name:)
+        else
+          apply_metadata_exists_operator(scope, node, operator)
+        end
       else
-        scope
+        case condition.operator
+        when '='
+          condition_equals(scope, node, value, field_name:)
+        when 'in'
+          condition_in(scope, node, value, field_name:)
+        when '!='
+          condition_not_equals(scope, node, value, field_name:)
+        when 'not_in'
+          condition_not_in(scope, node, value, field_name:)
+        when '<='
+          scope.where(node.lteq(value))
+        when '>='
+          scope.where(node.gteq(value))
+        when 'contains'
+          condition_contains(scope, node, value, model_class:, field_name:)
+        when 'not_contains'
+          condition_not_contains(scope, node, value, model_class:, field_name:)
+        when 'exists'
+          condition_exists(scope, node)
+        when 'not_exists'
+          condition_not_exists(scope, node)
+        else
+          scope
+        end
       end
     end
 
@@ -56,30 +69,72 @@ module AdvancedSearch
       condition.value
     end
 
-    def apply_less_than_or_equal(scope, node, value, field:, metadata_field:)
-      metadata_key = field.delete_prefix('metadata.')
-      condition_less_than_or_equal(scope, node, value, metadata_field:, metadata_key:)
+    def apply_metadata_exists_operator(scope, node, operator)
+      case operator
+      when 'EXISTS'
+        condition_exists(scope, node)
+      when 'NOT_EXISTS'
+        scope.where(node.eq(nil))
+      end
     end
 
-    def apply_greater_than_or_equal(scope, node, value, field:, metadata_field:)
-      metadata_key = field.delete_prefix('metadata.')
-      condition_greater_than_or_equal(scope, node, value, metadata_field:, metadata_key:)
+    def apply_metadata_text_operator(scope, node, value, operator, model_class:, field_name:) # rubocop:disable Metrics/ParameterLists
+      case operator
+      when 'TEXT_EQUALS'
+        metadata_condition_equals(scope, node, value, field_name:)
+      when 'TEXT_NOT_EQUALS'
+        metadata_condition_not_equals(scope, node, value, field_name:)
+      when 'TEXT_CONTAINS'
+        condition_contains(scope, node, value, model_class:, field_name:)
+      when 'TEXT_NOT_CONTAINS'
+        condition_not_contains(scope, node, value, model_class:, field_name:)
+      when 'TEXT_IN'
+        scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).in(downcase_values(value)))
+      when 'TEXT_NOT_IN'
+        lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
+        # Include NULL metadata values in negative set operations: NULL is not in the provided set.
+        # This maintains consistency with metadata_condition_not_equals, where "not X" includes records without the
+        # field.
+        scope.where(node.eq(nil).or(lower_function.not_in(downcase_values(value))))
+      end
     end
 
-    def apply_equals_operator(scope, node, value, metadata_field:, field_name:)
-      condition_equals(scope, node, value, metadata_field:, field_name:)
+    def apply_metadata_numeric_operator(scope, node, value, operator, field_name:)
+      case operator
+      when 'NUMERIC_EQUALS'
+        metadata_condition_equals(scope, node, value, field_name:)
+      when 'NUMERIC_NOT_EQUALS'
+        metadata_condition_not_equals(scope, node, value, field_name:)
+      when 'NUMERIC_LESS_THAN_EQUALS', 'NUMERIC_GREATER_THAN_EQUALS'
+        return scope.none unless valid_numeric_format?(value)
+
+        metadata_condition_numeric_comparison(scope, node, value,
+                                              operator == 'NUMERIC_LESS_THAN_EQUALS' ? :lteq : :gteq)
+      end
     end
 
-    def apply_in_operator(scope, node, value, metadata_field:, field_name:)
-      condition_in(scope, node, value, metadata_field:, field_name:)
+    def apply_metadata_date_operator(scope, node, value, operator, field_name:)
+      case operator
+      when 'DATE_EQUALS'
+        metadata_condition_equals(scope, node, value, field_name:)
+      when 'DATE_NOT_EQUALS'
+        metadata_condition_not_equals(scope, node, value, field_name:)
+      when 'DATE_LESS_THAN_EQUALS', 'DATE_GREATER_THAN_EQUALS'
+        return scope.none unless valid_date_format?(value)
+
+        metadata_condition_date_comparison(scope, node, value, operator == 'DATE_LESS_THAN_EQUALS' ? :lteq : :gteq)
+      end
     end
 
-    def apply_not_equals_operator(scope, node, value, metadata_field:, field_name:)
-      condition_not_equals(scope, node, value, metadata_field:, field_name:)
+    def valid_date_format?(value)
+      Date.iso8601(value.to_s)
+      true
+    rescue ArgumentError
+      false
     end
 
-    def apply_not_in_operator(scope, node, value, metadata_field:, field_name:)
-      condition_not_in(scope, node, value, metadata_field:, field_name:)
+    def valid_numeric_format?(value)
+      value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
     end
   end
 end

--- a/app/models/concerns/advanced_search/filtering.rb
+++ b/app/models/concerns/advanced_search/filtering.rb
@@ -21,6 +21,7 @@ module AdvancedSearch
       node = build_arel_node(field_name, model_class)
       value = normalize_condition_value(condition)
       metadata_field = field_name.starts_with?('metadata.')
+      operator = condition.operator
       placeholder = false
 
       if metadata_field && placeholder
@@ -33,7 +34,7 @@ module AdvancedSearch
         else
           apply_metadata_exists_operator(scope, node, operator)
         end
-      else
+      elsif placeholder
         case condition.operator
         when '='
           condition_equals(scope, node, value, field_name:)
@@ -55,6 +56,31 @@ module AdvancedSearch
           condition_exists(scope, node)
         when 'not_exists'
           condition_not_exists(scope, node)
+        else
+          scope
+        end
+      else
+        case operator
+        when '='
+          apply_equals_operator_v1(scope, node, value, metadata_field:, field_name:)
+        when 'in'
+          apply_in_operator_v1(scope, node, value, metadata_field:, field_name:)
+        when '!='
+          apply_not_equals_operator_v1(scope, node, value, metadata_field:, field_name:)
+        when 'not_in'
+          apply_not_in_operator_v1(scope, node, value, metadata_field:, field_name:)
+        when '<='
+          apply_less_than_or_equal_v1(scope, node, value, field: field_name, metadata_field:)
+        when '>='
+          apply_greater_than_or_equal_v1(scope, node, value, field: field_name, metadata_field:)
+        when 'contains'
+          condition_contains_v1(scope, node, value, model_class:, field_name:)
+        when 'not_contains'
+          condition_not_contains_v1(scope, node, value, model_class:, field_name:)
+        when 'exists'
+          condition_exists_v1(scope, node)
+        when 'not_exists'
+          condition_not_exists_v1(scope, node)
         else
           scope
         end
@@ -135,6 +161,34 @@ module AdvancedSearch
 
     def valid_numeric_format?(value)
       value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
+    end
+
+    ##############################
+
+    def apply_less_than_or_equal_v1(scope, node, value, field:, metadata_field:)
+      metadata_key = field.delete_prefix('metadata.')
+      condition_less_than_or_equal_v1(scope, node, value, metadata_field:, metadata_key:)
+    end
+
+    def apply_greater_than_or_equal_v1(scope, node, value, field:, metadata_field:)
+      metadata_key = field.delete_prefix('metadata.')
+      condition_greater_than_or_equal_v1(scope, node, value, metadata_field:, metadata_key:)
+    end
+
+    def apply_equals_operator_v1(scope, node, value, metadata_field:, field_name:)
+      condition_equals_v1(scope, node, value, metadata_field:, field_name:)
+    end
+
+    def apply_in_operator_v1(scope, node, value, metadata_field:, field_name:)
+      condition_in_v1(scope, node, value, metadata_field:, field_name:)
+    end
+
+    def apply_not_equals_operator_v1(scope, node, value, metadata_field:, field_name:)
+      condition_not_equals_v1(scope, node, value, metadata_field:, field_name:)
+    end
+
+    def apply_not_in_operator_v1(scope, node, value, metadata_field:, field_name:)
+      condition_not_in_v1(scope, node, value, metadata_field:, field_name:)
     end
   end
 end

--- a/app/models/concerns/advanced_search/filtering.rb
+++ b/app/models/concerns/advanced_search/filtering.rb
@@ -26,11 +26,11 @@ module AdvancedSearch
       feature_flag_enabled = Flipper.enabled?(:advanced_search_metadata_operators)
 
       if metadata_field && feature_flag_enabled
-        if operator.starts_with?('TEXT_')
+        if operator.starts_with?('text_')
           apply_metadata_text_operator(scope, node, value, operator, model_class:, field_name:)
-        elsif operator.starts_with?('NUMERIC_')
+        elsif operator.starts_with?('numeric_')
           apply_metadata_numeric_operator(scope, node, value, operator, field_name:)
-        elsif operator.starts_with?('DATE_')
+        elsif operator.starts_with?('date_')
           apply_metadata_date_operator(scope, node, value, operator, field_name:)
         else
           apply_metadata_exists_operator(scope, node, operator)
@@ -98,51 +98,50 @@ module AdvancedSearch
 
     def apply_metadata_exists_operator(scope, node, operator)
       case operator
-      when 'EXISTS'
+      when 'exists'
         condition_exists(scope, node)
-      when 'NOT_EXISTS'
+      when 'not_exists'
         scope.where(node.eq(nil))
       end
     end
 
     def apply_metadata_text_operator(scope, node, value, operator, model_class:, field_name:) # rubocop:disable Metrics/ParameterLists
       case operator
-      when 'TEXT_EQUALS'
+      when 'text_equals'
         metadata_condition_equals(scope, node, value, field_name:)
-      when 'TEXT_NOT_EQUALS'
+      when 'text_not_equals'
         metadata_condition_not_equals(scope, node, value, field_name:)
-      when 'TEXT_CONTAINS'
+      when 'text_contains'
         condition_contains(scope, node, value, model_class:, field_name:)
-      when 'TEXT_NOT_CONTAINS'
+      when 'text_not_contains'
         condition_not_contains(scope, node, value, model_class:, field_name:)
-      when 'TEXT_IN'
+      when 'text_in'
         metadata_condition_in(scope, node, value)
-      when 'TEXT_NOT_IN'
+      when 'text_not_in'
         metadata_condition_not_in(scope, node, value)
       end
     end
 
     def apply_metadata_numeric_operator(scope, node, value, operator, field_name:)
       case operator
-      when 'NUMERIC_EQUALS'
+      when 'numeric_equals'
         metadata_condition_equals(scope, node, value, field_name:)
-      when 'NUMERIC_NOT_EQUALS'
+      when 'numeric_not_equals'
         metadata_condition_not_equals(scope, node, value, field_name:)
-      when 'NUMERIC_LESS_THAN_EQUALS', 'NUMERIC_GREATER_THAN_EQUALS'
+      when 'numeric_less_than_equals', 'numeric_greater_than_equals'
         metadata_condition_numeric_comparison(scope, node, value,
-                                              operator == 'NUMERIC_LESS_THAN_EQUALS' ? :lteq : :gteq)
+                                              operator == 'numeric_less_than_equals' ? :lteq : :gteq)
       end
     end
 
     def apply_metadata_date_operator(scope, node, value, operator, field_name:)
       case operator
-      when 'DATE_EQUALS'
+      when 'date_equals'
         metadata_condition_equals(scope, node, value, field_name:)
-      when 'DATE_NOT_EQUALS'
+      when 'date_not_equals'
         metadata_condition_not_equals(scope, node, value, field_name:)
-      when 'DATE_LESS_THAN_EQUALS', 'DATE_GREATER_THAN_EQUALS'
-
-        metadata_condition_date_comparison(scope, node, value, operator == 'DATE_LESS_THAN_EQUALS' ? :lteq : :gteq)
+      when 'date_less_than_equals', 'date_greater_than_equals'
+        metadata_condition_date_comparison(scope, node, value, operator == 'date_less_than_equals' ? :lteq : :gteq)
       end
     end
 

--- a/app/models/concerns/advanced_search/filtering.rb
+++ b/app/models/concerns/advanced_search/filtering.rb
@@ -35,7 +35,7 @@ module AdvancedSearch
           apply_metadata_exists_operator(scope, node, operator)
         end
       elsif feature_flag_enabled
-        case condition.operator
+        case operator
         when '='
           condition_equals(scope, node, value, field_name:)
         when 'in'

--- a/app/models/concerns/advanced_search/operators.rb
+++ b/app/models/concerns/advanced_search/operators.rb
@@ -5,17 +5,10 @@ module AdvancedSearch
   module Operators
     extend ActiveSupport::Concern
 
-    if Flipper.enabled?('test')
-      include AdvancedSearch::Operators::EqualityOperators
-      include AdvancedSearch::Operators::SetOperators
-      include AdvancedSearch::Operators::ComparisonOperators
-      include AdvancedSearch::Operators::PatternOperators
-    else
-      include AdvancedSearch::Operators::V2::EqualityOperators
-      include AdvancedSearch::Operators::V2::SetOperators
-      include AdvancedSearch::Operators::V2::ComparisonOperators
-      include AdvancedSearch::Operators::V2::PatternOperators
-    end
+    include AdvancedSearch::Operators::EqualityOperators
+    include AdvancedSearch::Operators::SetOperators
+    include AdvancedSearch::Operators::ComparisonOperators
+    include AdvancedSearch::Operators::PatternOperators
 
     included do
       class_attribute :enum_metadata_fields, instance_accessor: false, default: [].freeze

--- a/app/models/concerns/advanced_search/operators.rb
+++ b/app/models/concerns/advanced_search/operators.rb
@@ -5,10 +5,17 @@ module AdvancedSearch
   module Operators
     extend ActiveSupport::Concern
 
-    include AdvancedSearch::Operators::EqualityOperators
-    include AdvancedSearch::Operators::SetOperators
-    include AdvancedSearch::Operators::ComparisonOperators
-    include AdvancedSearch::Operators::PatternOperators
+    if Flipper.enabled?('test')
+      include AdvancedSearch::Operators::EqualityOperators
+      include AdvancedSearch::Operators::SetOperators
+      include AdvancedSearch::Operators::ComparisonOperators
+      include AdvancedSearch::Operators::PatternOperators
+    else
+      include AdvancedSearch::Operators::V2::EqualityOperators
+      include AdvancedSearch::Operators::V2::SetOperators
+      include AdvancedSearch::Operators::V2::ComparisonOperators
+      include AdvancedSearch::Operators::V2::PatternOperators
+    end
 
     included do
       class_attribute :enum_metadata_fields, instance_accessor: false, default: [].freeze

--- a/app/models/concerns/advanced_search/operators/comparison_operators.rb
+++ b/app/models/concerns/advanced_search/operators/comparison_operators.rb
@@ -6,6 +6,8 @@ module AdvancedSearch
     module ComparisonOperators
       extend ActiveSupport::Concern
 
+      ### TODO: This file contains both new and old logic dependent on feature flag :advanced_search_metadata_operators
+
       # Suffix convention for date-type metadata fields
       DATE_FIELD_SUFFIX = '_date'
 
@@ -54,7 +56,7 @@ module AdvancedSearch
         value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
       end
 
-      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+      ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       def condition_less_than_or_equal_v1(scope, node, value, metadata_field:, metadata_key:)
         return scope.where(node.lteq(value)) unless metadata_field

--- a/app/models/concerns/advanced_search/operators/comparison_operators.rb
+++ b/app/models/concerns/advanced_search/operators/comparison_operators.rb
@@ -64,7 +64,7 @@ module AdvancedSearch
       end
 
       def condition_date_comparison_v1(scope, node, value, comparison_method)
-        return scope.none unless valid_date_format?(value)
+        return scope.none unless valid_date_format_v1?(value)
 
         scope
           .where(node.matches_regexp('^\\d{4}(-\\d{2}){0,2}$'))

--- a/app/models/concerns/advanced_search/operators/comparison_operators.rb
+++ b/app/models/concerns/advanced_search/operators/comparison_operators.rb
@@ -8,7 +8,7 @@ module AdvancedSearch
 
       # Suffix convention for date-type metadata fields
       # TODO: still necessary?
-      # DATE_FIELD_SUFFIX = '_date'
+      DATE_FIELD_SUFFIX = '_date'
 
       private
 
@@ -35,6 +35,67 @@ module AdvancedSearch
               'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
             ).public_send(comparison_method, value)
           )
+      end
+
+      ########################
+      #
+      def condition_less_than_or_equal_v1(scope, node, value, metadata_field:, metadata_key:)
+        return scope.where(node.lteq(value)) unless metadata_field
+
+        if date_metadata_field_v1?(metadata_key)
+          condition_date_comparison_v1(scope, node, value, :lteq)
+        else
+          condition_numeric_comparison_v1(scope, node, value, :lteq)
+        end
+      end
+
+      def condition_greater_than_or_equal_v1(scope, node, value, metadata_field:, metadata_key:)
+        return scope.where(node.gteq(value)) unless metadata_field
+
+        if date_metadata_field_v1?(metadata_key)
+          condition_date_comparison_v1(scope, node, value, :gteq)
+        else
+          condition_numeric_comparison_v1(scope, node, value, :gteq)
+        end
+      end
+
+      def date_metadata_field_v1?(metadata_key)
+        metadata_key.end_with?(DATE_FIELD_SUFFIX)
+      end
+
+      def condition_date_comparison_v1(scope, node, value, comparison_method)
+        return scope.none unless valid_date_format?(value)
+
+        scope
+          .where(node.matches_regexp('^\\d{4}(-\\d{2}){0,2}$'))
+          .where(
+            Arel::Nodes::NamedFunction.new(
+              'TO_DATE', [node, Arel::Nodes::SqlLiteral.new("'YYYY-MM-DD'")]
+            ).public_send(comparison_method, value)
+          )
+      end
+
+      def condition_numeric_comparison_v1(scope, node, value, comparison_method)
+        return scope.none unless valid_numeric_format_v1?(value)
+
+        scope
+          .where(node.matches_regexp('^-?\\d+(\\.\\d+)?$'))
+          .where(
+            Arel::Nodes::NamedFunction.new(
+              'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
+            ).public_send(comparison_method, value)
+          )
+      end
+
+      def valid_date_format_v1?(value)
+        Date.iso8601(value.to_s)
+        true
+      rescue ArgumentError
+        false
+      end
+
+      def valid_numeric_format_v1?(value)
+        value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
       end
     end
   end

--- a/app/models/concerns/advanced_search/operators/comparison_operators.rb
+++ b/app/models/concerns/advanced_search/operators/comparison_operators.rb
@@ -54,8 +54,8 @@ module AdvancedSearch
         value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
       end
 
-      ########################
-      #
+      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+
       def condition_less_than_or_equal_v1(scope, node, value, metadata_field:, metadata_key:)
         return scope.where(node.lteq(value)) unless metadata_field
 
@@ -114,6 +114,8 @@ module AdvancedSearch
       def valid_numeric_format_v1?(value)
         value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
       end
+
+      ### END feature flag :advanced_search_metadata_operators ###
     end
   end
 end

--- a/app/models/concerns/advanced_search/operators/comparison_operators.rb
+++ b/app/models/concerns/advanced_search/operators/comparison_operators.rb
@@ -7,37 +7,17 @@ module AdvancedSearch
       extend ActiveSupport::Concern
 
       # Suffix convention for date-type metadata fields
-      DATE_FIELD_SUFFIX = '_date'
+      # TODO: still necessary?
+      # DATE_FIELD_SUFFIX = '_date'
 
       private
 
-      def condition_less_than_or_equal(scope, node, value, metadata_field:, metadata_key:)
-        return scope.where(node.lteq(value)) unless metadata_field
+      # TODO: still necessary?
+      # def date_metadata_field?(metadata_key)
+      #   metadata_key.end_with?(DATE_FIELD_SUFFIX)
+      # end
 
-        if date_metadata_field?(metadata_key)
-          condition_date_comparison(scope, node, value, :lteq)
-        else
-          condition_numeric_comparison(scope, node, value, :lteq)
-        end
-      end
-
-      def condition_greater_than_or_equal(scope, node, value, metadata_field:, metadata_key:)
-        return scope.where(node.gteq(value)) unless metadata_field
-
-        if date_metadata_field?(metadata_key)
-          condition_date_comparison(scope, node, value, :gteq)
-        else
-          condition_numeric_comparison(scope, node, value, :gteq)
-        end
-      end
-
-      def date_metadata_field?(metadata_key)
-        metadata_key.end_with?(DATE_FIELD_SUFFIX)
-      end
-
-      def condition_date_comparison(scope, node, value, comparison_method)
-        return scope.none unless valid_date_format?(value)
-
+      def metadata_condition_date_comparison(scope, node, value, comparison_method)
         scope
           .where(node.matches_regexp('^\\d{4}(-\\d{2}){0,2}$'))
           .where(
@@ -47,9 +27,7 @@ module AdvancedSearch
           )
       end
 
-      def condition_numeric_comparison(scope, node, value, comparison_method)
-        return scope.none unless valid_numeric_format?(value)
-
+      def metadata_condition_numeric_comparison(scope, node, value, comparison_method)
         scope
           .where(node.matches_regexp('^-?\\d+(\\.\\d+)?$'))
           .where(
@@ -57,17 +35,6 @@ module AdvancedSearch
               'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
             ).public_send(comparison_method, value)
           )
-      end
-
-      def valid_date_format?(value)
-        Date.iso8601(value.to_s)
-        true
-      rescue ArgumentError
-        false
-      end
-
-      def valid_numeric_format?(value)
-        value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
       end
     end
   end

--- a/app/models/concerns/advanced_search/operators/comparison_operators.rb
+++ b/app/models/concerns/advanced_search/operators/comparison_operators.rb
@@ -11,11 +11,6 @@ module AdvancedSearch
 
       private
 
-      # TODO: still necessary?
-      # def date_metadata_field?(metadata_key)
-      #   metadata_key.end_with?(DATE_FIELD_SUFFIX)
-      # end
-
       def metadata_condition_date_comparison(scope, node, value, comparison_method)
         return scope.none unless valid_date_format?(value)
 

--- a/app/models/concerns/advanced_search/operators/comparison_operators.rb
+++ b/app/models/concerns/advanced_search/operators/comparison_operators.rb
@@ -7,7 +7,6 @@ module AdvancedSearch
       extend ActiveSupport::Concern
 
       # Suffix convention for date-type metadata fields
-      # TODO: still necessary?
       DATE_FIELD_SUFFIX = '_date'
 
       private
@@ -18,6 +17,8 @@ module AdvancedSearch
       # end
 
       def metadata_condition_date_comparison(scope, node, value, comparison_method)
+        return scope.none unless valid_date_format?(value)
+
         scope
           .where(node.matches_regexp('^\\d{4}(-\\d{2}){0,2}$'))
           .where(
@@ -28,6 +29,8 @@ module AdvancedSearch
       end
 
       def metadata_condition_numeric_comparison(scope, node, value, comparison_method)
+        return scope.none unless valid_numeric_format?(value)
+
         scope
           .where(node.matches_regexp('^-?\\d+(\\.\\d+)?$'))
           .where(
@@ -35,6 +38,25 @@ module AdvancedSearch
               'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
             ).public_send(comparison_method, value)
           )
+      end
+
+      def condition_less_than_or_equal(scope, node, value)
+        scope.where(node.lteq(value))
+      end
+
+      def condition_greater_than_or_equal(scope, node, value)
+        scope.where(node.gteq(value))
+      end
+
+      def valid_date_format?(value)
+        Date.iso8601(value.to_s)
+        true
+      rescue ArgumentError
+        false
+      end
+
+      def valid_numeric_format?(value)
+        value.to_s.match?(/\A-?\d+(\.\d+)?\z/)
       end
 
       ########################

--- a/app/models/concerns/advanced_search/operators/equality_operators.rb
+++ b/app/models/concerns/advanced_search/operators/equality_operators.rb
@@ -14,7 +14,7 @@ module AdvancedSearch
           equals_pattern_match(scope, node, value)
         else
           # Exact match for regular fields
-          equals(scope, node, value)
+          scope.where(node.eq(value))
         end
       end
 
@@ -24,7 +24,6 @@ module AdvancedSearch
           normalized_value = normalize_case_insensitive_value(value)
           scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).eq(normalized_value))
         else
-          # TODO: possibly need to match ints with floats and vice versa
           equals_pattern_match(scope, node, value)
         end
       end
@@ -58,10 +57,6 @@ module AdvancedSearch
 
       def equals_pattern_match(scope, node, value)
         scope.where(node.matches(value))
-      end
-
-      def equals(scope, node, value)
-        scope.where(node.eq(value))
       end
 
       def not_equals_pattern_match(scope, node, value)

--- a/app/models/concerns/advanced_search/operators/equality_operators.rb
+++ b/app/models/concerns/advanced_search/operators/equality_operators.rb
@@ -8,30 +8,42 @@ module AdvancedSearch
 
       private
 
-      def condition_equals(scope, node, value, metadata_field:, field_name:)
+      def condition_equals(scope, node, value, field_name:)
         # Use pattern matching only for non-enum metadata fields and name field
-        use_pattern_match = (metadata_field || field_name == 'name') && !enum_metadata_field?(field_name)
+        if field_name == 'name'
+          equals_pattern_match(scope, node, value)
+        else
+          # Exact match for regular fields
+          equals(scope, node, value)
+        end
+      end
 
-        if use_pattern_match
-          scope.where(node.matches(value))
-        elsif metadata_field && enum_metadata_field?(field_name)
+      def metadata_condition_equals(scope, node, value, field_name:)
+        if enum_metadata_field?(field_name)
           # Case-insensitive exact match for enum metadata fields
           normalized_value = normalize_case_insensitive_value(value)
           scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).eq(normalized_value))
         else
-          # Exact match for regular fields
-          scope.where(node.eq(value))
+          # TODO: possibly need to match ints with floats and vice versa
+          equals_pattern_match(scope, node, value)
         end
       end
 
-      def condition_not_equals(scope, node, value, metadata_field:, field_name:)
+      def condition_not_equals(scope, node, value, field_name:)
         # Use pattern matching only for non-enum metadata fields and name field
-        use_pattern_match = (metadata_field || field_name == 'name') && !enum_metadata_field?(field_name)
-
-        if use_pattern_match
+        if field_name == 'name'
           # Include NULL records - user searching for "not X" expects records without this field
-          scope.where(node.eq(nil).or(node.does_not_match(value)))
-        elsif metadata_field && enum_metadata_field?(field_name)
+          not_equals_pattern_match(scope, node, value)
+        else
+          # Exact matching for regular fields
+          scope.where(node.not_eq(value))
+        end
+      end
+
+      def metadata_condition_not_equals(scope, node, value, field_name:)
+        # Use pattern matching only for non-enum metadata fields and name field
+
+        if enum_metadata_field?(field_name)
           # Case-insensitive not-equals for enum metadata fields
           normalized_value = normalize_case_insensitive_value(value)
           lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
@@ -40,8 +52,20 @@ module AdvancedSearch
           scope.where(node.eq(nil).or(lower_function.not_eq(normalized_value)))
         else
           # Exact matching for regular fields
-          scope.where(node.not_eq(value))
+          not_equals_pattern_match(scope, node, value)
         end
+      end
+
+      def equals_pattern_match(scope, node, value)
+        scope.where(node.matches(value))
+      end
+
+      def equals(scope, node, value)
+        scope.where(node.eq(value))
+      end
+
+      def not_equals_pattern_match(scope, node, value)
+        scope.where(node.eq(nil).or(node.does_not_match(value)))
       end
 
       def normalize_case_insensitive_value(value)

--- a/app/models/concerns/advanced_search/operators/equality_operators.rb
+++ b/app/models/concerns/advanced_search/operators/equality_operators.rb
@@ -71,6 +71,48 @@ module AdvancedSearch
       def normalize_case_insensitive_value(value)
         value.to_s.downcase
       end
+
+      ###################################################
+
+      def condition_equals_v1(scope, node, value, metadata_field:, field_name:)
+        # Use pattern matching only for non-enum metadata fields and name field
+        use_pattern_match = (metadata_field || field_name == 'name') && !enum_metadata_field?(field_name)
+
+        if use_pattern_match
+          scope.where(node.matches(value))
+        elsif metadata_field && enum_metadata_field?(field_name)
+          # Case-insensitive exact match for enum metadata fields
+          normalized_value = normalize_case_insensitive_value_v1(value)
+          scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).eq(normalized_value))
+        else
+          # Exact match for regular fields
+          scope.where(node.eq(value))
+        end
+      end
+
+      def condition_not_equals_v1(scope, node, value, metadata_field:, field_name:)
+        # Use pattern matching only for non-enum metadata fields and name field
+        use_pattern_match = (metadata_field || field_name == 'name') && !enum_metadata_field?(field_name)
+
+        if use_pattern_match
+          # Include NULL records - user searching for "not X" expects records without this field
+          scope.where(node.eq(nil).or(node.does_not_match(value)))
+        elsif metadata_field && enum_metadata_field?(field_name)
+          # Case-insensitive not-equals for enum metadata fields
+          normalized_value = normalize_case_insensitive_value_v1(value)
+          lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
+
+          # Include NULL metadata values for consistency with other negative operators.
+          scope.where(node.eq(nil).or(lower_function.not_eq(normalized_value)))
+        else
+          # Exact matching for regular fields
+          scope.where(node.not_eq(value))
+        end
+      end
+
+      def normalize_case_insensitive_value_v1(value)
+        value.to_s.downcase
+      end
     end
   end
 end

--- a/app/models/concerns/advanced_search/operators/equality_operators.rb
+++ b/app/models/concerns/advanced_search/operators/equality_operators.rb
@@ -8,6 +8,7 @@ module AdvancedSearch
 
       private
 
+      ### TODO: This file contains both new and old logic dependent on feature flag :advanced_search_metadata_operators
       def condition_equals(scope, node, value, field_name:)
         # Use pattern matching only for non-enum metadata fields and name field
         if field_name == 'name'
@@ -67,7 +68,7 @@ module AdvancedSearch
         value.to_s.downcase
       end
 
-      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+      ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       def condition_equals_v1(scope, node, value, metadata_field:, field_name:)
         # Use pattern matching only for non-enum metadata fields and name field

--- a/app/models/concerns/advanced_search/operators/equality_operators.rb
+++ b/app/models/concerns/advanced_search/operators/equality_operators.rb
@@ -67,7 +67,7 @@ module AdvancedSearch
         value.to_s.downcase
       end
 
-      ###################################################
+      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       def condition_equals_v1(scope, node, value, metadata_field:, field_name:)
         # Use pattern matching only for non-enum metadata fields and name field
@@ -108,6 +108,8 @@ module AdvancedSearch
       def normalize_case_insensitive_value_v1(value)
         value.to_s.downcase
       end
+
+      ### END feature flag :advanced_search_metadata_operators ###
     end
   end
 end

--- a/app/models/concerns/advanced_search/operators/pattern_operators.rb
+++ b/app/models/concerns/advanced_search/operators/pattern_operators.rb
@@ -8,6 +8,7 @@ module AdvancedSearch
 
       private
 
+      ### TODO: This file contains both new and old logic dependent on feature flag :advanced_search_metadata_operators
       def condition_contains(scope, node, value, model_class: nil, field_name: nil)
         search_node = model_class && field_name ? cast_to_text_if_uuid(node, model_class, field_name) : node
         scope.where(search_node.matches("%#{escape_like_wildcards(value)}%"))
@@ -47,7 +48,7 @@ module AdvancedSearch
         value.to_s.gsub(/[\\%_]/) { |char| "\\#{char}" }
       end
 
-      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+      ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       def condition_contains_v1(scope, node, value, model_class: nil, field_name: nil)
         search_node = model_class && field_name ? cast_to_text_if_uuid_v1(node, model_class, field_name) : node

--- a/app/models/concerns/advanced_search/operators/pattern_operators.rb
+++ b/app/models/concerns/advanced_search/operators/pattern_operators.rb
@@ -50,13 +50,13 @@ module AdvancedSearch
       ##############################
 
       def condition_contains_v1(scope, node, value, model_class: nil, field_name: nil)
-        search_node = model_class && field_name ? cast_to_text_if_uuid(node, model_class, field_name) : node
-        scope.where(search_node.matches("%#{escape_like_wildcards(value)}%"))
+        search_node = model_class && field_name ? cast_to_text_if_uuid_v1(node, model_class, field_name) : node
+        scope.where(search_node.matches("%#{escape_like_wildcards_v1(value)}%"))
       end
 
       def condition_not_contains_v1(scope, node, value, model_class: nil, field_name: nil)
-        search_node = model_class && field_name ? cast_to_text_if_uuid(node, model_class, field_name) : node
-        scope.where(node.eq(nil).or(search_node.does_not_match("%#{escape_like_wildcards(value)}%")))
+        search_node = model_class && field_name ? cast_to_text_if_uuid_v1(node, model_class, field_name) : node
+        scope.where(node.eq(nil).or(search_node.does_not_match("%#{escape_like_wildcards_v1(value)}%")))
       end
 
       def condition_exists_v1(scope, node)

--- a/app/models/concerns/advanced_search/operators/pattern_operators.rb
+++ b/app/models/concerns/advanced_search/operators/pattern_operators.rb
@@ -46,6 +46,47 @@ module AdvancedSearch
       def escape_like_wildcards(value)
         value.to_s.gsub(/[\\%_]/) { |char| "\\#{char}" }
       end
+
+      ##############################
+
+      def condition_contains_v1(scope, node, value, model_class: nil, field_name: nil)
+        search_node = model_class && field_name ? cast_to_text_if_uuid(node, model_class, field_name) : node
+        scope.where(search_node.matches("%#{escape_like_wildcards(value)}%"))
+      end
+
+      def condition_not_contains_v1(scope, node, value, model_class: nil, field_name: nil)
+        search_node = model_class && field_name ? cast_to_text_if_uuid(node, model_class, field_name) : node
+        scope.where(node.eq(nil).or(search_node.does_not_match("%#{escape_like_wildcards(value)}%")))
+      end
+
+      def condition_exists_v1(scope, node)
+        scope.where(node.not_eq(nil))
+      end
+
+      def condition_not_exists_v1(scope, node)
+        scope.where(node.eq(nil))
+      end
+
+      # Cast UUID column to text for text-based operations
+      def cast_to_text_if_uuid_v1(node, model_class, field_name)
+        return node unless uuid_column_v1?(model_class, field_name)
+
+        Arel::Nodes::NamedFunction.new('CAST', [node.as(Arel::Nodes::SqlLiteral.new('TEXT'))])
+      end
+
+      # Check if a field is a UUID column in the given model
+      def uuid_column_v1?(model_class, field_name)
+        column = model_class.columns_hash[field_name.to_s]
+        column&.type == :uuid
+      end
+
+      # Escapes SQL LIKE wildcard characters (%, _) to treat them as literal characters.
+      # Escapes backslashes alongside %, _ in a single pass to avoid double-escaping.
+      # @param value [String] the value to escape
+      # @return [String] the escaped value
+      def escape_like_wildcards_v1(value)
+        value.to_s.gsub(/[\\%_]/) { |char| "\\#{char}" }
+      end
     end
   end
 end

--- a/app/models/concerns/advanced_search/operators/pattern_operators.rb
+++ b/app/models/concerns/advanced_search/operators/pattern_operators.rb
@@ -47,7 +47,7 @@ module AdvancedSearch
         value.to_s.gsub(/[\\%_]/) { |char| "\\#{char}" }
       end
 
-      ##############################
+      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       def condition_contains_v1(scope, node, value, model_class: nil, field_name: nil)
         search_node = model_class && field_name ? cast_to_text_if_uuid_v1(node, model_class, field_name) : node
@@ -87,6 +87,7 @@ module AdvancedSearch
       def escape_like_wildcards_v1(value)
         value.to_s.gsub(/[\\%_]/) { |char| "\\#{char}" }
       end
+      ### END feature flag :advanced_search_metadata_operators ###
     end
   end
 end

--- a/app/models/concerns/advanced_search/operators/set_operators.rb
+++ b/app/models/concerns/advanced_search/operators/set_operators.rb
@@ -40,24 +40,24 @@ module AdvancedSearch
       def condition_in_v1(scope, node, value, metadata_field:, field_name:)
         # Use case-insensitive matching for metadata fields (both enum and non-enum)
         if metadata_field
-          scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).in(downcase_values(value)))
+          scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).in(downcase_values_v1(value)))
         elsif field_name == 'name'
-          scope.where(node.lower.in(downcase_values(value)))
+          scope.where(node.lower.in(downcase_values_v1(value)))
         else
           # Exact matching for regular fields
-          scope.where(node.in(compact_values(value)))
+          scope.where(node.in(compact_values_v1(value)))
         end
       end
 
       def condition_not_in_v1(scope, node, value, metadata_field:, field_name:)
         # Use case-insensitive matching for metadata fields (both enum and non-enum)
         if metadata_field
-          condition_not_in_metadata(scope, node, value)
+          condition_not_in_metadata_v1(scope, node, value)
         elsif field_name == 'name'
-          scope.where(node.lower.not_in(downcase_values(value)))
+          scope.where(node.lower.not_in(downcase_values_v1(value)))
         else
           # Exact matching for regular fields
-          scope.where(node.not_in(compact_values(value)))
+          scope.where(node.not_in(compact_values_v1(value)))
         end
       end
 
@@ -65,11 +65,11 @@ module AdvancedSearch
         lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
         # Include NULL metadata values in negative set operations: NULL is not in the provided set.
         # This maintains consistency with condition_not_equals, where "not X" includes records without the field.
-        scope.where(node.eq(nil).or(lower_function.not_in(downcase_values(value))))
+        scope.where(node.eq(nil).or(lower_function.not_in(downcase_values_v1(value))))
       end
 
       def downcase_values_v1(value)
-        compact_values(value).map { |v| v.to_s.downcase }
+        compact_values_v1(value).map { |v| v.to_s.downcase }
       end
 
       def compact_values_v1(value)

--- a/app/models/concerns/advanced_search/operators/set_operators.rb
+++ b/app/models/concerns/advanced_search/operators/set_operators.rb
@@ -8,11 +8,9 @@ module AdvancedSearch
 
       private
 
-      def condition_in(scope, node, value, metadata_field:, field_name:)
+      def condition_in(scope, node, value, field_name:)
         # Use case-insensitive matching for metadata fields (both enum and non-enum)
-        if metadata_field
-          scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).in(downcase_values(value)))
-        elsif field_name == 'name'
+        if field_name == 'name'
           scope.where(node.lower.in(downcase_values(value)))
         else
           # Exact matching for regular fields
@@ -20,23 +18,13 @@ module AdvancedSearch
         end
       end
 
-      def condition_not_in(scope, node, value, metadata_field:, field_name:)
-        # Use case-insensitive matching for metadata fields (both enum and non-enum)
-        if metadata_field
-          condition_not_in_metadata(scope, node, value)
-        elsif field_name == 'name'
+      def condition_not_in(scope, node, value, field_name:)
+        if field_name == 'name'
           scope.where(node.lower.not_in(downcase_values(value)))
         else
           # Exact matching for regular fields
           scope.where(node.not_in(compact_values(value)))
         end
-      end
-
-      def condition_not_in_metadata(scope, node, value)
-        lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
-        # Include NULL metadata values in negative set operations: NULL is not in the provided set.
-        # This maintains consistency with condition_not_equals, where "not X" includes records without the field.
-        scope.where(node.eq(nil).or(lower_function.not_in(downcase_values(value))))
       end
 
       def downcase_values(value)

--- a/app/models/concerns/advanced_search/operators/set_operators.rb
+++ b/app/models/concerns/advanced_search/operators/set_operators.rb
@@ -8,6 +8,7 @@ module AdvancedSearch
 
       private
 
+      ### TODO: This file contains both new and old logic dependent on feature flag :advanced_search_metadata_operators
       def condition_in(scope, node, value, field_name:)
         # Use case-insensitive matching for metadata fields (both enum and non-enum)
         if field_name == 'name'
@@ -47,7 +48,7 @@ module AdvancedSearch
         Array(value).compact_blank
       end
 
-      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+      ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       def condition_in_v1(scope, node, value, metadata_field:, field_name:)
         # Use case-insensitive matching for metadata fields (both enum and non-enum)

--- a/app/models/concerns/advanced_search/operators/set_operators.rb
+++ b/app/models/concerns/advanced_search/operators/set_operators.rb
@@ -47,8 +47,8 @@ module AdvancedSearch
         Array(value).compact_blank
       end
 
-      ###################################
-      #
+      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+
       def condition_in_v1(scope, node, value, metadata_field:, field_name:)
         # Use case-insensitive matching for metadata fields (both enum and non-enum)
         if metadata_field
@@ -87,6 +87,8 @@ module AdvancedSearch
       def compact_values_v1(value)
         Array(value).compact_blank
       end
+
+      ### END feature flag :advanced_search_metadata_operators ###
     end
   end
 end

--- a/app/models/concerns/advanced_search/operators/set_operators.rb
+++ b/app/models/concerns/advanced_search/operators/set_operators.rb
@@ -18,6 +18,10 @@ module AdvancedSearch
         end
       end
 
+      def metadata_condition_in(scope, node, value)
+        scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).in(downcase_values(value)))
+      end
+
       def condition_not_in(scope, node, value, field_name:)
         if field_name == 'name'
           scope.where(node.lower.not_in(downcase_values(value)))
@@ -25,6 +29,14 @@ module AdvancedSearch
           # Exact matching for regular fields
           scope.where(node.not_in(compact_values(value)))
         end
+      end
+
+      def metadata_condition_not_in(scope, node, value)
+        lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
+        # Include NULL metadata values in negative set operations: NULL is not in the provided set.
+        # This maintains consistency with metadata_condition_not_equals, where "not X" includes records without the
+        # field.
+        scope.where(node.eq(nil).or(lower_function.not_in(downcase_values(value))))
       end
 
       def downcase_values(value)

--- a/app/models/concerns/advanced_search/operators/set_operators.rb
+++ b/app/models/concerns/advanced_search/operators/set_operators.rb
@@ -34,6 +34,47 @@ module AdvancedSearch
       def compact_values(value)
         Array(value).compact_blank
       end
+
+      ###################################
+      #
+      def condition_in_v1(scope, node, value, metadata_field:, field_name:)
+        # Use case-insensitive matching for metadata fields (both enum and non-enum)
+        if metadata_field
+          scope.where(Arel::Nodes::NamedFunction.new('LOWER', [node]).in(downcase_values(value)))
+        elsif field_name == 'name'
+          scope.where(node.lower.in(downcase_values(value)))
+        else
+          # Exact matching for regular fields
+          scope.where(node.in(compact_values(value)))
+        end
+      end
+
+      def condition_not_in_v1(scope, node, value, metadata_field:, field_name:)
+        # Use case-insensitive matching for metadata fields (both enum and non-enum)
+        if metadata_field
+          condition_not_in_metadata(scope, node, value)
+        elsif field_name == 'name'
+          scope.where(node.lower.not_in(downcase_values(value)))
+        else
+          # Exact matching for regular fields
+          scope.where(node.not_in(compact_values(value)))
+        end
+      end
+
+      def condition_not_in_metadata_v1(scope, node, value)
+        lower_function = Arel::Nodes::NamedFunction.new('LOWER', [node])
+        # Include NULL metadata values in negative set operations: NULL is not in the provided set.
+        # This maintains consistency with condition_not_equals, where "not X" includes records without the field.
+        scope.where(node.eq(nil).or(lower_function.not_in(downcase_values(value))))
+      end
+
+      def downcase_values_v1(value)
+        compact_values(value).map { |v| v.to_s.downcase }
+      end
+
+      def compact_values_v1(value)
+        Array(value).compact_blank
+      end
     end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,4 +1,7 @@
 features:
+  advanced_search_metadata_operators:
+    description: "Enable metadata specific operators"
+    enable_in_development: false
   advanced_search_with_auto_complete:
     description: "Enable auto-complete suggestions for the field dropdown within the\
       \ advanced search dialog."

--- a/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
@@ -100,7 +100,7 @@ module AdvancedSearch
         assert result.none?
       end
 
-      ##########################################
+      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       # condition_less_than_or_equal tests
       test 'condition_less_than_or_equal_v1 uses lteq for regular fields' do
@@ -207,6 +207,8 @@ module AdvancedSearch
         assert_includes sql, 'CAST'
         assert_includes sql, 'DOUBLE PRECISION'
       end
+
+      ### END feature flag :advanced_search_metadata_operators ###
     end
   end
 end

--- a/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
@@ -19,6 +19,91 @@ module AdvancedSearch
 
       # condition_less_than_or_equal tests
       test 'condition_less_than_or_equal uses lteq for regular fields' do
+        result = @test_instance.send(:condition_less_than_or_equal,
+                                     @scope, @created_at_node, '2024-01-01')
+        sql = result.to_sql
+        assert_includes sql, '<='
+        assert_not_includes sql, 'TO_DATE'
+        assert_not_includes sql, 'CAST'
+      end
+
+      test 'metadata_condition_date_comparison for lteq comparison' do
+        result = @test_instance.send(:metadata_condition_date_comparison,
+                                     @scope, @node, '2024-01-01', :lteq)
+        sql = result.to_sql
+        assert_includes sql, 'TO_DATE'
+        assert_includes sql, '<='
+        assert_includes sql, '~'
+      end
+
+      test 'metadata_condition_numeric_comparison for lteq comparison' do
+        result = @test_instance.send(:metadata_condition_numeric_comparison,
+                                     @scope, @node, '100', :lteq)
+        sql = result.to_sql
+        assert_includes sql, 'CAST'
+        assert_includes sql, 'DOUBLE PRECISION'
+        assert_includes sql, '<='
+      end
+
+      # condition_greater_than_or_equal tests
+      test 'condition_greater_than_or_equal uses gteq for regular fields' do
+        result = @test_instance.send(:condition_greater_than_or_equal,
+                                     @scope, @created_at_node, '2024-01-01')
+        sql = result.to_sql
+        assert_includes sql, '>='
+        assert_not_includes sql, 'TO_DATE'
+        assert_not_includes sql, 'CAST'
+      end
+
+      test 'metadata_condition_date_comparison for gteq comparison' do
+        result = @test_instance.send(:metadata_condition_date_comparison,
+                                     @scope, @node, '2024-01-01', :gteq)
+        sql = result.to_sql
+        assert_includes sql, 'TO_DATE'
+        assert_includes sql, '>='
+        assert_includes sql, '~'
+      end
+
+      test 'metadata_condition_numeric_comparison for gteq comparison' do
+        result = @test_instance.send(:metadata_condition_numeric_comparison,
+                                     @scope, @node, '50', :gteq)
+        sql = result.to_sql
+        assert_includes sql, 'CAST'
+        assert_includes sql, 'DOUBLE PRECISION'
+        assert_includes sql, '>='
+      end
+
+      test 'metadata_condition_date_comparison includes date regex validation' do
+        result = @test_instance.send(:metadata_condition_date_comparison, @scope, @node, '2024-01-01', :lteq)
+        sql = result.to_sql
+        # Regex matches YYYY, YYYY-MM, or YYYY-MM-DD formats
+        assert_includes sql, '~'
+        assert_includes sql, 'TO_DATE'
+        assert_includes sql, 'YYYY-MM-DD'
+      end
+
+      test 'metadata_condition_date_comparison returns none for invalid date format' do
+        result = @test_instance.send(:metadata_condition_date_comparison, @scope, @node, '2024-99-40', :lteq)
+        assert result.none?
+      end
+
+      test 'metadata_condition_numeric_comparison includes numeric regex validation' do
+        result = @test_instance.send(:metadata_condition_numeric_comparison, @scope, @node, '123', :lteq)
+        sql = result.to_sql
+        # Regex matches integers and decimals (including negatives)
+        assert_includes sql, '~'
+        assert_includes sql, 'CAST'
+      end
+
+      test 'metadata_condition_numeric_comparison returns none for invalid numeric format' do
+        result = @test_instance.send(:metadata_condition_numeric_comparison, @scope, @node, '12a3', :lteq)
+        assert result.none?
+      end
+
+      ##########################################
+
+      # condition_less_than_or_equal tests
+      test 'condition_less_than_or_equal_v1 uses lteq for regular fields' do
         result = @test_instance.send(:condition_less_than_or_equal_v1,
                                      @scope, @created_at_node, '2024-01-01',
                                      metadata_field: false, metadata_key: nil)
@@ -28,7 +113,7 @@ module AdvancedSearch
         assert_not_includes sql, 'CAST'
       end
 
-      test 'condition_less_than_or_equal uses date comparison for date metadata fields' do
+      test 'condition_less_than_or_equal_v1 uses date comparison for date metadata fields' do
         result = @test_instance.send(:condition_less_than_or_equal_v1,
                                      @scope, @node, '2024-01-01',
                                      metadata_field: true, metadata_key: 'created_date')
@@ -38,7 +123,7 @@ module AdvancedSearch
         assert_includes sql, '~'
       end
 
-      test 'condition_less_than_or_equal uses numeric comparison for numeric metadata fields' do
+      test 'condition_less_than_or_equal_v1 uses numeric comparison for numeric metadata fields' do
         result = @test_instance.send(:condition_less_than_or_equal_v1,
                                      @scope, @node, '100',
                                      metadata_field: true, metadata_key: 'count')
@@ -49,7 +134,7 @@ module AdvancedSearch
       end
 
       # condition_greater_than_or_equal tests
-      test 'condition_greater_than_or_equal uses gteq for regular fields' do
+      test 'condition_greater_than_or_equal_v1 uses gteq for regular fields' do
         result = @test_instance.send(:condition_greater_than_or_equal_v1,
                                      @scope, @created_at_node, '2024-01-01',
                                      metadata_field: false, metadata_key: nil)
@@ -59,7 +144,7 @@ module AdvancedSearch
         assert_not_includes sql, 'CAST'
       end
 
-      test 'condition_greater_than_or_equal uses date comparison for date metadata fields' do
+      test 'condition_greater_than_or_equal_v1 uses date comparison for date metadata fields' do
         result = @test_instance.send(:condition_greater_than_or_equal_v1,
                                      @scope, @node, '2024-01-01',
                                      metadata_field: true, metadata_key: 'updated_date')
@@ -69,7 +154,7 @@ module AdvancedSearch
         assert_includes sql, '~'
       end
 
-      test 'condition_greater_than_or_equal uses numeric comparison for numeric metadata fields' do
+      test 'condition_greater_than_or_equal_v1 uses numeric comparison for numeric metadata fields' do
         result = @test_instance.send(:condition_greater_than_or_equal_v1,
                                      @scope, @node, '50',
                                      metadata_field: true, metadata_key: 'score')
@@ -80,7 +165,7 @@ module AdvancedSearch
       end
 
       # condition_date_comparison tests
-      test 'condition_date_comparison includes date regex validation' do
+      test 'condition_date_comparison_v1 includes date regex validation' do
         result = @test_instance.send(:condition_date_comparison_v1, @scope, @node, '2024-01-01', :lteq)
         sql = result.to_sql
         # Regex matches YYYY, YYYY-MM, or YYYY-MM-DD formats
@@ -89,12 +174,12 @@ module AdvancedSearch
         assert_includes sql, 'YYYY-MM-DD'
       end
 
-      test 'condition_date_comparison returns none for invalid date format' do
+      test 'condition_date_comparison_v1 returns none for invalid date format' do
         result = @test_instance.send(:condition_date_comparison_v1, @scope, @node, '2024-99-40', :lteq)
         assert result.none?
       end
 
-      test 'condition_date_comparison works with gteq' do
+      test 'condition_date_comparison_v1 works with gteq' do
         result = @test_instance.send(:condition_date_comparison_v1, @scope, @node, '2024-06-15', :gteq)
         sql = result.to_sql
         assert_includes sql, '>='
@@ -102,7 +187,7 @@ module AdvancedSearch
       end
 
       # condition_numeric_comparison tests
-      test 'condition_numeric_comparison includes numeric regex validation' do
+      test 'condition_numeric_comparison_v1 includes numeric regex validation' do
         result = @test_instance.send(:condition_numeric_comparison_v1, @scope, @node, '123', :lteq)
         sql = result.to_sql
         # Regex matches integers and decimals (including negatives)
@@ -110,12 +195,12 @@ module AdvancedSearch
         assert_includes sql, 'CAST'
       end
 
-      test 'condition_numeric_comparison returns none for invalid numeric format' do
+      test 'condition_numeric_comparison_v1 returns none for invalid numeric format' do
         result = @test_instance.send(:condition_numeric_comparison_v1, @scope, @node, '12a3', :lteq)
         assert result.none?
       end
 
-      test 'condition_numeric_comparison works with gteq' do
+      test 'condition_numeric_comparison_v1 works with gteq' do
         result = @test_instance.send(:condition_numeric_comparison_v1, @scope, @node, '456.78', :gteq)
         sql = result.to_sql
         assert_includes sql, '>='

--- a/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
@@ -19,7 +19,7 @@ module AdvancedSearch
 
       # condition_less_than_or_equal tests
       test 'condition_less_than_or_equal uses lteq for regular fields' do
-        result = @test_instance.send(:condition_less_than_or_equal,
+        result = @test_instance.send(:condition_less_than_or_equal_v1,
                                      @scope, @created_at_node, '2024-01-01',
                                      metadata_field: false, metadata_key: nil)
         sql = result.to_sql
@@ -29,7 +29,7 @@ module AdvancedSearch
       end
 
       test 'condition_less_than_or_equal uses date comparison for date metadata fields' do
-        result = @test_instance.send(:condition_less_than_or_equal,
+        result = @test_instance.send(:condition_less_than_or_equal_v1,
                                      @scope, @node, '2024-01-01',
                                      metadata_field: true, metadata_key: 'created_date')
         sql = result.to_sql
@@ -39,7 +39,7 @@ module AdvancedSearch
       end
 
       test 'condition_less_than_or_equal uses numeric comparison for numeric metadata fields' do
-        result = @test_instance.send(:condition_less_than_or_equal,
+        result = @test_instance.send(:condition_less_than_or_equal_v1,
                                      @scope, @node, '100',
                                      metadata_field: true, metadata_key: 'count')
         sql = result.to_sql
@@ -50,7 +50,7 @@ module AdvancedSearch
 
       # condition_greater_than_or_equal tests
       test 'condition_greater_than_or_equal uses gteq for regular fields' do
-        result = @test_instance.send(:condition_greater_than_or_equal,
+        result = @test_instance.send(:condition_greater_than_or_equal_v1,
                                      @scope, @created_at_node, '2024-01-01',
                                      metadata_field: false, metadata_key: nil)
         sql = result.to_sql
@@ -60,7 +60,7 @@ module AdvancedSearch
       end
 
       test 'condition_greater_than_or_equal uses date comparison for date metadata fields' do
-        result = @test_instance.send(:condition_greater_than_or_equal,
+        result = @test_instance.send(:condition_greater_than_or_equal_v1,
                                      @scope, @node, '2024-01-01',
                                      metadata_field: true, metadata_key: 'updated_date')
         sql = result.to_sql
@@ -70,7 +70,7 @@ module AdvancedSearch
       end
 
       test 'condition_greater_than_or_equal uses numeric comparison for numeric metadata fields' do
-        result = @test_instance.send(:condition_greater_than_or_equal,
+        result = @test_instance.send(:condition_greater_than_or_equal_v1,
                                      @scope, @node, '50',
                                      metadata_field: true, metadata_key: 'score')
         sql = result.to_sql
@@ -81,7 +81,7 @@ module AdvancedSearch
 
       # condition_date_comparison tests
       test 'condition_date_comparison includes date regex validation' do
-        result = @test_instance.send(:condition_date_comparison, @scope, @node, '2024-01-01', :lteq)
+        result = @test_instance.send(:condition_date_comparison_v1, @scope, @node, '2024-01-01', :lteq)
         sql = result.to_sql
         # Regex matches YYYY, YYYY-MM, or YYYY-MM-DD formats
         assert_includes sql, '~'
@@ -90,12 +90,12 @@ module AdvancedSearch
       end
 
       test 'condition_date_comparison returns none for invalid date format' do
-        result = @test_instance.send(:condition_date_comparison, @scope, @node, '2024-99-40', :lteq)
+        result = @test_instance.send(:condition_date_comparison_v1, @scope, @node, '2024-99-40', :lteq)
         assert result.none?
       end
 
       test 'condition_date_comparison works with gteq' do
-        result = @test_instance.send(:condition_date_comparison, @scope, @node, '2024-06-15', :gteq)
+        result = @test_instance.send(:condition_date_comparison_v1, @scope, @node, '2024-06-15', :gteq)
         sql = result.to_sql
         assert_includes sql, '>='
         assert_includes sql, 'TO_DATE'
@@ -103,7 +103,7 @@ module AdvancedSearch
 
       # condition_numeric_comparison tests
       test 'condition_numeric_comparison includes numeric regex validation' do
-        result = @test_instance.send(:condition_numeric_comparison, @scope, @node, '123', :lteq)
+        result = @test_instance.send(:condition_numeric_comparison_v1, @scope, @node, '123', :lteq)
         sql = result.to_sql
         # Regex matches integers and decimals (including negatives)
         assert_includes sql, '~'
@@ -111,12 +111,12 @@ module AdvancedSearch
       end
 
       test 'condition_numeric_comparison returns none for invalid numeric format' do
-        result = @test_instance.send(:condition_numeric_comparison, @scope, @node, '12a3', :lteq)
+        result = @test_instance.send(:condition_numeric_comparison_v1, @scope, @node, '12a3', :lteq)
         assert result.none?
       end
 
       test 'condition_numeric_comparison works with gteq' do
-        result = @test_instance.send(:condition_numeric_comparison, @scope, @node, '456.78', :gteq)
+        result = @test_instance.send(:condition_numeric_comparison_v1, @scope, @node, '456.78', :gteq)
         sql = result.to_sql
         assert_includes sql, '>='
         assert_includes sql, 'CAST'

--- a/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/comparison_operators_test.rb
@@ -100,7 +100,7 @@ module AdvancedSearch
         assert result.none?
       end
 
-      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+      ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       # condition_less_than_or_equal tests
       test 'condition_less_than_or_equal_v1 uses lteq for regular fields' do

--- a/test/models/concerns/advanced_search/operators/equality_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/equality_operators_test.rb
@@ -107,7 +107,7 @@ module AdvancedSearch
         assert_not_includes sql, 'NOT ILIKE'
       end
 
-      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+      ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       # condition_equals tests
       test 'condition_equals_v1 uses exact match for regular fields' do

--- a/test/models/concerns/advanced_search/operators/equality_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/equality_operators_test.rb
@@ -23,7 +23,94 @@ module AdvancedSearch
       end
 
       # condition_equals tests
-      test 'condition_equals uses exact match for regular fields' do
+      test 'condition_equal uses exact match for regular fields' do
+        result = @test_instance.send(:condition_equals, @scope, @state_node, 'completed',
+                                     field_name: 'state')
+        sql = result.to_sql
+        assert_includes sql, '"workflow_executions"."state" = '
+        assert_not_includes sql, 'ILIKE'
+      end
+
+      test 'condition_equals uses pattern match for name field' do
+        result = @test_instance.send(:condition_equals, @scope, @node, 'test',
+                                     field_name: 'name')
+        sql = result.to_sql
+        assert_includes sql, 'ILIKE'
+      end
+
+      test 'metadata_condition_equals uses pattern match for metadata fields' do
+        result = @test_instance.send(:metadata_condition_equals, @scope, @node, 'test',
+                                     field_name: 'metadata.some_field')
+        sql = result.to_sql
+        assert_includes sql, 'ILIKE'
+      end
+
+      test 'metadata_condition_equals uses case-insensitive exact match for enum metadata fields' do
+        result = @test_instance.send(:metadata_condition_equals, @scope, @node, 'phac-nml/pipeline',
+                                     field_name: 'metadata.pipeline_id')
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_not_includes sql, 'ILIKE'
+      end
+
+      test 'metadata_condition_equals uses case-insensitive exact match for workflow_version enum field' do
+        result = @test_instance.send(:metadata_condition_equals, @scope, @node, '1.0.0',
+                                     field_name: 'metadata.workflow_version')
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_not_includes sql, 'ILIKE'
+      end
+
+      # condition_not_equals tests
+      test 'condition_not_equals uses not_eq for regular fields' do
+        result = @test_instance.send(:condition_not_equals, @scope, @state_node, 'completed',
+                                     field_name: 'state')
+        sql = result.to_sql
+        assert_includes sql, '"workflow_executions"."state" != '
+        assert_not_includes sql, 'NOT ILIKE'
+      end
+
+      test 'condition_not_equals uses NOT ILIKE with null check for name field' do
+        result = @test_instance.send(:condition_not_equals, @scope, @node, 'test',
+                                     field_name: 'name')
+        sql = result.to_sql
+        assert_includes sql, 'NOT ILIKE'
+        assert_includes sql, 'IS NULL'
+      end
+
+      test 'metadata_condition_not_equals uses NOT ILIKE with null check for metadata fields' do
+        result = @test_instance.send(:metadata_condition_not_equals, @scope, @node, 'test',
+                                     field_name: 'metadata.some_field')
+        sql = result.to_sql
+        assert_includes sql, 'NOT ILIKE'
+        assert_includes sql, 'IS NULL'
+      end
+
+      test 'metadata_condition_not_equals uses case-insensitive not_eq for enum metadata fields' do
+        result = @test_instance.send(:metadata_condition_not_equals,
+                                     @scope, @node, 'phac-nml/pipeline',
+                                     field_name: 'metadata.pipeline_id')
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_includes sql, '!='
+        assert_includes sql, 'IS NULL'
+        assert_not_includes sql, 'NOT ILIKE'
+      end
+
+      test 'metadata_condition_not_equals uses case-insensitive not_eq for workflow_version enum field' do
+        result = @test_instance.send(:metadata_condition_not_equals, @scope, @node, '1.0.0',
+                                     field_name: 'metadata.workflow_version')
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_includes sql, '!='
+        assert_includes sql, 'IS NULL'
+        assert_not_includes sql, 'NOT ILIKE'
+      end
+
+      ###################################
+
+      # condition_equals tests
+      test 'condition_equals_v1 uses exact match for regular fields' do
         result = @test_instance.send(:condition_equals_v1, @scope, @state_node, 'completed', metadata_field: false,
                                                                                              field_name: 'state')
         sql = result.to_sql
@@ -31,21 +118,21 @@ module AdvancedSearch
         assert_not_includes sql, 'ILIKE'
       end
 
-      test 'condition_equals uses pattern match for metadata fields' do
+      test 'condition_equals_v1 uses pattern match for metadata fields' do
         result = @test_instance.send(:condition_equals_v1, @scope, @node, 'test', metadata_field: true,
                                                                                   field_name: 'metadata.some_field')
         sql = result.to_sql
         assert_includes sql, 'ILIKE'
       end
 
-      test 'condition_equals uses pattern match for name field' do
+      test 'condition_equals_v1 uses pattern match for name field' do
         result = @test_instance.send(:condition_equals_v1, @scope, @node, 'test', metadata_field: false,
                                                                                   field_name: 'name')
         sql = result.to_sql
         assert_includes sql, 'ILIKE'
       end
 
-      test 'condition_equals uses case-insensitive exact match for enum metadata fields' do
+      test 'condition_equals_v1 uses case-insensitive exact match for enum metadata fields' do
         result = @test_instance.send(:condition_equals_v1, @scope, @node, 'phac-nml/pipeline',
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
         sql = result.to_sql
@@ -53,7 +140,7 @@ module AdvancedSearch
         assert_not_includes sql, 'ILIKE'
       end
 
-      test 'condition_equals uses case-insensitive exact match for workflow_version enum field' do
+      test 'condition_equals_v1 uses case-insensitive exact match for workflow_version enum field' do
         result = @test_instance.send(:condition_equals_v1, @scope, @node, '1.0.0',
                                      metadata_field: true,
                                      field_name: 'metadata.workflow_version')
@@ -63,7 +150,7 @@ module AdvancedSearch
       end
 
       # condition_not_equals tests
-      test 'condition_not_equals uses not_eq for regular fields' do
+      test 'condition_not_equals_v1 uses not_eq for regular fields' do
         result = @test_instance.send(:condition_not_equals_v1, @scope, @state_node, 'completed', metadata_field: false,
                                                                                                  field_name: 'state')
         sql = result.to_sql
@@ -71,7 +158,7 @@ module AdvancedSearch
         assert_not_includes sql, 'NOT ILIKE'
       end
 
-      test 'condition_not_equals uses NOT ILIKE with null check for metadata fields' do
+      test 'condition_not_equals_v1 uses NOT ILIKE with null check for metadata fields' do
         result = @test_instance.send(:condition_not_equals_v1, @scope, @node, 'test', metadata_field: true,
                                                                                       field_name: 'metadata.some_field')
         sql = result.to_sql
@@ -79,7 +166,7 @@ module AdvancedSearch
         assert_includes sql, 'IS NULL'
       end
 
-      test 'condition_not_equals uses NOT ILIKE with null check for name field' do
+      test 'condition_not_equals_v1 uses NOT ILIKE with null check for name field' do
         result = @test_instance.send(:condition_not_equals_v1, @scope, @node, 'test', metadata_field: false,
                                                                                       field_name: 'name')
         sql = result.to_sql
@@ -87,7 +174,7 @@ module AdvancedSearch
         assert_includes sql, 'IS NULL'
       end
 
-      test 'condition_not_equals uses case-insensitive not_eq for enum metadata fields' do
+      test 'condition_not_equals_v1 uses case-insensitive not_eq for enum metadata fields' do
         result = @test_instance.send(:condition_not_equals_v1,
                                      @scope, @node, 'phac-nml/pipeline',
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
@@ -98,7 +185,7 @@ module AdvancedSearch
         assert_not_includes sql, 'NOT ILIKE'
       end
 
-      test 'condition_not_equals uses case-insensitive not_eq for workflow_version enum field' do
+      test 'condition_not_equals_v1 uses case-insensitive not_eq for workflow_version enum field' do
         result = @test_instance.send(:condition_not_equals_v1, @scope, @node, '1.0.0',
                                      metadata_field: true, field_name: 'metadata.workflow_version')
         sql = result.to_sql

--- a/test/models/concerns/advanced_search/operators/equality_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/equality_operators_test.rb
@@ -24,29 +24,29 @@ module AdvancedSearch
 
       # condition_equals tests
       test 'condition_equals uses exact match for regular fields' do
-        result = @test_instance.send(:condition_equals, @scope, @state_node, 'completed', metadata_field: false,
-                                                                                          field_name: 'state')
+        result = @test_instance.send(:condition_equals_v1, @scope, @state_node, 'completed', metadata_field: false,
+                                                                                             field_name: 'state')
         sql = result.to_sql
         assert_includes sql, '"workflow_executions"."state" = '
         assert_not_includes sql, 'ILIKE'
       end
 
       test 'condition_equals uses pattern match for metadata fields' do
-        result = @test_instance.send(:condition_equals, @scope, @node, 'test', metadata_field: true,
-                                                                               field_name: 'metadata.some_field')
+        result = @test_instance.send(:condition_equals_v1, @scope, @node, 'test', metadata_field: true,
+                                                                                  field_name: 'metadata.some_field')
         sql = result.to_sql
         assert_includes sql, 'ILIKE'
       end
 
       test 'condition_equals uses pattern match for name field' do
-        result = @test_instance.send(:condition_equals, @scope, @node, 'test', metadata_field: false,
-                                                                               field_name: 'name')
+        result = @test_instance.send(:condition_equals_v1, @scope, @node, 'test', metadata_field: false,
+                                                                                  field_name: 'name')
         sql = result.to_sql
         assert_includes sql, 'ILIKE'
       end
 
       test 'condition_equals uses case-insensitive exact match for enum metadata fields' do
-        result = @test_instance.send(:condition_equals, @scope, @node, 'phac-nml/pipeline',
+        result = @test_instance.send(:condition_equals_v1, @scope, @node, 'phac-nml/pipeline',
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
         sql = result.to_sql
         assert_includes sql, 'LOWER'
@@ -54,8 +54,9 @@ module AdvancedSearch
       end
 
       test 'condition_equals uses case-insensitive exact match for workflow_version enum field' do
-        result = @test_instance.send(:condition_equals, @scope, @node, '1.0.0', metadata_field: true,
-                                                                                field_name: 'metadata.workflow_version')
+        result = @test_instance.send(:condition_equals_v1, @scope, @node, '1.0.0',
+                                     metadata_field: true,
+                                     field_name: 'metadata.workflow_version')
         sql = result.to_sql
         assert_includes sql, 'LOWER'
         assert_not_includes sql, 'ILIKE'
@@ -63,31 +64,31 @@ module AdvancedSearch
 
       # condition_not_equals tests
       test 'condition_not_equals uses not_eq for regular fields' do
-        result = @test_instance.send(:condition_not_equals, @scope, @state_node, 'completed', metadata_field: false,
-                                                                                              field_name: 'state')
+        result = @test_instance.send(:condition_not_equals_v1, @scope, @state_node, 'completed', metadata_field: false,
+                                                                                                 field_name: 'state')
         sql = result.to_sql
         assert_includes sql, '"workflow_executions"."state" != '
         assert_not_includes sql, 'NOT ILIKE'
       end
 
       test 'condition_not_equals uses NOT ILIKE with null check for metadata fields' do
-        result = @test_instance.send(:condition_not_equals, @scope, @node, 'test', metadata_field: true,
-                                                                                   field_name: 'metadata.some_field')
+        result = @test_instance.send(:condition_not_equals_v1, @scope, @node, 'test', metadata_field: true,
+                                                                                      field_name: 'metadata.some_field')
         sql = result.to_sql
         assert_includes sql, 'NOT ILIKE'
         assert_includes sql, 'IS NULL'
       end
 
       test 'condition_not_equals uses NOT ILIKE with null check for name field' do
-        result = @test_instance.send(:condition_not_equals, @scope, @node, 'test', metadata_field: false,
-                                                                                   field_name: 'name')
+        result = @test_instance.send(:condition_not_equals_v1, @scope, @node, 'test', metadata_field: false,
+                                                                                      field_name: 'name')
         sql = result.to_sql
         assert_includes sql, 'NOT ILIKE'
         assert_includes sql, 'IS NULL'
       end
 
       test 'condition_not_equals uses case-insensitive not_eq for enum metadata fields' do
-        result = @test_instance.send(:condition_not_equals,
+        result = @test_instance.send(:condition_not_equals_v1,
                                      @scope, @node, 'phac-nml/pipeline',
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
         sql = result.to_sql
@@ -98,7 +99,7 @@ module AdvancedSearch
       end
 
       test 'condition_not_equals uses case-insensitive not_eq for workflow_version enum field' do
-        result = @test_instance.send(:condition_not_equals, @scope, @node, '1.0.0',
+        result = @test_instance.send(:condition_not_equals_v1, @scope, @node, '1.0.0',
                                      metadata_field: true, field_name: 'metadata.workflow_version')
         sql = result.to_sql
         assert_includes sql, 'LOWER'

--- a/test/models/concerns/advanced_search/operators/equality_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/equality_operators_test.rb
@@ -107,7 +107,7 @@ module AdvancedSearch
         assert_not_includes sql, 'NOT ILIKE'
       end
 
-      ###################################
+      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       # condition_equals tests
       test 'condition_equals_v1 uses exact match for regular fields' do
@@ -194,6 +194,8 @@ module AdvancedSearch
         assert_includes sql, 'IS NULL'
         assert_not_includes sql, 'NOT ILIKE'
       end
+
+      ### END feature flag :advanced_search_metadata_operators ###
     end
   end
 end

--- a/test/models/concerns/advanced_search/operators/pattern_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/pattern_operators_test.rb
@@ -19,66 +19,66 @@ module AdvancedSearch
 
       # escape_like_wildcards tests
       test 'escape_like_wildcards escapes percent sign' do
-        assert_equal '\\%test', @test_instance.send(:escape_like_wildcards, '%test')
+        assert_equal '\\%test', @test_instance.send(:escape_like_wildcards_v1, '%test')
       end
 
       test 'escape_like_wildcards escapes underscore' do
-        assert_equal '\\_test', @test_instance.send(:escape_like_wildcards, '_test')
+        assert_equal '\\_test', @test_instance.send(:escape_like_wildcards_v1, '_test')
       end
 
       test 'escape_like_wildcards escapes backslash' do
-        assert_equal '\\\\test', @test_instance.send(:escape_like_wildcards, '\\test')
+        assert_equal '\\\\test', @test_instance.send(:escape_like_wildcards_v1, '\\test')
       end
 
       test 'escape_like_wildcards escapes multiple special characters' do
-        assert_equal '\\%\\_\\\\', @test_instance.send(:escape_like_wildcards, '%_\\')
+        assert_equal '\\%\\_\\\\', @test_instance.send(:escape_like_wildcards_v1, '%_\\')
       end
 
       test 'escape_like_wildcards returns string unchanged if no special characters' do
         # NOTE: underscore IS a special character in SQL LIKE, so it gets escaped
-        assert_equal 'normalstring', @test_instance.send(:escape_like_wildcards, 'normalstring')
+        assert_equal 'normalstring', @test_instance.send(:escape_like_wildcards_v1, 'normalstring')
       end
 
       # uuid_column? tests
       test 'uuid_column? returns true for uuid column' do
-        assert @test_instance.send(:uuid_column?, WorkflowExecution, 'id')
+        assert @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'id')
       end
 
       test 'uuid_column? returns false for non-uuid column' do
-        assert_not @test_instance.send(:uuid_column?, WorkflowExecution, 'name')
+        assert_not @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'name')
       end
 
       test 'uuid_column? returns false for non-existent column' do
-        assert_not @test_instance.send(:uuid_column?, WorkflowExecution, 'nonexistent')
+        assert_not @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'nonexistent')
       end
 
       # cast_to_text_if_uuid tests
       test 'cast_to_text_if_uuid returns original node for non-uuid column' do
-        result = @test_instance.send(:cast_to_text_if_uuid, @node, WorkflowExecution, 'name')
+        result = @test_instance.send(:cast_to_text_if_uuid_v1, @node, WorkflowExecution, 'name')
         assert_equal @node, result
       end
 
       test 'cast_to_text_if_uuid returns cast function for uuid column' do
-        result = @test_instance.send(:cast_to_text_if_uuid, @uuid_node, WorkflowExecution, 'id')
+        result = @test_instance.send(:cast_to_text_if_uuid_v1, @uuid_node, WorkflowExecution, 'id')
         assert_instance_of Arel::Nodes::NamedFunction, result
         assert_equal 'CAST', result.name
       end
 
       # condition_contains tests
       test 'condition_contains creates ILIKE query with wildcards' do
-        result = @test_instance.send(:condition_contains, @scope, @node, 'test')
+        result = @test_instance.send(:condition_contains_v1, @scope, @node, 'test')
         sql = result.to_sql
         assert_includes sql, "ILIKE '%test%'"
       end
 
       test 'condition_contains escapes special characters in value' do
-        result = @test_instance.send(:condition_contains, @scope, @node, '%test%')
+        result = @test_instance.send(:condition_contains_v1, @scope, @node, '%test%')
         sql = result.to_sql
         assert_includes sql, "ILIKE '%\\%test\\%%'"
       end
 
       test 'condition_contains casts uuid column to text' do
-        result = @test_instance.send(:condition_contains, @scope, @uuid_node, 'abc',
+        result = @test_instance.send(:condition_contains_v1, @scope, @uuid_node, 'abc',
                                      model_class: WorkflowExecution, field_name: 'id')
         sql = result.to_sql
         assert_includes sql, 'CAST'
@@ -87,28 +87,28 @@ module AdvancedSearch
 
       # condition_not_contains tests
       test 'condition_not_contains creates NOT ILIKE query with null check' do
-        result = @test_instance.send(:condition_not_contains, @scope, @node, 'test')
+        result = @test_instance.send(:condition_not_contains_v1, @scope, @node, 'test')
         sql = result.to_sql
         assert_includes sql, 'NOT ILIKE'
         assert_includes sql, 'IS NULL'
       end
 
       test 'condition_not_contains escapes special characters in value' do
-        result = @test_instance.send(:condition_not_contains, @scope, @node, '%test%')
+        result = @test_instance.send(:condition_not_contains_v1, @scope, @node, '%test%')
         sql = result.to_sql
         assert_includes sql, "NOT ILIKE '%\\%test\\%%'"
       end
 
       # condition_exists tests
       test 'condition_exists creates IS NOT NULL query' do
-        result = @test_instance.send(:condition_exists, @scope, @node)
+        result = @test_instance.send(:condition_exists_v1, @scope, @node)
         sql = result.to_sql
         assert_includes sql, 'IS NOT NULL'
       end
 
       # condition_not_exists tests
       test 'condition_not_exists creates IS NULL query' do
-        result = @test_instance.send(:condition_not_exists, @scope, @node)
+        result = @test_instance.send(:condition_not_exists_v1, @scope, @node)
         sql = result.to_sql
         assert_includes sql, 'IS NULL'
       end

--- a/test/models/concerns/advanced_search/operators/pattern_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/pattern_operators_test.rb
@@ -19,66 +19,66 @@ module AdvancedSearch
 
       # escape_like_wildcards tests
       test 'escape_like_wildcards escapes percent sign' do
-        assert_equal '\\%test', @test_instance.send(:escape_like_wildcards_v1, '%test')
+        assert_equal '\\%test', @test_instance.send(:escape_like_wildcards, '%test')
       end
 
       test 'escape_like_wildcards escapes underscore' do
-        assert_equal '\\_test', @test_instance.send(:escape_like_wildcards_v1, '_test')
+        assert_equal '\\_test', @test_instance.send(:escape_like_wildcards, '_test')
       end
 
       test 'escape_like_wildcards escapes backslash' do
-        assert_equal '\\\\test', @test_instance.send(:escape_like_wildcards_v1, '\\test')
+        assert_equal '\\\\test', @test_instance.send(:escape_like_wildcards, '\\test')
       end
 
       test 'escape_like_wildcards escapes multiple special characters' do
-        assert_equal '\\%\\_\\\\', @test_instance.send(:escape_like_wildcards_v1, '%_\\')
+        assert_equal '\\%\\_\\\\', @test_instance.send(:escape_like_wildcards, '%_\\')
       end
 
       test 'escape_like_wildcards returns string unchanged if no special characters' do
         # NOTE: underscore IS a special character in SQL LIKE, so it gets escaped
-        assert_equal 'normalstring', @test_instance.send(:escape_like_wildcards_v1, 'normalstring')
+        assert_equal 'normalstring', @test_instance.send(:escape_like_wildcards, 'normalstring')
       end
 
       # uuid_column? tests
       test 'uuid_column? returns true for uuid column' do
-        assert @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'id')
+        assert @test_instance.send(:uuid_column?, WorkflowExecution, 'id')
       end
 
       test 'uuid_column? returns false for non-uuid column' do
-        assert_not @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'name')
+        assert_not @test_instance.send(:uuid_column?, WorkflowExecution, 'name')
       end
 
       test 'uuid_column? returns false for non-existent column' do
-        assert_not @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'nonexistent')
+        assert_not @test_instance.send(:uuid_column?, WorkflowExecution, 'nonexistent')
       end
 
       # cast_to_text_if_uuid tests
       test 'cast_to_text_if_uuid returns original node for non-uuid column' do
-        result = @test_instance.send(:cast_to_text_if_uuid_v1, @node, WorkflowExecution, 'name')
+        result = @test_instance.send(:cast_to_text_if_uuid, @node, WorkflowExecution, 'name')
         assert_equal @node, result
       end
 
       test 'cast_to_text_if_uuid returns cast function for uuid column' do
-        result = @test_instance.send(:cast_to_text_if_uuid_v1, @uuid_node, WorkflowExecution, 'id')
+        result = @test_instance.send(:cast_to_text_if_uuid, @uuid_node, WorkflowExecution, 'id')
         assert_instance_of Arel::Nodes::NamedFunction, result
         assert_equal 'CAST', result.name
       end
 
       # condition_contains tests
       test 'condition_contains creates ILIKE query with wildcards' do
-        result = @test_instance.send(:condition_contains_v1, @scope, @node, 'test')
+        result = @test_instance.send(:condition_contains, @scope, @node, 'test')
         sql = result.to_sql
         assert_includes sql, "ILIKE '%test%'"
       end
 
       test 'condition_contains escapes special characters in value' do
-        result = @test_instance.send(:condition_contains_v1, @scope, @node, '%test%')
+        result = @test_instance.send(:condition_contains, @scope, @node, '%test%')
         sql = result.to_sql
         assert_includes sql, "ILIKE '%\\%test\\%%'"
       end
 
       test 'condition_contains casts uuid column to text' do
-        result = @test_instance.send(:condition_contains_v1, @scope, @uuid_node, 'abc',
+        result = @test_instance.send(:condition_contains, @scope, @uuid_node, 'abc',
                                      model_class: WorkflowExecution, field_name: 'id')
         sql = result.to_sql
         assert_includes sql, 'CAST'
@@ -87,27 +87,123 @@ module AdvancedSearch
 
       # condition_not_contains tests
       test 'condition_not_contains creates NOT ILIKE query with null check' do
-        result = @test_instance.send(:condition_not_contains_v1, @scope, @node, 'test')
+        result = @test_instance.send(:condition_not_contains, @scope, @node, 'test')
         sql = result.to_sql
         assert_includes sql, 'NOT ILIKE'
         assert_includes sql, 'IS NULL'
       end
 
       test 'condition_not_contains escapes special characters in value' do
-        result = @test_instance.send(:condition_not_contains_v1, @scope, @node, '%test%')
+        result = @test_instance.send(:condition_not_contains, @scope, @node, '%test%')
         sql = result.to_sql
         assert_includes sql, "NOT ILIKE '%\\%test\\%%'"
       end
 
       # condition_exists tests
       test 'condition_exists creates IS NOT NULL query' do
-        result = @test_instance.send(:condition_exists_v1, @scope, @node)
+        result = @test_instance.send(:condition_exists, @scope, @node)
         sql = result.to_sql
         assert_includes sql, 'IS NOT NULL'
       end
 
       # condition_not_exists tests
       test 'condition_not_exists creates IS NULL query' do
+        result = @test_instance.send(:condition_not_exists, @scope, @node)
+        sql = result.to_sql
+        assert_includes sql, 'IS NULL'
+      end
+
+      # escape_like_wildcards tests
+      test 'escape_like_wildcards_v1 escapes percent sign' do
+        assert_equal '\\%test', @test_instance.send(:escape_like_wildcards_v1, '%test')
+      end
+
+      test 'escape_like_wildcards_v1 escapes underscore' do
+        assert_equal '\\_test', @test_instance.send(:escape_like_wildcards_v1, '_test')
+      end
+
+      test 'escape_like_wildcards_v1 escapes backslash' do
+        assert_equal '\\\\test', @test_instance.send(:escape_like_wildcards_v1, '\\test')
+      end
+
+      test 'escape_like_wildcards_v1 escapes multiple special characters' do
+        assert_equal '\\%\\_\\\\', @test_instance.send(:escape_like_wildcards_v1, '%_\\')
+      end
+
+      test 'escape_like_wildcards_v1 returns string unchanged if no special characters' do
+        # NOTE: underscore IS a special character in SQL LIKE, so it gets escaped
+        assert_equal 'normalstring', @test_instance.send(:escape_like_wildcards_v1, 'normalstring')
+      end
+
+      # uuid_column? tests
+      test 'uuid_column_v1? returns true for uuid column' do
+        assert @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'id')
+      end
+
+      test 'uuid_column_v1? returns false for non-uuid column' do
+        assert_not @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'name')
+      end
+
+      test 'uuid_column_v1? returns false for non-existent column' do
+        assert_not @test_instance.send(:uuid_column_v1?, WorkflowExecution, 'nonexistent')
+      end
+
+      # cast_to_text_if_uuid tests
+      test 'cast_to_text_if_uuid_v1 returns original node for non-uuid column' do
+        result = @test_instance.send(:cast_to_text_if_uuid_v1, @node, WorkflowExecution, 'name')
+        assert_equal @node, result
+      end
+
+      test 'cast_to_text_if_uuid_v1 returns cast function for uuid column' do
+        result = @test_instance.send(:cast_to_text_if_uuid_v1, @uuid_node, WorkflowExecution, 'id')
+        assert_instance_of Arel::Nodes::NamedFunction, result
+        assert_equal 'CAST', result.name
+      end
+
+      # condition_contains tests
+      test 'condition_contains_v1 creates ILIKE query with wildcards' do
+        result = @test_instance.send(:condition_contains_v1, @scope, @node, 'test')
+        sql = result.to_sql
+        assert_includes sql, "ILIKE '%test%'"
+      end
+
+      test 'condition_contains_v1 escapes special characters in value' do
+        result = @test_instance.send(:condition_contains_v1, @scope, @node, '%test%')
+        sql = result.to_sql
+        assert_includes sql, "ILIKE '%\\%test\\%%'"
+      end
+
+      test 'condition_contains_v1 casts uuid column to text' do
+        result = @test_instance.send(:condition_contains_v1, @scope, @uuid_node, 'abc',
+                                     model_class: WorkflowExecution, field_name: 'id')
+        sql = result.to_sql
+        assert_includes sql, 'CAST'
+        assert_includes sql, 'TEXT'
+      end
+
+      # condition_not_contains tests
+      test 'condition_not_contains_v1 creates NOT ILIKE query with null check' do
+        result = @test_instance.send(:condition_not_contains_v1, @scope, @node, 'test')
+        sql = result.to_sql
+        assert_includes sql, 'NOT ILIKE'
+        assert_includes sql, 'IS NULL'
+      end
+
+      test 'condition_not_contains_v1 escapes special characters in value' do
+        result = @test_instance.send(:condition_not_contains_v1, @scope, @node, '%test%')
+        sql = result.to_sql
+        assert_includes sql, "NOT ILIKE '%\\%test\\%%'"
+      end
+
+      # condition_exists tests
+      test 'condition_exists creates_v1 IS NOT NULL query' do
+        result = @test_instance.send(:condition_exists_v1, @scope, @node)
+        sql = result.to_sql
+        assert_includes sql, 'IS NOT NULL'
+      end
+
+      # condition_not_exists tests
+      test 'condition_not_exists_v1 creates IS NULL query' do
         result = @test_instance.send(:condition_not_exists_v1, @scope, @node)
         sql = result.to_sql
         assert_includes sql, 'IS NULL'

--- a/test/models/concerns/advanced_search/operators/set_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/set_operators_test.rb
@@ -24,27 +24,153 @@ module AdvancedSearch
 
       # downcase_values tests
       test 'downcase_values downcases all string values' do
-        result = @test_instance.send(:downcase_values_v1, %w[Test VALUE Mixed])
+        result = @test_instance.send(:downcase_values, %w[Test VALUE Mixed])
         assert_equal %w[test value mixed], result
       end
 
       test 'downcase_values removes nil values' do
-        result = @test_instance.send(:downcase_values_v1, ['Test', nil, 'Value'])
+        result = @test_instance.send(:downcase_values, ['Test', nil, 'Value'])
         assert_equal %w[test value], result
       end
 
       test 'downcase_values converts non-strings to downcased strings' do
-        result = @test_instance.send(:downcase_values_v1, [123, :Symbol])
+        result = @test_instance.send(:downcase_values, [123, :Symbol])
         assert_equal %w[123 symbol], result
       end
 
       test 'downcase_values handles scalar values' do
-        result = @test_instance.send(:downcase_values_v1, 'TeSt')
+        result = @test_instance.send(:downcase_values, 'TeSt')
         assert_equal ['test'], result
       end
 
       # condition_in tests
       test 'condition_in uses exact match IN for regular fields' do
+        result = @test_instance.send(:condition_in,
+                                     @scope, @state_node, %w[completed running],
+                                     field_name: 'state')
+        sql = result.to_sql
+        assert_includes sql, '"workflow_executions"."state" IN'
+        assert_not_includes sql, 'LOWER'
+      end
+
+      test 'metadata_condition_in uses case-insensitive IN for metadata fields' do
+        result = @test_instance.send(:metadata_condition_in,
+                                     @scope, @node, %w[Test Value])
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_includes sql, 'IN'
+      end
+
+      test 'condition_in uses case-insensitive IN for name field' do
+        result = @test_instance.send(:condition_in,
+                                     @scope, @node, %w[Test Value],
+                                     field_name: 'name')
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_includes sql, 'IN'
+      end
+
+      test 'metadata_condition_in uses case-insensitive IN for enum metadata fields' do
+        result = @test_instance.send(:metadata_condition_in,
+                                     @scope, @node, %w[phac-nml/pipeline1 phac-nml/pipeline2])
+        sql = result.to_sql
+        assert_includes sql, 'IN'
+        assert_includes sql, 'LOWER'
+      end
+
+      test 'metadata_condition_in uses case-insensitive IN for workflow_version enum field' do
+        result = @test_instance.send(:metadata_condition_in,
+                                     @scope, @node, %w[1.0.0 2.0.0])
+        sql = result.to_sql
+        assert_includes sql, 'IN'
+        assert_includes sql, 'LOWER'
+      end
+
+      test 'condition_in handles scalar value for regular fields' do
+        result = @test_instance.send(:condition_in,
+                                     @scope, @state_node, 'completed',
+                                     field_name: 'state')
+        sql = result.to_sql
+        assert_includes sql, '"workflow_executions"."state" IN'
+      end
+
+      # condition_not_in tests
+      test 'condition_not_in uses exact match NOT IN for regular fields' do
+        result = @test_instance.send(:condition_not_in,
+                                     @scope, @state_node, %w[completed running],
+                                     field_name: 'state')
+        sql = result.to_sql
+        assert_includes sql, '"workflow_executions"."state" NOT IN'
+        assert_not_includes sql, 'LOWER'
+      end
+
+      test 'metadata_condition_not_in uses case-insensitive NOT IN with null check for metadata fields' do
+        result = @test_instance.send(:metadata_condition_not_in,
+                                     @scope, @node, %w[Test Value])
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_includes sql, 'NOT IN'
+        assert_includes sql, 'IS NULL'
+      end
+
+      test 'condition_not_in uses case-insensitive NOT IN for name field' do
+        result = @test_instance.send(:condition_not_in,
+                                     @scope, @node, %w[Test Value],
+                                     field_name: 'name')
+        sql = result.to_sql
+        assert_includes sql, 'LOWER'
+        assert_includes sql, 'NOT IN'
+      end
+
+      test 'metadata_condition_not_in uses case-insensitive NOT IN for enum metadata fields' do
+        result = @test_instance.send(:metadata_condition_not_in,
+                                     @scope, @node, %w[phac-nml/pipeline1 phac-nml/pipeline2])
+        sql = result.to_sql
+        assert_includes sql, 'NOT IN'
+        assert_includes sql, 'LOWER'
+      end
+
+      test 'metadata_condition_not_in uses case-insensitive NOT IN for workflow_version enum field' do
+        result = @test_instance.send(:metadata_condition_not_in,
+                                     @scope, @node, %w[1.0.0 2.0.0])
+        sql = result.to_sql
+        assert_includes sql, 'NOT IN'
+        assert_includes sql, 'LOWER'
+      end
+
+      test 'condition_not_in handles scalar value for regular fields' do
+        result = @test_instance.send(:condition_not_in,
+                                     @scope, @state_node, 'completed',
+                                     field_name: 'state')
+        sql = result.to_sql
+        assert_includes sql, '"workflow_executions"."state" NOT IN'
+      end
+
+      ####################################
+
+      # downcase_values tests
+      test 'downcase_values_v1 downcases all string values' do
+        result = @test_instance.send(:downcase_values_v1, %w[Test VALUE Mixed])
+        assert_equal %w[test value mixed], result
+      end
+
+      test 'downcase_values_v1 removes nil values' do
+        result = @test_instance.send(:downcase_values_v1, ['Test', nil, 'Value'])
+        assert_equal %w[test value], result
+      end
+
+      test 'downcase_values_v1 converts non-strings to downcased strings' do
+        result = @test_instance.send(:downcase_values_v1, [123, :Symbol])
+        assert_equal %w[123 symbol], result
+      end
+
+      test 'downcase_values_v1 handles scalar values' do
+        result = @test_instance.send(:downcase_values_v1, 'TeSt')
+        assert_equal ['test'], result
+      end
+
+      # condition_in tests
+      test 'condition_in_v1 uses exact match IN for regular fields' do
         result = @test_instance.send(:condition_in_v1,
                                      @scope, @state_node, %w[completed running],
                                      metadata_field: false, field_name: 'state')
@@ -53,7 +179,7 @@ module AdvancedSearch
         assert_not_includes sql, 'LOWER'
       end
 
-      test 'condition_in uses case-insensitive IN for metadata fields' do
+      test 'condition_in_v1 uses case-insensitive IN for metadata fields' do
         result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: true, field_name: 'metadata.some_field')
@@ -62,7 +188,7 @@ module AdvancedSearch
         assert_includes sql, 'IN'
       end
 
-      test 'condition_in uses case-insensitive IN for name field' do
+      test 'condition_in_v1 uses case-insensitive IN for name field' do
         result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: false, field_name: 'name')
@@ -71,7 +197,7 @@ module AdvancedSearch
         assert_includes sql, 'IN'
       end
 
-      test 'condition_in uses case-insensitive IN for enum metadata fields' do
+      test 'condition_in_v1 uses case-insensitive IN for enum metadata fields' do
         result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[phac-nml/pipeline1 phac-nml/pipeline2],
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
@@ -80,7 +206,7 @@ module AdvancedSearch
         assert_includes sql, 'LOWER'
       end
 
-      test 'condition_in uses case-insensitive IN for workflow_version enum field' do
+      test 'condition_in_v1 uses case-insensitive IN for workflow_version enum field' do
         result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[1.0.0 2.0.0],
                                      metadata_field: true, field_name: 'metadata.workflow_version')
@@ -89,7 +215,7 @@ module AdvancedSearch
         assert_includes sql, 'LOWER'
       end
 
-      test 'condition_in handles scalar value for regular fields' do
+      test 'condition_in_v1 handles scalar value for regular fields' do
         result = @test_instance.send(:condition_in_v1,
                                      @scope, @state_node, 'completed',
                                      metadata_field: false, field_name: 'state')
@@ -98,7 +224,7 @@ module AdvancedSearch
       end
 
       # condition_not_in tests
-      test 'condition_not_in uses exact match NOT IN for regular fields' do
+      test 'condition_not_in_v1 uses exact match NOT IN for regular fields' do
         result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @state_node, %w[completed running],
                                      metadata_field: false, field_name: 'state')
@@ -107,7 +233,7 @@ module AdvancedSearch
         assert_not_includes sql, 'LOWER'
       end
 
-      test 'condition_not_in uses case-insensitive NOT IN with null check for metadata fields' do
+      test 'condition_not_in_v1 uses case-insensitive NOT IN with null check for metadata fields' do
         result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: true, field_name: 'metadata.some_field')
@@ -117,7 +243,7 @@ module AdvancedSearch
         assert_includes sql, 'IS NULL'
       end
 
-      test 'condition_not_in uses case-insensitive NOT IN for name field' do
+      test 'condition_not_in_v1 uses case-insensitive NOT IN for name field' do
         result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: false, field_name: 'name')
@@ -126,7 +252,7 @@ module AdvancedSearch
         assert_includes sql, 'NOT IN'
       end
 
-      test 'condition_not_in uses case-insensitive NOT IN for enum metadata fields' do
+      test 'condition_not_in_v1 uses case-insensitive NOT IN for enum metadata fields' do
         result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[phac-nml/pipeline1 phac-nml/pipeline2],
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
@@ -135,7 +261,7 @@ module AdvancedSearch
         assert_includes sql, 'LOWER'
       end
 
-      test 'condition_not_in uses case-insensitive NOT IN for workflow_version enum field' do
+      test 'condition_not_in_v1 uses case-insensitive NOT IN for workflow_version enum field' do
         result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[1.0.0 2.0.0],
                                      metadata_field: true, field_name: 'metadata.workflow_version')
@@ -144,7 +270,7 @@ module AdvancedSearch
         assert_includes sql, 'LOWER'
       end
 
-      test 'condition_not_in handles scalar value for regular fields' do
+      test 'condition_not_in_v1 handles scalar value for regular fields' do
         result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @state_node, 'completed',
                                      metadata_field: false, field_name: 'state')

--- a/test/models/concerns/advanced_search/operators/set_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/set_operators_test.rb
@@ -24,28 +24,28 @@ module AdvancedSearch
 
       # downcase_values tests
       test 'downcase_values downcases all string values' do
-        result = @test_instance.send(:downcase_values, %w[Test VALUE Mixed])
+        result = @test_instance.send(:downcase_values_v1, %w[Test VALUE Mixed])
         assert_equal %w[test value mixed], result
       end
 
       test 'downcase_values removes nil values' do
-        result = @test_instance.send(:downcase_values, ['Test', nil, 'Value'])
+        result = @test_instance.send(:downcase_values_v1, ['Test', nil, 'Value'])
         assert_equal %w[test value], result
       end
 
       test 'downcase_values converts non-strings to downcased strings' do
-        result = @test_instance.send(:downcase_values, [123, :Symbol])
+        result = @test_instance.send(:downcase_values_v1, [123, :Symbol])
         assert_equal %w[123 symbol], result
       end
 
       test 'downcase_values handles scalar values' do
-        result = @test_instance.send(:downcase_values, 'TeSt')
+        result = @test_instance.send(:downcase_values_v1, 'TeSt')
         assert_equal ['test'], result
       end
 
       # condition_in tests
       test 'condition_in uses exact match IN for regular fields' do
-        result = @test_instance.send(:condition_in,
+        result = @test_instance.send(:condition_in_v1,
                                      @scope, @state_node, %w[completed running],
                                      metadata_field: false, field_name: 'state')
         sql = result.to_sql
@@ -54,7 +54,7 @@ module AdvancedSearch
       end
 
       test 'condition_in uses case-insensitive IN for metadata fields' do
-        result = @test_instance.send(:condition_in,
+        result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: true, field_name: 'metadata.some_field')
         sql = result.to_sql
@@ -63,7 +63,7 @@ module AdvancedSearch
       end
 
       test 'condition_in uses case-insensitive IN for name field' do
-        result = @test_instance.send(:condition_in,
+        result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: false, field_name: 'name')
         sql = result.to_sql
@@ -72,7 +72,7 @@ module AdvancedSearch
       end
 
       test 'condition_in uses case-insensitive IN for enum metadata fields' do
-        result = @test_instance.send(:condition_in,
+        result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[phac-nml/pipeline1 phac-nml/pipeline2],
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
         sql = result.to_sql
@@ -81,7 +81,7 @@ module AdvancedSearch
       end
 
       test 'condition_in uses case-insensitive IN for workflow_version enum field' do
-        result = @test_instance.send(:condition_in,
+        result = @test_instance.send(:condition_in_v1,
                                      @scope, @node, %w[1.0.0 2.0.0],
                                      metadata_field: true, field_name: 'metadata.workflow_version')
         sql = result.to_sql
@@ -90,7 +90,7 @@ module AdvancedSearch
       end
 
       test 'condition_in handles scalar value for regular fields' do
-        result = @test_instance.send(:condition_in,
+        result = @test_instance.send(:condition_in_v1,
                                      @scope, @state_node, 'completed',
                                      metadata_field: false, field_name: 'state')
         sql = result.to_sql
@@ -99,7 +99,7 @@ module AdvancedSearch
 
       # condition_not_in tests
       test 'condition_not_in uses exact match NOT IN for regular fields' do
-        result = @test_instance.send(:condition_not_in,
+        result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @state_node, %w[completed running],
                                      metadata_field: false, field_name: 'state')
         sql = result.to_sql
@@ -108,7 +108,7 @@ module AdvancedSearch
       end
 
       test 'condition_not_in uses case-insensitive NOT IN with null check for metadata fields' do
-        result = @test_instance.send(:condition_not_in,
+        result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: true, field_name: 'metadata.some_field')
         sql = result.to_sql
@@ -118,7 +118,7 @@ module AdvancedSearch
       end
 
       test 'condition_not_in uses case-insensitive NOT IN for name field' do
-        result = @test_instance.send(:condition_not_in,
+        result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[Test Value],
                                      metadata_field: false, field_name: 'name')
         sql = result.to_sql
@@ -127,7 +127,7 @@ module AdvancedSearch
       end
 
       test 'condition_not_in uses case-insensitive NOT IN for enum metadata fields' do
-        result = @test_instance.send(:condition_not_in,
+        result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[phac-nml/pipeline1 phac-nml/pipeline2],
                                      metadata_field: true, field_name: 'metadata.pipeline_id')
         sql = result.to_sql
@@ -136,7 +136,7 @@ module AdvancedSearch
       end
 
       test 'condition_not_in uses case-insensitive NOT IN for workflow_version enum field' do
-        result = @test_instance.send(:condition_not_in,
+        result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @node, %w[1.0.0 2.0.0],
                                      metadata_field: true, field_name: 'metadata.workflow_version')
         sql = result.to_sql
@@ -145,7 +145,7 @@ module AdvancedSearch
       end
 
       test 'condition_not_in handles scalar value for regular fields' do
-        result = @test_instance.send(:condition_not_in,
+        result = @test_instance.send(:condition_not_in_v1,
                                      @scope, @state_node, 'completed',
                                      metadata_field: false, field_name: 'state')
         sql = result.to_sql

--- a/test/models/concerns/advanced_search/operators/set_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/set_operators_test.rb
@@ -146,7 +146,7 @@ module AdvancedSearch
         assert_includes sql, '"workflow_executions"."state" NOT IN'
       end
 
-      ####################################
+      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       # downcase_values tests
       test 'downcase_values_v1 downcases all string values' do
@@ -277,6 +277,8 @@ module AdvancedSearch
         sql = result.to_sql
         assert_includes sql, '"workflow_executions"."state" NOT IN'
       end
+
+      ### END feature flag :advanced_search_metadata_operators ###
     end
   end
 end

--- a/test/models/concerns/advanced_search/operators/set_operators_test.rb
+++ b/test/models/concerns/advanced_search/operators/set_operators_test.rb
@@ -146,7 +146,7 @@ module AdvancedSearch
         assert_includes sql, '"workflow_executions"."state" NOT IN'
       end
 
-      ### V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
+      ### TODO: V1 methods block below, remove when feature flag :advanced_search_metadata_operators is deleted ###
 
       # downcase_values tests
       test 'downcase_values_v1 downcases all string values' do


### PR DESCRIPTION
[PR2017](https://github.com/phac-nml/irida-next/pull/2017) may be a simpler/cleaner solution

## What does this PR do and why?
This PR is part 1 for [issue 1953](https://github.com/phac-nml/irida-next/issues/1953) lays the foundation for the backend logic for when metadata specific operators are added to `Advanced Search`.

Changes:
- Added feature flag `:advanced_search_metadata_operators`. 
  - This has no functionality currently other than to act as a placeholder, blocking new logic from being used (would break current advanced search).
- Separated metadata and non-metadata operator logic. 
  - The current advanced search operator logic has lots of `if metadata` trees. Now this has been parsed out and logic is now metadata/non-metadata specific.
- Added backend tests for the above new logic

Follow up PRs include:
- Validation of passed metadata operator
- GraphQL integration
- UI integration

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Verify tests pass

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
