### PR TITLE
ART-9237 - Bots access token section fix

### DIFF
--- a/app/components/bots/table_component.html.erb
+++ b/app/components/bots/table_component.html.erb
@@ -1,6 +1,6 @@
-<%= helpers.turbo_frame_tag "bots-table" do %>
+<%= helpers.turbo_frame_tag "bots-table-section" do %>
   <% if @bot_accounts.count.positive? %>
-    <%= viral_data_table(@bot_accounts) do |table| %>
+    <%= viral_data_table(@bot_accounts, id: "bots-table") do |table| %>
       <% table.with_column(t("bots.index.table.header.username")) do |row| %>
         <%= row.user.email %>
       <% end %>

--- a/app/components/bots/table_component.html.erb
+++ b/app/components/bots/table_component.html.erb
@@ -1,14 +1,15 @@
-<% if @bot_accounts.count.positive? %>
-  <%= viral_data_table(@bot_accounts, id: "bots-table") do |table| %>
-    <% table.with_column(t("bots.index.table.header.username")) do |row| %>
-      <%= row.user.email %>
-    <% end %>
+<%= helpers.turbo_frame_tag "bots-table" do %>
+  <% if @bot_accounts.count.positive? %>
+    <%= viral_data_table(@bot_accounts) do |table| %>
+      <% table.with_column(t("bots.index.table.header.username")) do |row| %>
+        <%= row.user.email %>
+      <% end %>
 
-    <% table.with_column(t("bots.index.table.header.active_tokens")) do |row| %>
-      <% active_count = row.user.personal_access_tokens.active.count %>
+      <% table.with_column(t("bots.index.table.header.active_tokens")) do |row| %>
+        <% active_count = row.user.personal_access_tokens.active.count %>
 
