### PR TITLE
Fix attachment table sort history and page size navigation

### DIFF
--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -48,13 +48,7 @@
                       label: t("components.attachments.table_component.#{column}"),
                       url: helpers.sorting_url(@q, "puid"),
                       field: "puid",
-                      **(
-                        if @attachable.instance_of?(Sample)
-                          {}
-                        else
-                          { data: { turbo_action: "replace" } }
-                        end
-                      ),
+                      **sort_link_arguments,
                     ) %>
                   <% elsif column == :byte_size || column == :filename %>
                     <%= render Ransack::SortComponent.new(
@@ -62,13 +56,7 @@
                       label: t("components.attachments.table_component.#{column}"),
                       url: helpers.sorting_url(@q, "file_blob_#{column}"),
                       field: "file_blob_#{column}",
-                      **(
-                        if @attachable.instance_of?(Sample)
-                          {}
-                        else
-                          { data: { turbo_action: "replace" } }
-                        end
-                      ),
+                      **sort_link_arguments,
                     ) %>
                   <% elsif column == :format || column == :type %>
                     <%= render Ransack::SortComponent.new(
@@ -80,13 +68,7 @@
                           URI.encode_www_form_component("metadata_#{column}"),
                         ),
                       field: "metadata_#{column}",
-                      **(
-                        if @attachable.instance_of?(Sample)
-                          {}
-                        else
-                          { data: { turbo_action: "replace" } }
-                        end
-                      ),
+                      **sort_link_arguments,
                     ) %>
                   <% else %>
                     <%= render Ransack::SortComponent.new(
@@ -94,13 +76,7 @@
                       label: t("components.attachments.table_component.#{column}"),
                       url: helpers.sorting_url(@q, column),
                       field: column,
-                      **(
-                        if @attachable.instance_of?(Sample)
-                          {}
-                        else
-                          { data: { turbo_action: "replace" } }
-                        end
-                      ),
+                      **sort_link_arguments,
                     ) %>
                   <% end %>
                 </div>

--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -333,6 +333,7 @@
     <%= render Viral::Pagy::FullComponent.new(
       @pagy,
       item: t("components.attachments.table_component.limit.item"),
+      params: @pagination_params,
     ) %>
   <% end %>
 <% else %>

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -4,7 +4,7 @@ require 'ransack/helpers/form_helper'
 
 module Attachments
   # Component for rendering a table of Attachments
-  class TableComponent < Component
+  class TableComponent < Component # rubocop:disable Metrics/ClassLength
     include Ransack::Helpers::FormHelper
 
     METADATA_COLUMNS = %w[format type].freeze
@@ -18,6 +18,7 @@ module Attachments
       attachable,
       render_individual_attachments,
       has_attachments,
+      pagination_params: {},
       sort_replaces_history: false,
       row_actions: false,
       abilities: {},
@@ -30,6 +31,7 @@ module Attachments
       @attachable = attachable
       @render_individual_attachments = render_individual_attachments
       @has_attachments = has_attachments
+      @pagination_params = pagination_params
       @sort_replaces_history = sort_replaces_history
       @abilities = abilities
       @row_actions = row_actions

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -7,9 +7,7 @@ module Attachments
   class TableComponent < Component
     include Ransack::Helpers::FormHelper
 
-    # 📝 Define columns related to attachment metadata for sorting/filtering.
     METADATA_COLUMNS = %w[format type].freeze
-    # 📝 Define columns related to the actual file data for sorting/filtering.
     FILE_DATA_COLUMNS = %w[filename byte_size].freeze
 
     # rubocop:disable Naming/MethodParameterName,Metrics/ParameterLists
@@ -20,6 +18,7 @@ module Attachments
       attachable,
       render_individual_attachments,
       has_attachments,
+      sort_replaces_history: false,
       row_actions: false,
       abilities: {},
       empty: {},
@@ -31,13 +30,13 @@ module Attachments
       @attachable = attachable
       @render_individual_attachments = render_individual_attachments
       @has_attachments = has_attachments
+      @sort_replaces_history = sort_replaces_history
       @abilities = abilities
       @row_actions = row_actions
       # 🚀 Determine if any row actions are enabled for rendering the actions column.
       @renders_row_actions = @row_actions.any? { |_key, value| value }
       @empty = empty
       @system_arguments = system_arguments
-
       # 📝 Set the columns to be displayed in the table.
       @columns = columns
     end
@@ -109,6 +108,8 @@ module Attachments
       end
     end
 
