### PR TITLE
Chore(deps): Bump concurrent-ruby and nokogiri versions in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 2.4, < 4)
     cgi (0.5.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
@@ -463,9 +463,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.24)
       anonymous_loader (~> 0.1, >= 0.1.1)


### PR DESCRIPTION
## What does this PR do and why?
- Bumps `concurrent-ruby` to 1.3.7 and `nokogiri` to 1.19.4 in `Gemfile.lock` to clear `bundler-audit` findings and unblock the `scan_ruby` CI job.

## Screenshots or screen recordings
- N/A (dependency-only change; no UI impact)

## How to set up and validate locally
1. Check out this branch and run `bundle install`.
2. Run `bin/bundler-audit` and confirm it reports no vulnerabilities.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.