-      <% if active_count.positive? %>
-        <%= button_to active_count,
+        <% if active_count.positive? %>
+          <%= button_to active_count,
         bot_tokens_path(row),
         data: {
           turbo_stream: true,
@@ -19,16 +20,16 @@
         method: :get,
         class:
           "font-semibold text-slate-800 dark:text-slate-300 underline hover:decoration-2 cursor-pointer" %>
-      <% else %>
-        0
+        <% else %>
+          0
+        <% end %>
       <% end %>
-    <% end %>
 
-    <% table.with_column(t("bots.index.table.header.inactive_tokens")) do |row| %>
-      <% inactive_count = row.user.personal_access_tokens.inactive.count %>
+      <% table.with_column(t("bots.index.table.header.inactive_tokens")) do |row| %>
+        <% inactive_count = row.user.personal_access_tokens.inactive.count %>
 
-      <% if inactive_count.positive? %>
-        <%= button_to inactive_count,
+        <% if inactive_count.positive? %>
+          <%= button_to inactive_count,
         bot_inactive_tokens_path(row),
         data: {
           turbo_stream: true,
@@ -39,34 +40,34 @@
         method: :get,
         class:
           "font-semibold text-slate-800 dark:text-slate-300 underline hover:decoration-2 cursor-pointer" %>
-      <% else %>
-        0
+        <% else %>
+          0
+        <% end %>
       <% end %>
-    <% end %>
 
-    <% table.with_column(t("bots.index.table.header.created")) do |row| %>
-      <%= helpers.local_time_ago(row.user.created_at) %>
-    <% end %>
-
-    <% table.with_column(t("bots.index.table.header.access_level")) do |row| %>
-      <% unless row.membership.nil? %>
-        <%= t(:"bots.index.table.access_level.level_#{row.membership.access_level}") %>
+      <% table.with_column(t("bots.index.table.header.created")) do |row| %>
+        <%= helpers.local_time_ago(row.user.created_at) %>
       <% end %>
-    <% end %>
 
-    <% table.with_column(t("bots.index.table.header.expiration")) do |row| %>
-      <% if !row.membership&.expires_at.nil? %>
-        <%= helpers.local_date(row.membership.expires_at, :long) %>
-      <% else %>
-        <%= t("bots.index.table.never") %>
+      <% table.with_column(t("bots.index.table.header.access_level")) do |row| %>
+        <% unless row.membership.nil? %>
+          <%= t(:"bots.index.table.access_level.level_#{row.membership.access_level}") %>
+        <% end %>
       <% end %>
-    <% end %>
 
-    <% table.with_column(t("bots.index.table.header.actions"),
+      <% table.with_column(t("bots.index.table.header.expiration")) do |row| %>
+        <% if !row.membership&.expires_at.nil? %>
+          <%= helpers.local_date(row.membership.expires_at, :long) %>
+        <% else %>
+          <%= t("bots.index.table.never") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_column(t("bots.index.table.header.actions"),
         classes: "flex justify-start"
       ) do |row| %>
-      <% if @abilities[:generate_token] %>
-        <%= button_to t("bots.index.table.actions.generate_new_token"),
+        <% if @abilities[:generate_token] %>
+          <%= button_to t("bots.index.table.actions.generate_new_token"),
         new_token_path(row),
         data: {
           turbo_stream: true,
@@ -81,10 +82,10 @@
         },
         class:
           "font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer mr-2" %>
-      <% end %>
+        <% end %>
 
-      <% if @abilities[:destroy_bot] %>
-        <%= button_to t('common.actions.delete'),
+        <% if @abilities[:destroy_bot] %>
+          <%= button_to t('common.actions.delete'),
         destroy_path(row),
         data: {
           turbo_stream: true,
@@ -95,16 +96,17 @@
         },
         class:
           "font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer" %>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
-  <%= render Viral::Pagy::FullComponent.new(@pagy, item: t("bots.index.pagy_item")) %>
-<% else %>
-  <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::Pagy::FullComponent.new(@pagy, item: t("bots.index.pagy_item")) %>
+  <% else %>
+    <div class="empty_state_message">
+      <%= viral_empty(
       title: t("bots.index.table.empty_state.title"),
       description: t("bots.index.table.empty_state.description"),
       icon_name: NamespaceBot.icon,
     ) %>
-  </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/controllers/concerns/bot_actions.rb
+++ b/app/controllers/concerns/bot_actions.rb
@@ -10,7 +10,7 @@ module BotActions
     before_action proc { bot_account }, only: %i[destroy destroy_confirmation]
     before_action proc { bot_type }, only: %i[create]
     before_action proc { bot_accounts }
-    before_action proc { view_authorizations }, only: %i[index]
+    before_action proc { view_authorizations }, only: %i[index create]
   end
 
   def index
@@ -34,12 +34,14 @@ module BotActions
     end
   end
 
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     @bot_account = Bots::CreateService.new(current_user, @namespace, @bot_type, bot_params).execute
 
     respond_to do |format|
       format.turbo_stream do
         if @bot_account.persisted?
+          @pagy, @bot_accounts = pagy(@bot_accounts, raise_range_error: true)
+
           render status: :ok, locals: {
             type: 'success',
             message: t('concerns.bot_actions.create.success'),

--- a/app/controllers/concerns/bot_personal_access_token_actions.rb
+++ b/app/controllers/concerns/bot_personal_access_token_actions.rb
@@ -7,10 +7,11 @@ module BotPersonalAccessTokenActions # rubocop:disable Metrics/ModuleLength
   included do
     before_action proc { namespace }
     before_action proc { bot_account }
-    before_action proc { personal_access_tokens }, only: %i[index revoke rotate]
+    before_action proc { personal_access_tokens }, only: %i[index revoke rotate create]
     before_action proc { inactive_personal_access_tokens }, only: %i[inactive]
     before_action proc { personal_access_token }, only: %i[revoke revoke_confirmation rotate rotate_confirmation]
     before_action proc { bot_accounts }
+    before_action proc { view_authorizations }, only: %i[create]
   end
 
   def index
@@ -48,6 +49,8 @@ module BotPersonalAccessTokenActions # rubocop:disable Metrics/ModuleLength
   def create # rubocop:disable Metrics/MethodLength
     @personal_access_token = PersonalAccessTokens::CreateService.new(current_user, bot_personal_access_token_params,
                                                                      @namespace, @bot_account.user).execute
+    @pagy, @bot_accounts = pagy(@bot_accounts, raise_range_error: true)
+
     respond_to do |format|
       format.turbo_stream do
         if @personal_access_token.persisted?
@@ -64,7 +67,8 @@ module BotPersonalAccessTokenActions # rubocop:disable Metrics/ModuleLength
                       end
 
           render status: :unprocessable_content,
-                 locals: { type: 'alert', message: error_msg }
+                 locals: { type: 'alert',
+                           message: error_msg }
 
         end
       end
@@ -140,6 +144,15 @@ module BotPersonalAccessTokenActions # rubocop:disable Metrics/ModuleLength
   end
 
   private
+
+  def view_authorizations
+    @allowed_to = {
+      generate_bot_personal_access_token:
+      allowed_to?(:generate_bot_personal_access_token?, @namespace),
+      destroy_bot_accounts: allowed_to?(:destroy_bot_accounts?, @namespace),
+      create_bot_accounts: allowed_to?(:create_bot_accounts?, @namespace)
+    }
+  end
 
   def bot_account
     @bot_account = @namespace.namespace_bots.find_by(id: params[:bot_id]) || not_found

--- a/app/views/groups/bots/_access_token_section.html.erb
+++ b/app/views/groups/bots/_access_token_section.html.erb
@@ -1,23 +1,21 @@
 <%= turbo_frame_tag "access-token-section" do %>
   <div
-    data-turbo-permanent
+    data-turbo-temporary
     class="
-      p-4 bg-white border border-slate-200 rounded-lg shadow-sm 2xl:col-span-2
-      dark:border-slate-700 sm:p-6 dark:bg-slate-800 mb-4
+      mb-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6 2xl:col-span-2 dark:border-slate-700
+      dark:bg-slate-800
     "
   >
-    <h2
-      class="
-        text-xl font-semibold leading-tight break-words text-slate-900 dark:text-white
-      "
-    >
+    <h2 class="text-xl leading-tight font-semibold break-words text-slate-900 dark:text-white">
       <%= t("groups.bots.index.access_token_section.label", bot_name: bot_account_name) %>
     </h2>
+
     <%= render TokenComponent.new(
       value: token,
       aria_label: t("groups.bots.index.access_token_section.aria_label"),
       classes: "my-2",
     ) %>
+
     <p class="text-slate-500 dark:text-slate-400"><%= t("groups.bots.index.access_token_section.description") %></p>
   </div>
 <% end %>

--- a/app/views/groups/bots/create.turbo_stream.erb
+++ b/app/views/groups/bots/create.turbo_stream.erb
@@ -15,6 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <%= turbo_stream.replace "bots-table",
+  <%= turbo_stream.replace "bots-table-section",
                        partial: "table" %>
 <% end %>

--- a/app/views/groups/bots/create.turbo_stream.erb
+++ b/app/views/groups/bots/create.turbo_stream.erb
@@ -15,5 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <turbo-stream action="refresh"></turbo-stream>
+  <%= turbo_stream.replace "bots-table",
+                       partial: "table" %>
 <% end %>

--- a/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
@@ -15,6 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <%= turbo_stream.replace "bots-table",
+  <%= turbo_stream.replace "bots-table-section",
                        partial: "groups/bots/table" %>
 <% end %>

--- a/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
@@ -15,5 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <turbo-stream action="refresh"></turbo-stream>
+  <%= turbo_stream.replace "bots-table",
+                       partial: "groups/bots/table" %>
 <% end %>

--- a/app/views/projects/bots/_access_token_section.html.erb
+++ b/app/views/projects/bots/_access_token_section.html.erb
@@ -1,23 +1,21 @@
 <%= turbo_frame_tag "access-token-section" do %>
   <div
-    data-turbo-permanent
+    data-turbo-temporary
     class="
-      p-4 bg-white border border-slate-200 rounded-lg shadow-sm 2xl:col-span-2
-      dark:border-slate-700 sm:p-6 dark:bg-slate-800 mb-4
+      mb-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6 2xl:col-span-2 dark:border-slate-700
+      dark:bg-slate-800
     "
   >
-    <h2
-      class="
-        text-xl font-semibold leading-tight break-words text-slate-900 dark:text-white
-      "
-    >
+    <h2 class="text-xl leading-tight font-semibold break-words text-slate-900 dark:text-white">
       <%= t("projects.bots.index.access_token_section.label", bot_name: bot_account_name) %>
     </h2>
+
     <%= render TokenComponent.new(
       value: token,
       aria_label: t("projects.bots.index.access_token_section.aria_label"),
       classes: "my-2",
     ) %>
+
     <p class="text-slate-500 dark:text-slate-400"><%= t("projects.bots.index.access_token_section.description") %></p>
   </div>
 <% end %>

--- a/app/views/projects/bots/create.turbo_stream.erb
+++ b/app/views/projects/bots/create.turbo_stream.erb
@@ -15,6 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <%= turbo_stream.replace "bots-table",
+  <%= turbo_stream.replace "bots-table-section",
                        partial: "table" %>
 <% end %>

--- a/app/views/projects/bots/create.turbo_stream.erb
+++ b/app/views/projects/bots/create.turbo_stream.erb
@@ -15,5 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <turbo-stream action="refresh"></turbo-stream>
+  <%= turbo_stream.replace "bots-table",
+                       partial: "table" %>
 <% end %>

--- a/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
@@ -15,5 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <turbo-stream action="refresh"></turbo-stream>
+  <%= turbo_stream.replace "bots-table",
+                       partial: "projects/bots/table" %>
 <% end %>

--- a/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
@@ -15,6 +15,6 @@
                          bot_account_name: @bot_account.user.email,
                          token: personal_access_token.token,
                        } %>
-  <%= turbo_stream.replace "bots-table",
+  <%= turbo_stream.replace "bots-table-section",
                        partial: "projects/bots/table" %>
 <% end %>

--- a/test/system/groups/bots_test.rb
+++ b/test/system/groups/bots_test.rb
@@ -113,6 +113,66 @@ module Groups
       ### VERIFY END ###
     end
 
+    test 'can create a new group bot account and switching locale removes access token section' do
+      ### VERIFY START ###
+      namespace = groups(:group_two)
+      visit group_bots_path(namespace)
+
+      assert_selector 'h1', text: I18n.t(:'groups.bots.index.title')
+      assert_selector 'p', text: I18n.t(:'groups.bots.index.subtitle')
+
+      assert_selector 'a', text: I18n.t(:'groups.bots.index.add_new_bot'), count: 1
+
+      assert_selector 'tr', count: 0
+
+      within('div.empty_state_message') do
+        assert_text I18n.t(:'bots.index.table.empty_state.title')
+        assert_text I18n.t(:'bots.index.table.empty_state.description')
+      end
+      ### SETUP END ###
+
+      ### ACTIONS START ###
+      click_link I18n.t(:'groups.bots.index.add_new_bot')
+
+      assert_selector '#dialog'
+      within('#dialog') do
+        assert_selector 'h1', text: I18n.t(:'groups.bots.index.bot_listing.new_bot_modal.title')
+        assert_selector 'p', text: I18n.t(:'groups.bots.index.bot_listing.new_bot_modal.description')
+
+        fill_in I18n.t(:'activerecord.attributes.personal_access_token.name'), with: 'Uploader'
+        select I18n.t('activerecord.models.member.access_level.analyst'),
+               from: I18n.t(:'activerecord.attributes.member.access_level')
+
+        all('input[type=checkbox]').each(&:click)
+
+        click_button I18n.t('common.controls.submit')
+      end
+      ### ACTIONS END ###
+
+      ### VERIFY START ###
+      assert_no_selector '#dialog'
+
+      assert_selector '#access-token-section div'
+      within('#access-token-section') do
+        bot_account_name = namespace.bots.last.email
+
+        assert_selector 'h2', text: I18n.t('groups.bots.index.access_token_section.label', bot_name: bot_account_name)
+        assert_selector 'p', text: I18n.t('groups.bots.index.access_token_section.description')
+        assert_selector 'button', text: I18n.t('components.token.copy')
+      end
+
+      assert_selector 'tr', count: 1 + header_row_count
+
+      # switch locale
+      find('#language-selection-dd-trigger').click
+      within find('#language-selection-dd-trigger-menu') do
+        click_button I18n.t(:'locales.fr', locale: :fr)
+      end
+
+      assert_no_selector '#access-token-section div'
+      ### VERIFY END ###
+    end
+
     test 'can\'t create a new group bot account without selecting scopes' do
       ### SETUP START ###
       visit group_bots_path(groups(:group_two))

--- a/test/system/projects/bots_test.rb
+++ b/test/system/projects/bots_test.rb
@@ -113,6 +113,64 @@ module Projects
       ### VERIFY END ###
     end
 
+    test 'can create a new project bot account and switching locale removes access token section' do
+      ### VERIFY START ###
+      visit namespace_project_bots_path(@namespace, @project2)
+
+      assert_selector 'h1', text: I18n.t(:'projects.bots.index.title')
+      assert_selector 'p', text: I18n.t(:'projects.bots.index.subtitle')
+
+      assert_selector 'button', text: I18n.t(:'projects.bots.index.add_new_bot'), count: 1
+
+      assert_selector 'tr', count: 0
+
+      within('div.empty_state_message') do
+        assert_text I18n.t(:'bots.index.table.empty_state.title')
+        assert_text I18n.t(:'bots.index.table.empty_state.description')
+      end
+      ### SETUP END ###
+
+      ### ACTIONS START ###
+      click_button I18n.t(:'projects.bots.index.add_new_bot')
+
+      assert_selector '#dialog'
+      within('#dialog') do
+        assert_selector 'h1', text: I18n.t(:'projects.bots.index.bot_listing.new_bot_modal.title')
+        assert_selector 'p', text: I18n.t(:'projects.bots.index.bot_listing.new_bot_modal.description')
+
+        fill_in I18n.t(:'activerecord.attributes.personal_access_token.name'), with: 'Uploader'
+        select I18n.t('activerecord.models.member.access_level.analyst'),
+               from: I18n.t(:'activerecord.attributes.member.access_level')
+
+        all('input[type=checkbox]').each(&:click)
+
+        click_button I18n.t('common.controls.submit')
+      end
+      ### ACTIONS END ###
+
+      ### VERIFY START ###
+      assert_no_selector '#dialog'
+
+      assert_selector '#access-token-section div'
+      within('#access-token-section') do
+        bot_account_name = @project2.namespace.bots.last.email
+        assert_selector 'h2', text: I18n.t('projects.bots.index.access_token_section.label', bot_name: bot_account_name)
+        assert_selector 'p', text: I18n.t('projects.bots.index.access_token_section.description')
+        assert_selector 'button', text: I18n.t('components.token.copy')
+      end
+
+      assert_selector 'tr', count: 1 + header_row_count
+
+      # switch locale
+      find('#language-selection-dd-trigger').click
+      within find('#language-selection-dd-trigger-menu') do
+        click_button I18n.t(:'locales.fr', locale: :fr)
+      end
+
+      assert_no_selector '#access-token-section div'
+      ### VERIFY END ###
+    end
+
     test 'can\'t create a new project bot account without selecting scopes' do
       ### SETUP START ###
       visit namespace_project_bots_path(@namespace, @project2)


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes an accessibility bug on the project and group bot accounts page [ART-9237](https://jill.hc-sc.gc.ca/jira/browse/ART-9237?jql=%22Epic%20Link%22%20%3D%20ART-7084%20AND%20status%20%3D%20%22To%20Do%22). The bug would arise if a user created a personal access token for a bot in one locale, and then switched to another locale while the personal access token section was still displayed, the screen reader would read out the personal access token section in the previous locale. This was caused by setting a data-turbo-permanent on the section which has now been removed and the create.turbo_stream files for bots and bot personal access tokens have been updated to replace the turbo_frame contents instead of refreshing the page

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

**Existing behaviour**

<img width="800" height="374" alt="image" src="https://github.com/user-attachments/assets/0f075ff7-f7fa-486a-bad4-ee5aec6b95c6" />



## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Turn on nvda screen reader
2. Verify that creating a bot account personal access token results in the access token section to display and is read out by the screen reader. 
3. Switch the locale to `Francais` and verify that the access token section is no longer displayed or being read out

**Ensure the above steps were done for both a project and group**

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [X] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
