### PR TITLE
Attachments maintain sort and pagination

### DIFF
--- a/app/components/viral/pagy/limit_component.html.erb
+++ b/app/components/viral/pagy/limit_component.html.erb
@@ -1,13 +1,13 @@
 <div id="limit-component" class="w-full text-slate-500 @max-md:flex @max-md:flex-col dark:text-slate-400">
   <%= form_with(
-    url: helpers.url_for(request.query_parameters.except("limit", *@params.keys.map(&:to_s))),
+    url: request.path,
     method: :get,
     html: {
       id: "limit-component-form",
       class: "@max-md:space-y-4",
     },
   ) do %>
-    <% @params.each do |name, value| %>
+    <% preserved_hidden_fields.each do |name, value| %>
       <%= hidden_field_tag name, value %>
     <% end %>
 

--- a/app/components/viral/pagy/limit_component.rb
+++ b/app/components/viral/pagy/limit_component.rb
@@ -22,10 +22,10 @@ module Viral
 
       def preserved_query_params
         request.query_parameters
-               .except('limit')
                .to_h
                .deep_stringify_keys
                .deep_merge(@params.deep_stringify_keys)
+               .except('limit', 'page')
       end
 
       def flatten_params(value, prefix = nil)

--- a/app/components/viral/pagy/limit_component.rb
+++ b/app/components/viral/pagy/limit_component.rb
@@ -11,6 +11,37 @@ module Viral
         @item = item
         @params = params
       end
+
+      # GET forms replace the action query string with submitted fields, so every
+      # query param that must survive a page-size change has to be a form field.
+      def preserved_hidden_fields
+        flatten_params(preserved_query_params)
+      end
+
+      private
+
+      def preserved_query_params
+        request.query_parameters
+               .except('limit')
+               .to_h
+               .deep_stringify_keys
+               .deep_merge(@params.deep_stringify_keys)
+      end
+
+      def flatten_params(value, prefix = nil)
+        case value
+        when Hash
+          value.flat_map { |key, nested| flatten_params(nested, param_name(prefix, key)) }
+        when Array
+          value.flat_map { |nested| flatten_params(nested, "#{prefix}[]") }
+        else
+          [[prefix, value]]
+        end
+      end
+
+      def param_name(prefix, key)
+        prefix ? "#{prefix}[#{key}]" : key.to_s
+      end
     end
   end
 end

--- a/test/components/viral/pagy/limit_component_test.rb
+++ b/test/components/viral/pagy/limit_component_test.rb
@@ -42,6 +42,30 @@ module Viral
         end
       end
 
+      test 'does not preserve page when changing page size' do
+        with_request_url '/-/groups/group-1/-/attachments?page=3&q%5Bs%5D=puid+asc' do
+          render_inline Viral::Pagy::LimitComponent.new(pagy_for(count: 25), item: 'items')
+
+          assert_no_selector '#limit-component-form input[type="hidden"][name="page"]', visible: :hidden
+          assert_selector '#limit-component-form input[type="hidden"][name="q[s]"][value="puid asc"]',
+                          visible: :hidden
+        end
+      end
+
+      test 'strips limit even when reintroduced by explicit params' do
+        with_request_url '/-/groups/group-1/-/attachments?q%5Bs%5D=puid+asc' do
+          render_inline Viral::Pagy::LimitComponent.new(
+            pagy_for(count: 25),
+            item: 'items',
+            params: { limit: 50, tab: 'files' }
+          )
+
+          assert_no_selector '#limit-component-form input[type="hidden"][name="limit"]', visible: :hidden
+          assert_selector '#limit-component-form input[type="hidden"][name="tab"][value="files"]',
+                          visible: :hidden
+        end
+      end
+
       private
 
       def pagy_for(count:)

