### PR TITLE
refactor(samples): extract select/deselect controls into shared partial

### DIFF
--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -1,6 +1,8 @@
 <% if @has_attachments %>
   <%= render Viral::BaseComponent.new(**wrapper_arguments) do %>
     <%= render Viral::BaseComponent.new(**system_arguments) do %>
+      <%= render LiveRegionComponent.new(controller: "selection") %>
+
       <table
         class="w-full text-left text-sm whitespace-nowrap text-slate-500 rtl:text-right dark:text-slate-400"
         style="--puid-width: <%= helpers.puid_width(object_class: Attachment, has_checkbox: @abilities[:select_attachments]) %>;"

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -43,15 +43,12 @@ module Attachments
     end
     # rubocop:enable Naming/MethodParameterName,Metrics/ParameterLists
 
-    def system_arguments # rubocop:disable Metrics/AbcSize
+    def system_arguments
       { tag: 'div' }.deep_merge(@system_arguments).tap do |args|
         args[:id] = 'attachments-table'
         args[:classes] = class_names(args[:classes], 'overflow-auto scrollbar')
         if @abilities[:select_attachments]
-          args[:data] ||= {}
-          args[:data][:controller] = 'selection'
-          args[:data][:'selection-total-value'] = @pagy.count
-          args[:data][:'selection-action-button-outlet'] = '.action-button'
+          args[:data] = (args[:data] || {}).merge(selection_data_attributes)
           if @attachable.instance_of?(Sample)
             args[:data][:'selection-storage-key-value'] =
               "files-#{@attachable.id}"
@@ -110,6 +107,16 @@ module Attachments
       else
         column_str # 📝 Return the original column name if no specific mapping exists.
       end
+    end
+
+    def selection_data_attributes
+      {
+        controller: 'selection',
+        'selection-total-value': @pagy.count,
+        'selection-action-button-outlet': '.action-button',
+        'selection-count-message-value':
+          I18n.t('components.attachments.table_component.counts.status')
+      }
     end
 
     private

--- a/app/views/groups/samples/index.html.erb
+++ b/app/views/groups/samples/index.html.erb
@@ -157,39 +157,19 @@
   <% if @group_project_ids.count.positive? %>
     <div class="mb-4 flex flex-wrap gap-2">
       <% if @allowed_to[:submit_workflow] || @allowed_to[:export_data] %>
-        <%= form_with(
-                  url: select_group_samples_url,
-                  method: :get,
-                  id: "select-all-form",
-                  class: "max-sm:grow",
-                  data: { turbo_frame: "selected" },
-                ) do |f| %>
-          <input type="hidden" name="select" value="on">
-          <%= render "shared/samples/timestamp_input" %>
-
-          <%= f.submit t("common.controls.select_all"),
-                   id: "select-all-button",
-                   class: "button button-default w-full",
-                   aria: {
-                     label: t(".select_all_tooltip"),
-                   },
-                   title: t(".select_all_tooltip") %>
-        <% end %>
-        <%= form_with(
-                  url: select_group_samples_url,
-                  method: :get,
-                  id: "deselect-all-form",
-                  class: "max-sm:grow",
-                  data: { turbo_frame: "selected" },
-                ) do |f| %>
-          <%= f.submit t("common.controls.deselect_all"),
-                   id: "deselect-all-button",
-                   class: "button button-default w-full",
-                   title: t(".deselect_all_tooltip"),
-                   aria: {
-                     label: t(".deselect_all_tooltip"),
-                   } %>
-        <% end %>
+        <%= render "shared/selection_buttons",
+        url: select_group_samples_url,
+        form_data: { turbo_frame: "selected" },
+        select_form_fields: { select: "on", timestamp: @timestamp },
+        deselect_form_fields: {},
+        select_button_options: {
+          title: t(".select_all_tooltip"),
+          aria: { label: t(".select_all_tooltip") },
+        },
+        deselect_button_options: {
+          title: t(".deselect_all_tooltip"),
+          aria: { label: t(".deselect_all_tooltip") },
+        } %>
       <% end %>
 
       <div class="max-sm:hidden sm:grow" role="presentation"></div>

