### PR TITLE
refactor(styles): replace Flowbite Tailwind plugin with @tailwindcss/forms

### DIFF
--- a/app/assets/stylesheets/active_admin.tailwind.css
+++ b/app/assets/stylesheets/active_admin.tailwind.css
@@ -3,6 +3,6 @@
 @source "../../admin/**/*.{arb,erb,html,rb}";
 
 @plugin "@activeadmin/activeadmin/plugin";
-@plugin "flowbite/plugin";
+@plugin "@tailwindcss/forms";
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -196,6 +196,23 @@ input[type="search"] {
     @apply block w-full rounded-lg border-slate-300 text-slate-900 sm:text-sm dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:placeholder-slate-400;
   }
 
+  & input[type="file"] {
+    @apply block h-11 w-full overflow-hidden rounded-lg border border-slate-300 bg-slate-50 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-400 dark:placeholder-slate-400;
+  }
+
+  & input[type="file"]::file-selector-button {
+    @apply mr-4 h-full cursor-pointer border-0 border-r border-solid border-slate-300 bg-slate-200 px-4 text-sm font-medium text-slate-900 dark:border-slate-600 dark:bg-slate-600 dark:text-white;
+  }
+
+  & input[type="file"]:not(:disabled)::file-selector-button:hover {
+    @apply bg-slate-300 dark:bg-slate-500;
+  }
+
+  & input[type="file"]:disabled,
+  & input[type="file"]:disabled::file-selector-button {
+    @apply cursor-not-allowed;
+  }
+
   & select:has(option[value=""]:checked) {
     @apply text-slate-500 dark:text-slate-400;
   }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,10 +2,9 @@
 @source "../../components/**/*.{rb,erb}";
 @source "../../javascript/**/*.js";
 @source "../../views/**/*.erb";
-@source "../../../node_modules/flowbite/dist";
 @source "../../helpers/**/*.rb";
 
-@plugin "flowbite/plugin";
+@plugin "@tailwindcss/forms";
 
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -653,11 +652,11 @@ div.field_with_errors :is(input, select, textarea):focus-visible {
 }
 
 input[type="checkbox"] {
-  @apply text-primary-600 checked:border-primary-500 dark:checked:border-primary-500 dark:checked:bg-primary-500 mt-0.5 mr-2 shrink-0 rounded-sm border-slate-200 disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800;
+  @apply text-primary-600 checked:border-primary-500 dark:checked:border-primary-500 dark:checked:bg-primary-500 mt-0.5 mr-2 shrink-0 rounded-sm border-slate-200 checked:bg-current disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800;
 }
 
 input[type="radio"] {
-  @apply text-primary-600 checked:border-primary-500 dark:checked:border-primary-500 dark:checked:bg-primary-500 mt-0.5 shrink-0 rounded-full border-slate-200 disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-600;
+  @apply text-primary-600 checked:border-primary-500 dark:checked:border-primary-500 dark:checked:bg-primary-500 mt-0.5 shrink-0 rounded-full border-slate-200 checked:bg-current disabled:pointer-events-none disabled:opacity-50 dark:border-slate-700 dark:bg-slate-600;
 }
 
 /* Suppress global focus ring for specific anchors; keep pill span ring only */

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@activeadmin/activeadmin": "4.0.0-beta22",
     "@tailwindcss/cli": "4.3.2",
+    "@tailwindcss/forms": "^0.5.11",
     "flowbite": "^3.1.2",
     "tailwindcss": "4.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tailwindcss/cli':
         specifier: 4.3.2
         version: 4.3.2
+      '@tailwindcss/forms':
+        specifier: ^0.5.11
+        version: 0.5.11(tailwindcss@4.3.2)
       flowbite:
         specifier: ^3.1.2
         version: 3.1.2(rollup@4.62.2)
@@ -678,6 +681,11 @@ packages:
   '@tailwindcss/cli@4.3.2':
     resolution: {integrity: sha512-Fzt+HrIZHDlkRYKdLMBeufaroaPvwCBG70sMLdmurdeadNMO/LxbmT8Sbb+P83ep0iAlAImettb7Y+rO+37rXw==}
     hasBin: true
+
+  '@tailwindcss/forms@0.5.11':
+    resolution: {integrity: sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1'
 
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
@@ -2172,6 +2180,11 @@ snapshots:
       enhanced-resolve: 5.21.6
       mri: 1.2.0
       picocolors: 1.1.1
+      tailwindcss: 4.3.2
+
+  '@tailwindcss/forms@0.5.11(tailwindcss@4.3.2)':
+    dependencies:
+      mini-svg-data-uri: 1.4.4
       tailwindcss: 4.3.2
 
   '@tailwindcss/node@4.3.2':


### PR DESCRIPTION
## What does this PR do and why?

Replaces `@plugin "flowbite/plugin"` with `@plugin "@tailwindcss/forms"` in both `application.tailwind.css` and `active_admin.tailwind.css`. Also removes the Flowbite `@source` directive since it is no longer needed.

This is the first step toward removing Flowbite as a dependency. The `@tailwindcss/forms` plugin provides the same form base styles (inputs, selects, textareas, checkboxes, radios, file inputs, range sliders) without the Flowbite-specific extras that were unused.

Because `@tailwindcss/forms` uses low-specificity `:where()` selectors (unlike Flowbite which used `!important`), `checked:bg-current` was added to the checkbox and radio rules so the checked fill renders correctly in light mode.

### What is still needed to fully remove Flowbite

1. Enable the `v2_dropdown` and `v2_select2` Flipper flags for all users (the v2 controllers already use `FloatingDropdown` instead of Flowbite)
2. Remove the v1 dropdown and select2 controllers/components
3. Remove `import "flowbite"` from `app/javascript/application.js`
4. Remove the `flowbite` and `@popperjs/core` pins from `config/importmap.rb`
5. Remove `flowbite` from `package.json`

## Screenshots or screen recordings

N/A — no visual change expected. Radio/checkbox fill in light mode is preserved by the `checked:bg-current` addition.

## How to set up and validate locally

1. `pnpm install`
2. `pnpm run build:css` — should succeed with no errors
3. `bin/dev` — verify radio buttons and checkboxes render correctly in light and dark mode (e.g. Preferences page colour theme radios)

## PR acceptance checklist

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.