### PR TITLE
a11y: Override button_to to move button outside of form element

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -103,19 +103,15 @@ Turbo.config.forms.confirm = (message, element) => {
   const defaultState = dialog.innerHTML;
 
   // Determine if custom content is provided
-  // This can be hidden on a button inside a form created by rails
-  const contentIdElement = element.querySelector("[data-turbo-content]");
-
-  if (contentIdElement) {
-    const contentId = contentIdElement.getAttribute("data-turbo-content");
+  if (element.hasAttribute("data-turbo-content")) {
+    const contentId = element.getAttribute("data-turbo-content");
     dialog.querySelector(".dialog--content").innerHTML =
       document.querySelector(contentId).innerHTML;
   }
 
   // See if there is a custom form to display
-  const confirmValueElement = element.querySelector("[data-confirm-value]");
-  if (confirmValueElement) {
-    const value = confirmValueElement.getAttribute("data-confirm-value");
+  if (element.hasAttribute("data-confirm-value")) {
+    const value = element.getAttribute("data-confirm-value");
     const confirmForm = dialog.querySelector(".dialog--form--validate");
     confirmForm.setAttribute("data-confirmation-input-value", value);
 

--- a/app/views/groups/_edit_advanced_delete.html.erb
+++ b/app/views/groups/_edit_advanced_delete.html.erb
@@ -47,10 +47,12 @@
       <%= button_to t(:"groups.edit.advanced.delete.submit"),
       @group,
       method: :delete,
-      data: {
-        turbo_confirm: "",
-        turbo_content: ".confirm-delete",
-        confirm_value: @group.path,
+      form: {
+        data: {
+          turbo_confirm: "",
+          turbo_content: ".confirm-delete",
+          confirm_value: @group.path,
+        }
       },
       class: "button button-destructive" %>
     </div>

--- a/app/views/groups/_edit_advanced_transfer_form.html.erb
+++ b/app/views/groups/_edit_advanced_transfer_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_with(model: @transfer_form, url: group_transfer_path, method: :put, class: "grid gap-4", id: "edit_advanced_transfer_form",
-data:
-if Flipper.enabled?(:v2_select2, Current.user)
-    { turbo_confirm: "", controller: "select2--v2" }
-  else
-    { turbo_confirm: "", controller: "select2--v1" }
-  end) do |form| %>
+data: {
+  turbo_confirm: "",
+  turbo_content: ".confirm-transfer",
+  confirm_value: confirm_value,
+  controller: Flipper.enabled?(:v2_select2, Current.user) ? "select2--v2" : "select2--v1"
+}) do |form| %>
   <%= render partial: "shared/form/required_field_legend" %>
 
   <% invalid_new_parent_id = @transfer_form.errors.include?(:new_parent_id) %>
@@ -68,12 +68,8 @@ if Flipper.enabled?(:v2_select2, Current.user)
                 if Flipper.enabled?(:v2_select2, Current.user)
                 {
                   "select2--v2-target": "submitButton",
-                  turbo_content: ".confirm-transfer",
-                  confirm_value: confirm_value,
                 } else {
                   "select2--v1-target": "submitButton",
-                  turbo_content: ".confirm-transfer",
-                  confirm_value: confirm_value,
                 }
                 end %>
   </div>

--- a/app/views/groups/_edit_change_visibility.html.erb
+++ b/app/views/groups/_edit_change_visibility.html.erb
@@ -48,10 +48,12 @@
       group_path,
       method: :patch,
       params: { group: { public: !group.public}},
-      data: {
-        turbo_confirm: "",
-        turbo_content: ".confirm-change-visibility",
-        confirm_value: group.path,
+      form: {
+        data: {
+          turbo_confirm: "",
+          turbo_content: ".confirm-change-visibility",
+          confirm_value: group.path,
+        }
       },
       class: "button button-primary inline-block" %>
     </div>

--- a/app/views/projects/_destroy.html.erb
+++ b/app/views/projects/_destroy.html.erb
@@ -43,10 +43,12 @@
       <%= button_to t(:"projects.edit.advanced.destroy.submit"),
       namespace_project_path,
       method: :delete,
-      data: {
-        turbo_confirm: "",
-        turbo_content: ".confirm-destroy",
-        confirm_value: @project.name,
+      form: {
+        data: {
+          turbo_confirm: "",
+          turbo_content: ".confirm-destroy",
+          confirm_value: @project.name,
+        }
       },
       class: "button button-destructive" %>
     </div>

--- a/app/views/projects/_transfer_form.html.erb
+++ b/app/views/projects/_transfer_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with(model: @transfer_form, url: namespace_project_transfer_path, method: :post, class: "grid gap-4", id: "edit_advanced_transfer",
               data:
               if Flipper.enabled?(:v2_select2, Current.user)
-                { turbo_confirm: "", controller: "select2--v2" }
+                { turbo_confirm: "", turbo_content: ".confirm-transfer", confirm_value: @project.name, controller: "select2--v2" }
               else
-                { turbo_confirm: "", controller: "select2--v1" }
+                { turbo_confirm: "", turbo_content: ".confirm-transfer", confirm_value: @project.name, controller: "select2--v1" }
               end) do |form| %>
   <div class="mb-2"><%= render partial: "shared/form/required_field_legend" %></div>
 
@@ -64,12 +64,8 @@
                 if Flipper.enabled?(:v2_select2, Current.user)
                 {
                   "select2--v2-target": "submitButton",
-                  turbo_content: ".confirm-transfer",
-                  confirm_value: @project.name,
                 } else {
                   "select2--v1-target": "submitButton",
-                  turbo_content: ".confirm-transfer",
-                  confirm_value: @project.name,
                 }
                 end %>
   </div>

--- a/config/initializers/button_to_override.rb
+++ b/config/initializers/button_to_override.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Override for rails button_to, which moves button outside of the form so that screenreaders don't announce that the
+# button is inside a form which can be confusing to users
+module ButtonToOverride
+  def button_to(name = nil, options = nil, html_options = {}, &)
+    # 1. Safely normalize html_options if a block is passed
+    html_options = options || {} if block_given?
+
+    html_options[:form] ||= {}
+    html_options[:form][:id] ||= SecureRandom.uuid
+    form_id = html_options[:form][:id]
+
+    button_to_fragment = Nokogiri::HTML::DocumentFragment.parse(super)
+
+    button_fragment = button_to_fragment.at_css('button').remove
+    button_fragment['form'] = form_id
+    button_to_fragment.add_child(button_fragment)
+
+    button_to_fragment.to_html.html_safe # rubocop:disable Rails/OutputSafety
+  end
+end
+
+ActionView::Helpers::UrlHelper.prepend(ButtonToOverride)

--- a/test/components/activities/dialogs/activity_list_dialog_component_test.rb
+++ b/test/components/activities/dialogs/activity_list_dialog_component_test.rb
@@ -84,10 +84,6 @@ module Activities
           activity[:key].include?('project_namespace.samples.transferred_from')
         end)
 
-        activities.find do |a|
-          a[:key] == 'activity.namespaces_project_namespace.samples.transferred_from_html'
-        end
-
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
         click_button(I18n.t('components.activity.samples.transfer.more_details.button_descriptive_text'))
@@ -114,10 +110,6 @@ module Activities
         assert_equal(1, activities.count do |activity|
           activity[:key].include?('namespaces_project_namespace.import_samples.create')
         end)
-
-        activities.find do |a|
-          a[:key] == 'activity.namespaces_project_namespace.import_samples.create_html'
-        end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
@@ -154,10 +146,6 @@ module Activities
         assert_equal(1, activities.count do |activity|
           activity[:key].include?('project_namespace.samples.bulk_metadata_update')
         end)
-
-        activities.find do |a|
-          a[:key] == 'activity.namespaces_project_namespace.samples.bulk_metadata_update_html'
-        end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
@@ -199,10 +187,6 @@ module Activities
           activity[:key].include?('project_namespace.samples.bulk_metadata_update')
         end)
 
-        activities.find do |a|
-          a[:key] == 'activity.namespaces_project_namespace.samples.bulk_metadata_update_html'
-        end
-
         visit namespace_project_activity_path(project30_namespace.parent, project30_namespace.project)
 
         click_button(I18n.t('components.activity.more_details'))
@@ -225,10 +209,6 @@ module Activities
         assert_equal(1, activities.count do |activity|
           activity[:key].include?('project_namespace.samples.bulk_metadata_update')
         end)
-
-        activities.find do |a|
-          a[:key] == 'activity.namespaces_project_namespace.samples.bulk_metadata_update_html'
-        end
 
         visit namespace_project_activity_path(project31_namespace.parent, project31_namespace.project)
 

--- a/test/components/activities/dialogs/activity_list_dialog_component_test.rb
+++ b/test/components/activities/dialogs/activity_list_dialog_component_test.rb
@@ -23,15 +23,13 @@ module Activities
           activity[:key].include?('project_namespace.samples.destroy_multiple')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.destroy_multiple_html'
         end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.destroy.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.sample_destroy.title')
 
@@ -55,15 +53,13 @@ module Activities
           activity[:key].include?('project_namespace.samples.transfer')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.transfer_html'
         end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.transfer.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.sample_transfer.title')
 
@@ -88,15 +84,13 @@ module Activities
           activity[:key].include?('project_namespace.samples.transferred_from')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.transferred_from_html'
         end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.transfer.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.sample_transfer.title')
 
@@ -121,7 +115,7 @@ module Activities
           activity[:key].include?('namespaces_project_namespace.import_samples.create')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.import_samples.create_html'
         end
 
@@ -130,9 +124,7 @@ module Activities
         load_more_button = find('button', text: 'Load more')
         click_button 'Load more' if load_more_button
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.import.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.import_samples.title')
 
@@ -163,15 +155,13 @@ module Activities
           activity[:key].include?('project_namespace.samples.bulk_metadata_update')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.bulk_metadata_update_html'
         end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.more_details'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.bulk_metadata_update.title')
 
@@ -209,15 +199,13 @@ module Activities
           activity[:key].include?('project_namespace.samples.bulk_metadata_update')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.bulk_metadata_update_html'
         end
 
         visit namespace_project_activity_path(project30_namespace.parent, project30_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.more_details'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.bulk_metadata_update.title')
 
@@ -238,15 +226,13 @@ module Activities
           activity[:key].include?('project_namespace.samples.bulk_metadata_update')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.bulk_metadata_update_html'
         end
 
         visit namespace_project_activity_path(project31_namespace.parent, project31_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.more_details'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.bulk_metadata_update.title')
 

--- a/test/components/activities/dialogs/activity_table_listing_dialog_component_test.rb
+++ b/test/components/activities/dialogs/activity_table_listing_dialog_component_test.rb
@@ -21,10 +21,6 @@ module Activities
           activity[:key].include?('project_namespace.samples.clone')
         end)
 
-        activities.find do |a|
-          a[:key] == 'activity.namespaces_project_namespace.samples.clone_html'
-        end
-
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
         load_more_button = find('button', text: 'Load more')
@@ -58,10 +54,6 @@ module Activities
         assert_equal(1, activities.count do |activity|
           activity[:key].include?('project_namespace.samples.cloned_from')
         end)
-
-        activities.find do |a|
-          a[:key] == 'activity.namespaces_project_namespace.samples.cloned_from_html'
-        end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
@@ -128,10 +120,6 @@ module Activities
           activity[:key].include?('group.samples.destroy')
         end)
 
-        activities.find do |a|
-          a[:key] == 'activity.group.samples.destroy_html'
-        end
-
         visit group_activity_path(group_namespace)
 
         click_button(I18n.t('components.activity.samples.destroy.more_details.button_descriptive_text'))
@@ -165,10 +153,6 @@ module Activities
           activity[:key].include?('group.import_samples.create')
         end)
 