--- a/app/views/groups/workflow_executions/index.html.erb
+++ b/app/views/groups/workflow_executions/index.html.erb
@@ -29,29 +29,10 @@
 
 <% if @has_workflow_executions %>
   <div class="mb-4 flex flex-wrap gap-2">
-    <%= form_with(
-                  url: select_group_workflow_executions_url,
-                  method: :get,
-                  id: "select-all-form",
-                  class: "max-sm:grow",
-                ) do |f| %>
-      <input type="hidden" name="format" value="turbo_stream">
-      <input type="hidden" name="select" value="on">
-
-      <%= f.submit t("common.controls.select_all"), class: "button button-default w-full" %>
-    <% end %>
-
-    <%= form_with(
-                  url: select_group_workflow_executions_url,
-                  method: :get,
-                  id: "deselect-all-form",
-                  class: "max-sm:grow",
-                ) do |f| %>
-      <input type="hidden" name="format" value="turbo_stream">
-
-      <%= f.submit t("common.controls.deselect_all"),
-               class: "button button-default w-full" %>
-    <% end %>
+    <%= render "shared/selection_buttons",
+    url: select_group_workflow_executions_url,
+    select_form_fields: { format: "turbo_stream", select: "on" },
+    deselect_form_fields: { format: "turbo_stream" } %>
 
     <div class="max-sm:hidden sm:grow" role="presentation"></div>
 

--- a/app/views/groups/workflow_executions/index.html.erb
+++ b/app/views/groups/workflow_executions/index.html.erb
@@ -32,7 +32,15 @@
     <%= render "shared/selection_buttons",
     url: select_group_workflow_executions_url,
     select_form_fields: { format: "turbo_stream", select: "on" },
-    deselect_form_fields: { format: "turbo_stream" } %>
+    deselect_form_fields: { format: "turbo_stream" },
+    select_button_options: {
+      title: t(".select_all_tooltip"),
+      aria: { label: t(".select_all_tooltip") },
+    },
+    deselect_button_options: {
+      title: t(".deselect_all_tooltip"),
+      aria: { label: t(".deselect_all_tooltip") },
+    } %>
 
     <div class="max-sm:hidden sm:grow" role="presentation"></div>
 

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -3,32 +3,14 @@
     <div class="mb-4 flex flex-wrap gap-2">
       <% if @allowed_to[:update_sample] %>
         <% if Flipper.enabled?(:sample_attachments_searching, current_user) %>
-          <%= form_with(
-                      url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
-                      method: :get,
-                      id: "select-all-form",
-                      class: "max-sm:grow"
-                    ) do |f| %>
-            <input type="hidden" name="format" value="turbo_stream">
-            <input type="hidden" name="select" value="on">
-
-            <input
-              type="hidden"
-              name="q[puid_or_file_blob_filename_cont]"
-              value="<%= params.dig(:q, :puid_or_file_blob_filename_cont) %>"
-            >
-
-            <%= f.submit t('common.controls.select_all'), class: "button button-default w-full" %>
-          <% end %>
-          <%= form_with(
-                      url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
-                      method: :get,
-                      id: "deselect-all-form" ,
-                      class: "max-sm:grow",
-                    ) do |f| %>
-            <input type="hidden" name="format" value="turbo_stream">
-            <%= f.submit t('common.controls.deselect_all'), class: "button button-default w-full" %>
-          <% end %>
+          <%= render "shared/selection_buttons",
+          url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
+          select_form_fields: {
+            format: "turbo_stream",
+            select: "on",
+            "q[puid_or_file_blob_filename_cont]": params.dig(:q, :puid_or_file_blob_filename_cont),
+          },
+          deselect_form_fields: { format: "turbo_stream" } %>
         <% end %>
       <% end %>
 

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -10,7 +10,15 @@
             select: "on",
             "q[puid_or_file_blob_filename_cont]": params.dig(:q, :puid_or_file_blob_filename_cont),
           },
