### PR TITLE
feat(admin): back-end setup for  experimental features settings

### DIFF
--- a/app/forms/profiles/experimental_features/opt_in_form.rb
+++ b/app/forms/profiles/experimental_features/opt_in_form.rb
@@ -77,7 +77,7 @@ module Profiles
       end
 
       def feature_available?
-        FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
+        Irida::ExperimentalFeatureCatalog.available?(feature_key)
       end
 
       def feature_config

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -60,7 +60,7 @@ class ApplicationSetting < ApplicationRecord
   def flipper_feature_available?(feature_key)
     return false if feature_key.blank?
 
-    FLIPPER_FEATURE_CONFIG['features'].key?(feature_key)
+    Irida::ExperimentalFeatureCatalog.available?(feature_key)
   end
 
   def user_eligible_for_opt_in_feature?(feature_config, user)
@@ -72,17 +72,15 @@ class ApplicationSetting < ApplicationRecord
     Array(allowlist).any? { |email| email.casecmp?(user.email) }
   end
 
-  def user_opt_in_feature_payload(feature_key, feature_config, user)
+  def user_opt_in_feature_payload(feature_key, _feature_config, user)
+    catalog_feature = Irida::ExperimentalFeatureCatalog.fetch(feature_key)
+
     {
       key: feature_key.to_sym,
-      name: localized_opt_in_feature_value(feature_config['name']),
-      description: localized_opt_in_feature_value(feature_config['description']),
+      name: catalog_feature[:name],
+      description: catalog_feature[:description],
       enabled: user_opted_in_to_feature?(feature_key, user)
     }
-  end
-
-  def localized_opt_in_feature_value(translations)
-    translations[I18n.locale.to_s].presence || translations['en']
   end
 
   def user_opted_in_to_feature?(feature_key, user)

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -41,7 +41,7 @@ class ApplicationSetting < ApplicationRecord
       next unless flipper_feature_available?(feature_key)
       next unless user_eligible_for_opt_in_feature?(feature_config, user)
 
-      user_opt_in_feature_payload(feature_key, feature_config, user)
+      user_opt_in_feature_payload(feature_key, user)
     end
   end
 
@@ -52,7 +52,7 @@ class ApplicationSetting < ApplicationRecord
     feature_config = (user_opt_in_features || {})[normalized_feature_key]
     return nil if feature_config.blank?
 
-    user_opt_in_feature_payload(normalized_feature_key, feature_config, user)
+    user_opt_in_feature_payload(normalized_feature_key, user)
   end
 
   private
@@ -72,7 +72,7 @@ class ApplicationSetting < ApplicationRecord
     Array(allowlist).any? { |email| email.casecmp?(user.email) }
   end
 