-        activities.find do |a|
-          a[:key] == 'activity.group.import_samples.create_html'
-        end
-
         visit group_activity_path(group_namespace)
 
         click_button(I18n.t('components.activity.samples.import.more_details.button_descriptive_text'))
@@ -201,10 +185,6 @@ module Activities
         assert_equal(1, activities.count do |activity|
           activity[:key].include?('group.samples.transfer')
         end)
-
-        activities.find do |a|
-          a[:key] == 'activity.group.samples.transfer_html'
-        end
 
         visit group_activity_path(group)
 
@@ -315,10 +295,6 @@ module Activities
         assert_equal(1, activities.count do |activity|
           activity[:key].include?('group.samples.bulk_metadata_update')
         end)
-
-        activities.find do |a|
-          a[:key] == 'activity.group.samples.bulk_metadata_update_html'
-        end
 
         visit group_activity_path(group_namespace)
 

--- a/test/components/activities/dialogs/activity_table_listing_dialog_component_test.rb
+++ b/test/components/activities/dialogs/activity_table_listing_dialog_component_test.rb
@@ -21,7 +21,7 @@ module Activities
           activity[:key].include?('project_namespace.samples.clone')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.clone_html'
         end
 
@@ -30,9 +30,7 @@ module Activities
         load_more_button = find('button', text: 'Load more')
         click_button 'Load more' if load_more_button
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.clone.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.sample_clone.title')
 
