### PR TITLE
feat(active-admin): System users can administrate site banners

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -73,6 +73,9 @@ linter:
       enabled: true
     html-no-block-inside-inline:
       enabled: true
+      # ActiveAdmin icon buttons use inline <svg>; Herb treats unknown <svg> as block.
+      exclude:
+        - "app/views/active_admin/**"
     html-no-space-in-tag:
       enabled: true
     html-no-title-attribute:

--- a/app/admin/site_banners.rb
+++ b/app/admin/site_banners.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
+  permit_params :enabled, :style, messages: I18n.available_locales.map(&:to_sym)
+
+  filter :enabled
+  filter :style, as: :select, collection: SiteBanner.styles.keys
+  filter :created_at
+  filter :updated_at
+
+  index do
+    selectable_column
+    id_column
+    column :enabled
+    column :style
+    I18n.available_locales.each do |locale|
+      column "Message (#{locale})" do |site_banner|
+        truncate(site_banner.messages[locale.to_s].to_s, length: 80)
+      end
+    end
+    column :created_at
+    column :updated_at
+    actions do |site_banner|
+      if site_banner.enabled?
+        item I18n.t('active_admin.site_banners.disable'),
+             disable_admin_site_banner_path(site_banner),
+             method: :patch,
+             data: { confirm: I18n.t('active_admin.site_banners.disable_confirm') }
+      else
+        item I18n.t('active_admin.site_banners.enable'),
+             enable_admin_site_banner_path(site_banner),
+             method: :patch,
+             data: { confirm: I18n.t('active_admin.site_banners.enable_confirm') }
+      end
+    end
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :enabled
+      row :style
+      I18n.available_locales.each do |locale|
+        row "Message (#{locale})" do |site_banner|
+          site_banner.messages[locale.to_s]
+        end
+      end
+      row :created_at
+      row :updated_at
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+
+    f.inputs do
+      f.input :enabled
+      f.input :style, as: :select, collection: SiteBanner.styles.keys
+    end
+
+    f.inputs 'Messages' do
+      I18n.available_locales.each do |locale|
+        f.input :messages,
+                as: :text,
+                label: "Message (#{locale})",
+                input_html: {
+                  id: "site_banner_message_#{locale}",
+                  name: "site_banner[messages][#{locale}]",
+                  rows: 3,
+                  value: f.object.messages[locale.to_s]
+                }
+      end
+    end
+
+    f.actions
+  end
+
+  member_action :disable, method: :patch do
+    resource.update!(enabled: false)
+
+    redirect_to resource_path(resource), notice: I18n.t('active_admin.site_banners.disabled')
+  end
+
+  member_action :enable, method: :patch do
+    if resource.update(enabled: true)
+      redirect_to resource_path(resource), notice: I18n.t('active_admin.site_banners.enabled')
+    else
+      redirect_to resource_path(resource), alert: resource.errors.full_messages.to_sentence
+    end
+  end
+
+  action_item :disable, only: :show, if: proc { resource.enabled? } do
+    link_to I18n.t('active_admin.site_banners.disable'),
+            disable_admin_site_banner_path(resource),
+            class: 'action-item-button',
+            method: :patch,
+            data: { confirm: I18n.t('active_admin.site_banners.disable_confirm') }
+  end
+
+  action_item :enable, only: :show, if: proc { !resource.enabled? } do
+    link_to I18n.t('active_admin.site_banners.enable'),
+            enable_admin_site_banner_path(resource),
+            class: 'action-item-button',
+            method: :patch,
+            data: { confirm: I18n.t('active_admin.site_banners.enable_confirm') }
+  end
+end

--- a/app/admin/site_banners.rb
+++ b/app/admin/site_banners.rb
@@ -22,7 +22,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
     column :updated_at
     actions do |site_banner|
       action = toggle_action_for(site_banner)
-      item action[:label], action[:path], method: :patch, data: { confirm: action[:confirm] }
+      item action[:label], action[:path], method: :patch, data: { turbo_confirm: action[:confirm] }
     end
   end
 
@@ -88,7 +88,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
             action[:path],
             class: 'action-item-button',
             method: :patch,
-            data: { confirm: action[:confirm] }
+            data: { turbo_confirm: action[:confirm] }
   end
 
   action_item :enable, only: :show, if: proc { !resource.enabled? } do
@@ -98,7 +98,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
             action[:path],
             class: 'action-item-button',
             method: :patch,
-            data: { confirm: action[:confirm] }
+            data: { turbo_confirm: action[:confirm] }
   end
 
   controller do

--- a/app/admin/site_banners.rb
+++ b/app/admin/site_banners.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
     column :enabled
     column :style
     I18n.available_locales.each do |locale|