-  def user_opt_in_feature_payload(feature_key, _feature_config, user)
+  def user_opt_in_feature_payload(feature_key, user)
     catalog_feature = Irida::ExperimentalFeatureCatalog.fetch(feature_key)
 
     {

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,53 +1,136 @@
 features:
   advanced_search_with_auto_complete:
-    description: "Enable auto-complete suggestions for the field dropdown within the\
-      \ advanced search dialog."
+    admin_manageable: true
+    description:
+      en: "Enable auto-complete suggestions for the field dropdown within the advanced\
+        \ search dialog."
+      fr: "Activer les suggestions de saisie semi-automatique dans la liste des champs\
+        \ de la recherche avancée."
     enable_in_development: true
+    name:
+      en: "Advanced Search Autocomplete"
+      fr: "Saisie semi-automatique de la recherche avancée"
   cancel_multiple_workflows:
-    description: "Allow users to select and cancel multiple workflow executions at\
-      \ once."
+    admin_manageable: true
+    description:
+      en: "Allow users to select and cancel multiple workflow executions at once."
+      fr: "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
+        \ de flux de travail à la fois."
     enable_in_development: true
+    name:
+      en: "Cancel Multiple Workflows"
+      fr: "Annulation de plusieurs flux de travail"
   client_linelist_exports_v1:
-    description: "Enable the experimental client side linelist export."
+    admin_manageable: true
+    description:
+      en: "Enable the experimental client side linelist export."
+      fr: "Activer l'exportation expérimentale de listes linéaires côté client."
     enable_in_development: false
+    name:
+      en: "Client-Side Linelist Exports"
+      fr: "Exportations de listes linéaires côté client"
   client_linelist_imports_v1:
-    description: "Enable the experimental client side linelist import."
+    admin_manageable: true
+    description:
+      en: "Enable the experimental client side linelist import."
+      fr: "Activer l'importation expérimentale de listes linéaires côté client."
     enable_in_development: false
+    name:
+      en: "Client-Side Linelist Imports"
+      fr: "Importations de listes linéaires côté client"
   compose_with_retry:
     description: "Exponentially backoff and retry failed compose operations. This\
       \ is intended to mitigate transient errors in the compose process."
     enable_in_development: true
   data_grid_samples_table:
-    description: "Enable the new data grid for the samples table."
+    admin_manageable: true
+    description:
+      en: "Enable the new data grid for the samples table."
+      fr: "Activer la nouvelle grille de données pour le tableau des échantillons."
     enable_in_development: false
+    name:
+      en: "Data Grid Samples Table"
+      fr: "Tableau de données des échantillons"
   integration_access_token_generation:
     description: "Allow users to generate access tokens for API access."
     enable_in_development: true
   sample_attachments_searching:
-    description: "Enable searching within the sample attachments table."
+    admin_manageable: true
+    description:
+      en: "Enable searching within the sample attachments table."
+      fr: "Activer la recherche dans le tableau des pièces jointes d'échantillons."
     enable_in_development: true
+    name:
+      en: "Sample Attachment Search"
+      fr: "Recherche de pièces jointes d'échantillons"
   samples_refresh_notice:
-    description: "Show a notice on the samples table when samples table is out of\
-      \ date due to additions, deletions, or updates."
+    admin_manageable: true
+    description:
+      en: "Show a notice on the samples table when samples table is out of date due\
+        \ to additions, deletions, or updates."
+      fr: "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
+        \ après un ajout, une suppression ou une modification."
     enable_in_development: true
+    name:
+      en: "Samples Refresh Notice"
+      fr: "Avis d'actualisation des échantillons"
   v2_dropdown:
-    description: "Enable the new v2 dropdown component in the UI."
+    admin_manageable: true
+    description:
+      en: "Enable the new v2 dropdown component in the UI."
+      fr: "Activer le nouveau composant de liste déroulante version 2 dans l'interface."
     enable_in_development: true
+    name:
+      en: "Version 2 Dropdown"
+      fr: "Liste déroulante version 2"
   v2_prefixed_select2:
-    description: "Enable the new v2 prefixed select2 component in the UI."
+    admin_manageable: true
+    description:
+      en: "Enable the new v2 prefixed select2 component in the UI."
+      fr: "Activer le nouveau composant de sélection préfixé version 2 dans l'interface."
+    name:
+      en: "Version 2 Prefixed Select"
+      fr: "Sélecteur préfixé version 2"
   v2_samplesheet:
-    description: "Enable the new v2 nextflow samplesheet display and submission process."
+    admin_manageable: true
+    description:
+      en: "Enable the new v2 nextflow samplesheet display and submission process."
+      fr: "Activer le nouvel affichage et le nouveau processus de soumission de la\
+        \ feuille d'échantillons Nextflow version 2."
     enable_in_development: true
+    name:
+      en: "Version 2 Samplesheet"
+      fr: "Feuille d'échantillons version 2"
   v2_select2:
-    description: "Enable the new v2 select2 component in the UI."
+    admin_manageable: true
+    description:
+      en: "Enable the new v2 select2 component in the UI."
+      fr: "Activer le nouveau composant de sélection version 2 dans l'interface."
     enable_in_development: true
+    name:
+      en: "Version 2 Select"
+      fr: "Sélecteur version 2"
   wes_extended_metadata:
     description: "Include additional metadata in WES submission, such as namespaceId\
       \ and samplesCount."
     enable_in_development: true
   workflow_execution_advanced_search:
-    description: "Enable the advanced search dialog for workflow executions."
+    admin_manageable: true
+    description:
+      en: "Enable the advanced search dialog for workflow executions."
+      fr: "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
+        \ flux de travail."
     enable_in_development: true
+    name:
+      en: "Workflow Execution Advanced Search"
+      fr: "Recherche avancée des exécutions de flux de travail"
   workflow_execution_attachments_searching:
-    description: "Enable searching within the workflow execution attachments table."
+    admin_manageable: true
+    description:
+      en: "Enable searching within the workflow execution attachments table."
+      fr: "Activer la recherche dans le tableau des pièces jointes des exécutions\
+        \ de flux de travail."
     enable_in_development: true
+    name:
+      en: "Workflow Execution Attachment Search"
+      fr: "Recherche de pièces jointes des exécutions de flux de travail"

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -14,7 +14,7 @@ Rails.application.reloader.to_prepare do # rubocop:disable Metrics/BlockLength
     config.confirm_disable = true
     config.confirm_fully_enable = true
     config.descriptions_source = lambda do |_keys|
-      FLIPPER_FEATURE_CONFIG['features'].transform_values { |value| value['description'] }
+      Irida::ExperimentalFeatureCatalog.descriptions
     end
   end
 

--- a/config/schemas/user_opt_in_features.json
+++ b/config/schemas/user_opt_in_features.json
@@ -4,7 +4,7 @@
   "patternProperties": {
     "^[a-z0-9_]+$": {
       "type": "object",
-      "required": ["allowlist", "name", "description"],
+      "required": ["allowlist"],
       "properties": {
         "allowlist": {
           "oneOf": [
@@ -14,22 +14,6 @@
               "items": { "type": "string", "minLength": 1 }
             }
           ]
-        },
-        "name": {
-          "type": "object",
-          "required": ["en"],
-          "properties": {
-            "en": { "type": "string", "minLength": 1 }
-          },
-          "additionalProperties": { "type": "string" }
-        },
-        "description": {
-          "type": "object",
-          "required": ["en"],
-          "properties": {
-            "en": { "type": "string", "minLength": 1 }
-          },
-          "additionalProperties": { "type": "string" }
         }
       },
       "additionalProperties": false

--- a/db/migrate/20260619150000_normalize_user_opt_in_feature_settings.rb
+++ b/db/migrate/20260619150000_normalize_user_opt_in_feature_settings.rb
@@ -26,6 +26,9 @@ class NormalizeUserOptInFeatureSettings < ActiveRecord::Migration[8.1]
 
   private
 
+  # Stricter than the runtime catalog (which falls back to English): before dropping the
+  # stored copy we require complete English and French replacements in config/features.yml
+  # so no display text is lost.
   def ensure_localized_catalog_entry!(feature_catalog, feature_key)
     config = feature_catalog[feature_key]
     return if localized_copy?(config&.fetch('name', nil)) && localized_copy?(config&.fetch('description', nil))

--- a/db/migrate/20260619150000_normalize_user_opt_in_feature_settings.rb
+++ b/db/migrate/20260619150000_normalize_user_opt_in_feature_settings.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Removes display copy from user opt-in settings after it moved to config/features.yml.
+class NormalizeUserOptInFeatureSettings < ActiveRecord::Migration[8.1]
+  # Migration-local model that bypasses the application model's evolving validations.
+  class ApplicationSettingRecord < ActiveRecord::Base
+    self.table_name = 'application_settings'
+  end
+
+  def up
+    feature_catalog = YAML.safe_load(Rails.root.join('config/features.yml').read).fetch('features')
+
+    ApplicationSettingRecord.find_each do |settings|
+      normalized_features = settings.user_opt_in_features.to_h.each_with_object({}) do |(feature_key, config), result|
+        ensure_localized_catalog_entry!(feature_catalog, feature_key)
+        result[feature_key] = { 'allowlist' => config.fetch('allowlist') }
+      end
+
+      settings.update!(user_opt_in_features: normalized_features)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'Feature display copy cannot be restored from application settings'
+  end
+
+  private
+
+  def ensure_localized_catalog_entry!(feature_catalog, feature_key)
+    config = feature_catalog[feature_key]
+    return if localized_copy?(config&.fetch('name', nil)) && localized_copy?(config&.fetch('description', nil))
+
+    message = "Feature #{feature_key.inspect} must define English and French name and description values"
+    raise ActiveRecord::MigrationError, "#{message} in config/features.yml"
+  end
+
+  def localized_copy?(value)
+    value.is_a?(Hash) && value.values_at('en', 'fr').all?(&:present?)
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -918,28 +918,8 @@ if Rails.env.development?
   # Seed default user opt-in features into ApplicationSetting
   app_setting = ApplicationSetting.current || ApplicationSetting.create_from_defaults
   default_opt_in_features = {
-    'data_grid_samples_table' => {
-      'allowlist' => 'all',
-      'name' => {
-        'en' => 'Data Grid Samples Table',
-        'fr' => 'Tableau de données des échantillons'
-      },
-      'description' => {
-        'en' => 'Enable the new data grid for the samples table.',
-        'fr' => "Activer la nouvelle grille de données pour le tableau d'échantillons."
-      }
-    },
-    'client_linelist_exports_v1' => {
-      'allowlist' => ['user1@email.com'],
-      'name' => {
-        'en' => 'Client Linelist Exports',
-        'fr' => 'Exports de listes de clients'
-      },
-      'description' => {
-        'en' => 'Enable the new client linelist exports feature.',
-        'fr' => "Activer la nouvelle fonctionnalité d'exports de listes de clients."
-      }
-    }
+    'data_grid_samples_table' => { 'allowlist' => 'all' },
+    'client_linelist_exports_v1' => { 'allowlist' => ['user1@email.com'] }
   }
   app_setting.update!(
     user_opt_in_features: default_opt_in_features.merge(app_setting.user_opt_in_features)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2192,6 +2192,7 @@ ALTER TABLE ONLY public.workflow_executions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260619150000'),
 ('20260616131525'),
 ('20260424121251'),
 ('20260421182359'),

--- a/lib/irida/experimental_feature_catalog.rb
+++ b/lib/irida/experimental_feature_catalog.rb
@@ -27,7 +27,7 @@ module Irida
       end
 
       def descriptions(locale: I18n.locale)
-        entries(locale: locale).to_h { |feature| [feature[:key], feature[:description]] }
+        feature_config.transform_values { |config| localized_value(config['description'], locale) }
       end
 
       private

--- a/lib/irida/experimental_feature_catalog.rb
+++ b/lib/irida/experimental_feature_catalog.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Irida
+  # Read-only interface for feature metadata declared in config/features.yml.
+  module ExperimentalFeatureCatalog
+    class << self
+      def entries(locale: I18n.locale)
+        feature_config.map do |key, config|
+          entry(key, config, locale)
+        end
+      end
+
+      def admin_entries(locale: I18n.locale)
+        entries(locale: locale).select { |feature| feature[:admin_manageable] }
+      end
+
+      def fetch(feature_key, locale: I18n.locale)
+        normalized_key = feature_key.to_s
+        config = feature_config[normalized_key]
+        return if config.nil?
+
+        entry(normalized_key, config, locale)
+      end
+
+      def available?(feature_key)
+        feature_config.key?(feature_key.to_s)
+      end
+
+      def descriptions(locale: I18n.locale)
+        entries(locale: locale).to_h { |feature| [feature[:key], feature[:description]] }
+      end
+
+      private
+
+      def feature_config
+        FLIPPER_FEATURE_CONFIG.fetch('features')
+      end
+
+      def entry(key, config, locale)
+        {
+          key: key,
+          name: localized_value(config['name'], locale),
+          description: localized_value(config['description'], locale),
+          admin_manageable: config['admin_manageable'] == true
+        }
+      end
+
+      def localized_value(value, locale)
+        return value unless value.is_a?(Hash)
+
+        value[locale.to_s].presence || value['en']
+      end
+    end
+  end
+end

--- a/test/lib/irida/experimental_feature_catalog_test.rb
+++ b/test/lib/irida/experimental_feature_catalog_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Irida
+  class ExperimentalFeatureCatalogTest < ActiveSupport::TestCase
+    test 'returns admin-manageable features in configuration order' do
+      entries = ExperimentalFeatureCatalog.admin_entries
+
+      assert_equal %w[
+        advanced_search_with_auto_complete
+        cancel_multiple_workflows
+        client_linelist_exports_v1
+        client_linelist_imports_v1
+        data_grid_samples_table
+        sample_attachments_searching
+        samples_refresh_notice
+        v2_dropdown
+        v2_prefixed_select2
+        v2_samplesheet
+        v2_select2
+        workflow_execution_advanced_search
+        workflow_execution_attachments_searching
+      ], entries.pluck(:key)
+    end
+
+    test 'excludes operational features from admin entries' do
+      keys = ExperimentalFeatureCatalog.admin_entries.pluck(:key)
+
+      assert_not_includes keys, 'compose_with_retry'
+      assert_not_includes keys, 'integration_access_token_generation'
+      assert_not_includes keys, 'wes_extended_metadata'
+    end
+
+    test 'returns localized names and descriptions with english fallback' do
+      I18n.with_locale(:fr) do
+        entry = ExperimentalFeatureCatalog.fetch(:data_grid_samples_table)
+
+        assert_equal 'Tableau de données des échantillons', entry[:name]
+        assert_equal 'Activer la nouvelle grille de données pour le tableau des échantillons.', entry[:description]
+      end
+
+      entry = ExperimentalFeatureCatalog.fetch(:data_grid_samples_table, locale: :es)
+
+      assert_equal 'Data Grid Samples Table', entry[:name]
+      assert_equal 'Enable the new data grid for the samples table.', entry[:description]
+    end
+
+    test 'admin-manageable features have complete english and french copy' do
+      configured_features = FLIPPER_FEATURE_CONFIG.fetch('features')
+
+      configured_features.each do |key, config|
+        next unless config['admin_manageable']
+
+        assert config.dig('name', 'en').present?, "#{key} is missing an English name"
+        assert config.dig('name', 'fr').present?, "#{key} is missing a French name"
+        assert config.dig('description', 'en').present?, "#{key} is missing an English description"
+        assert config.dig('description', 'fr').present?, "#{key} is missing a French description"
+      end
+    end
+
+    test 'returns nil for unknown features' do
+      assert_nil ExperimentalFeatureCatalog.fetch(:unknown_feature)
+    end
+  end
+end

--- a/test/migrations/normalize_user_opt_in_feature_settings_test.rb
+++ b/test/migrations/normalize_user_opt_in_feature_settings_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require Rails.root.join('db/migrate/20260619150000_normalize_user_opt_in_feature_settings')
+
+class NormalizeUserOptInFeatureSettingsTest < ActiveSupport::TestCase
+  setup do
+    ApplicationSetting.delete_all
+    @settings = ApplicationSetting.create_from_defaults
+  end
+
+  test 'retains feature keys and allowlists while removing display copy' do
+    migration_settings.update!(
+      user_opt_in_features: {
+        'data_grid_samples_table' => {
+          'allowlist' => ['USER@example.com'],
+          'name' => { 'en' => 'Legacy name' },
+          'description' => { 'en' => 'Legacy description' }
+        }
+      }
+    )
+
+    NormalizeUserOptInFeatureSettings.new.up
+
+    assert_equal(
+      { 'data_grid_samples_table' => { 'allowlist' => ['USER@example.com'] } },
+      @settings.reload.user_opt_in_features
+    )
+  end
+
+  test 'fails when a configured opt-in feature has no localized catalog entry' do
+    migration_settings.update!(
+      user_opt_in_features: { 'unknown_experiment' => { 'allowlist' => 'all' } }
+    )
+
+    error = assert_raises(ActiveRecord::MigrationError) do
+      NormalizeUserOptInFeatureSettings.new.up
+    end
+
+    assert_includes error.message, 'unknown_experiment'
+  end
+
+  private
+
+  def migration_settings
+    NormalizeUserOptInFeatureSettings::ApplicationSettingRecord.find(@settings.id)
+  end
+end

--- a/test/models/application_setting_test.rb
+++ b/test/models/application_setting_test.rb
@@ -83,9 +83,7 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     settings = ApplicationSetting.build_from_defaults(
       user_opt_in_features: {
         'data_grid_samples_table' => {
-          'allowlist' => ['john_doe@email.com'],
-          'name' => { 'en' => 'Data Grid Samples Table' },
-          'description' => { 'en' => 'Enable the new data grid for the samples table.' }
+          'allowlist' => ['john_doe@email.com']
         }
       }
     )
@@ -97,9 +95,7 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     settings = ApplicationSetting.build_from_defaults(
       user_opt_in_features: {
         'data_grid_samples_table' => {
-          'allowlist' => 'all',
-          'name' => { 'en' => 'Data Grid Samples Table' },
-          'description' => { 'en' => 'Enable the new data grid for the samples table.' }
+          'allowlist' => 'all'
         }
       }
     )
@@ -111,9 +107,7 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     settings = ApplicationSetting.build_from_defaults(
       user_opt_in_features: {
         'InvalidKey' => {
-          'allowlist' => 'all',
-          'name' => { 'en' => 'Feature' },
-          'description' => { 'en' => 'Description' }
+          'allowlist' => 'all'
         }
       }
     )
@@ -126,9 +120,7 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     settings = ApplicationSetting.build_from_defaults(
       user_opt_in_features: {
         'data_grid_samples_table' => {
-          'allowlist' => '',
-          'name' => { 'en' => 'Data Grid Samples Table' },
-          'description' => { 'en' => 'Enable the new data grid for the samples table.' }
+          'allowlist' => ''
         }
       }
     )
@@ -138,13 +130,12 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     assert_includes error_text, '/data_grid_samples_table/allowlist'
   end
 
-  test 'user_opt_in_features requires english fallback translations' do
+  test 'user_opt_in_features rejects display copy stored with eligibility' do
     settings = ApplicationSetting.build_from_defaults(
       user_opt_in_features: {
         'data_grid_samples_table' => {
           'allowlist' => 'all',
-          'name' => { 'fr' => 'Tableau de donnees des echantillons' },
-          'description' => { 'fr' => 'Activer la nouvelle grille.' }
+          'name' => { 'en' => 'Data Grid Samples Table' }
         }
       }
     )
@@ -152,8 +143,6 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     assert_not settings.valid?
     error_text = settings.errors[:user_opt_in_features].join(' ')
     assert_includes error_text, '/data_grid_samples_table/name'
-    assert_includes error_text, '/data_grid_samples_table/description'
-    assert_includes error_text, 'en'
   end
 
   test '#require_personal_access_token_expiry? returns the value of require_personal_access_token_expiry' do
@@ -228,8 +217,8 @@ class ApplicationSettingTest < ActiveSupport::TestCase
     I18n.with_locale(:fr) do
       feature = settings.eligible_user_opt_in_features(user).first
 
-      assert_equal 'Tableau de donnees des echantillons', feature[:name]
-      assert_equal "Activer la nouvelle grille de donnees pour le tableau d'echantillons.",
+      assert_equal 'Tableau de données des échantillons', feature[:name]
+      assert_equal 'Activer la nouvelle grille de données pour le tableau des échantillons.',
                    feature[:description]
     end
   end

--- a/test/test_helpers/user_opt_in_features_test_helper.rb
+++ b/test/test_helpers/user_opt_in_features_test_helper.rb
@@ -15,15 +15,7 @@ module UserOptInFeaturesTestHelper
   def user_opt_in_feature_config(feature_key: :data_grid_samples_table, allowlist: 'all')
     {
       feature_key.to_s => {
-        'allowlist' => allowlist,
-        'name' => {
-          'en' => 'Data Grid Samples Table',
-          'fr' => 'Tableau de donnees des echantillons'
-        },
-        'description' => {
-          'en' => 'Enable the new data grid for the samples table.',
-          'fr' => "Activer la nouvelle grille de donnees pour le tableau d'echantillons."
-        }
+        'allowlist' => allowlist
       }
     }
   end


### PR DESCRIPTION
## What does this PR do and why?
- Centralizes admin-managed experimental features.
- Normalizes `user_opt_in_features` to an allowlist-only with migration and schema updates to simplify eligibility handling.

## Screenshots or screen recordings
- N/A (no UI changes).

## How to set up and validate locally
- N/A all internal code

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.


Closes #2008