@@ -61,15 +59,13 @@ module Activities
           activity[:key].include?('project_namespace.samples.cloned_from')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.namespaces_project_namespace.samples.cloned_from_html'
         end
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.clone.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.sample_clone.title')
 
@@ -103,13 +99,11 @@ module Activities
           a[:key] == 'activity.namespaces_project_namespace.workflow_executions.destroy_html'
         end
 
-        activity_to_render = PublicActivity::Activity.find(activity_to_render[:id])
+        PublicActivity::Activity.find(activity_to_render[:id])
 
         visit namespace_project_activity_path(project_namespace.parent, project_namespace.project)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.workflow_executions.destroy.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.workflow_execution_destroy.title')
 
@@ -134,15 +128,13 @@ module Activities
           activity[:key].include?('group.samples.destroy')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.group.samples.destroy_html'
         end
 
         visit group_activity_path(group_namespace)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.destroy.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.sample_destroy.title')
 
@@ -173,15 +165,13 @@ module Activities
           activity[:key].include?('group.import_samples.create')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.group.import_samples.create_html'
         end
 
         visit group_activity_path(group_namespace)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.import.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.import_samples.title')
 
@@ -212,15 +202,13 @@ module Activities
           activity[:key].include?('group.samples.transfer')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.group.samples.transfer_html'
         end
 
         visit group_activity_path(group)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.more_details'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.group_sample_transfer.title')
 
