### PR TITLE
Feat: Set Clear-Site-Data header on sign out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,9 +26,11 @@ class SessionsController < Devise::SessionsController
   end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    response.set_header('Clear-Site-Data', '"cookies", "storage", "cache"')
+
+    super
+  end
 
   # protected
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SessionControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'should set Clear-Site-Data header on sign_out' do
+    sign_in users(:john_doe)
+
+    delete destroy_user_session_path
+
+    assert_equal '"cookies", "storage", "cache"', response.headers['Clear-Site-Data']
+  end
+
+  test 'should update the user locale when locale param is present on sign in' do
+    assert_changes -> { users(:john_doe).reload.locale }, from: 'en', to: 'fr' do
+      post user_session_path, params: {
+        user: {
+          email: users(:john_doe).email,
+          password: 'password1'
+        },
+        locale: 'fr'
+      }
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR sets the `Clear-Site-Data` header on sign out to `"cookies", "storage", "cache"` which means that sample selection is cleared on logout and backwards navigation no longer loads cache pages (ensuring that private data is no longer available after sign out).

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

https://github.com/user-attachments/assets/39c39e88-6931-46c3-9150-a5c284109c47

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Launch server with `bin/setup`
2. Login as user of your choice
3. Navigate to a project of your choice
4. Navigate to samples page
5. Select all samples
6. Logout
7. Hit browser back button (observe no cache load)
8. Login with same user
9. You should be back on samples page and have no samples selected

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.