### PR TITLE
Accessibility Statement Fixes

### DIFF
--- a/app/components/layout/sidebar/v1/component.html.erb
+++ b/app/components/layout/sidebar/v1/component.html.erb
@@ -209,10 +209,12 @@
 
     <div class="border-t border-slate-200 p-2 dark:border-slate-800">
       <%= render DropdownComponent.new(label: t('general.help'), icon: :question, icon_size: :md) do |dropdown| %>
-        <%= dropdown.with_item(
-        label: t(:"general.accessibility"),
-        url: helpers.accessibility_path,
-      ) %>
+        <% if Flipper.enabled?(:accessibility_statement, Current.user) %>
+          <%= dropdown.with_item(
+          label: t(:"general.accessibility"),
+          url: helpers.accessibility_path,
+        ) %>
+        <% end %>
 
         <%= dropdown.with_item(
         label: t(:"general.documentation"),

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,7 @@
 # Controller actions for Pages
 class PagesController < ApplicationController
   def accessibility_statement
+    @title = t('.title')
     not_found unless Flipper.enabled?(:accessibility_statement, current_user)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,5 +2,7 @@
 
 # Controller actions for Pages
 class PagesController < ApplicationController
-  def accessibility_statement; end
+  def accessibility_statement
+    not_found unless Flipper.enabled?(:accessibility_statement, current_user)
+  end
 end

--- a/app/views/pages/accessibility_statement.en.html.erb
+++ b/app/views/pages/accessibility_statement.en.html.erb
@@ -1,191 +1,43 @@
 <% external_link_classes = "min-w-0 font-semibold wrap-anywhere underline hover:decoration-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:rounded-sm dark:text-white" %>
 
 <div class="mx-auto max-w-7xl space-y-12">
-  <%= pathogen_typography_preset(:article) do |group| %>
-    <%= group.with_heading { "Accessibility Statement for IRIDA Next" } %>
+  <%= pathogen_section(level: 1) do |section| %>
+    <% section.with_heading { "Accessibility Statement for IRIDA Next" } %>
+
+    <%= pathogen_text { "Health Canada and the Public Health Agency of Canada is committed to making its websites and mobile applications accessible, in accordance with the Accessible Canada Regulations." } %>
   <% end %>
 
   <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Our Commitment to Accessibility" } %>
+    <% section.with_heading { "Compliance status" } %>
 
-    <%= pathogen_text { "IRIDA Next is committed to ensuring that our application is accessible to all users, including those with
-      disabilities. We are dedicated to providing a user experience that is inclusive and compliant with established
-      accessibility standards." } %>
+    <%= pathogen_text { "The website has been tested against the Web Content Accessibility Guidelines (WCAG) 2.2 AA standard as per Canada's adopted accessibility standard EN 301 549."} %>
+    <%= pathogen_text { "IRIDA Next is fully compliant with the Web Content Accessibility Guidelines (WCAG) version 2.2 AA standard." } %>
+    <%= pathogen_text { "IRIDA Next is partially compliant with the Web Content Accessibility Guidelines version 2.2 AA standard. For more details please see the included Accessibility Conformance Report (ACR)." } %>
+    <%= pathogen_text { "IRIDA Next is not compliant with the Web Content Accessibility Guidelines version 2.2 AA standard. For more details please see the included Accessibility Conformance Report (ACR)." } %>
   <% end %>
 
   <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Accessibility Standards and Conformance" } %>
+    <% section.with_heading { "What we are doing to improve accessibility" } %>
+
+    <%= pathogen_text { "Our accessibility roadmap [add link to roadmap] shows how and when we plan to improve accessibility on this website." } %>
+  <% end %>
+
+  <%= pathogen_section(level: 2) do |section| %>
+    <% section.with_heading { "Preparation of this accessibility statement" } %>
+
+    <%= pathogen_text { "This statement was prepared on [date when it was first published]." } %>
+    <%= pathogen_text { "This website was last tested on [date] against the WCAG 2.2 AA standard." } %>
+    <%= pathogen_text { "The test was carried out by [add name of organisation that carried out the assessment, or indicate that you did your own testing/assessment]." } %>
+    <%= pathogen_text { "You can read the full accessibility test report [add link to report]." } %>
+  <% end %>
+
+  <%= pathogen_section(level: 2) do |section| %>
+    <% section.with_heading { "Feedback and contact information" } %>
 
     <%= pathogen_text do %>
-      IRIDA Next strives to meet the
-      <a href="https://www.w3.org/WAI/WCAG21/quickref/" target="_blank" rel="noopener noreferrer" class="<%= external_link_classes %>">Web Content Accessibility Guidelines (WCAG) 2.1<span class="sr-only"> (opens in a new tab)</span></a>
-      Level AA standard. This includes:
-    <% end %>
-
-    <%= pathogen_list do |list| %>
-      <%= list.with_item do %>
-        <strong>Perceivable</strong>: Information and user interface components must be presented in ways that are
-        perceivable to all users
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Operable</strong>: User interface components and navigation must be operable through multiple methods
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Understandable</strong>: Information and user interface operation must be understandable
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Robust</strong>: Content must be compatible with current and future assistive technologies
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Accessible Features" } %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Navigation and Structure" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Semantic HTML markup ensures proper document structure" } %>
-        <%= list.with_item { "Logical heading hierarchy (H1 through H6) for screen reader navigation" } %>
-        <%= list.with_item { "Skip navigation links to bypass repetitive content" } %>
-        <%= list.with_item { "Keyboard-accessible navigation throughout the application" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Interactive Elements" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "All interactive elements (buttons, links, form controls) are keyboard accessible" } %>
-        <%= list.with_item { "Clear focus indicators for keyboard navigation" } %>
-        <%= list.with_item { "Proper ARIA labels and roles for custom components" } %>
-        <%= list.with_item { "Form labels clearly associated with input fields" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Visual Accessibility" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Sufficient color contrast ratios (WCAG AA compliant)" } %>
-        <%= list.with_item { "Text is resizable without loss of functionality" } %>
-        <%= list.with_item { "No reliance on color alone to convey information" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Assistive Technology Support" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Compatible with screen readers (NVDA and JAWS)" } %>
-        <%= list.with_item { "Proper semantic markup and ARIA attributes" } %>
-        <%= list.with_item { "Alternative text for images and visual content" } %>
-        <%= list.with_item { "Accessible data tables with proper header associations" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Keyboard Navigation" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Full functionality available via keyboard" } %>
-        <%= list.with_item { "Logical tab order through interactive elements" } %>
-        <%= list.with_item { "Escape key functionality for closing dialogs" } %>
-        <%= list.with_item { "Proper keyboard shortcuts for widgets" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Motion and Animation" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "No flashing or blinking content" } %>
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Limitations and Alternatives" } %>
-
-    <%= pathogen_text do %>
-      Despite our best efforts to ensure accessibility of IRIDA Next, there may be some limitations. Below is a
-      description of known limitations and potential solutions. Please contact us if you observe an issue not listed
-      below. Currently known limitations include:
-    <% end %>
-
-    <%= pathogen_list do |list| %>
-      <%= list.with_item do %>
-        <strong>Files from users and/or pipelines</strong>: Uploaded images may not have text alternatives, because we
-        do not have control of what the users/pipelines produce. Typically pipelines will also produce text based files
-        which would represent the same content as image files.
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "How to Report Accessibility Issues" } %>
-
-    <%= pathogen_text do %>
-      We take accessibility seriously and welcome feedback to help us improve. If you encounter an accessibility
-      barrier, please report it by:
-    <% end %>
-
-    <%= pathogen_list(ordered: true) do |list| %>
-      <%= list.with_item do %>
-        <strong>Creating a GitHub Issue</strong>: Open an issue on our
-        <a href="https://github.com/phac-nml/irida-next/issues" target="_blank" rel="noopener noreferrer" class="<%= external_link_classes %>">GitHub repository<span class="sr-only"> (opens in a new tab)</span></a>
-        with:
-        <%= pathogen_list do |list| %>
-          <%= list.with_item { "A clear description of the accessibility barrier" } %>
-          <%= list.with_item { "The browser and assistive technology used (if applicable)" } %>
-          <%= list.with_item { "Steps to reproduce the issue" } %>
-          <%= list.with_item { "Screenshots or screen reader output if possible" } %>
-          <%= list.with_item { "Relevant WCAG criterion numbers" } %>
-        <% end %>
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Email</strong>: Contact the
-        <a href="mailto:gsp-psg@phac-aspc.gc.ca" class="<%= external_link_classes %>">GSP team<span class="sr-only"> (opens default email client)</span></a>.
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Accessibility Improvement Process" } %>
-
-    <%= pathogen_list do |list| %>
-      <%= list.with_item do %>
-        <strong>Regular Audits</strong>: Periodic accessibility audits using automated tools and manual testing
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Screen Reader Testing</strong>: Testing with NVDA and JAWS
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Keyboard Navigation Testing</strong>: Verification of keyboard-only navigation
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Color Contrast Verification</strong>: Compliance with WCAG AA contrast requirements
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>User Feedback</strong>: Incorporation of feedback from users with disabilities
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Version Information" } %>
-
-    <%= pathogen_text do %>
-      <strong>Last Updated</strong>: June 2, 2026
+      To provide feedback or to report a barrier, you can use the Health Canada
+      <a href="https://health.canada.ca/en/accessibility-form/hc-external" class="<%= external_link_classes %>">accessibility feedback form</a>
+      or call 1-833-725-2751.
     <% end %>
   <% end %>
 </div>

--- a/app/views/pages/accessibility_statement.fr.html.erb
+++ b/app/views/pages/accessibility_statement.fr.html.erb
@@ -1,196 +1,50 @@
 <% external_link_classes = "min-w-0 font-semibold wrap-anywhere underline hover:decoration-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:rounded-sm dark:text-white" %>
 
 <div class="mx-auto max-w-7xl space-y-12">
-  <%= pathogen_typography_preset(:article) do |group| %>
-    <%= group.with_heading { "Déclaration d'accessibilité pour IRIDA Next" } %>
+  <%= pathogen_section(level: 1) do |section| %>
+    <% section.with_heading { "Déclaration d'accessibilité pour IRIDA Next" } %>
+
+    <%= pathogen_text { "Santé Canada et l'Agence de la santé publique du Canada s'engagent à rendre leurs sites Web et applications mobiles accessibles, conformément au Règlement sur l'accessibilité du Canada." } %>
   <% end %>
 
   <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Notre engagement envers l'accessibilité" } %>
+    <% section.with_heading { "état de conformité" } %>
 
-    <%= pathogen_text { "IRIDA Next s'engage à garantir que notre application est accessible à tous les utilisateurs, y compris ceux ayant
-      un handicap. Nous nous engageons à fournir une expérience utilisateur inclusive et conforme aux
-      normes d'accessibilité établies." } %>
+    <%= pathogen_text { "Le site Web a été testé conformément aux Règles pour l'accessibilité du contenu Web (WCAG) 2.2 AA, conformément à la norme canadienne d'accessibilité EN 301 549."} %>
+
+    <%= pathogen_text { "IRIDA Next est entièrement conforme aux Règles pour l'accessibilité du contenu Web (WCAG) version 2.2 AA." } %>
+
+    <%= pathogen_text { "IRIDA Next est partiellement conforme aux Règles pour l'accessibilité du contenu Web version 2.2 AA. Pour plus de détails, veuillez consulter le rapport de conformité à l'accessibilité (RCA) inclus." } %>
+
+    <%= pathogen_text { "IRIDA Next n'est pas conforme aux Règles pour l'accessibilité du contenu Web version 2.2 AA. Pour plus de détails, veuillez consulter le rapport de conformité à l'accessibilité (RCA) inclus." } %>
   <% end %>
 
   <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Normes d'accessibilité et conformité" } %>
+    <% section.with_heading { "Ce qu'on fait pour améliorer l'accessibilité" } %>
+
+    <%= pathogen_text { "Notre feuille de route pour l'accessibilité [ajouter le lien vers la feuille de route] explique comment et quand nous prévoyons d'améliorer l'accessibilité de ce site web." } %>
+  <% end %>
+
+  <%= pathogen_section(level: 2) do |section| %>
+    <% section.with_heading { "Préparation de cette déclaration d'accessibilité" } %>
+
+    <%= pathogen_text { "Cette déclaration a été préparée le [date de sa première publication]." } %>
+
+    <%= pathogen_text { "Ce site Web a été testé pour la dernière fois le [date] selon la norme WCAG 2.2 AA." } %>
+
+    <%= pathogen_text { "Le test a été effectué par [ajouter le nom de l'organisation qui a réalisé l'évaluation, ou indiquer que vous avez effectué vos propres tests/évaluations]." } %>
+
+    <%= pathogen_text { "Vous pouvez consulter le rapport complet du test d'accessibilité [ajouter le lien vers le rapport]." } %>
+  <% end %>
+
+  <%= pathogen_section(level: 2) do |section| %>
+    <% section.with_heading { "Commentaires et coordonnées" } %>
 
     <%= pathogen_text do %>
-      IRIDA Next s'efforce de respecter les
-      <a href="https://www.w3.org/WAI/WCAG21/quickref/" target="_blank" rel="noopener noreferrer" class="<%= external_link_classes %>">Directives pour l'accessibilité des contenus Web (WCAG) 2.1<span class="sr-only"> (s'ouvre dans un nouvel onglet)</span></a>
-      au niveau AA. Cela comprend:
-    <% end %>
-
-    <%= pathogen_list do |list| %>
-      <%= list.with_item do %>
-        <strong>Perceptible</strong>: Les informations et les éléments de l'interface utilisateur doivent être présentés
-        de manière perceptible à tous les utilisateurs
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Utilisable</strong>: Les éléments de l'interface utilisateur et la navigation doivent être utilisables
-        par plusieurs méthodes
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Compréhensible</strong>: Les informations et le fonctionnement de l'interface utilisateur doivent être
-        compréhensibles
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Robuste</strong>: Le contenu doit être compatible avec les technologies d'assistance actuelles et
-        futures
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Fonctionnalités accessibles" } %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Navigation et structure" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Le balisage HTML sémantique assure une structure correcte du document" } %>
-        <%= list.with_item { "Hiérarchie logique des titres (H1 à H6) pour la navigation par lecteur d'écran" } %>
-        <%= list.with_item { "Liens de navigation rapide pour contourner le contenu répétitif" } %>
-        <%= list.with_item { "Navigation accessible au clavier dans toute l'application" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Éléments interactifs" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Tous les éléments interactifs (boutons, liens, contrôles de formulaire) sont accessibles au clavier" } %>
-        <%= list.with_item { "Indicateurs de focus visibles pour la navigation au clavier" } %>
-        <%= list.with_item { "Étiquettes et rôles ARIA appropriés pour les composants personnalisés" } %>
-        <%= list.with_item { "Étiquettes de formulaire clairement associées aux champs de saisie" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Accessibilité visuelle" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Rapports de contraste des couleurs suffisants (conformes aux WCAG AA)" } %>
-        <%= list.with_item { "Le texte peut être redimensionné sans perte de fonctionnalité" } %>
-        <%= list.with_item { "Pas de dépendance à la couleur seule pour transmettre l'information" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Support des technologies d'assistance" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Compatible avec les lecteurs d'écran (NVDA et JAWS)" } %>
-        <%= list.with_item { "Balisage sémantique approprié et attributs ARIA" } %>
-        <%= list.with_item { "Texte alternatif pour les images et le contenu visuel" } %>
-        <%= list.with_item { "Tableaux de données accessibles avec des associations d'en-têtes appropriées" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Navigation au clavier" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Fonctionnalité complète disponible via le clavier" } %>
-        <%= list.with_item { "Ordre logique des tabulations dans les éléments interactifs" } %>
-        <%= list.with_item { "Fonctionnalité de la touche Échap pour fermer les boîtes de dialogue" } %>
-        <%= list.with_item { "Raccourcis clavier appropriés pour les widgets" } %>
-      <% end %>
-    <% end %>
-
-    <%= pathogen_section(level: 3) do |section| %>
-      <% section.with_heading { "Mouvement et animation" } %>
-
-      <%= pathogen_list do |list| %>
-        <%= list.with_item { "Pas de contenu clignotant ou scintillant" } %>
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Limitations et alternatives" } %>
-
-    <%= pathogen_text do %>
-      Malgré nos meilleurs efforts pour assurer l'accessibilité d'IRIDA Next, il peut y avoir quelques limitations.
-      Ci-dessous vous trouverez une description des limitations connues et des solutions potentielles. Veuillez nous
-      contacter si vous observez un problème non répertorié ci-dessous. Les limitations actuellement connues incluent :
-    <% end %>
-
-    <%= pathogen_list do |list| %>
-      <%= list.with_item do %>
-        <strong>Fichiers des utilisateurs et/ou pipelines</strong>: Les images téléchargées peuvent ne pas avoir
-        d'alternatives textuelles, car nous n'avons pas le contrôle de ce que les utilisateurs/pipelines produisent. En
-        règle générale, les pipelines produisent également des fichiers texte qui représentent le même contenu que les
-        fichiers image.
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Comment signaler les problèmes d'accessibilité" } %>
-
-    <%= pathogen_text do %>
-      Nous prenons l'accessibilité au sérieux et accueillons les commentaires pour nous aider à nous améliorer. Si vous
-      rencontrez un obstacle à l'accessibilité, veuillez le signaler en :
-    <% end %>
-
-    <%= pathogen_list(ordered: true) do |list| %>
-      <%= list.with_item do %>
-        <strong>Créer un problème GitHub</strong>: Ouvrez un problème sur notre
-        <a href="https://github.com/phac-nml/irida-next/issues" target="_blank" rel="noopener noreferrer" class="<%= external_link_classes %>">dépôt GitHub<span class="sr-only"> (s'ouvre dans un nouvel onglet)</span></a>
-        avec:
-        <%= pathogen_list do |list| %>
-          <%= list.with_item { "Une description claire de l'obstacle à l'accessibilité" } %>
-          <%= list.with_item { "Le navigateur et la technologie d'assistance utilisée (le cas échéant)" } %>
-          <%= list.with_item { "Étapes pour reproduire le problème" } %>
-          <%= list.with_item { "Captures d'écran ou sortie du lecteur d'écran si possible" } %>
-          <%= list.with_item { "Numéros de critères WCAG pertinents" } %>
-        <% end %>
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Email</strong>: Contactez l'
-        <a href="mailto:gsp-psg@phac-aspc.gc.ca" class="<%= external_link_classes %>">équipe GSP<span class="sr-only"> (ouvre le client de messagerie par défaut)</span></a>.
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Processus d'amélioration de l'accessibilité" } %>
-
-    <%= pathogen_list do |list| %>
-      <%= list.with_item do %>
-        <strong>Audits réguliers</strong>: Audits de l'accessibilité périodiques utilisant des outils automatisés et des
-        tests manuels
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Test du lecteur d'écran</strong>: Tests avec NVDA et JAWS
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Test de navigation au clavier</strong>: Vérification de la navigation au clavier seul
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Vérification du contraste des couleurs</strong>: Conformité aux exigences de contraste WCAG AA
-      <% end %>
-
-      <%= list.with_item do %>
-        <strong>Retours d'utilisateurs</strong>: Intégration des commentaires d'utilisateurs en situation de handicap
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <%= pathogen_section(level: 2) do |section| %>
-    <% section.with_heading { "Informations de version" } %>
-
-    <%= pathogen_text do %>
-      <strong>Dernière mise à jour</strong>: 2 juin 2026
+      Pour nous faire part de vos commentaires ou signaler un obstacle, vous pouvez utiliser le formulaire de
+      commentaires sur l'accessibilité de Santé Canada :
+      <a href="https://health.canada.ca/fr/accessibility-form/hc-external" class="<%= external_link_classes %>">formulaire de commentaires sur l'accessibilité</a>
+      ou composer le 1-833-725-2751.
     <% end %>
   <% end %>
 </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,4 +1,13 @@
 features:
+  accessibility_statement:
+    admin_manageable: true
+    description:
+      en: "Show the accessibility link item in the help dropdown menu."
+      fr: "Afficher le lien d'accessibilite dans le menu deroulant d'aide."
+    enable_in_development: true
+    name:
+      en: "Accessibility Statement"
+      fr: "Déclaration d'accessibilité"
   advanced_search_metadata_operators:
     admin_manageable: true
     description:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1312,6 +1312,9 @@ en:
     precision:
       format:
         delimiter: ''
+  pages:
+    accessibility_statement:
+      title: Accessibility Statement
   personal_access_tokens:
     information_component:
       active_tokens: Active tokens

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1316,6 +1316,9 @@ fr:
     precision:
       format:
         delimiter: ''
+  pages:
+    accessibility_statement:
+      title: Déclaration d'accessibilité
   personal_access_tokens:
     information_component:
       active_tokens: Jetons actifs

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -4,9 +4,18 @@ require 'test_helper'
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
   test 'should get accessibility' do
+    Flipper.enable(:accessibility_statement)
     sign_in users(:john_doe)
 
     get accessibility_path
     assert_response :success
+  end
+
+  test 'should return not found when accessibility statement feature is disabled' do
+    Flipper.disable(:accessibility_statement)
+    sign_in users(:john_doe)
+
+    get accessibility_path
+    assert_response :not_found
   end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -9,6 +9,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
 
     get accessibility_path
     assert_response :success
+    assert_select 'title', text: /#{Regexp.escape(I18n.t('pages.accessibility_statement.title'))}/
   end
 
   test 'should return not found when accessibility statement feature is disabled' do
@@ -17,5 +18,6 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
 
     get accessibility_path
     assert_response :not_found
+    assert_select 'title', text: /#{Regexp.escape(I18n.t('pages.accessibility_statement.title'))}/, count: 0
   end
 end

--- a/test/lib/irida/experimental_feature_catalog_test.rb
+++ b/test/lib/irida/experimental_feature_catalog_test.rb
@@ -8,6 +8,7 @@ module Irida
       entries = ExperimentalFeatureCatalog.admin_entries
 
       assert_equal %w[
+        accessibility_statement
         advanced_search_metadata_operators
         advanced_search_with_auto_complete
         cancel_multiple_workflows


### PR DESCRIPTION
## What does this PR do and why?
Updates the accessibility statement to use the DTB format and fixes the page title.
Information in square brackets still needs to be filled in after accessibility testing is complete.
Resolves ART-13332 & ART-13333

## Screenshots or screen recordings
N/A

## How to set up and validate locally
Enable the new feature:
1. Launch rails console and run the following:
```irb
Flipper.enable(:accessibility_statement)
```

Test the new feature:
1. Click the `Help` button from within the sidebar.
1. Select the `Accessibility Statement` option.
1. Review the accessibility statement. 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