@@ -286,9 +274,7 @@ module Activities
 
         visit group_activity_path(group)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.samples.clone.more_details.button_descriptive_text'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.sample_clone.title')
 
@@ -330,15 +316,13 @@ module Activities
           activity[:key].include?('group.samples.bulk_metadata_update')
         end)
 
-        activity_to_render = activities.find do |a|
+        activities.find do |a|
           a[:key] == 'activity.group.samples.bulk_metadata_update_html'
         end
 
         visit group_activity_path(group_namespace)
 
-        within("form[action='#{activity_path(activity_to_render[:id])}']") do
-          click_button(I18n.t('components.activity.more_details'))
-        end
+        click_button(I18n.t('components.activity.more_details'))
 
         assert_selector 'h1', text: I18n.t(:'components.activity.dialog.bulk_metadata_update.title')
 

--- a/test/components/previews/confirmation_component_preview/custom_content.html.erb
+++ b/test/components/previews/confirmation_component_preview/custom_content.html.erb
@@ -1,5 +1,6 @@
 <%# This should be loaded once into the layout %>
 <%= render ConfirmationComponent.new %>
+
 <%# ------------------------------------------ %>
 
 <div id="confirmation-content" class="hidden">
@@ -8,8 +9,10 @@
 
 <%= button_to "Confirmation",
 "#",
-data: {
-  turbo_confirm: "",
-  turbo_content: "#confirmation-content",
+form: {
+  data: {
+    turbo_confirm: "",
+    turbo_content: "#confirmation-content",
+  }
 },
 class: "button button-destructive" %>

--- a/test/components/previews/confirmation_component_preview/default.html.erb
+++ b/test/components/previews/confirmation_component_preview/default.html.erb
@@ -1,10 +1,13 @@
 <%# This should be loaded once into the layout %>
 <%= render ConfirmationComponent.new %>
+
 <%# ------------------------------------------ %>
 
 <%= button_to "Confirmation",
 "#",
-data: {
-  turbo_confirm: "Custom modal text here!",
+form: {
+  data: {
+    turbo_confirm: "Custom modal text here!",
+  }
 },
 class: "button button-destructive" %>

--- a/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
+++ b/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
@@ -1,19 +1,21 @@
 <%# This should be loaded once into the layout %>
 <%= render ConfirmationComponent.new %>
+
 <%# ------------------------------------------ %>
 
-<div class="hidden custom-content">
+<div class="custom-content hidden">
   <%= viral_alert(
     message: "You are about to delete this project.  This cannot be undone.",
     type: :alert,
   ) %>
+
   <p class="text-base text-slate-900 dark:text-white">Enter the following to confirm:</p>
+
   <p class="text-slate-500 dark:text-slate-400">
     <kbd
       class="
-        px-2 py-1.5 text-xs font-semibold text-slate-800 bg-slate-100 border
-        border-slate-200 rounded-lg dark:bg-slate-600 dark:text-slate-100
-        dark:border-slate-500
+        rounded-lg border border-slate-200 bg-slate-100 px-2 py-1.5 text-xs font-semibold text-slate-800
+        dark:border-slate-500 dark:bg-slate-600 dark:text-slate-100
       "
     >
       Project X
@@ -23,9 +25,11 @@
 
 <%= button_to "Delete project",
 "#",
-data: {
-  turbo_confirm: "",
-  turbo_content: ".custom-content",
-  confirm_value: "Project X",
+form: {
+  data: {
+    turbo_confirm: "",
+    turbo_content: ".custom-content",
+    confirm_value: "Project X",
+  }
 },
 class: "button button-destructive" %>


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR fixes an accessibility issues for users who require the use of a screen reader. `button_to` creates a form with a button, but there is no visible form. The screen reader will prefix the announcement of the button with `form` which can confuse users. In this PR, I've added an override for `button_to` which moves the button outside of the form element, which prevents the screen reader from announcing form, but functionality stays the same.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._


https://github.com/user-attachments/assets/8e22a7ac-c1ff-4779-88a3-ed7a00562db4


## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Start up the server
2. Activate screenreader
3. Navigate to a page that uses `button_to` e.g. members table
4. Tab to the `Edit` button and make sure it doesn't announce form and still works as expected with interaction
5. Tab to the `Remove` button and make it doesn't announce form and still shows the confirmation with interaction

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
