### PR TITLE
fix: Two list selection aria live remove announcements

### DIFF
--- a/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
+++ b/app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js
@@ -99,11 +99,7 @@ export default class extends Controller {
 
   #ensureAriaLiveReady() {
     // check if aria-live exists as it's added after file selection in import metadata (can't be done in connect())
-    if (
-      !this.#ariaLiveTranslations &&
-      this.hasAriaLiveUpdateTarget &&
-      !this.#wordConnector
-    ) {
+    if (!this.#ariaLiveTranslations && this.hasAriaLiveUpdateTarget) {
       this.#ariaLiveTranslations = JSON.parse(
         this.ariaLiveUpdateTarget.getAttribute("data-translations"),
       );
@@ -113,9 +109,13 @@ export default class extends Controller {
         twoWordsConnector: this.#ariaLiveTranslations["two_words_connector"],
         lastWordConnector: this.#ariaLiveTranslations["last_word_connector"],
       });
-      return true;
     }
-    return false;
+
+    return Boolean(
+      this.#ariaLiveTranslations &&
+      this.#wordConnector &&
+      this.hasAriaLiveUpdateTarget,
+    );
   }
 
   #cleanupAvailableList() {

--- a/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
+++ b/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
@@ -445,4 +445,58 @@ describe("sortable lists two-lists selection controller", () => {
       ),
     ).toHaveTextContent("Two was moved up to position 1 in Selected list.");
   });
+
+  it("announces each add and remove action via the aria-live region", async () => {
+    vi.useFakeTimers();
+    renderFixture({
+      available: [option("available-foo", "foo")],
+      selected: [],
+    });
+    application = await startController();
+
+    const availableList = list("available-list");
+    const selectedList = list("selected-list");
+    const addButton = document.querySelector(
+      '[data-sortable-lists--v1--two-lists-selection-target="addButton"]',
+    );
+    const removeButton = document.querySelector(
+      '[data-sortable-lists--v1--two-lists-selection-target="removeButton"]',
+    );
+    const ariaLive = document.querySelector(
+      '[data-sortable-lists--v1--two-lists-selection-target="ariaLiveUpdate"]',
+    );
+
+    availableList.focus();
+    keydown(availableList, " ");
+    addButton.focus();
+    addButton.click();
+    vi.runAllTimers();
+    expect(ariaLive).toHaveTextContent(
+      "The following item was moved to Selected list: foo",
+    );
+    expect(document.activeElement).toBe(addButton);
+    expect(addButton).toHaveAttribute("aria-disabled", "true");
+
+    selectedList.focus();
+    keydown(selectedList, " ");
+    removeButton.focus();
+    removeButton.click();
+    vi.runAllTimers();
+    expect(ariaLive).toHaveTextContent(
+      "The following item was moved to Available list: foo",
+    );
+    expect(document.activeElement).toBe(removeButton);
+    expect(removeButton).toHaveAttribute("aria-disabled", "true");
+
+    availableList.focus();
+    keydown(availableList, " ");
+    addButton.focus();
+    addButton.click();
+    vi.runAllTimers();
+    expect(ariaLive).toHaveTextContent(
+      "The following item was moved to Selected list: foo",
+    );
+    expect(document.activeElement).toBe(addButton);
+    expect(addButton).toHaveAttribute("aria-disabled", "true");
+  });
 });


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Fixes issue where when selecting metatadata fields for a metadata template:

1. Add field to "Currently in template" list -> aria live announced correctly
2. Remove that field -> not announced
3. Add field again -> not announced 

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

<img width="496" height="452" alt="image" src="https://github.com/user-attachments/assets/66b0106d-f7a7-4522-b308-42967dcc4cf9" />

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Create a new project
2. Add a sample to that project and create one metadata field within it.
3. In the project, go to create a new metadata template (make sure NVDA is open)
4. Using the keyboard, add the metadata field to "Currently in template" -> Should be read properly (_The following item was moved to Currently in template: foo_)
5. Using the keyboard, remove the metadata field from "Currently in template" -> Should be read properly (_The following item was moved to Not currently in template: foo_)
6. Add and remove a couple more times to ensure that it continues to be read properly.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.