### PR TITLE
Fix broken links in components for ViewComponent 4

### DIFF
--- a/app/components/activities/base_activity_component.rb
+++ b/app/components/activities/base_activity_component.rb
@@ -29,7 +29,7 @@ module Activities
 
     def more_details_button(dialog_type, descriptive_text)
       button_to t(:'components.activity.more_details'),
-                activity_path(@activity[:id]),
+                helpers.activity_path(@activity[:id]),
                 params: { dialog_type: dialog_type },
                 data: { turbo_stream: true },
                 method: :get,

--- a/app/components/activities/group_activity_component.rb
+++ b/app/components/activities/group_activity_component.rb
@@ -26,7 +26,7 @@ module Activities
 
         href = link_to(
           group.puid,
-          group_path(group),
+          helpers.group_path(group),
           class: active_link_classes
         )
 

--- a/app/components/activities/groups/metadata_template_activity_component.rb
+++ b/app/components/activities/groups/metadata_template_activity_component.rb
@@ -18,7 +18,7 @@ module Activities
         href = if template_exists?
                  link_to(
                    @activity[:template_name],
-                   group_metadata_templates_path(@activity[:group]),
+                   helpers.group_metadata_templates_path(@activity[:group]),
                    class: active_link_classes,
                    title:
                      t('components.activity.metadata_templates.group.link_descriptive_text'),

--- a/app/components/activities/groups/projects/crud_activity_component.rb
+++ b/app/components/activities/groups/projects/crud_activity_component.rb
@@ -15,7 +15,7 @@ module Activities
           href = if project_exists?
                    link_to(
                      @activity[:project_puid],
-                     namespace_project_path(@activity[:group], @activity[:project].project),
+                     helpers.namespace_project_path(@activity[:group], @activity[:project].project),
                      class: active_link_classes,
                      title:
                        t(

--- a/app/components/activities/groups/projects/transfer_activity_component.rb
+++ b/app/components/activities/groups/projects/transfer_activity_component.rb
@@ -15,7 +15,7 @@ module Activities
           href = if project_exists?
                    link_to(
                      @activity[:project_puid],
-                     namespace_project_path(
+                     helpers.namespace_project_path(
                        @activity[:project].parent,
                        @activity[:project].project
                      ),

--- a/app/components/activities/groups/subgroup_activity_component.rb
+++ b/app/components/activities/groups/subgroup_activity_component.rb
@@ -20,7 +20,7 @@ module Activities
                elsif subgroup_exists?
                  link_to(
                    @activity[:created_group_puid],
-                   group_path(@activity[:created_group]),
+                   helpers.group_path(@activity[:created_group]),
                    class: active_link_classes,
                    title:
                      t(

--- a/app/components/activities/groups/transfer_in_activity_component.rb
+++ b/app/components/activities/groups/transfer_in_activity_component.rb
@@ -18,7 +18,7 @@ module Activities
         href = if transferred_group_exists?
                  link_to(
                    @activity[:transferred_group_puid],
-                   group_path(@activity[:transferred_group]),
+                   helpers.group_path(@activity[:transferred_group]),
                    class: active_link_classes,
                    title:
                      t(

--- a/app/components/activities/member_activity_component.rb
+++ b/app/components/activities/member_activity_component.rb
@@ -5,9 +5,9 @@ module Activities
   class MemberActivityComponent < BaseActivityComponent
     def members_page
       if @activity[:member].namespace.group_namespace?
-        group_members_path(@activity[:member].namespace)
+        helpers.group_members_path(@activity[:member].namespace)
       elsif @activity[:member].namespace.project_namespace?
-        namespace_project_members_path(
+        helpers.namespace_project_members_path(
           @activity[:member].namespace.project.parent,
           @activity[:member].namespace.project
         )

--- a/app/components/activities/namespace_group_link_activity_component.rb
+++ b/app/components/activities/namespace_group_link_activity_component.rb
@@ -36,7 +36,7 @@ module Activities
       if link_to_shared_group?
         link_to(
           @activity[:namespace_puid],
-          group_path(@activity[:group_link].namespace),
+          helpers.group_path(@activity[:group_link].namespace),
           class: active_link_classes,
           title: t(
             'components.activity.groups.link_descriptive_text',
@@ -51,7 +51,7 @@ module Activities
       else
         link_to(
           @activity[:group_puid],
-          group_path(@activity[:group_link].group),
+          helpers.group_path(@activity[:group_link].group),
           class: active_link_classes,
           title: t(
             'components.activity.groups.link_descriptive_text',

--- a/app/components/activities/projects/metadata_template_activity_component.rb
+++ b/app/components/activities/projects/metadata_template_activity_component.rb
@@ -19,7 +19,7 @@ module Activities
 
                  link_to(
                    @activity[:template_name],
-                   namespace_project_metadata_templates_path(
+                   helpers.namespace_project_metadata_templates_path(
                      @activity[:current_project].parent,
                      @activity[:current_project].project
                    ),

--- a/app/components/activities/projects/sample_activity_component.rb
+++ b/app/components/activities/projects/sample_activity_component.rb
@@ -39,7 +39,7 @@ module Activities
                              href: highlighted_text(@activity[:imported_metadata_samples_count]))
         else
           if sample_exists?(@activity[:sample])
-            url = namespace_project_sample_path(
+            url = helpers.namespace_project_sample_path(
               @activity[:current_project].parent,
               @activity[:current_project].project,
               id: @activity[:sample_id]

--- a/app/components/activities/projects/sample_clone_activity_component.rb
+++ b/app/components/activities/projects/sample_clone_activity_component.rb
@@ -21,12 +21,12 @@ module Activities
         @activity[:source_project].presence || @activity[:target_project]
       end
 
-      def activity_message # rubocop:disable Metrics/MethodLength
+      def activity_message # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         namespace = activity_namespace
         href = if project_exists?(namespace)
                  link_to(
                    namespace_puid(namespace),
-                   namespace_project_samples_path(namespace.parent, namespace.project),
+                   helpers.namespace_project_samples_path(namespace.parent, namespace.project),
                    class: active_link_classes,
                    title:
                      t(

--- a/app/components/activities/projects/sample_transfer_activity_component.rb
+++ b/app/components/activities/projects/sample_transfer_activity_component.rb
@@ -21,12 +21,12 @@ module Activities
         @activity[:source_project].presence || @activity[:target_project]
       end
 
-      def activity_message # rubocop:disable Metrics/MethodLength
+      def activity_message # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         namespace = activity_namespace
         href = if project_exists?(namespace)
                  link_to(
                    namespace_puid(namespace),
-                   namespace_project_samples_path(namespace.parent, namespace.project),
+                   helpers.namespace_project_samples_path(namespace.parent, namespace.project),
                    class: active_link_classes,
                    title:
                      t(

--- a/app/components/activities/workflow_execution_activity_component.rb
+++ b/app/components/activities/workflow_execution_activity_component.rb
@@ -40,7 +40,7 @@ module Activities
       href = if workflow_execution_exists?
                link_to(
                  @activity[:workflow_id],
-                 namespace_project_automated_workflow_executions_path(
+                 helpers.namespace_project_automated_workflow_executions_path(
                    @activity[:namespace].parent,
                    @activity[:namespace].project
                  ),
@@ -60,7 +60,7 @@ module Activities
     def workflow_execution_and_sample_exists_activity # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       href = link_to(
         @activity[:workflow_id],
-        namespace_project_workflow_execution_path(
+        helpers.namespace_project_workflow_execution_path(
           @activity[:namespace].parent,
           @activity[:namespace].project,
           @activity[:workflow_id]
@@ -80,7 +80,7 @@ module Activities
 
       sample_href = link_to(
         @activity[:sample_puid],
-        namespace_project_sample_path(
+        helpers.namespace_project_sample_path(
           @activity[:namespace].parent,
           @activity[:namespace].project,
           @activity[:sample_id]
@@ -105,7 +105,7 @@ module Activities
     def workflow_execution_exists_activity # rubocop:disable Metrics/MethodLength
       href = link_to(
         @activity[:workflow_id],
-        namespace_project_workflow_execution_path(
+        helpers.namespace_project_workflow_execution_path(
           @activity[:namespace].parent,
           @activity[:namespace].project,
           @activity[:workflow_id]
@@ -133,7 +133,7 @@ module Activities
       href = highlighted_text(@activity[:workflow_id])
       sample_href = link_to(
         @activity[:sample_puid],
-        namespace_project_sample_path(
+        helpers.namespace_project_sample_path(
           @activity[:namespace].parent,
           @activity[:namespace].project,
           @activity[:sample_id]

--- a/app/components/attachments/dialogs/delete_attachment_component.rb
+++ b/app/components/attachments/dialogs/delete_attachment_component.rb
@@ -16,9 +16,9 @@ module Attachments
 
       def destroy_path
         if @namespace.type == 'Group'
-          group_attachment_path(id: @attachment.id)
+          helpers.group_attachment_path(id: @attachment.id)
         else
-          namespace_project_attachment_path(id: @attachment.id)
+          helpers.namespace_project_attachment_path(id: @attachment.id)
         end
       end
     end

--- a/app/components/attachments/dialogs/new_attachment_component.rb
+++ b/app/components/attachments/dialogs/new_attachment_component.rb
@@ -16,9 +16,9 @@ module Attachments
 
       def upload_path
         if @namespace.type == 'Group'
-          group_attachments_path(id: @namespace.id)
+          helpers.group_attachments_path(id: @namespace.id)
         else
-          namespace_project_attachments_path(id: @namespace.project.id)
+          helpers.namespace_project_attachments_path(id: @namespace.project.id)
         end
       end
     end

--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -151,7 +151,7 @@
                             <%= icon(Attachment.icon, size: :sm, class: "ml-0 mr-2") %>
                           <% end %>
                           <span>
-                            <%= link_to rails_blob_path(attachment.file),
+                            <%= link_to helpers.rails_blob_path(attachment.file),
                             data: {
                               turbo: false,
                             },
@@ -171,7 +171,7 @@
                                 <%= icon(:arrow_right, size: :sm, class: "ml-0 mr-2") %>
 
                                 <span>
-                                  <%= link_to rails_blob_path(attachment.file),
+                                  <%= link_to helpers.rails_blob_path(attachment.file),
                               data: {
                                 turbo: false,
                               },
@@ -190,7 +190,7 @@
                                 <%= icon(:arrow_left, size: :sm, class: "ml-0 mr-2") %>
 
                                 <span>
-                                  <%= link_to rails_blob_path(attachment.associated_attachment.file),
+                                  <%= link_to helpers.rails_blob_path(attachment.associated_attachment.file),
                               data: {
                                 turbo: false,
                               },
@@ -211,7 +211,7 @@
                                 <%= icon(Attachment.icon, size: :sm, class: "ml-0 mr-2") %>
 
                                 <span>
-                                  <%= link_to rails_blob_path(attachment.file),
+                                  <%= link_to helpers.rails_blob_path(attachment.file),
                               data: {
                                 turbo: false,
                               },
@@ -252,7 +252,7 @@
                     <% if @row_actions[:preview] && attachment.previewable? %>
                       <%= link_to(
                       t("components.attachments.table_component.preview"),
-                      attachment_path(attachment),
+                      helpers.attachment_path(attachment),
                       aria: {
                         label:
                           t(

--- a/app/components/attachments/table_component.rb
+++ b/app/components/attachments/table_component.rb
@@ -79,16 +79,16 @@ module Attachments
 
     def destroy_path(attachment_id)
       if @attachable.instance_of?(Sample)
-        namespace_project_sample_attachment_new_destroy_path(
+        helpers.namespace_project_sample_attachment_new_destroy_path(
           sample_id: @attachable.id,
           attachment_id:
         )
       elsif @attachable.instance_of?(Group)
-        group_attachment_new_destroy_path(
+        helpers.group_attachment_new_destroy_path(
           attachment_id:
         )
       elsif @attachable.instance_of?(Namespaces::ProjectNamespace)
-        namespace_project_attachment_new_destroy_path(
+        helpers.namespace_project_attachment_new_destroy_path(
           attachment_id:
         )
       end

--- a/app/components/bots/table_component.rb
+++ b/app/components/bots/table_component.rb
@@ -29,33 +29,33 @@ module Bots
 
     def bot_tokens_path(bot)
       if @namespace.is_a?(Group)
-        group_bot_personal_access_tokens_path(bot_id: bot.id)
+        helpers.group_bot_personal_access_tokens_path(bot_id: bot.id)
       elsif @namespace.is_a?(Namespaces::ProjectNamespace)
-        namespace_project_bot_personal_access_tokens_path(bot_id: bot.id)
+        helpers.namespace_project_bot_personal_access_tokens_path(bot_id: bot.id)
       end
     end
 
     def bot_inactive_tokens_path(bot)
       if @namespace.is_a?(Group)
-        inactive_group_bot_personal_access_tokens_path(bot_id: bot.id)
+        helpers.inactive_group_bot_personal_access_tokens_path(bot_id: bot.id)
       elsif @namespace.is_a?(Namespaces::ProjectNamespace)
-        inactive_namespace_project_bot_personal_access_tokens_path(bot_id: bot.id)
+        helpers.inactive_namespace_project_bot_personal_access_tokens_path(bot_id: bot.id)
       end
     end
 
     def new_token_path(bot)
       if @namespace.is_a?(Group)
-        new_group_bot_personal_access_token_path(bot_id: bot.id)
+        helpers.new_group_bot_personal_access_token_path(bot_id: bot.id)
       elsif @namespace.is_a?(Namespaces::ProjectNamespace)
-        new_namespace_project_bot_personal_access_token_path(bot_id: bot.id)
+        helpers.new_namespace_project_bot_personal_access_token_path(bot_id: bot.id)
       end
     end
 
     def destroy_path(bot)
       if @namespace.is_a?(Group)
-        group_bot_destroy_confirmation_path(bot_id: bot.id)
+        helpers.group_bot_destroy_confirmation_path(bot_id: bot.id)
       elsif @namespace.is_a?(Namespaces::ProjectNamespace)
-        namespace_project_bot_destroy_confirmation_path(bot_id: bot.id)
+        helpers.namespace_project_bot_destroy_confirmation_path(bot_id: bot.id)
       end
     end
   end

--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -1,6 +1,6 @@
 <% linelist_data = {
   controller: "linelist-export",
-  "linelist-export-worker-url-value": asset_path("workers/linelist_export_worker.js"),
+  "linelist-export-worker-url-value": helpers.asset_path("workers/linelist_export_worker.js"),
   "linelist-export-graphql-url-value": graphql_url,
   "linelist-export-sample-graphql-id-prefix-value": sample_graphql_id_prefix,
   "linelist-export-minimum-visible-duration-ms-value": 3500,

--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -42,7 +42,7 @@
             <%= render Viral::BaseComponent.new(**row_arguments(data_export)) do %>
               <td class="px-3 py-3">
                 <%= link_to data_export.id,
-                data_export_path(data_export),
+                helpers.data_export_path(data_export),
                 class:
                   "text-slate-900 dark:text-slate-100 font-semibold underline hover:decoration-2" %>
               </td>
@@ -50,7 +50,7 @@
               <td class="px-3 py-3">
                 <% unless data_export.name.nil? %>
                   <%= link_to data_export.name,
-                  data_export_path(data_export),
+                  helpers.data_export_path(data_export),
                   class:
                     "text-slate-900 dark:text-slate-100 font-semibold underline hover:decoration-2" %>
                 <% end %>
@@ -83,7 +83,7 @@
               <td class="space-x-2 px-3 py-3">
                 <% if data_export.status == 'ready' %>
                   <%= button_to t('common.actions.download'),
-                  rails_blob_path(data_export.file),
+                  helpers.rails_blob_path(data_export.file),
                   data: {
                     turbo: false,
                   },
@@ -102,7 +102,7 @@
                 <% end %>
 
                 <%= button_to t('common.actions.delete'),
-                data_export_path(data_export),
+                helpers.data_export_path(data_export),
                 data: {
                   turbo_method: :delete,
                   turbo_confirm:

--- a/app/components/groups/table_component.rb
+++ b/app/components/groups/table_component.rb
@@ -49,9 +49,9 @@ module Groups
 
     def select_group_link_path(namespace_group_link)
       if @namespace.type == 'Group'
-        group_group_link_path(@namespace, namespace_group_link)
+        helpers.group_group_link_path(@namespace, namespace_group_link)
       else
-        namespace_project_group_link_path(@namespace.parent, @namespace.project, namespace_group_link)
+        helpers.namespace_project_group_link_path(@namespace.parent, @namespace.project, namespace_group_link)
       end
     end
 

--- a/app/components/layout/breadcrumb_component.html.erb
+++ b/app/components/layout/breadcrumb_component.html.erb
@@ -16,7 +16,7 @@
 
           <%= dropdown.with_item(
             label: link[:name],
-            url: URI.join(root_url, link[:path]).to_s,
+            url: URI.join(helpers.root_url, link[:path]).to_s,
             data: {
               turbo_frame: "_top",
             },
@@ -40,7 +40,7 @@
         <% else %>
           <!-- Navigable link -->
           <%= link_to link[:name],
-          URI.join(root_url, link[:path]).to_s,
+          URI.join(helpers.root_url, link[:path]).to_s,
           class:
             "text-sm text-slate-600 dark:text-slate-400 underline hover:decoration-2 py-3 font-normal",
           data: {

--- a/app/components/layout/language_selection/v1/component.html.erb
+++ b/app/components/layout/language_selection/v1/component.html.erb
@@ -40,7 +40,7 @@
               dark:hover:text-white
             "
           >
-            <%= form_with(model: @user, url: profile_preferences_path, method: :patch) do |form| %>
+            <%= form_with(model: @user, url: helpers.profile_preferences_path, method: :patch) do |form| %>
               <%= form.hidden_field :locale,
                                 value: locale_value,
                                 id: "language_selection_#{locale_value}" %>

--- a/app/components/layout/sidebar/item_component.rb
+++ b/app/components/layout/sidebar/item_component.rb
@@ -6,19 +6,19 @@ module Layout
     #
     # @example Basic usage
     #   <%= render Layout::Sidebar::ItemComponent.new(
-    #     url: root_path,
+    #     url: helpers.root_path,
     #     label: 'Dashboard',
     #     icon_name: :house,
-    #     selected: current_page?(root_path)
+    #     selected: helpers.current_page?(helpers.root_path)
     #   ) %>
     #
     # @example With badge
     #   <%= render Layout::Sidebar::ItemComponent.new(
-    #     url: notifications_path,
+    #     url: helpers.notifications_path,
     #     label: 'Notifications',
     #     icon_name: :bell,
     #     badge: '3',
-    #     selected: current_page?(notifications_path)
+    #     selected: helpers.current_page?(helpers.notifications_path)
     #   ) %>
     class ItemComponent < Component
       # @!attribute [r] url

--- a/app/components/layout/sidebar/multi_level_menu_component.rb
+++ b/app/components/layout/sidebar/multi_level_menu_component.rb
@@ -8,14 +8,20 @@ module Layout
     #   <%= render Layout::Sidebar::MultiLevelMenuComponent.new(
     #     title: 'Projects',
     #     icon: :folder,
-    #     selectable_pages: [projects_path, new_project_path],
-    #     current_page: request.path
+    #     selectable_pages: [helpers.projects_path, helpers.new_project_path],
+    #     current_page: helpers.request.path
     #   ) do |menu| %>
-    #     <% menu.with_menu_item(url: projects_path, selected: current_page?(projects_path)) do |item| %>
+    #     <% menu.with_menu_item(
+    #       url: helpers.projects_path,
+    #       selected: helpers.current_page?(helpers.projects_path)
+    #     ) do |item| %>
     #       <% item.with_icon { icon(Group.icon) } %>
     #       All Projects
     #     <% end %>
-    #     <% menu.with_menu_item(url: new_project_path, selected: current_page?(new_project_path)) do |item| %>
+    #     <% menu.with_menu_item(
+    #       url: helpers.new_project_path,
+    #       selected: helpers.current_page?(helpers.new_project_path)
+    #     ) do |item| %>
     #       <% item.with_icon { icon(:plus) } %>
     #       New Project
     #     <% end %>

--- a/app/components/layout/sidebar/v1/component.html.erb
+++ b/app/components/layout/sidebar/v1/component.html.erb
@@ -15,7 +15,11 @@
           @min-[279px]/sidebar:justify-between
         "
       >
-        <a href="<%= root_path %>" class="inline-flex items-center py-2.5 whitespace-nowrap" data-layout-target="logo">
+        <a
+          href="<%= helpers.root_path %>"
+          class="inline-flex items-center py-2.5 whitespace-nowrap"
+          data-layout-target="logo"
+        >
           <%= icon(
             :beaker,
             library: :heroicons,
@@ -74,12 +78,12 @@
           ) do |dropdown| %>
             <%= dropdown.with_item(
               label: t(:"general.navbar.new_dropdown.project"),
-              url: new_project_path,
+              url: helpers.new_project_path,
             ) %>
 
             <%= dropdown.with_item(
               label: t(:"general.navbar.new_dropdown.group"),
-              url: new_group_path,
+              url: helpers.new_group_path,
             ) %>
           <% end %>
 
@@ -100,12 +104,12 @@
           ) do |dropdown| %>
             <%= dropdown.with_item(
               label: t(:"general.navbar.account_dropdown.profile"),
-              url: profile_path,
+              url: helpers.profile_path,
             ) %>
 
             <%= dropdown.with_item(
               label: t(:"general.navbar.account_dropdown.sign_out"),
-              url: destroy_user_session_path,
+              url: helpers.destroy_user_session_path,
               data: {
                 turbo_method: :delete,
               },
@@ -145,7 +149,7 @@
               >
                 <li role="presentation">
                   <%= link_to t(:"general.default_sidebar.projects"),
-                  dashboard_projects_path,
+                  helpers.dashboard_projects_path,
                   role: "menuitem",
                   class:
                     "px-4 py-2 relative focus-visible:z-10 block text-base hover:bg-slate-100 hover:cursor-pointer dark:hover:bg-slate-600" %>
@@ -153,7 +157,7 @@
 
                 <li role="presentation">
                   <%= link_to t(:"general.default_sidebar.groups"),
-                  groups_path,
+                  helpers.groups_path,
                   role: "menuitem",
                   class:
                     "px-4 py-2 block relative focus-visible:z-10 text-base hover:bg-slate-100 hover:cursor-pointer dark:hover:bg-slate-600" %>
@@ -161,7 +165,7 @@
 
                 <li role="presentation">
                   <%= link_to t(:"general.default_sidebar.workflows"),
-                  workflow_executions_path,
+                  helpers.workflow_executions_path,
                   role: "menuitem",
                   class:
                     "px-4 py-2 block relative focus-visible:z-10 text-base hover:bg-slate-100 hover:cursor-pointer dark:hover:bg-slate-600" %>
@@ -169,7 +173,7 @@
 
                 <li role="presentation">
                   <%= link_to t(:"general.default_sidebar.data_exports"),
-                  data_exports_path,
+                  helpers.data_exports_path,
                   role: "menuitem",
                   class:
                     "px-4 py-2 block relative focus-visible:z-10 text-base hover:bg-slate-100 hover:cursor-pointer dark:hover:bg-slate-600" %>
@@ -207,7 +211,7 @@
       <%= render DropdownComponent.new(label: t('general.help'), icon: :question, icon_size: :md) do |dropdown| %>
         <%= dropdown.with_item(
         label: t(:"general.accessibility"),
-        url: accessibility_path,
+        url: helpers.accessibility_path,
       ) %>
 
         <%= dropdown.with_item(

--- a/app/components/layout/sidebar/v1/component.rb
+++ b/app/components/layout/sidebar/v1/component.rb
@@ -8,7 +8,10 @@ module Layout
       # @example Basic usage
       #   <%= render Layout::SidebarComponent.new do |sidebar| %>
       #     <% sidebar.with_section(title: 'Main') do |section| %>
-      #       <% section.with_item(url: root_path, selected: current_page?(root_path)) do |item| %>
+      #       <% section.with_item(
+      #         url: helpers.root_path,
+      #         selected: helpers.current_page?(helpers.root_path)
+      #       ) do |item| %>
       #         <% item.with_icon { icon(:house) } %>
       #         Dashboard
       #       <% end %>

--- a/app/components/metadata_templates/row_component.rb
+++ b/app/components/metadata_templates/row_component.rb
@@ -29,17 +29,17 @@ module MetadataTemplates
 
     def edit_path
       if @namespace.group_namespace?
-        edit_group_metadata_template_path(@namespace, @metadata_template)
+        helpers.edit_group_metadata_template_path(@namespace, @metadata_template)
       else
-        edit_namespace_project_metadata_template_path(@namespace.parent, @namespace.project, @metadata_template)
+        helpers.edit_namespace_project_metadata_template_path(@namespace.parent, @namespace.project, @metadata_template)
       end
     end
 
     def individual_path
       if @namespace.group_namespace?
-        group_metadata_template_path(@namespace, @metadata_template)
+        helpers.group_metadata_template_path(@namespace, @metadata_template)
       else
-        namespace_project_metadata_template_path(@namespace.parent, @namespace.project, @metadata_template)
+        helpers.namespace_project_metadata_template_path(@namespace.parent, @namespace.project, @metadata_template)
       end
     end
 

--- a/app/components/namespace_row/contents_component.html.erb
+++ b/app/components/namespace_row/contents_component.html.erb
@@ -81,7 +81,7 @@
             <%= @namespace.project_namespaces.count %>
           </span>
         <% end %>
-        <%= pathogen_link(href: group_samples_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: helpers.group_samples_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -104,7 +104,7 @@
       <% end %>
 
       <% if @namespace.project_namespace? %>
-        <%= pathogen_link(href: namespace_project_samples_path(@namespace.parent, @namespace.project), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= pathogen_link(href: helpers.namespace_project_samples_path(@namespace.parent, @namespace.project), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(

--- a/app/components/nextflow/shared/workflow_param_property_component.html.erb
+++ b/app/components/nextflow/shared/workflow_param_property_component.html.erb
@@ -34,7 +34,7 @@
 
         <a
           id="<%= fields.field_id(name, "link") %>"
-          href="<%= new_workflow_executions_file_selector_path(
+          href="<%= helpers.new_workflow_executions_file_selector_path(
                             file_selector: {
                               pattern: property[:pattern] || ".*",
                               property: name,

--- a/app/components/nextflow/v1/samplesheet_component.html.erb
+++ b/app/components/nextflow/v1/samplesheet_component.html.erb
@@ -74,7 +74,7 @@
     "
   >
     <div class="flex w-full items-start">
-      <div class="mr-3 flex-shrink-0"><%= icon :x_circle, color: :danger %></div>
+      <div class="mr-3 shrink-0"><%= icon :x_circle, color: :danger %></div>
 
       <div class="mt-0.5 min-w-0 flex-1">
         <div class="text-sm leading-5 font-medium" data-nextflow--v1--samplesheet-target="errorMessage"></div>
@@ -153,9 +153,9 @@
 <template data-nextflow--v1--samplesheet-target="fileTemplate">
   <a
     data-turbo-stream="true"
-    data-base-path="/-/workflow_executions/file_selector/new"
+    data-base-path="<%= helpers.new_workflow_executions_file_selector_path %>"
     data-namespace-id="<%= @namespace_id %>"
-    href="/-/workflow_executions/file_selector/new"
+    href="<%= helpers.new_workflow_executions_file_selector_path %>"
     class="
       block cursor-pointer border-2 border-transparent bg-inherit p-2 text-sm text-slate-900
       focus-visible:-outline-offset-2! dark:text-white

--- a/app/components/nextflow/v1/samplesheet_component.html.erb
+++ b/app/components/nextflow/v1/samplesheet_component.html.erb
@@ -155,7 +155,7 @@
     data-turbo-stream="true"
     data-base-path="/-/workflow_executions/file_selector/new"
     data-namespace-id="<%= @namespace_id %>"
-    href="#"
+    href="/-/workflow_executions/file_selector/new"
     class="
       block cursor-pointer border-2 border-transparent bg-inherit p-2 text-sm text-slate-900
       focus-visible:-outline-offset-2! dark:text-white
@@ -241,7 +241,7 @@
 </template>
 
 <template data-nextflow--v1--samplesheet-target="metadataHeaderForm">
-  <%= form_with url: fields_workflow_executions_metadata_path do |f| %>
+  <%= form_with url: helpers.fields_workflow_executions_metadata_path do |f| %>
     <%= f.hidden_field :namespace_id, value: namespace_id %>
   <% end %>
 </template>

--- a/app/components/nextflow/v2/component.html.erb
+++ b/app/components/nextflow/v2/component.html.erb
@@ -250,7 +250,7 @@
   <% unless @automated_workflow %>
     <template data-nextflow--v2--samplesheet-target="samplesheetParamsFormTemplate">
       <%= form_with(
-      url: samplesheet_workflow_executions_submissions_path,
+      url: helpers.samplesheet_workflow_executions_submissions_path,
     ) do |f| %>
       <% end %>
     </template>

--- a/app/components/nextflow/v2/samplesheet_component.html.erb
+++ b/app/components/nextflow/v2/samplesheet_component.html.erb
@@ -156,8 +156,8 @@
 
 <template data-nextflow--v2--samplesheet-target="fileTemplate">
   <a
-    href="/-/workflow_executions/file_selector/new"
-    data-base-path="/-/workflow_executions/file_selector/new"
+    href="<%= helpers.new_workflow_executions_file_selector_path %>"
+    data-base-path="<%= helpers.new_workflow_executions_file_selector_path %>"
     data-turbo-stream="true"
     data-namespace-id="<%= @namespace_id %>"
     class="

--- a/app/components/nextflow/v2/samplesheet_component.html.erb
+++ b/app/components/nextflow/v2/samplesheet_component.html.erb
@@ -156,7 +156,7 @@
 
 <template data-nextflow--v2--samplesheet-target="fileTemplate">
   <a
-    href="#"
+    href="/-/workflow_executions/file_selector/new"
     data-base-path="/-/workflow_executions/file_selector/new"
     data-turbo-stream="true"
     data-namespace-id="<%= @namespace_id %>"
@@ -251,7 +251,7 @@
 </template>
 
 <template data-nextflow--v2--samplesheet-target="metadataHeaderForm">
-  <%= form_with(url: fields_workflow_executions_metadata_path) do |f| %>
+  <%= form_with(url: helpers.fields_workflow_executions_metadata_path) do |f| %>
     <%= f.hidden_field :namespace_id, value: namespace_id %>
   <% end %>
 </template>

--- a/app/components/personal_access_tokens/information_component.rb
+++ b/app/components/personal_access_tokens/information_component.rb
@@ -15,7 +15,7 @@ module PersonalAccessTokens
 
     def statistic_button(type, count)
       button_to t("personal_access_tokens.information_component.view_#{type}"),
-                list_profile_personal_access_tokens_path,
+                helpers.list_profile_personal_access_tokens_path,
                 data: { 'turbo-stream': true },
                 params: { type: type },
                 method: :get,

--- a/app/components/personal_access_tokens/table_component.rb
+++ b/app/components/personal_access_tokens/table_component.rb
@@ -28,17 +28,17 @@ module PersonalAccessTokens
 
     def revoke_path(token)
       if @namespace.is_a?(Group)
-        revoke_confirmation_group_bot_personal_access_token_path(
+        helpers.revoke_confirmation_group_bot_personal_access_token_path(
           bot_id: @bot_account.id,
           id: token.id
         )
       elsif @namespace.is_a?(Namespaces::ProjectNamespace)
-        revoke_confirmation_namespace_project_bot_personal_access_token_path(
+        helpers.revoke_confirmation_namespace_project_bot_personal_access_token_path(
           bot_id: @bot_account.id,
           id: token.id
         )
       else
-        revoke_profile_personal_access_token_path(id: token.id)
+        helpers.revoke_profile_personal_access_token_path(id: token.id)
       end
     end
 
@@ -63,17 +63,17 @@ module PersonalAccessTokens
 
     def rotate_path(token)
       if @namespace.is_a?(Group)
-        rotate_confirmation_group_bot_personal_access_token_path(
+        helpers.rotate_confirmation_group_bot_personal_access_token_path(
           bot_id: @bot_account.id,
           id: token.id
         )
       elsif @namespace.is_a?(Namespaces::ProjectNamespace)
-        rotate_confirmation_namespace_project_bot_personal_access_token_path(
+        helpers.rotate_confirmation_namespace_project_bot_personal_access_token_path(
           bot_id: @bot_account.id,
           id: token.id
         )
       else
-        rotate_profile_personal_access_token_path(id: token.id)
+        helpers.rotate_profile_personal_access_token_path(id: token.id)
       end
     end
 

--- a/app/components/prefixed/select2/v1/component.html.erb
+++ b/app/components/prefixed/select2/v1/component.html.erb
@@ -6,9 +6,9 @@
         text-ellipsis text-slate-700 @md:!rounded-r-none @md:border-r-0 dark:border-slate-600 dark:bg-slate-700
         dark:text-slate-300
       "
-      title="<%= root_url %>"
+      title="<%= helpers.root_url %>"
     >
-      <%= root_url %>
+      <%= helpers.root_url %>
     </div>
 
     <div class="grow">

--- a/app/components/prefixed/select2/v2/component.html.erb
+++ b/app/components/prefixed/select2/v2/component.html.erb
@@ -6,9 +6,9 @@
         text-ellipsis text-slate-700 @md:!rounded-r-none @md:border-r-0 dark:border-slate-600 dark:bg-slate-700
         dark:text-slate-300
       "
-      title="<%= root_url %>"
+      title="<%= helpers.root_url %>"
     >
-      <%= root_url %>
+      <%= helpers.root_url %>
     </div>
 
     <div class="grow">

--- a/app/components/project_dashboard/samples_component.html.erb
+++ b/app/components/project_dashboard/samples_component.html.erb
@@ -20,7 +20,7 @@
           <%# Sample name with improved wrapping %>
           <div>
             <%= link_to sample.name,
-            sample_path(sample),
+            helpers.sample_path(sample),
             class:
               "underline hover:decoration-2 font-medium text-slate-900 dark:text-slate-300 dark:text-white break-words leading-tight" %>
           </div>

--- a/app/components/project_dashboard_component.html.erb
+++ b/app/components/project_dashboard_component.html.erb
@@ -74,7 +74,7 @@
 
           <footer class="mt-6 border-t border-slate-200 pt-4 dark:border-slate-700">
             <%= link_to t(:"components.project_dashboard.view_more_activity"),
-            namespace_project_activity_path(@project.namespace.parent, @project),
+            helpers.namespace_project_activity_path(@project.namespace.parent, @project),
             class:
               "button bg-teal-100 hover:bg-teal-200 text-teal-800 border border-teal-200 hover:border-teal-300 dark:bg-teal-900/30 dark:hover:bg-teal-900/50 dark:text-teal-200 dark:border-teal-700/50 dark:hover:border-teal-600/50 transition-colors duration-200" %>
           </footer>
@@ -118,7 +118,7 @@
 
           <footer class="mt-6 border-t border-slate-200 pt-4 dark:border-slate-700">
             <%= link_to t(:"components.project_dashboard.view_more_samples"),
-            namespace_project_samples_path(@project.namespace.parent, @project),
+            helpers.namespace_project_samples_path(@project.namespace.parent, @project),
             class:
               "button bg-blue-100 hover:bg-blue-200 text-blue-800 border border-blue-200 hover:border-blue-300 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 dark:text-blue-200 dark:border-blue-700/50 dark:hover:border-blue-600/50 transition-colors duration-200" %>
           </footer>

--- a/app/components/samples/table/url_helpers.rb
+++ b/app/components/samples/table/url_helpers.rb
@@ -12,10 +12,10 @@ module Samples
                       end
 
         if @namespace.type == 'Group'
-          group_samples_url(@namespace, q: { sort: sort_string }, limit: @pagy.limit)
+          helpers.group_samples_url(@namespace, q: { sort: sort_string }, limit: @pagy.limit)
         else
-          namespace_project_samples_url(@namespace.parent, @namespace.project, q: { sort: sort_string },
-                                                                               limit: @pagy.limit)
+          helpers.namespace_project_samples_url(@namespace.parent, @namespace.project, q: { sort: sort_string },
+                                                                                       limit: @pagy.limit)
         end
       end
 

--- a/app/components/samples/table/v1/component.html.erb
+++ b/app/components/samples/table/v1/component.html.erb
@@ -127,7 +127,7 @@
                       </span>
                     <% elsif column == :name %>
                       <%= link_to(
-                        sample_path(sample),
+                        helpers.sample_path(sample),
                         class: "text-slate-700 dark:text-slate-300 font-sans font-semibold underline hover:decoration-2"
                       ) do %>
                         <%= highlight(
@@ -140,7 +140,7 @@
                       <% end %>
                     <% elsif column == "namespaces.puid" %>
                       <%= link_to sample.project.puid,
-                      namespace_project_samples_path(sample.project.namespace.parent, sample.project),
+                      helpers.namespace_project_samples_path(sample.project.namespace.parent, sample.project),
                       class: "font-semibold underline hover:decoration-2" %>
                     <% elsif column == :created_at %>
                       <%= helpers.local_date(sample[column], :long) %>
@@ -198,7 +198,7 @@
     <% if @abilities[:edit_sample_metadata] %>
       <template data-editable-cell-target="formTemplate">
         <%= form_with(
-              url: sample_metadatum_path(sample_id: 'SAMPLE_ID_PLACEHOLDER', id: 'FIELD_ID_PLACEHOLDER'),
+              url: helpers.sample_metadatum_path(sample_id: 'SAMPLE_ID_PLACEHOLDER', id: 'FIELD_ID_PLACEHOLDER'),
               method: :patch,
               class: "w-full"
             ) do |form| %>

--- a/app/components/viral/pagy/limit_component.html.erb
+++ b/app/components/viral/pagy/limit_component.html.erb
@@ -1,6 +1,6 @@
 <div id="limit-component" class="w-full text-slate-500 @max-md:flex @max-md:flex-col dark:text-slate-400">
   <%= form_with(
-    url: url_for(request.query_parameters.except("limit", *@params.keys.map(&:to_s))),
+    url: helpers.url_for(request.query_parameters.except("limit", *@params.keys.map(&:to_s))),
     method: :get,
     html: {
       id: "limit-component-form",

--- a/app/components/workflow_executions/table_component.rb
+++ b/app/components/workflow_executions/table_component.rb
@@ -112,37 +112,37 @@ module WorkflowExecutions
 
     def individual_path(workflow_execution)
       if @namespace&.project_namespace?
-        namespace_project_workflow_execution_path(
+        helpers.namespace_project_workflow_execution_path(
           @namespace.parent,
           @namespace.project,
           workflow_execution
         )
       elsif @namespace&.group_namespace?
-        group_workflow_execution_path(@namespace, workflow_execution)
+        helpers.group_workflow_execution_path(@namespace, workflow_execution)
       else
-        workflow_execution_path(workflow_execution)
+        helpers.workflow_execution_path(workflow_execution)
       end
     end
 
     def cancel_path(workflow_execution)
       if @namespace
-        cancel_namespace_project_workflow_execution_path(
+        helpers.cancel_namespace_project_workflow_execution_path(
           @namespace.parent,
           @namespace.project,
           workflow_execution
         )
       else
-        cancel_workflow_execution_path(workflow_execution)
+        helpers.cancel_workflow_execution_path(workflow_execution)
       end
     end
 
     def destroy_confirmation_path(workflow_execution)
       if @namespace
-        destroy_confirmation_namespace_project_workflow_execution_path(@namespace.parent,
-                                                                       @namespace.project,
-                                                                       workflow_execution)
+        helpers.destroy_confirmation_namespace_project_workflow_execution_path(@namespace.parent,
+                                                                               @namespace.project,
+                                                                               workflow_execution)
       else
-        destroy_confirmation_workflow_execution_path(workflow_execution)
+        helpers.destroy_confirmation_workflow_execution_path(workflow_execution)
       end
     end
   end

--- a/app/helpers/namespace_path_helper.rb
+++ b/app/helpers/namespace_path_helper.rb
@@ -6,9 +6,9 @@ module NamespacePathHelper
     return if namespace.deleted?
 
     if namespace&.group_namespace?
-      group_path(namespace)
+      helpers.group_path(namespace)
     elsif namespace&.project_namespace?
-      namespace_project_path(namespace.parent, namespace.project)
+      helpers.namespace_project_path(namespace.parent, namespace.project)
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?

ViewComponent 4 no longer lets you call Rails route/URL helpers directly inside a
component. Any component that called a bare route helper (for example
`namespace_project_path(...)`, `group_path(...)`, `root_url`, `url_for(...)`, or
`form_with url: some_path`) now raises:

```
undefined method 'some_path' for an instance of SomeComponent
Did you mean `helpers.some_path`?
```

## Screenshots or screen recordings

No visual changes — links and forms render exactly as before, they just no longer
raise inside components.

## How to set up and validate locally

1. `bin/dev`
2. Visit pages that render the affected components (e.g. `/dashboard/projects`,
   a project's activity/samples pages, workflow executions, personal access
   tokens) and confirm they render without `NoMethodError`.
3. `PARALLEL_WORKERS=4 bin/rails test test/components` (with dev services up for
   the system/dialog tests that use the W3C validator).

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