+    def sort_link_arguments = @sort_replaces_history ? { data: { turbo_action: 'replace' } } : {}
+
     def selection_data_attributes
       {
         controller: 'selection',
@@ -121,8 +122,6 @@ module Attachments
 
     private
 
-    def columns
-      %i[id filename format type byte_size created_at]
-    end
+    def columns = %i[id filename format type byte_size created_at]
   end
 end

--- a/app/components/ransack/sort_component.rb
+++ b/app/components/ransack/sort_component.rb
@@ -14,13 +14,15 @@ module Ransack
     end
 
     def system_arguments
-      if @system_arguments.empty?
-        { data: {
-          turbo_stream: 'true'
-        } }
-      else
-        @system_arguments
-      end
+      args = if @system_arguments.empty?
+               { data: {
+                 turbo_stream: 'true'
+               } }
+             else
+               @system_arguments.dup
+             end
+      args[:id] ||= "sort-#{field}-#{label}"
+      args
     end
 
     def sort_icon

--- a/app/components/ransack/sort_component.rb
+++ b/app/components/ransack/sort_component.rb
@@ -21,7 +21,7 @@ module Ransack
              else
                @system_arguments.dup
              end
-      args[:id] ||= "sort-#{field}-#{label}"
+      args[:id] ||= "sort-#{field}-#{label}".parameterize
       args
     end
 

--- a/app/components/sort_component.rb
+++ b/app/components/sort_component.rb
@@ -12,6 +12,7 @@ class SortComponent < Component
     @url = url
     @field = field
     @system_arguments = system_arguments
+    @system_arguments[:id] ||= "sort-#{field}-#{label}"
   end
 
   def sort_icon

--- a/app/components/sort_component.rb
+++ b/app/components/sort_component.rb
@@ -12,7 +12,7 @@ class SortComponent < Component
     @url = url
     @field = field
     @system_arguments = system_arguments
-    @system_arguments[:id] ||= "sort-#{field}-#{label}"
+    @system_arguments[:id] ||= "sort-#{field}-#{label}".parameterize
   end
 
   def sort_icon

--- a/app/components/viral/pagy/full_component.html.erb
+++ b/app/components/viral/pagy/full_component.html.erb
@@ -1,7 +1,7 @@
 <% if pagy.count.positive? %>
   <div class="my-2 flex items-center justify-between max-[920px]:flex-col max-[920px]:space-y-4">
     <div class="min-[921px]:mr-4 min-[921px]:flex-1">
-      <%= render Viral::Pagy::LimitComponent.new(pagy, item: item) %>
+      <%= render Viral::Pagy::LimitComponent.new(pagy, item: item, params: @params) %>
     </div>
 
     <div class="min-[921px]:shrink-0"><%= render Viral::Pagy::PaginationComponent.new(pagy) %></div>

--- a/app/components/viral/pagy/full_component.rb
+++ b/app/components/viral/pagy/full_component.rb
@@ -5,9 +5,10 @@ module Viral
     # FullComponent is a component that renders the full pagy pagination
     # including the limit and pagination components.
     class FullComponent < Viral::Component
-      def initialize(pagy, item:)
+      def initialize(pagy, item:, params: {})
         @pagy = pagy
         @item = item
+        @params = params
       end
 
       private

--- a/app/components/viral/pagy/limit_component.html.erb
+++ b/app/components/viral/pagy/limit_component.html.erb
@@ -7,6 +7,10 @@
       class: "@max-md:space-y-4",
     },
   ) do %>
+    <% @params.each do |name, value| %>
+      <%= hidden_field_tag name, value %>
+    <% end %>
+
     <div
       class="
         @max-md:flex @max-md:flex-col @max-md:space-y-4 @md:@max-xl:space-y-2 @2xl:flex @2xl:items-center

