### PR TITLE
A11y: Fix tabbing issue with treegrid component when using screenreader navigation

### DIFF
--- a/app/javascript/controllers/treegrid_controller.js
+++ b/app/javascript/controllers/treegrid_controller.js
@@ -91,6 +91,9 @@ export default class extends Controller {
 
   focusin(event) {
     const newFocusedRow = this.#getContainingRow(event.target);
+    if (!newFocusedRow) {
+      return;
+    }
 
     tabbable(this.element).forEach((elem) => {
       if (elem !== newFocusedRow && !newFocusedRow.contains(elem)) {

--- a/app/javascript/controllers/treegrid_controller.js
+++ b/app/javascript/controllers/treegrid_controller.js
@@ -164,8 +164,9 @@ export default class extends Controller {
     const newRow = rows[direction > 0 ? rows.length - 1 : 0];
 
     if (currentRow !== newRow) {
+      const cellIndex = tabbable(currentRow).indexOf(document.activeElement);
       currentRow.tabIndex = -1;
-      this.#focus(newRow, -1);
+      this.#focus(newRow, cellIndex);
     }
   }
 

--- a/app/javascript/controllers/treegrid_controller.js
+++ b/app/javascript/controllers/treegrid_controller.js
@@ -186,6 +186,8 @@ export default class extends Controller {
   }
 
   #focus(elem, cellIndex) {
+    elem.tabIndex = 0;
+    this.#setTabIndexForElementsInRow(elem, 0);
     if (cellIndex < 0) {
       elem.focus();
     } else {

--- a/app/javascript/controllers/treegrid_controller.js
+++ b/app/javascript/controllers/treegrid_controller.js
@@ -10,27 +10,26 @@ export default class extends Controller {
 
   initialize() {
     this.boundKeydown = this.keydown.bind(this);
+    this.boundFocusin = this.focusin.bind(this);
   }
 
   connect() {
     this.element.addEventListener("keydown", this.boundKeydown);
+    this.element.addEventListener("focusin", this.boundFocusin);
     this.element.setAttribute("data-controller-connected", "true");
-
-    // Make sure focusable elements are not in the tab order
-    // They will be added back in for the active row
-    this.#setTabIndexOfFocusableElements(this.element, -1);
 
     this.rowTargets[0].tabIndex = 0;
     this.#setTabIndexForElementsInRow(this.rowTargets[0], 0);
   }
 
+  disconnect() {
+    this.element.removeEventListener("keydown", this.boundKeydown);
+    this.element.removeEventListener("focusin", this.boundFocusin);
+  }
+
   rowTargetConnected(row) {
-    if (
-      row !== document.activeElement &&
-      !row.contains(document.activeElement)
-    ) {
-      this.#setTabIndexForElementsInRow(row, -1);
-    }
+    row.tabIndex = -1;
+    this.#setTabIndexForElementsInRow(row, -1);
   }
 
   keydown(event) {
@@ -83,8 +82,6 @@ export default class extends Controller {
       this.#moveToExtremeRow(-1);
     } else if (event.key === "PageDown") {
       this.#moveToExtremeRow(+1);
-    } else if (event.key === "Tab") {
-      this.#handleTab(event);
     } else {
       return;
     }
@@ -92,30 +89,19 @@ export default class extends Controller {
     event.preventDefault();
   }
 
-  #handleTab(event) {
-    const direction = event.shiftKey ? -1 : +1;
-    const currentRow = this.#getRowWithFocus();
+  focusin(event) {
+    const newFocusedRow = this.#getContainingRow(event.target);
 
-    const focusableElements = tabbable(document);
-    const currentIndex = focusableElements.indexOf(event.target);
-    let nextElement = null;
-    for (
-      let i = currentIndex + direction;
-      i >= 0 && i < focusableElements.length;
-      i += direction
-    ) {
-      if (
-        currentRow.contains(focusableElements[i]) ||
-        !this.element.contains(focusableElements[i])
-      ) {
-        nextElement = focusableElements[i];
-        break;
+    tabbable(this.element).forEach((elem) => {
+      if (elem !== newFocusedRow && !newFocusedRow.contains(elem)) {
+        elem.tabIndex = -1;
       }
+    });
+
+    if (newFocusedRow) {
+      newFocusedRow.tabIndex = 0;
+      this.#setTabIndexForElementsInRow(newFocusedRow, 0);
     }
-    if (nextElement) {
-      nextElement.focus();
-    }
-    event.preventDefault();
   }
 
   toggleRow(event) {
@@ -161,8 +147,6 @@ export default class extends Controller {
 
     if (newRowIndex !== rowIndex) {
       const cellIndex = tabbable(currentRow).indexOf(document.activeElement);
-      currentRow.tabIndex = -1;
-      this.#setTabIndexForElementsInRow(currentRow, -1);
       this.#focus(rows[newRowIndex], cellIndex);
     }
   }
@@ -202,8 +186,6 @@ export default class extends Controller {
   }
 
   #focus(elem, cellIndex) {
-    elem.tabIndex = 0;
-    this.#setTabIndexForElementsInRow(elem, 0);
     if (cellIndex < 0) {
       elem.focus();
     } else {
@@ -263,14 +245,6 @@ export default class extends Controller {
         if (willHideRow !== isRowHidden) {
           if (willHideRow) {
             nextRow.classList.add("hidden");
-            // if row was currently tabbable then move tabindex to first row
-            if (nextRow.tabIndex === 0) {
-              nextRow.tabIndex = -1;
-              this.#setTabIndexForElementsInRow(nextRow, -1);
-              // set first row as tabbable
-              this.rowTargets[0].tabIndex = 0;
-              this.#setTabIndexForElementsInRow(this.rowTargets[0], 0);
-            }
           } else {
             nextRow.classList.remove("hidden");
           }
@@ -296,12 +270,6 @@ export default class extends Controller {
     } else {
       toggleButton.setAttribute("aria-label", this.expandTextValue);
     }
-  }
-
-  #setTabIndexOfFocusableElements(element, tabIndex) {
-    tabbable(element).forEach((el) => {
-      el.tabIndex = tabIndex;
-    });
   }
 
   #setTabIndexForElementsInRow(row, tabIndex) {


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes a tabbing issue within the treegrid component when using a screenreader (e.g. NVDA) that switches to browse mode (which intercepts keyboard navigation). 

e.g. When using the treegrid with NVDA and after tabbing to a `button` or `link` in the row, then using arrow key navigation (this bypasses javascript) followed by a tab key could get the user into a situation where they can't tab out of the component.

To address this, instead of manually handling tab keypresses, I instead changed the javascript to listen to `focusin` events and update tabindex appropriately (this fixes the tab index after using arrow key navigation with a screen reader).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

After:

https://github.com/user-attachments/assets/586e1472-b19a-4617-a43d-8551341f2171


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Start the server with `bin/setup`
2. Launch NVDA
3. Navigate to Projects page (e.g. treegrid)
4. Tab into the treegrid and then tab to a `button` or `link` within the first row.
5. Hit the down arrow key 10 times followed by a tab
6. Observe that you are within a row and can tab normally which will go to end of row then out of component. Follow that with shift tabbing and confirm you renter the component and then go out of the component. This confirms tab navigation still works after using arrow key navigation with a screenreader

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
