### PR TITLE
fix(pagy): retain focus and label-in-name compliance

### DIFF
--- a/app/components/viral/pagy/pagination_component.html.erb
+++ b/app/components/viral/pagy/pagination_component.html.erb
@@ -1,6 +1,9 @@
 <%= tag.nav(
   class: "pagy nav flex-none",
-  aria: { label: t("components.viral.pagy.pagination_component.aria_label") },
+  aria: {
+    label: t("components.viral.pagy.pagination_component.aria_label"),
+    live: "polite",
+  },
 ) do %>
   <%# Large screen layout with numbered buttons %>
   <%= tag.ul(class: "@max-lg:hidden @lg:inline-flex h-11 -space-x-px text-base") do %>
@@ -44,6 +47,7 @@
           <%= tag.a(
             item,
             href: @pagy.page_url(item.to_i),
+            autofocus: @autofocus_link,
             aria: { current: "page" },
             class:
               "flex items-center relative focus-visible:z-10 justify-center px-4 h-11 ms-0 leading-tight border border-primary-600 bg-primary-600 text-white dark:border-primary-600 dark:text-white font-medium text-sm cursor-default",

--- a/app/components/viral/pagy/pagination_component.rb
+++ b/app/components/viral/pagy/pagination_component.rb
@@ -6,12 +6,17 @@ module Viral
   module Pagy
     # Pagy pagination component
     class PaginationComponent < Viral::Component
-      def initialize(pagy)
+      def initialize(pagy, autofocus_link: nil)
         @pagy = pagy
+        @autofocus_link = autofocus_link
       end
 
       def render?
         @pagy.next || @pagy.previous
+      end
+
+      def before_render
+        @autofocus_link = helpers.request&.query_parameters&.key?('page') || false if @autofocus_link.nil?
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   around_action :set_current_user
   around_action :use_logidze_responsible, only: %i[create destroy update transfer] # rubocop:disable Rails/LexicallyScopedActionFilter
   around_action :switch_locale
+  before_action :set_pagy_locale
 
   helper IconHelper
   helper_method :error_message
@@ -84,5 +85,9 @@ class ApplicationController < ActionController::Base
   # Rescues from Pagy::RangeError by redirecting to the first page
   def redirect_to_first_page
     redirect_to url_for(page: 1, limit: params[:limit] || 20)
+  end
+
+  def set_pagy_locale
+    Pagy::I18n.locale = params[:locale] || I18n.locale
   end
 end

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -27,8 +27,8 @@ en:
           title: Imported Samples
         pagination:
           aria_label: Pagination
-          at_first_aria_label: You are on the first page
-          at_last_aria_label: You are on the last page
+          at_first_aria_label: Previous, you are on the first page
+          at_last_aria_label: Next, you are on the last page
           next: Next
           next_aria_label: Go to next page
           previous: Previous

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -27,12 +27,12 @@ fr:
           title: Échantillons importés
         pagination:
           aria_label: Pagination
-          at_first_aria_label: Vous êtes sur la première page.
-          at_last_aria_label: Vous êtes sur la dernière page.
+          at_first_aria_label: Précédent, vous êtes sur la première page
+          at_last_aria_label: Suivant, vous êtes sur la dernière page
           next: Suivant
-          next_aria_label: Passer à la page suivant
+          next_aria_label: Suivant, passer à la page suivante
           previous: Précédent
-          previous_aria_label: Aller à la page précédente.
+          previous_aria_label: Précédent, aller à la page précédente
         sample_clone:
           copied_from: Copiés de
           copied_to: Copiés à
@@ -424,10 +424,10 @@ fr:
           current_page_aria_label: Page actuelle %{number}
           item_aria_label: Aller à la page %{number}
           next: Suivant
-          next_aria_label: Passer à la prochaine page.
+          next_aria_label: Suivant, passer à la page suivante
           page_number: Page %{number}
           previous: Précédent
-          previous_aria_label: Aller à la page précédente.
+          previous_aria_label: Précédent, aller à la page précédente
           select_page_aria_label: Sélectionner la page
     workflow_executions:
       table_component:

--- a/test/components/previews/viral_pagy_pagination_component_preview.rb
+++ b/test/components/previews/viral_pagy_pagination_component_preview.rb
@@ -18,4 +18,10 @@ class ViralPagyPaginationComponentPreview < ViewComponent::Preview
                             request: Pagy::Request.new(request: { base_url: 'localhost:3000', path: '/', params: {} }))
     render(Viral::Pagy::PaginationComponent.new(pagy))
   end
+
+  def autofocus
+    pagy = Pagy::Offset.new(count: 1000, page: 5,
+                            request: Pagy::Request.new(request: { base_url: 'localhost:3000', path: '/', params: {} }))
+    render(Viral::Pagy::PaginationComponent.new(pagy, autofocus_link: true))
+  end
 end

--- a/test/components/viral/pagy_pagination_component_preview_test.rb
+++ b/test/components/viral/pagy_pagination_component_preview_test.rb
@@ -7,11 +7,12 @@ module Viral
     test 'renders default' do
       render_preview(:default)
 
-      assert_selector 'nav.pagy.nav'
+      assert_selector 'nav.pagy.nav[aria-live="polite"]'
       assert_selector 'li span.cursor-not-allowed', text: I18n.t('components.viral.pagy.pagination_component.previous')
       assert_selector 'li > a', text: I18n.t('components.viral.pagy.pagination_component.next')
       assert_selector 'li a[aria-current="page"]', text: '1', count: 1
       assert_selector 'li > a:not([aria-disabled="true"])', count: 6
+      assert_no_selector 'a[aria-current="page"][autofocus]'
     end
 
     test 'does not render when only one page' do
@@ -29,6 +30,13 @@ module Viral
       assert_selector 'li a[aria-current="page"]', text: '5', count: 1
       assert_selector 'li > a:not([aria-disabled="true"])', count: 7
       assert_selector 'li span.cursor-default', text: '...', count: 2
+    end
+
+    test 'renders autofocus when enabled' do
+      render_preview(:autofocus)
+
+      assert_selector 'li a[aria-current="page"][autofocus]', text: '5', count: 1
+      assert_no_selector 'select[autofocus]'
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
- Retains keyboard/screen-reader focus on the active pagination control after page changes.
- Fixes pagination label-in-name accessibility by aligning English/French accessible names with visible Previous/Next labels.

## Screenshots or screen recordings
- N/A (focus-management and accessible-name text updates only).

## How to set up and validate locally
1. `git checkout fix/pagy-pagination-focus`
2. `bin/bundle exec i18n-tasks health`
3. `PARALLEL_WORKERS=4 bin/test test/components/viral/pagy_pagination_component_preview_test.rb`
4. Open a paginated view and activate page navigation; verify focus remains on the current page control and French/English previous/next controls announce names that include visible labels.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.