--- a/test/components/viral/pagy/limit_component_test.rb
+++ b/test/components/viral/pagy/limit_component_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Viral
+  module Pagy
+    class LimitComponentTest < ViewComponent::TestCase
+      test 'preserves nested search and sort query params as hidden fields' do
+        query = 'q%5Bs%5D=puid+asc&q%5Bpuid_or_file_blob_filename_cont%5D=report'
+        with_request_url "/-/groups/group-1/-/attachments?#{query}" do
+          render_inline Viral::Pagy::LimitComponent.new(pagy_for(count: 25), item: 'items')
+
+          assert_selector '#limit-component-form input[type="hidden"][name="q[s]"][value="puid asc"]',
+                          visible: :hidden
+          assert_selector(
+            '#limit-component-form input[type="hidden"][name="q[puid_or_file_blob_filename_cont]"][value="report"]',
+            visible: :hidden
+          )
+        end
+      end
+
+      test 'preserves explicit pagination params as hidden fields' do
+        with_request_url '/workflow_executions/1' do
+          render_inline Viral::Pagy::LimitComponent.new(
+            pagy_for(count: 2),
+            item: 'items',
+            params: { tab: 'files' }
+          )
+
+          assert_selector '#limit-component-form input[type="hidden"][name="tab"][value="files"]',
+                          visible: :hidden
+        end
+      end
+
+      test 'does not include limit as a hidden field' do
+        with_request_url '/-/groups/group-1/-/attachments?limit=20&q%5Bs%5D=puid+asc' do
+          render_inline Viral::Pagy::LimitComponent.new(pagy_for(count: 25), item: 'items')
+
+          assert_no_selector '#limit-component-form input[type="hidden"][name="limit"]', visible: :hidden
+          assert_selector '#limit-component-form input[type="hidden"][name="q[s]"][value="puid asc"]',
+                          visible: :hidden
+        end
+      end
+
+      private
+
+      def pagy_for(count:)
+        ::Pagy::Offset.new(
+          count:,
+          page: 1,
+          limit: 20,
+          request: ::Pagy::Request.new(
+            request: { base_url: 'localhost:3000', path: '/', params: {} }
+          )
+        )
+      end
+    end
+  end
+end

--- a/test/system/projects/attachments_test.rb
+++ b/test/system/projects/attachments_test.rb
@@ -265,6 +265,67 @@ module Projects
       end
     end
 
+    test 'changing page size preserves search' do
+      visit namespace_project_attachments_path(@namespace, @project1)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      assert_selector 'table tbody tr', count: 2
+
+      fill_in placeholder: I18n.t(:'projects.attachments.index.search.placeholder'),
+              with: @attachment1.file.filename.to_s
+      find('input.t-search-component').send_keys(:return)
+
+      assert_text 'Displaying 1 item'
+      assert_selector 'table tbody tr', count: 1
+      assert_text @attachment1.puid
+
+      select '10', from: 'pagy-limit-select'
+
+      assert_selector '#pagy-limit-select option[value="10"]:checked'
+      assert_text 'Displaying 1 item'
+      assert_selector 'table tbody tr', count: 1
+      assert_text @attachment1.puid
+      assert_no_text @attachment2.puid
+      assert_selector '#limit-component-form input[type="hidden"][name="q[puid_or_file_blob_filename_cont]"]' \
+                      "[value=\"#{@attachment1.file.filename}\"]",
+                      visible: :hidden
+    end
+
+    test 'changing page size preserves sort' do
+      visit namespace_project_attachments_path(@namespace, @project1)
+
+      assert_text 'Displaying 1-2 of 2 items'
+      click_link I18n.t('components.attachments.table_component.id')
+
+      assert_selector 'th[aria-sort]'
+      assert_selector 'a[href*="q%5Bs%5D=puid"]'
+
+      select '10', from: 'pagy-limit-select'
+
+      assert_selector '#pagy-limit-select option[value="10"]:checked'
+      assert_selector 'th[aria-sort]'
+      assert_selector 'a[href*="limit=10"][href*="q%5Bs%5D=puid"]'
+      assert_selector '#limit-component-form input[type="hidden"][name="q[s]"][value="puid asc"]',
+                      visible: :hidden
+    end
+
+    test 'changing page preserves sort' do
+      visit namespace_project_attachments_path(@namespace, @project1, limit: 1)
+
+      assert_selector 'table tbody tr', count: 1
+      click_link I18n.t('components.attachments.table_component.id')
+
+      assert_selector 'th[aria-sort]'
+      first_page_puid = find('table tbody tr th').text
+
+      click_on I18n.t('components.viral.pagy.pagination_component.next')
+
+      assert_selector 'th[aria-sort]'
+      assert_selector 'a[href*="q%5Bs%5D=puid"]'
+      assert_selector 'table tbody tr', count: 1
+      assert_no_text first_page_puid
+    end
+
     test 'member with role >= analyst can see attachment preview link' do
       project2 = projects(:project2)
       attachment = attachments(:attachmentCSV)


### PR DESCRIPTION
## What does this PR do and why?
- Keeps attachment table sort and search when changing page size.
- GET limit forms discard the action query string, so current request params (including nested `q`) are now rendered as hidden fields.

## Screenshots or screen recordings
- N/A (behavior-only: query params preserved on pagination; no visual UI change)

## How to set up and validate locally
1. `bin/rails test test/components/viral/pagy/limit_component_test.rb`
2. `bin/rails test test/system/projects/attachments_test.rb -n "/preserves/"`
3. Manually: open project attachments, search or sort, change page size, confirm filters remain.  Also confirm it does not break any other tables.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.