-          deselect_form_fields: { format: "turbo_stream" } %>
+          deselect_form_fields: { format: "turbo_stream" },
+          select_button_options: {
+            title: t(".select_all_tooltip"),
+            aria: { label: t(".select_all_tooltip") },
+          },
+          deselect_button_options: {
+            title: t(".deselect_all_tooltip"),
+            aria: { label: t(".deselect_all_tooltip") },
+          } %>
         <% end %>
       <% end %>
 

--- a/app/views/projects/samples/index.html.erb
+++ b/app/views/projects/samples/index.html.erb
@@ -171,39 +171,19 @@
   <% if @has_samples %>
     <div class="mb-4 flex flex-wrap gap-2">
       <% if @allowed_to[:submit_workflow] || @allowed_to[:clone_sample] || @allowed_to[:transfer_sample] || @allowed_to[:export_data] %>
-        <%= form_with(
-              url: select_namespace_project_samples_url,
-              method: :get,
-              id: "select-all-form",
-              class: "max-sm:grow",
-              data: { turbo_frame: "selected" },
-            ) do |f| %>
-          <input type="hidden" name="select" value="on">
-          <%= render "shared/samples/timestamp_input" %>
-
-          <%= f.submit t("common.controls.select_all"),
-                   id: "select-all-button",
-                   class: "button button-default w-full",
-                   title: t(".select_all_tooltip"),
-                   aria: {
-                     label: t(".select_all_tooltip"),
-                   } %>
-        <% end %>
-        <%= form_with(
-                    url: select_namespace_project_samples_url,
-                    method: :get,
-                    id: "deselect-all-form",
-                    class: "max-sm:grow",
-                    data: { turbo_frame: "selected" },
-                  ) do |f| %>
-          <%= f.submit t("common.controls.deselect_all"),
-                   id: "deselect-all-button",
-                   class: "button button-default w-full",
-                   title: t(".deselect_all_tooltip"),
-                   aria: {
-                     label: t(".deselect_all_tooltip"),
-                   } %>
-        <% end %>
+        <%= render "shared/selection_buttons",
+        url: select_namespace_project_samples_url,
+        form_data: { turbo_frame: "selected" },
+        select_form_fields: { select: "on", timestamp: @timestamp },
+        deselect_form_fields: {},
+        select_button_options: {
+          title: t(".select_all_tooltip"),
+          aria: { label: t(".select_all_tooltip") },
+        },
+        deselect_button_options: {
+          title: t(".deselect_all_tooltip"),
+          aria: { label: t(".deselect_all_tooltip") },
+        } %>
       <% end %>
 
       <div class="max-sm:hidden sm:grow" role="presentation"></div>

--- a/app/views/projects/workflow_executions/index.html.erb
+++ b/app/views/projects/workflow_executions/index.html.erb
@@ -79,7 +79,15 @@
     url: select_namespace_project_workflow_executions_url,
     form_data: { turbo_frame: "selected" },
     select_form_fields: { select: "on" },
-    deselect_form_fields: {} %>
+    deselect_form_fields: {},
+    select_button_options: {
+      title: t(".select_all_tooltip"),
+      aria: { label: t(".select_all_tooltip") },
+    },
+    deselect_button_options: {
+      title: t(".deselect_all_tooltip"),
+      aria: { label: t(".deselect_all_tooltip") },
+    } %>
 
     <div class="max-sm:hidden sm:grow" role="presentation"></div>
 

--- a/app/views/projects/workflow_executions/index.html.erb
+++ b/app/views/projects/workflow_executions/index.html.erb
@@ -75,31 +75,11 @@
 
 <% if @has_workflow_executions %>
   <div class="mb-4 flex flex-wrap gap-2">