-      column "Message (#{locale})" do |site_banner|
+      column I18n.t('active_admin.site_banners.message_for', locale_code: locale) do |site_banner|
         truncate(site_banner.messages[locale.to_s].to_s, length: 80)
       end
     end
@@ -41,7 +41,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
       row :enabled
       row :style
       I18n.available_locales.each do |locale|
-        row "Message (#{locale})" do |site_banner|
+        row I18n.t('active_admin.site_banners.message_for', locale_code: locale) do |site_banner|
           site_banner.messages[locale.to_s]
         end
       end
@@ -58,11 +58,12 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
       f.input :style, as: :select, collection: SiteBanner.styles.keys
     end
 
-    f.inputs 'Messages' do
+    f.inputs I18n.t('active_admin.site_banners.messages_fieldset') do
       I18n.available_locales.each do |locale|
         f.input :messages,
                 as: :text,
-                label: "Message (#{locale})",
+                label: I18n.t('active_admin.site_banners.message_for', locale_code: locale),
+                wrapper_html: { id: "site_banner_message_#{locale}_input" },
                 input_html: {
                   id: "site_banner_message_#{locale}",
                   name: "site_banner[messages][#{locale}]",

--- a/app/admin/site_banners.rb
+++ b/app/admin/site_banners.rb
@@ -21,17 +21,8 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
     column :created_at
     column :updated_at
     actions do |site_banner|
-      if site_banner.enabled?
-        item I18n.t('active_admin.site_banners.disable'),
-             disable_admin_site_banner_path(site_banner),
-             method: :patch,
-             data: { confirm: I18n.t('active_admin.site_banners.disable_confirm') }
-      else
-        item I18n.t('active_admin.site_banners.enable'),
-             enable_admin_site_banner_path(site_banner),
-             method: :patch,
-             data: { confirm: I18n.t('active_admin.site_banners.enable_confirm') }
-      end
+      action = toggle_action_for(site_banner)
+      item action[:label], action[:path], method: :patch, data: { confirm: action[:confirm] }
     end
   end
 
@@ -91,18 +82,42 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
   end
 
   action_item :disable, only: :show, if: proc { resource.enabled? } do
-    link_to I18n.t('active_admin.site_banners.disable'),
-            disable_admin_site_banner_path(resource),
+    action = toggle_action_for(resource)
+
+    link_to action[:label],
+            action[:path],
             class: 'action-item-button',
             method: :patch,
-            data: { confirm: I18n.t('active_admin.site_banners.disable_confirm') }
+            data: { confirm: action[:confirm] }
   end
 
   action_item :enable, only: :show, if: proc { !resource.enabled? } do
-    link_to I18n.t('active_admin.site_banners.enable'),
-            enable_admin_site_banner_path(resource),
+    action = toggle_action_for(resource)
+
+    link_to action[:label],
+            action[:path],
             class: 'action-item-button',
             method: :patch,
-            data: { confirm: I18n.t('active_admin.site_banners.enable_confirm') }
+            data: { confirm: action[:confirm] }
+  end
+
+  controller do
+    helper_method :toggle_action_for
+
+    def toggle_action_for(site_banner)
+      if site_banner.enabled?
+        {
+          label: I18n.t('active_admin.site_banners.disable'),
+          path: disable_admin_site_banner_path(site_banner),
+          confirm: I18n.t('active_admin.site_banners.disable_confirm')
+        }
+      else
+        {
+          label: I18n.t('active_admin.site_banners.enable'),
+          path: enable_admin_site_banner_path(site_banner),
+          confirm: I18n.t('active_admin.site_banners.enable_confirm')
+        }
+      end
+    end
   end
 end

--- a/app/admin/site_banners.rb
+++ b/app/admin/site_banners.rb
@@ -22,7 +22,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
     column :updated_at
     actions do |site_banner|
       action = toggle_action_for(site_banner)
-      item action[:label], action[:path], method: :patch, data: { turbo_confirm: action[:confirm] }
+      item action[:label], action[:path], method: :patch, data: { confirm: action[:confirm] }
     end
   end
 
@@ -88,7 +88,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
             action[:path],
             class: 'action-item-button',
             method: :patch,
-            data: { turbo_confirm: action[:confirm] }
+            data: { confirm: action[:confirm] }
   end
 
   action_item :enable, only: :show, if: proc { !resource.enabled? } do
@@ -98,7 +98,7 @@ ActiveAdmin.register SiteBanner do # rubocop:disable Metrics/BlockLength
             action[:path],
             class: 'action-item-button',
             method: :patch,
-            data: { turbo_confirm: action[:confirm] }
+            data: { confirm: action[:confirm] }
   end
 
   controller do

--- a/app/assets/stylesheets/active_admin.tailwind.css
+++ b/app/assets/stylesheets/active_admin.tailwind.css
@@ -6,3 +6,22 @@
 @plugin "@tailwindcss/forms";
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+/*
+  Pathogen's check_box_tag helper adds utility classes such as `bg-white` /
+  `!border-neutral-*`. Those utilities sit above ActiveAdmin's base-layer
+  `:checked` styles, so checked boxes look identical to unchecked ones.
+  Unlayered rules restore a visible checked state for admin forms.
+*/
+input[type="checkbox"]:checked {
+  background-color: var(--color-blue-600);
+  border-color: transparent !important;
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+}
+
+input[type="checkbox"]:checked:where(.dark, .dark *) {
+  background-color: var(--color-blue-500);
+}

--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -14,6 +14,14 @@ class SiteBanner < ApplicationRecord
   scope :enabled, -> { where(enabled: true) }
   attribute :enabled, :boolean, default: true
 
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at enabled id messages style updated_at]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[]
+  end
+
   validates :singleton_guard, inclusion: { in: [SINGLETON_GUARD] }
   validate :all_locale_messages_present, if: :enabled?
 

