### PR TITLE
chore: fix negative equality operators for metadata in advanced search

### DIFF
--- a/app/models/concerns/advanced_search/metadata_comparison.rb
+++ b/app/models/concerns/advanced_search/metadata_comparison.rb
@@ -28,26 +28,41 @@ module AdvancedSearch
     def metadata_condition_date_comparison(scope, node, value, comparison_method)
       return scope.none unless valid_date_format?(value)
 
-      scope
-        .where(node.matches_regexp('^\\d{4}(-\\d{2}){0,2}$'))
-        .where(
-          Arel::Nodes::NamedFunction.new(
-            'TO_DATE', [node, Arel::Nodes::SqlLiteral.new("'YYYY-MM-DD'")]
-          ).public_send(comparison_method, value)
-        )
+      condition = node.matches_regexp('^\\d{4}(-\\d{2}){0,2}$').and(
+        Arel::Nodes::NamedFunction.new(
+          'TO_DATE', [node, Arel::Nodes::SqlLiteral.new("'YYYY-MM-DD'")]
+        ).public_send(comparison_method, value)
+      )
+
+      if comparison_method == :not_eq
+        # Include NULL or non-date metadata values in negative comparisons: NULL is not equal to the provided value.
+        scope.where(node.eq(nil).or(node.does_not_match_regexp('^\\d{4}(-\\d{2}){0,2}$')).or(
+                      condition
+                    ))
+      else
+        scope.where(condition)
+      end
     end
 
     # handles all numeric comparisons (:eq, :not_eq, :gteq, :lteq)
     def metadata_condition_numeric_comparison(scope, node, value, comparison_method)
       return scope.none unless valid_numeric_format?(value)
 
-      scope
-        .where(node.matches_regexp('^-?\\d+(\\.\\d+)?$'))
-        .where(
-          Arel::Nodes::NamedFunction.new(
-            'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
-          ).public_send(comparison_method, value.to_f)
-        )
+      condition = node.matches_regexp('^-?\\d+(\\.\\d+)?$').and(
+        Arel::Nodes::NamedFunction.new(
+          'CAST', [node.as(Arel::Nodes::SqlLiteral.new('DOUBLE PRECISION'))]
+        ).public_send(comparison_method, value.to_f)
+      )
+
+      if comparison_method == :not_eq
+        # Include NULL or non-numeric metadata values in negative comparisons: NULL is not equal to the provided value.
+        scope.where(node.eq(nil).or(node.does_not_match_regexp('^-?\\d+(\\.\\d+)?$')).or(
+                      condition
+                    ))
+      else
+        scope
+          .where(condition)
+      end
     end
 
     def valid_date_format?(value)

--- a/test/models/sample/query_test.rb
+++ b/test/models/sample/query_test.rb
@@ -384,6 +384,30 @@ class QueryTest < ActiveSupport::TestCase
     assert_includes results4, sample2
   end
 
+  test 'metadata numeric not equals operator with null and non-numeric values' do
+    project = projects(:project1)
+    sample1 = samples(:sample1)
+    sample2 = samples(:sample2)
+    sample30 = samples(:sample30)
+    sample1.update(metadata: { 'int_field' => 100 })
+    sample30.update(metadata: { 'int_field' => 'not_a_number' })
+
+    search_params = { sort: 'updated_at desc',
+                      groups_attributes: { '0': {
+                        conditions_attributes:
+                     { '0': { field: 'metadata.int_field', operator: 'numeric_not_equals', value: '100' } }
+                      } },
+                      project_ids: [project.id] }
+    query = Sample::Query.new(search_params)
+    assert query.advanced_query?
+    assert query.valid?
+    results = query.results
+
+    assert_not_includes results, sample1
+    assert_includes results, sample2
+    assert_includes results, sample30
+  end
+
   test 'metadata date operators' do
     project = projects(:project1)
     sample1 = samples(:sample1)
@@ -447,6 +471,30 @@ class QueryTest < ActiveSupport::TestCase
 
     assert_not_includes results4, sample1
     assert_includes results4, sample2
+  end
+
+  test 'metadata date not equals operator with null and non-date values' do
+    project = projects(:project1)
+    sample1 = samples(:sample1)
+    sample2 = samples(:sample2)
+    sample30 = samples(:sample30)
+    sample1.update(metadata: { 'date_field' => '2026-01-01' })
+    sample30.update(metadata: { 'date_field' => 'not_a_date' })
+
+    search_params = { sort: 'updated_at desc',
+                      groups_attributes: { '0': {
+                        conditions_attributes:
+                     { '0': { field: 'metadata.date_field', operator: 'date_not_equals', value: '2026-01-01' } }
+                      } },
+                      project_ids: [project.id] }
+    query = Sample::Query.new(search_params)
+    assert query.advanced_query?
+    assert query.valid?
+    results = query.results
+
+    assert_not_includes results, sample1
+    assert_includes results, sample2
+    assert_includes results, sample30
   end
 
   test 'metadata text operators' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This updates the`:not_eq` metadata comparison for `numeric` and `date` comparisons to include nulls and non numeric/date values respectively. This matches existing behaviour prior to introduction of type specific metadata operators.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Start server with `bin/setup``
2. Login as your user of choice
3. Create a new project with 3 samples
4. For the first sample don't add any metadata
5. For the second sample add metadata fields below:
```json
  date_field: "Not a date"
  numeric_field: "100"
```
6. For the third sample add metadata fields below:
```json
  date_field: "2000-01-01"
  numeric_field: "Not a number"
```
7. Create an advanced search and specify field: `date_field`, operator: `date not equals`, value:`2000-01-01` and then apply the filter
8. Confirm that first and second sample are present, and that third sample is not shown
9. Replace the advanced search with field: `numeric_field`, operator: `numeric not equals`, value: `100` and then apply the filter
10. Confirm that first and third sample are present and that second sample is not shown 

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