-    <%= form_with(
-                    url: select_namespace_project_workflow_executions_url,
-                    method: :get,
-                    id: "select-all-form",
-                    class: "max-sm:grow",
-                    data: { turbo_frame: "selected" },
-                  ) do |f| %>
-      <input type="hidden" name="select" value="on">
-
-      <%= f.submit t("common.controls.select_all"),
-               id: "select-all-button",
-               class: "button button-default w-full" %>
-    <% end %>
-
-    <%= form_with(
-                    url: select_namespace_project_workflow_executions_url,
-                    method: :get,
-                    id: "deselect-all-form" ,
-                    class: "max-sm:grow",
-                    data: { turbo_frame: "selected" },
-                  ) do |f| %>
-      <%= f.submit t("common.controls.deselect_all"),
-               id: "deselect-all-button",
-               class: "button button-default w-full" %>
-    <% end %>
+    <%= render "shared/selection_buttons",
+    url: select_namespace_project_workflow_executions_url,
+    form_data: { turbo_frame: "selected" },
+    select_form_fields: { select: "on" },
+    deselect_form_fields: {} %>
 
     <div class="max-sm:hidden sm:grow" role="presentation"></div>
 

--- a/app/views/shared/_selection_buttons.html.erb
+++ b/app/views/shared/_selection_buttons.html.erb
@@ -5,14 +5,14 @@
      id: "select-all-button",
      type: "submit",
      form: select_form_id,
-     class: "button button-default max-sm:grow",
+     class: "button button-default max-md:flex-1 max-md:basis-0 md:flex-none",
    }.merge(local_assigns.fetch(:select_button_options, {})) %>
 
 <% deselect_button_options = {
      id: "deselect-all-button",
      type: "submit",
      form: deselect_form_id,
-     class: "button button-default max-sm:grow",
+     class: "button button-default max-md:flex-1 max-md:basis-0 md:flex-none",
    }.merge(local_assigns.fetch(:deselect_button_options, {})) %>
 
 <% select_form_fields = local_assigns.fetch(:select_form_fields, {}) %>
@@ -30,8 +30,6 @@
   <% end %>
 <% end %>
 
