### PR TITLE
Fix Nextflow File Selector

### DIFF
--- a/app/components/nextflow/shared/workflow_param_property_component.html.erb
+++ b/app/components/nextflow/shared/workflow_param_property_component.html.erb
@@ -2,7 +2,7 @@
   <% help_text_id = fields.field_id(name, "help") %>
 
   <% if property[:type] != "boolean" %>
-    <% if property[:format] == "path" || property[:format] == "file-path" %>
+    <% if (property[:format] == "path" || property[:format] == "file-path") && !property[:enum].present? %>
       <% legend_id = fields.field_id(name, "legend") %>
       <% prefix_id = fields.field_id(name, "prefix") %>
       <% describedby_ids = [prefix_id] %>

--- a/test/components/nextflow_component_test.rb
+++ b/test/components/nextflow_component_test.rb
@@ -63,6 +63,12 @@ class NextflowComponentTest < ViewComponentTestCase
         assert_text 'Kraken2 database'
         assert_selector 'select[name="workflow_execution[workflow_params][kraken2_db]"] option[value="PATH_TO_DB"]',
                         text: 'DBNAME'
+        # verify that the file-path property with enum renders a select instead of a file selector
+        assert_selector 'select[name="workflow_execution[workflow_params][dehosting_idx]"]', count: 1
+        assert_selector 'select[name="workflow_execution[workflow_params][dehosting_idx]"]
+                         option[value="PATH_TO_REF_SKETCH"]',
+                        text: 'REF_SKETCH'
+        assert_no_selector 'a[id$="_dehosting_idx_link"]'
       end
     end
   end
@@ -87,6 +93,12 @@ class NextflowComponentTest < ViewComponentTestCase
         assert_text 'Kraken2 database'
         assert_selector 'select[name="workflow_execution[workflow_params][kraken2_db]"] option[value="PATH_TO_DB"]',
                         text: 'DBNAME'
+        # verify that the file-path property with enum renders a select instead of a file selector
+        assert_selector 'select[name="workflow_execution[workflow_params][dehosting_idx]"]', count: 1
+        assert_selector 'select[name="workflow_execution[workflow_params][dehosting_idx]"]
+                         option[value="PATH_TO_REF_SKETCH"]',
+                        text: 'REF_SKETCH'
+        assert_no_selector 'a[id$="_dehosting_idx_link"]'
       end
     end
   end
@@ -247,6 +259,18 @@ class NextflowComponentTest < ViewComponentTestCase
                   %w[
                     ANOTHER_DB
                     ANOTHER_PATH
+                  ]
+                ]
+              },
+              dehosting_idx: {
+                enum: [
+                  %w[
+                    REF_SKETCH
+                    PATH_TO_REF_SKETCH
+                  ],
+                  %w[
+                    ALT_SKETCH
+                    PATH_TO_ALT_SKETCH
                   ]
                 ]
               }


### PR DESCRIPTION
## What does this PR do and why?
Fix to only render the file selector when an enum is not present from a bug that was introduced in #2002.

## Screenshots or screen recordings
<img width="3721" height="2102" alt="image" src="https://github.com/user-attachments/assets/cb15f2c3-e576-4c05-a69c-2284308f1d25" />

## How to set up and validate locally
1. Select a workflow that contains a path or file-path parameter with enum options.
1. Verify the file selector is not displayed.
1. Repeat all steps with the v2_samplesheet feature disabled.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