--- a/app/components/viral/pagy/limit_component.html.erb
+++ b/app/components/viral/pagy/limit_component.html.erb
@@ -1,6 +1,6 @@
 <div id="limit-component" class="w-full text-slate-500 @max-md:flex @max-md:flex-col dark:text-slate-400">
   <%= form_with(
-    url: url_for(request.query_parameters.except("limit")),
+    url: url_for(request.query_parameters.except("limit", *@params.keys.map(&:to_s))),
     method: :get,
     html: {
       id: "limit-component-form",

--- a/app/components/viral/pagy/limit_component.rb
+++ b/app/components/viral/pagy/limit_component.rb
@@ -6,9 +6,10 @@ module Viral
     class LimitComponent < Viral::Component
       LIMITS = [10, 20, 50, 100].freeze
 
-      def initialize(pagy, item:)
+      def initialize(pagy, item:, params: {})
         @pagy = pagy
         @item = item
+        @params = params
       end
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -60,14 +60,37 @@ function isElementInViewport(el) {
   );
 }
 
+// Preserve focus across Turbo Drive/frame renders when the focused element has an id.
+// (ES modules have no meaningful top-level `this`, so keep the id in module scope.)
+let focusedElementId = null;
+
+function saveFocusedElementId() {
+  const id = document.activeElement?.id;
+  if (id) {
+    focusedElementId = id;
+  }
+}
+
+function restoreFocusedElement() {
+  if (!focusedElementId) return;
+
+  document.getElementById(focusedElementId)?.focus();
+}
+
+document.addEventListener("turbo:before-render", saveFocusedElementId);
+document.addEventListener("turbo:before-frame-render", saveFocusedElementId);
+
 document.addEventListener("turbo:render", () => {
   // Reconfigure LocalTime with updated locale and i18n data
   configureLocalTime();
+  restoreFocusedElement();
   // ensure focused element is scrolled into view if out of view
-  if (!isElementInViewport(document.activeElement)) {
+  if (document.activeElement && !isElementInViewport(document.activeElement)) {
     document.activeElement.scrollIntoView();
   }
 });
+
+document.addEventListener("turbo:frame-render", restoreFocusedElement);
 
 document.addEventListener("turbo:before-stream-render", (event) => {
   const fallbackToDefaultActions = event.detail.render;

--- a/app/views/groups/attachments/_table.html.erb
+++ b/app/views/groups/attachments/_table.html.erb
@@ -6,6 +6,7 @@
   namespace,
   render_individual_attachments,
   has_attachments,
+  sort_replaces_history: true,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, namespace)

--- a/app/views/projects/attachments/_table.html.erb
+++ b/app/views/projects/attachments/_table.html.erb
@@ -6,6 +6,7 @@
   namespace,
   render_individual_attachments,
   has_attachments,
+  sort_replaces_history: true,
   abilities: {
     # Uncomment when ready to use multi-select functionality
     # select_attachments: allowed_to?(:destroy_attachment?, namespace.project)

--- a/app/views/workflow_executions/_files.html.erb
+++ b/app/views/workflow_executions/_files.html.erb
@@ -25,6 +25,7 @@
   workflow_execution,
   true,
   has_attachments,
+  pagination_params: { tab: "files" },
   abilities: {
   },
   row_actions: {

--- a/app/views/workflow_executions/_files.html.erb
+++ b/app/views/workflow_executions/_files.html.erb
@@ -26,6 +26,7 @@
   true,
   has_attachments,
   pagination_params: { tab: "files" },
+  sort_replaces_history: true,
   abilities: {
   },
   row_actions: {

--- a/test/components/attachments/table_component_test.rb
+++ b/test/components/attachments/table_component_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Attachments
+  class TableComponentTest < ViewComponent::TestCase
+    test 'adds turbo_action replace to sort links when sort_replaces_history is true' do
+      render_table_component(sort_replaces_history: true)
+
+      assert_selector 'table thead a[data-turbo-action="replace"]', count: 6
+    end
+
+    test 'does not add turbo_action replace to sort links when sort_replaces_history is false' do
+      render_table_component(sort_replaces_history: false)
+
+      assert_no_selector 'table thead a[data-turbo-action="replace"]'
+    end
+
+    private
+
+    def render_table_component(sort_replaces_history:)
+      with_request_url '/-/groups/group-1/-/attachments' do
+        attachments = Attachment.where(id: attachments(:attachment1).id)
+        pagy = pagy_for(attachments)
+        q = Attachment.ransack({ s: 'puid asc' })
+        render_inline Attachments::TableComponent.new(
+          attachments,
+          pagy,
+          q,
+          groups(:group_one),
+          true,
+          true,
+          sort_replaces_history:
+        )
+      end
+    end
+
+    def pagy_for(attachments)
+      Pagy::Offset.new(count: attachments.count, page: 1, limit: 20,
+                       request: Pagy::Request.new(
+                         request: { base_url: 'localhost:3000', path: '/', params: {} }
+                       ))
+    end
+  end
+end

--- a/test/components/attachments/table_component_test.rb
+++ b/test/components/attachments/table_component_test.rb
@@ -16,9 +16,21 @@ module Attachments
       assert_no_selector 'table thead a[data-turbo-action="replace"]'
     end
 
+    test 'preserves pagination params as hidden limit form fields' do
+      render_table_component(sort_replaces_history: false, pagination_params: { tab: 'files' })
+
+      assert_selector '#limit-component-form input[type="hidden"][name="tab"][value="files"]', visible: :hidden
+    end
+
+    test 'does not add pagination params by default' do
+      render_table_component(sort_replaces_history: false)
+
+      assert_no_selector '#limit-component-form input[type="hidden"][name="tab"]', visible: :hidden
+    end
+
     private
 
-    def render_table_component(sort_replaces_history:)
+    def render_table_component(sort_replaces_history:, pagination_params: {})
       with_request_url '/-/groups/group-1/-/attachments' do
         attachments = Attachment.where(id: attachments(:attachment1).id)
         pagy = pagy_for(attachments)
@@ -30,7 +42,8 @@ module Attachments
           groups(:group_one),
           true,
           true,
-          sort_replaces_history:
+          sort_replaces_history:,
+          pagination_params:, row_actions: {}
         )
       end
     end

--- a/test/components/ransack/sort_component_test.rb
+++ b/test/components/ransack/sort_component_test.rb
@@ -18,7 +18,7 @@ module Ransack
       )
 
       assert_selector "a[href='#{url}']", count: 1
-      assert_selector "a#sort-#{column}-#{label}", count: 1
+      assert_selector "a##{"sort-#{column}-#{label}".parameterize}", count: 1
       assert_text label
       assert_selector 'svg.arrow-up-icon', count: 1
     end
@@ -37,9 +37,25 @@ module Ransack
       )
 
       assert_selector "a[href='#{url}']", count: 1
-      assert_selector "a#sort-#{column}-#{label}", count: 1
+      assert_selector "a##{"sort-#{column}-#{label}".parameterize}", count: 1
       assert_text label
       assert_selector 'svg.arrow-down-icon', count: 1
+    end
+
+    test 'parameterizes id when label contains whitespace' do
+      q = Member.ransack({ s: 'created_at asc' })
+      label = 'Created at'
+      url = 'http://localhost:3000/members?q%5Bs%5D=created_at+asc'
+      column = :created_at
+
+      render_inline SortComponent.new(
+        ransack_obj: q,
+        label:,
+        url:,
+        field: column
+      )
+
+      assert_selector 'a#sort-created_at-created-at', count: 1
     end
   end
 end

--- a/test/components/ransack/sort_component_test.rb
+++ b/test/components/ransack/sort_component_test.rb
@@ -18,6 +18,7 @@ module Ransack
       )
 
       assert_selector "a[href='#{url}']", count: 1
+      assert_selector "a#sort-#{column}-#{label}", count: 1
       assert_text label
       assert_selector 'svg.arrow-up-icon', count: 1
     end
@@ -36,6 +37,7 @@ module Ransack
       )
 
       assert_selector "a[href='#{url}']", count: 1
+      assert_selector "a#sort-#{column}-#{label}", count: 1
       assert_text label
       assert_selector 'svg.arrow-down-icon', count: 1
     end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -440,6 +440,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     select '10', from: 'pagy-limit-select'
 
+    # Assert on markup that only changes after the server re-renders with the new
+    # limit: the table's sort links carry the updated limit while preserving the tab.
+    assert_selector '#files-panel-content a[href*="limit=10"][href*="tab=files"]'
     assert_selector '#files-panel-content tbody tr', count: 2
     assert_selector '#files-panel-content #pagy-limit-select option[value="10"]:checked'
   end

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -429,6 +429,21 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'can change workflow execution files page size' do
+    visit workflow_execution_path(@workflow_execution3)
+
+    within 'main' do
+      click_on I18n.t('workflow_executions.show.tabs.files')
+    end
+
+    assert_selector '#files-panel-content tbody tr', count: 2
+
+    select '10', from: 'pagy-limit-select'
+
+    assert_selector '#files-panel-content tbody tr', count: 2
+    assert_selector '#files-panel-content #pagy-limit-select option[value="10"]:checked'
+  end
+
   test 'can view workflow execution with samplesheet' do
     visit workflow_execution_path(@workflow_execution1)
 


### PR DESCRIPTION
## What does this PR do and why?

- Sort links in attachment tables now only replace browser history when a table opts in, instead of special-casing samples. Group and project attachment tables opt in, so sorting there does not pile up back-button history.
- Changing the page size on a workflow execution now keeps you on the Files tab instead of dropping the tab context.

## Screenshots or screen recordings

_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally

1. Start the app with `bin/dev`.
2. Open a workflow execution, click the Files tab, and change the page size select — confirm you stay on the Files tab.
3. Visit a group or project attachments page, sort a column, then use the browser back button and confirm it does not step through each sort.
4. Run the component tests: `bin/rails test test/components/attachments/table_component_test.rb`.
5. Run the system test: `bin/rails test test/system/workflow_executions_test.rb`.

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