-<%= button_tag t("common.controls.select_all"), **select_button_options %>
-
 <%= form_with(
       url: url,
       method: :get,
@@ -44,4 +42,8 @@
   <% end %>
 <% end %>
 
-<%= button_tag t("common.controls.deselect_all"), **deselect_button_options %>
+<div class="flex w-full gap-2 md:w-auto">
+  <%= button_tag t("common.controls.select_all"), **select_button_options %>
+
+  <%= button_tag t("common.controls.deselect_all"), **deselect_button_options %>
+</div>

--- a/app/views/shared/_selection_buttons.html.erb
+++ b/app/views/shared/_selection_buttons.html.erb
@@ -3,7 +3,7 @@
 
 <% select_button_options = {
      id: "select-all-button",
-  name: nil,
+     name: nil,
      type: "submit",
      form: select_form_id,
      class: "button button-default max-md:flex-1 max-md:basis-0 md:flex-none",
@@ -11,7 +11,7 @@
 
 <% deselect_button_options = {
      id: "deselect-all-button",
-  name: nil,
+     name: nil,
      type: "submit",
      form: deselect_form_id,
      class: "button button-default max-md:flex-1 max-md:basis-0 md:flex-none",

--- a/app/views/shared/_selection_buttons.html.erb
+++ b/app/views/shared/_selection_buttons.html.erb
@@ -3,6 +3,7 @@
 
 <% select_button_options = {
      id: "select-all-button",
+  name: nil,
      type: "submit",
      form: select_form_id,
      class: "button button-default max-md:flex-1 max-md:basis-0 md:flex-none",
@@ -10,6 +11,7 @@
 
 <% deselect_button_options = {
      id: "deselect-all-button",
+  name: nil,
      type: "submit",
      form: deselect_form_id,
      class: "button button-default max-md:flex-1 max-md:basis-0 md:flex-none",

--- a/app/views/shared/_selection_buttons.html.erb
+++ b/app/views/shared/_selection_buttons.html.erb
@@ -1,0 +1,47 @@
+<% select_form_id = local_assigns.fetch(:select_form_id, "select-all-form") %>
+<% deselect_form_id = local_assigns.fetch(:deselect_form_id, "deselect-all-form") %>
+
+<% select_button_options = {
+     id: "select-all-button",
+     type: "submit",
+     form: select_form_id,
+     class: "button button-default max-sm:grow",
+   }.merge(local_assigns.fetch(:select_button_options, {})) %>
+
+<% deselect_button_options = {
+     id: "deselect-all-button",
+     type: "submit",
+     form: deselect_form_id,
+     class: "button button-default max-sm:grow",
+   }.merge(local_assigns.fetch(:deselect_button_options, {})) %>
+
+<% select_form_fields = local_assigns.fetch(:select_form_fields, {}) %>
+<% deselect_form_fields = local_assigns.fetch(:deselect_form_fields, {}) %>
+
+<%= form_with(
+      url: url,
+      method: :get,
+      id: select_form_id,
+      class: "hidden",
+      data: local_assigns[:form_data],
+    ) do %>
+  <% select_form_fields.each do |field_name, field_value| %>
+    <%= hidden_field_tag field_name, field_value, id: nil %>
+  <% end %>
+<% end %>
+
+<%= button_tag t("common.controls.select_all"), **select_button_options %>
+
+<%= form_with(
+      url: url,
+      method: :get,
+      id: deselect_form_id,
+      class: "hidden",
+      data: local_assigns[:form_data],
+    ) do %>
+  <% deselect_form_fields.each do |field_name, field_value| %>
+    <%= hidden_field_tag field_name, field_value, id: nil %>
+  <% end %>
+<% end %>
+
+<%= button_tag t("common.controls.deselect_all"), **deselect_button_options %>

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -68,31 +68,11 @@
 
 <% if @has_workflow_executions %>
   <div class="mb-4 flex flex-wrap gap-2">
-    <%= form_with(
-              url: select_workflow_executions_url,
-              method: :get,
-              id: "select-all-form",
-              class: "max-sm:grow",
-              data: { turbo_frame: "selected" },
-                  ) do |f| %>
-      <input type="hidden" name="select" value="on">
-
-      <%= f.submit t("common.controls.select_all"),
-               id: "select-all-button",
-               class: "button button-default w-full" %>
-    <% end %>
-
-    <%= form_with(
-              url: select_workflow_executions_url,
-              method: :get,
-              id: "deselect-all-form",
-              class: "max-sm:grow",
-              data: { turbo_frame: "selected" },
-                  ) do |f| %>
-      <%= f.submit t("common.controls.deselect_all"),
-               id: "deselect-all-button",
-               class: "button button-default w-full" %>
-    <% end %>
+    <%= render "shared/selection_buttons",
+    url: select_workflow_executions_url,
+    form_data: { turbo_frame: "selected" },
+    select_form_fields: { select: "on" },
+    deselect_form_fields: {} %>
 
     <div class="max-sm:hidden sm:grow" role="presentation"></div>
 

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -72,7 +72,15 @@
     url: select_workflow_executions_url,
     form_data: { turbo_frame: "selected" },
     select_form_fields: { select: "on" },
-    deselect_form_fields: {} %>
+    deselect_form_fields: {},
+    select_button_options: {
+      title: t(".select_all_tooltip"),
+      aria: { label: t(".select_all_tooltip") },
+    },
+    deselect_button_options: {
+      title: t(".deselect_all_tooltip"),
+      aria: { label: t(".deselect_all_tooltip") },
+    } %>
 
     <div class="max-sm:hidden sm:grow" role="presentation"></div>
 

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -163,6 +163,7 @@ en:
         counts:
           attachments: Attachments
           selected: Selected
+          status: "%{selected} of %{total} attachments selected"
         created_at: Uploaded
         delete_aria_label:
           one: 'Delete file: %{name}'

--- a/config/locales/components.fr.yml
+++ b/config/locales/components.fr.yml
@@ -163,6 +163,7 @@ fr:
         counts:
           attachments: Pièces jointes
           selected: Sélectionné
+          status: "%{selected} sur %{total} pièces jointes sélectionnées"
         created_at: Créé à
         delete_aria_label:
           one: 'Supprimer le fichier : %{name}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1100,6 +1100,8 @@ en:
         title: Edit workflow execution
       index:
         create_export_button: Create Export
+        deselect_all_tooltip: Deselect all workflow executions in this group
+        select_all_tooltip: Select all workflow executions in this group
         subtitle: These are the workflow executions that have been shared within this group
       show:
         cancel_button_confirmation: Are you sure that you want to cancel this workflow execution?
@@ -1713,6 +1715,7 @@ en:
           error: 'File %{filename} was not removed due to the following errors: %{errors}'
           success: File %{filename} was successfully removed.
         table:
+          deselect_all_tooltip: Deselect all files for this sample
           empty_state:
             action_text: Upload Files
             description: This sample currently has no attached files. Get started by uploading sequence data, assembly files, or other relevant documents.
@@ -1720,6 +1723,7 @@ en:
             title: No files have been uploaded
           search:
             placeholder: Search files
+          select_all_tooltip: Select all files for this sample
       create:
         success: Sample was successfully created.
       edit:
@@ -1843,6 +1847,8 @@ en:
         submit_button: Submit
         title: Edit automated workflow execution
       index:
+        deselect_all_tooltip: Deselect all workflow executions in this project
+        select_all_tooltip: Select all workflow executions in this project
         subtitle: These are the workflow executions that have been automatically launched for this project, along with workflow executions that have been shared by any of its members.
       show:
         cancel_button_confirmation: Are you sure that you want to cancel this workflow execution?
@@ -2253,6 +2259,9 @@ en:
         title: No Files
       search:
         placeholder: Search files
+    index:
+      deselect_all_tooltip: Deselect all workflow executions
+      select_all_tooltip: Select all workflow executions
     samples:
       empty: No samples could be found for this workflow execution
     show:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1102,6 +1102,8 @@ fr:
         title: Modifier l’exécution du flux de travail
       index:
         create_export_button: Créer une exportation
+        deselect_all_tooltip: Désélectionner toutes les exécutions de flux de travail de ce groupe
+        select_all_tooltip: Sélectionner toutes les exécutions de flux de travail de ce groupe
         subtitle: Ce sont les exécutions du flux de travail qui ont été partagées au sein de ce groupe.
       show:
         cancel_button_confirmation: Êtes-vous sûr de vouloir annuler cette exécution de flux de travail?
@@ -1717,6 +1719,7 @@ fr:
           error: 'Le fichier %{filename} n’a pas été supprimé en raison des erreurs suivantes : %{errors}'
           success: Le fichier %{filename} a été supprimé avec succès.
         table:
+          deselect_all_tooltip: Désélectionner tous les fichiers de cet échantillon
           empty_state:
             action_text: Télécharger des fichiers
             description: Cet échantillon n’a actuellement aucun fichier joint. Commencer par télécharger les données de séquence, les fichiers d’assemblage ou d’autres documents pertinents
@@ -1724,6 +1727,7 @@ fr:
             title: Aucun fichier n’a été téléchargé
           search:
             placeholder: Rechercher des fichiers
+          select_all_tooltip: Sélectionner tous les fichiers de cet échantillon
       create:
         success: L’échantillon a été créé avec succès.
       edit:
@@ -1847,6 +1851,8 @@ fr:
         submit_button: Envoyer
         title: Modifier l’exécution automatisée du flux de travail
       index:
+        deselect_all_tooltip: Désélectionner toutes les exécutions de flux de travail de ce projet
+        select_all_tooltip: Sélectionner toutes les exécutions de flux de travail de ce projet
         subtitle: Il s’agit des exécutions de flux de travail qui ont été lancées automatiquement pour ce projet, ainsi que des exécutions de flux de travail qui ont été partagées par l’un de ses membres.
       show:
         cancel_button_confirmation: Êtes-vous sûr de vouloir annuler cette exécution de flux de travail?
@@ -2257,6 +2263,9 @@ fr:
         title: Aucun fichier
       search:
         placeholder: Rechercher des fichiers
+    index:
+      deselect_all_tooltip: Désélectionner toutes les exécutions de flux de travail
+      select_all_tooltip: Sélectionner toutes les exécutions de flux de travail
     samples:
       empty: Aucun échantillon n’a pu être trouvé pour cette exécution de flux de travail
     show:

--- a/test/system/projects/samples_test.rb
+++ b/test/system/projects/samples_test.rb
@@ -73,8 +73,11 @@ module Projects
       assert_text strip_tags(I18n.t(:'components.viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
                                                                                       locale: @user.locale))
 
-      assert_selector 'form#select-all-form'
-      assert_selector 'form#deselect-all-form'
+      # The submit buttons are visible and linked to their hidden forms via the form attribute
+      assert_selector 'button#select-all-button'
+      assert_selector 'button#deselect-all-button'
+      assert_selector 'form#select-all-form', visible: false
+      assert_selector 'form#deselect-all-form', visible: false
     end
 
     test 'User with role < Analyst does not see select and deselect buttons for samples table' do
@@ -84,8 +87,10 @@ module Projects
       assert_text strip_tags(I18n.t(:'components.viral.pagy.limit_component.summary', from: 1, to: 3, count: 3,
                                                                                       locale: @user.locale))
 
-      assert_no_selector 'form#select-all-form'
-      assert_no_selector 'form#deselect-all-form'
+      assert_no_selector 'button#select-all-button'
+      assert_no_selector 'button#deselect-all-button'
+      assert_no_selector 'form#select-all-form', visible: :all
+      assert_no_selector 'form#deselect-all-form', visible: :all
     end
 
     test 'User with role >= Analyst sees sample table checkboxes' do


### PR DESCRIPTION
## What does this PR do and why?

Extracts the select-all/deselect-all controls on the samples and workflow-execution index pages (and the sample attachments table) into a single shared partial, `app/views/shared/_selection_buttons.html.erb`.

**Why (screen reader accessibility):** Previously each select/deselect control was rendered as a submit button nested inside its own `<form>` element. Screen readers announce the surrounding `form` boundary before reaching the control, so users heard "form" before the button label.

**Why (layout):** Wrapping each button in its own block-level `<form>` also made the controls awkward to lay out in the flex action toolbars.

## Screenshots or screen recordings

No visual change — the select-all/deselect-all buttons render and behave as before. The change is in the underlying markup (button no longer nested inside a `<form>`) so screen readers announce the button directly.

Rendered HTML:

```html
<form id="select-all-form" class="hidden" data-turbo-frame="selected" action="http://localhost:3000/yersinia/yersinia-pseudotuberculosis/outbreak-2025/-/samples/select" accept-charset="UTF-8" method="get">
    <input type="hidden" name="select" value="on">
    <input type="hidden" name="timestamp" value="2026-07-03T13:36:13+00:00">
</form>
<form id="deselect-all-form" class="hidden" data-turbo-frame="selected" action="http://localhost:3000/yersinia/yersinia-pseudotuberculosis/outbreak-2025/-/samples/select" accept-charset="UTF-8" method="get"></form>
<div class="flex w-full gap-2 md:w-auto">
  <button name="button" type="submit" id="select-all-button" form="select-all-form" class="button button-default max-md:flex-1 max-md:basis-0 md:flex-none" title="Select all samples in this project" aria-label="Select all samples in this project">Select All</button>
  <button name="button" type="submit" id="deselect-all-button" form="deselect-all-form" class="button button-default max-md:flex-1 max-md:basis-0 md:flex-none" title="Deselect all samples in this project" aria-label="Deselect all samples in this project">Deselect All</button>
</div>

```

## How to set up and validate locally

1. Check out branch `feat/detached-button-to-helper`.
2. Server-side render + HTML validity checks:
   - `PARALLEL_WORKERS=4 bin/rails test test/controllers/workflow_executions_controller_test.rb test/controllers/groups/workflow_executions_controller_test.rb test/controllers/projects/workflow_executions_controller_test.rb test/controllers/groups/samples_controller_test.rb test/controllers/projects/samples_controller_test.rb test/controllers/projects/samples/attachments_controller_test.rb`
3. Behavioural check (browser):
   - `PARALLEL_WORKERS=1 bin/rails test test/system/workflow_executions_test.rb -n "/should delete a completed workflow/"`
4. Lint:
   - `pnpm run herb:lint app/views/shared/_selection_buttons.html.erb`
5. Accessibility spot check: with a screen reader (e.g. VoiceOver/NVDA), navigate to a samples or workflow-executions index and confirm the select all / deselect all controls are announced as buttons rather than being prefaced by a form boundary.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.