--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -15,7 +15,7 @@ class SiteBanner < ApplicationRecord
   attribute :enabled, :boolean, default: true
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[created_at enabled id messages style updated_at]
+    %w[created_at enabled id style updated_at]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -26,7 +26,7 @@ class SiteBanner < ApplicationRecord
   validate :all_locale_messages_present, if: :enabled?
 
   before_validation :set_singleton_guard
-  before_save :disable_other_enabled_notifications, if: :enabled?
+  before_save :disable_other_enabled_banners, if: :enabled?
 
   def self.current
     enabled.order(updated_at: :desc, id: :desc).first
@@ -46,14 +46,16 @@ class SiteBanner < ApplicationRecord
     missing = I18n.available_locales.select { |locale| messages[locale.to_s].blank? }
     return if missing.empty?
 
-    missing.each { |locale| errors.add(:messages, "must include a message for #{locale}") }
+    missing.each { |locale| errors.add(:messages, :missing_locale_message, locale_code: locale) }
   end
 
   def set_singleton_guard
     self.singleton_guard = SINGLETON_GUARD
   end
 
-  def disable_other_enabled_notifications
+  def disable_other_enabled_banners
+    # Serialize banner enable transitions so the unique partial index is not hit under concurrent writes.
+    self.class.connection.execute("LOCK TABLE #{self.class.quoted_table_name} IN SHARE ROW EXCLUSIVE MODE")
     self.class.enabled.where.not(id: id).update_all(enabled: false, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -26,7 +26,7 @@ class SiteBanner < ApplicationRecord
   validate :all_locale_messages_present, if: :enabled?
 
   before_validation :set_singleton_guard
-  before_save :disable_other_enabled_banners, if: :enabled?
+  before_save :disable_other_enabled_banners, if: :enabling?
 
   def self.current
     enabled.order(updated_at: :desc, id: :desc).first
@@ -51,6 +51,10 @@ class SiteBanner < ApplicationRecord
 
   def set_singleton_guard
     self.singleton_guard = SINGLETON_GUARD
+  end
+
+  def enabling?
+    enabled? && (new_record? || will_save_change_to_enabled?)
   end
 
   def disable_other_enabled_banners

--- a/app/views/active_admin/_main_navigation.html.erb
+++ b/app/views/active_admin/_main_navigation.html.erb
@@ -1,0 +1,95 @@
+<%# Override ActiveAdmin 4.0.0.beta22 to avoid rendering false as an HTML attribute. %>
+<div
+  id="main-menu"
+  class="
+    fixed inset-s-0 top-0 bottom-0 z-40 w-72 -translate-x-full overflow-y-auto bg-white p-4 transition-transform
+    duration-200 xl:top-16 xl:w-60 xl:translate-x-0 xl:border-e xl:border-gray-200 dark:bg-gray-950
+    xl:dark:border-white/10
+  "
+  tabindex="-1"
+>
+  <ul role="list" class="flex flex-1 flex-col space-y-1.5">
+    <% current_menu.items(self).each do |item| %>
+      <% children = item.items(self).presence %>
+      <% url = item.url(self) %>
+
+      <% label = capture do %>
+        <% if url.present? %>
+          <%= link_to item.label(self), url, item.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white flex items-center w-full rounded-md p-2 gap-x-2 text-sm no-underline #{(current_menu_item?(item, children: false) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
+        <% else %>
+          <%= item.label(self) %>
+        <% end %>
+      <% end %>
+
+      <li <%= "data-open" if current_menu_item?(item) %> class="group" data-item-id="<%= item.id %>">
+        <% if children %>
+          <% if url.present? && url == "#" %>
+            <button
+              data-menu-button
+              class="
+                flex w-full items-center gap-x-2 rounded-md p-2 text-sm text-gray-600 hover:text-gray-900
+                dark:text-gray-400 dark:hover:text-white
+              "
+              aria-label="<%= t('active_admin.toggle_section') %>"
+            >
+              <%= item.label(self) %>
+
+              <svg
+                class="ms-auto h-5 w-5 shrink-0 group-data-open:rotate-90 rtl:-scale-x-100 group-data-open:rtl:-rotate-90"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </button>
+          <% elsif url.present? && url != "#" %>
+            <div data-parent-id="<%= item.id %>" data-menu-button class="flex">
+              <%= label %>
+
+              <button
+                class="
+                  flex items-center p-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400
+                  dark:hover:text-white
+                "
+                aria-label="<%= t('active_admin.toggle_section') %>"
+              >
+                <svg
+                  class="
+                    ms-auto h-5 w-5 shrink-0 group-data-open:rotate-90 rtl:-scale-x-100
+                    group-data-open:rtl:-rotate-90
+                  "
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+          <% end %>
+          <ul
+            role="list"
+            class="ms-1 mt-1 hidden space-y-1 border-s-2 border-gray-100 ps-2 group-data-open:block dark:border-white/5"
+          >
+            <% children.each do |j| %>
+              <li data-item-id="<%= j.id %>">
+                <%= link_to j.label(self), j.url(self), j.html_options.merge(class: "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white block rounded-md py-1.5 px-2 text-sm no-underline #{(current_menu_item?(j) ? "bg-gray-100 dark:bg-white/5 text-gray-900 dark:text-white selected" : "")}") %>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <%= label %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/active_admin/_main_navigation.html.erb
+++ b/app/views/active_admin/_main_navigation.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <%# Override ActiveAdmin 4.0.0.beta22 to avoid rendering false as an HTML attribute. %>
 <div
   id="main-menu"
@@ -21,10 +23,14 @@
         <% end %>
       <% end %>
 
-      <li <%= "data-open" if current_menu_item?(item) %> class="group" data-item-id="<%= item.id %>">
+      <%= tag.li(
+            class: "group",
+            data: { item_id: item.id, open: (true if current_menu_item?(item)) }
+          ) do %>
         <% if children %>
           <% if url.present? && url == "#" %>
             <button
+              type="button"
               data-menu-button
               class="
                 flex w-full items-center gap-x-2 rounded-md p-2 text-sm text-gray-600 hover:text-gray-900
@@ -52,6 +58,7 @@
               <%= label %>
 
               <button
+                type="button"
                 class="
                   flex items-center p-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400
                   dark:hover:text-white
@@ -89,7 +96,7 @@
         <% else %>
           <%= label %>
         <% end %>
-      </li>
+      <% end %>
     <% end %>
   </ul>
 </div>

--- a/app/views/active_admin/_site_header.html.erb
+++ b/app/views/active_admin/_site_header.html.erb
@@ -1,0 +1,122 @@
+<%# Override ActiveAdmin 4.0.0.beta22 so the user menu's accessible name is attached to its semantic list. %>
+<div
+  class="
+    fixed top-0 z-20 flex h-16 w-full items-center border-b border-gray-200 px-4 py-2 backdrop-blur-md
+    dark:border-white/10 dark:bg-gray-950/75
+  "
+>
+  <button
+    class="
+      focus-visible:ring-ring inline-flex h-8 w-8 items-center justify-center pe-3 text-sm text-gray-500
+      focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-hidden
+      xl:hidden dark:text-gray-400
+    "
+    data-drawer-target="main-menu"
+    data-drawer-show="main-menu"
+    aria-controls="main-menu"
+    aria-label="<%= t('active_admin.toggle_main_navigation_menu') %>"
+  >
+    <svg
+      class="h-5 w-5 text-gray-800 dark:text-white"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 17 14"
+    >
+      <path
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M1 1h15M1 7h15M1 13h15"
+      />
+    </svg>
+  </button>
+
+  <div class="grow">
+    <h1 data-test-site-title class="text-lg font-semibold">
+      <%= title %>
+    </h1>
+  </div>
+
+  <button
+    type="button"
+    class="
+      dark-mode-toggle me-1 flex h-9 w-9 items-center justify-center text-sm text-gray-400 hover:text-gray-500
+      focus:outline-hidden dark:text-gray-500 dark:hover:text-gray-400
+    "
+    aria-label="<%= t('active_admin.toggle_dark_mode') %>"
+  >
+    <svg
+      class="hidden h-5 w-5 rtl:-scale-x-100 dark:block"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 18 20"
+    >
+      <path
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M8.509 5.75c0-1.493.394-2.96 1.144-4.25h-.081a8.5 8.5 0 1 0 7.356 12.746A8.5 8.5 0 0 1 8.509 5.75Z"
+      />
+    </svg>
+
+    <svg
+      class="h-5 w-5 dark:hidden"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 20 20"
+    >
+      <path
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M10 3V1m0 18v-2M5.05 5.05 3.636 3.636m12.728 12.728L14.95 14.95M3 10H1m18 0h-2M5.05 14.95l-1.414 1.414M16.364 3.636 14.95 5.05M14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"
+      />
+    </svg>
+  </button>
+
+  <button
+    id="user-menu-button"
+    class="flex h-9 w-9 items-center justify-center text-sm text-gray-500 focus:outline-hidden dark:text-gray-200"
+    data-dropdown-toggle="user-menu"
+    data-dropdown-offset-distance="3"
+    data-dropdown-placement="bottom-end"
+    aria-label="<%= t('active_admin.toggle_user_menu') %>"
+  >
+    <svg
+      class="h-7 w-7"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z"
+      />
+    </svg>
+  </button>
+
+  <div
+    id="user-menu"
+    class="
+      z-50 hidden min-w-max rounded bg-white py-1 text-sm text-gray-700 shadow-lg outline outline-black/5
+      focus:outline-hidden dark:bg-gray-800 dark:text-gray-300 dark:-outline-offset-1 dark:outline-white/10
+    "
+  >
+    <ul aria-labelledby="user-menu-button">
+      <% if current_active_admin_user? %>
+        <li>
+          <%= auto_link current_active_admin_user, class: "block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white" %>
+        </li>
+        <li>
+          <%= link_to I18n.t("active_admin.logout"), auto_logout_link_path, class: "block px-2.5 py-2 no-underline text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white", data: { method: :delete } %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/active_admin/_site_header.html.erb
+++ b/app/views/active_admin/_site_header.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (title:) %>
+
 <%# Override ActiveAdmin 4.0.0.beta22 so the user menu's accessible name is attached to its semantic list. %>
 <div
   class="
@@ -6,6 +8,7 @@
   "
 >
   <button
+    type="button"
     class="
       focus-visible:ring-ring inline-flex h-8 w-8 items-center justify-center pe-3 text-sm text-gray-500
       focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-hidden
@@ -81,6 +84,7 @@
   </button>
 
   <button
+    type="button"
     id="user-menu-button"
     class="flex h-9 w-9 items-center justify-center text-sm text-gray-500 focus:outline-hidden dark:text-gray-200"
     data-dropdown-toggle="user-menu"

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -2,6 +2,7 @@
 en:
   active_admin:
     dashboard: Dashboard
+    logout: Sign out
     site_banners:
       disable: Disable
       disable_confirm: Disable this site banner?
@@ -11,3 +12,7 @@ en:
       enabled: Site banner enabled.
       message_for: Message (%{locale_code})
       messages_fieldset: Messages
+    toggle_dark_mode: Toggle dark mode
+    toggle_main_navigation_menu: Toggle main navigation menu
+    toggle_section: Toggle section
+    toggle_user_menu: Toggle user menu

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -9,3 +9,5 @@ en:
       enable: Enable
       enable_confirm: Enable this site banner?
       enabled: Site banner enabled.
+      message_for: Message (%{locale_code})
+      messages_fieldset: Messages

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -2,3 +2,10 @@
 en:
   active_admin:
     dashboard: Dashboard
+    site_banners:
+      disable: Disable
+      disable_confirm: Disable this site banner?
+      disabled: Site banner disabled.
+      enable: Enable
+      enable_confirm: Enable this site banner?
+      enabled: Site banner enabled.

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -2,6 +2,7 @@
 fr:
   active_admin:
     dashboard: Tableau de bord
+    logout: Déconnexion
     site_banners:
       disable: Désactiver
       disable_confirm: Désactiver cette bannière du site?
@@ -11,3 +12,7 @@ fr:
       enabled: Bannière du site activée.
       message_for: Message (%{locale_code})
       messages_fieldset: Messages
+    toggle_dark_mode: Basculer le mode sombre
+    toggle_main_navigation_menu: Basculer le menu de navigation principal
+    toggle_section: Basculer la section
+    toggle_user_menu: Basculer le menu utilisateur

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -2,3 +2,10 @@
 fr:
   active_admin:
     dashboard: Tableau de bord
+    site_banners:
+      disable: Désactiver
+      disable_confirm: Désactiver cette bannière du site?
+      disabled: Bannière du site désactivée.
+      enable: Activer
+      enable_confirm: Activer cette bannière du site?
+      enabled: Bannière du site activée.

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -9,3 +9,5 @@ fr:
       enable: Activer
       enable_confirm: Activer cette bannière du site?
       enabled: Bannière du site activée.
+      message_for: Message (%{locale_code})
+      messages_fieldset: Messages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,10 @@ en:
         personal_access_tokens:
           rotate:
             only_active: Only active tokens can be rotated
+        site_banner:
+          attributes:
+            messages:
+              missing_locale_message: must include a message for %{locale_code}
         user:
           attributes:
             password:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,11 @@ en:
       sample:
         description: Description
         name: Name
+      site_banner:
+        created_at: Created at
+        enabled: Enabled
+        style: Style
+        updated_at: Updated at
       user:
         confirmation_sent_at: Confirmation sent at
         confirmation_token: Confirmation token
@@ -253,6 +258,9 @@ en:
       sample:
         one: Sample
         other: Samples
+      site_banner:
+        one: Site Banner
+        other: Site Banners
       workflow_execution:
         one: Workflow Execution
         other: Workflow Executions

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -211,6 +211,10 @@ fr:
         personal_access_tokens:
           rotate:
             only_active: Seuls les jetons actifs peuvent être remis en rotation
+        site_banner:
+          attributes:
+            messages:
+              missing_locale_message: doit inclure un message pour %{locale_code}
         user:
           attributes:
             password:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -97,6 +97,11 @@ fr:
       sample:
         description: Description
         name: Nom
+      site_banner:
+        created_at: Créé le
+        enabled: Activé
+        style: Style
+        updated_at: Mis à jour le
       user:
         confirmation_sent_at: Date d'envoi de la confirmation
         confirmation_token: Clé de confirmation du mot de passe
@@ -253,6 +258,9 @@ fr:
       sample:
         one: Échantillon
         other: Échantillons
+      site_banner:
+        one: Bannière du site
+        other: Bannières du site
       workflow_execution:
         one: Exécution de flux de travail
         other: Exécutions de flux de travail

--- a/test/controllers/admin/site_banners_test.rb
+++ b/test/controllers/admin/site_banners_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class SiteBannersTest < ActionDispatch::IntegrationTest
+    setup do
+      sign_in users(:system_user)
+    end
+
+    test 'system user can view site banner index' do
+      SiteBanner.create!(
+        style: :info,
+        messages: localized_messages('Maintenance notice')
+      )
+
+      get admin_site_banners_path
+
+      assert_response :success
+      assert_includes response.body, 'Maintenance notice'
+      assert_includes response.body, I18n.t('active_admin.site_banners.disable')
+      assert_includes response.body, disable_admin_site_banner_path(SiteBanner.current)
+    end
+
+    test 'system user sees translated French resource name' do
+      users(:system_user).update!(locale: 'fr')
+
+      get admin_site_banners_path
+
+      assert_response :success
+      assert_includes response.body, I18n.t('activerecord.models.site_banner.other', locale: :fr)
+      assert_includes response.body, I18n.t('activerecord.attributes.site_banner.enabled', locale: :fr)
+      assert_includes response.body, I18n.t('activerecord.attributes.site_banner.style', locale: :fr)
+      assert_includes response.body, I18n.t('activerecord.attributes.site_banner.created_at', locale: :fr)
+      assert_includes response.body, I18n.t('activerecord.attributes.site_banner.updated_at', locale: :fr)
+      assert_not_includes response.body, 'Site Banners'
+    end
+
+    test 'system user can view new site banner form' do
+      get new_admin_site_banner_path
+
+      assert_response :success
+      assert_includes response.body, 'site_banner_message_en'
+      assert_includes response.body, 'site_banner_message_fr'
+    end
+
+    test 'system user can create a site banner' do
+      assert_difference -> { SiteBanner.count }, 1 do
+        post admin_site_banners_path, params: {
+          site_banner: {
+            enabled: '1',
+            style: 'warning',
+            messages: {
+              en: 'Scheduled maintenance',
+              fr: 'Maintenance planifiée'
+            }
+          }
+        }
+      end
+
+      banner = SiteBanner.order(:created_at).last
+      assert_redirected_to admin_site_banner_path(banner)
+      assert banner.enabled?
+      assert_equal 'warning', banner.style
+      assert_equal 'Scheduled maintenance', banner.messages['en']
+      assert_equal 'Maintenance planifiée', banner.messages['fr']
+    end
+
+    test 'system user can disable an enabled site banner' do
+      banner = SiteBanner.create!(
+        style: :danger,
+        messages: localized_messages('Service outage')
+      )
+
+      patch disable_admin_site_banner_path(banner)
+
+      assert_redirected_to admin_site_banner_path(banner)
+      assert_not banner.reload.enabled?
+    end
+
+    test 'system user can view enable action for disabled site banner' do
+      banner = SiteBanner.create!(
+        enabled: false,
+        style: :info,
+        messages: localized_messages('Maintenance notice')
+      )
+
+      get admin_site_banners_path
+
+      assert_response :success
+      assert_includes response.body, I18n.t('active_admin.site_banners.enable')
+      assert_includes response.body, enable_admin_site_banner_path(banner)
+    end
+
+    test 'system user sees enable action as a show page button' do
+      banner = SiteBanner.create!(
+        enabled: false,
+        style: :info,
+        messages: localized_messages('Maintenance notice')
+      )
+
+      get admin_site_banner_path(banner)
+
+      assert_response :success
+      assert_select "a.action-item-button[href='#{enable_admin_site_banner_path(banner)}']",
+                    text: I18n.t('active_admin.site_banners.enable')
+    end
+
+    test 'system user can enable a disabled site banner' do
+      banner = SiteBanner.create!(
+        enabled: false,
+        style: :success,
+        messages: localized_messages('Service restored')
+      )
+
+      patch enable_admin_site_banner_path(banner)
+
+      assert_redirected_to admin_site_banner_path(banner)
+      assert banner.reload.enabled?
+    end
+
+    test 'system user can delete a site banner' do
+      banner = SiteBanner.create!(
+        enabled: false,
+        style: :info,
+        messages: {}
+      )
+
+      assert_difference -> { SiteBanner.count }, -1 do
+        delete admin_site_banner_path(banner)
+      end
+
+      assert_redirected_to admin_site_banners_path
+    end
+
+    private
+
+    def localized_messages(message)
+      I18n.available_locales.index_with { |_locale| message }
+    end
+  end
+end

--- a/test/controllers/admin/site_banners_test.rb
+++ b/test/controllers/admin/site_banners_test.rb
@@ -119,6 +119,35 @@ module Admin
       assert banner.reload.enabled?
     end
 
+    test 'enabling a site banner disables the previously enabled one' do
+      previously_enabled = SiteBanner.create!(
+        style: :info,
+        messages: localized_messages('Old notice')
+      )
+      banner = SiteBanner.create!(
+        enabled: false,
+        style: :warning,
+        messages: localized_messages('New notice')
+      )
+
+      patch enable_admin_site_banner_path(banner)
+
+      assert_redirected_to admin_site_banner_path(banner)
+      assert banner.reload.enabled?
+      assert_not previously_enabled.reload.enabled?
+    end
+
+    test 'enabling a site banner with missing messages shows an error' do
+      incomplete = I18n.available_locales.first(1).index_with { |_locale| 'Only one locale' }
+      banner = SiteBanner.create!(enabled: false, style: :info, messages: incomplete)
+
+      patch enable_admin_site_banner_path(banner)
+
+      assert_redirected_to admin_site_banner_path(banner)
+      assert_not banner.reload.enabled?
+      assert flash[:alert].present?
+    end
+
     test 'system user can delete a site banner' do
       banner = SiteBanner.create!(
         enabled: false,

--- a/test/controllers/admin/site_banners_test.rb
+++ b/test/controllers/admin/site_banners_test.rb
@@ -20,6 +20,9 @@ module Admin
       assert_includes response.body, 'Maintenance notice'
       assert_includes response.body, I18n.t('active_admin.site_banners.disable')
       assert_includes response.body, disable_admin_site_banner_path(SiteBanner.current)
+      assert_select 'nav li[false]', count: 0
+      assert_select '#user-menu[aria-labelledby]', count: 0
+      assert_select '#user-menu > ul[aria-labelledby="user-menu-button"]', count: 1
     end
 
     test 'system user sees translated French resource name' do

--- a/test/controllers/admin/site_banners_test.rb
+++ b/test/controllers/admin/site_banners_test.rb
@@ -69,6 +69,32 @@ module Admin
       assert_equal 'Maintenance planifiée', banner.messages['fr']
     end
 
+    test 'system user can create a disabled site banner' do
+      assert_difference -> { SiteBanner.count }, 1 do
+        post admin_site_banners_path, params: {
+          site_banner: {
+            enabled: '0',
+            style: 'info',
+            messages: {
+              en: 'Draft notice',
+              fr: 'Avis brouillon'
+            }
+          }
+        }
+      end
+
+      banner = SiteBanner.order(:created_at).last
+      assert_redirected_to admin_site_banner_path(banner)
+      assert_not banner.enabled?
+    end
+
+    test 'new site banner form renders an enabled checkbox' do
+      get new_admin_site_banner_path
+
+      assert_response :success
+      assert_select '#site_banner_enabled_input input[type=checkbox][name="site_banner[enabled]"][checked]'
+    end
+
     test 'system user can disable an enabled site banner' do
       banner = SiteBanner.create!(
         style: :danger,

--- a/test/models/site_banner_test.rb
+++ b/test/models/site_banner_test.rb
@@ -92,6 +92,16 @@ class SiteBannerTest < ActiveSupport::TestCase
     assert notification.valid?
   end
 
+  test 'updating an enabled notification does not disable other notifications' do
+    previous = SiteBanner.create!(enabled: false, style: :info, messages: localized_messages('Previous'))
+    current = SiteBanner.create!(style: :warning, messages: localized_messages('Current'))
+
+    current.update!(messages: localized_messages('Updated current'))
+
+    assert current.reload.enabled?
+    assert_not previous.reload.enabled?
+  end
+
   private
 
   def localized_messages(message)

--- a/test/system/admin/site_banners_test.rb
+++ b/test/system/admin/site_banners_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module Admin
+  class SiteBannersTest < ApplicationSystemTestCase
+    setup do
+      login_as users(:system_user)
+    end
+
+    test 'disable action opens a confirmation dialog' do
+      banner = SiteBanner.create!(
+        style: :info,
+        messages: I18n.available_locales.index_with { |_locale| 'Maintenance notice' }
+      )
+
+      visit admin_site_banner_path(banner)
+
+      dismiss_confirm(I18n.t('active_admin.site_banners.disable_confirm')) do
+        click_link I18n.t('active_admin.site_banners.disable')
+      end
+    end
+  end
+end

--- a/test/system/admin/site_banners_test.rb
+++ b/test/system/admin/site_banners_test.rb
@@ -20,5 +20,33 @@ module Admin
         click_link I18n.t('active_admin.site_banners.disable')
       end
     end
+
+    test 'enabled checkbox can be toggled on the new form' do
+      visit new_admin_site_banner_path
+
+      checkbox = find('#site_banner_enabled')
+      assert checkbox.checked?
+
+      checked_styles = page.evaluate_script(<<~JS)
+        (() => {
+          const style = getComputedStyle(document.querySelector('#site_banner_enabled'));
+          return { bg: style.backgroundColor, image: style.backgroundImage };
+        })()
+      JS
+      assert_not_equal 'none', checked_styles['image']
+
+      uncheck I18n.t('activerecord.attributes.site_banner.enabled')
+
+      unchecked_styles = page.evaluate_script(<<~JS)
+        (() => {
+          const el = document.querySelector('#site_banner_enabled');
+          const style = getComputedStyle(el);
+          return { bg: style.backgroundColor, image: style.backgroundImage, checked: el.checked };
+        })()
+      JS
+      assert_not unchecked_styles['checked']
+      assert_equal 'none', unchecked_styles['image']
+      assert_not_equal checked_styles['bg'], unchecked_styles['bg']
+    end
   end
 end

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -23,7 +23,7 @@ module Projects
     end
 
     test 'samples index table' do
-      freeze_time
+      travel_to(@sample1.updated_at + 3.hours)
       visit namespace_project_samples_url(@namespace, @project)
       # verify samples table has loaded to prevent flakes
       assert_text strip_tags(I18n.t(:'components.viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
@@ -3856,7 +3856,7 @@ module Projects
     end
 
     test 'local_time localization with language toggle' do
-      freeze_time
+      travel_to(@sample1.updated_at + 3.hours)
       visit namespace_project_samples_url(@namespace, @project)
 
       # verify samples table has loaded to prevent flakes


### PR DESCRIPTION
## What does this PR do and why?
- Adds an ActiveAdmin resource so system users can manage site banners (create, edit, enable, disable, delete).
- Adds en/fr translations for labels and actions, plus ransack support for admin filters.

## Screenshots or screen recordings
- Active Admin site banners index (enable/disable actions)
<img width="1395" height="761" alt="image" src="https://github.com/user-attachments/assets/4216e990-6d3d-4a03-b0db-950dfaee3515" />

- Site banner create/edit form with per-locale messages
<img width="1395" height="761" alt="image" src="https://github.com/user-attachments/assets/d2b28c14-96a5-404b-9fc7-83788ece8038" />

<img width="1395" height="761" alt="image" src="https://github.com/user-attachments/assets/39bc65fb-4dcd-441e-a29e-80463b6f96c3" />

<img width="1395" height="761" alt="image" src="https://github.com/user-attachments/assets/2e64b16a-2091-4add-a872-37e23ba956ad" />

## How to set up and validate locally
1. Start the app (`bin/dev`).
2. Sign in as a system user (e.g. `user1@email.com`).
3. Open `/-/system/admin/site_banners` and verify index, create, enable/disable, and delete flows.
4. Ensure the site banner is display properly on the IRIDA Next main site
5. Run `PARALLEL_WORKERS=4 bin/rails test test/controllers/admin/site_banners_test.rb`.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.