### PR TITLE
chore: Retire feature flags 2026 07 21

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -65,7 +65,6 @@ linter:
       enabled: true
     erb-strict-locals-required:
       enabled: true
-    # Same scope as erb-no-silent-statement.
     erb-no-unused-expressions:
       enabled: true
       only:

--- a/.herb.yml
+++ b/.herb.yml
@@ -63,11 +63,6 @@ linter:
       enabled: true
     actionview-strict-locals-first-line:
       enabled: true
-    # Scoped to classic Rails views only — ViewComponent slot APIs use silent ERB.
-    erb-no-silent-statement:
-      enabled: true
-      only:
-        - "app/views/**/*"
     erb-strict-locals-required:
       enabled: true
     # Same scope as erb-no-silent-statement.

--- a/app/components/refresh_notice_component.html.erb
+++ b/app/components/refresh_notice_component.html.erb
@@ -5,57 +5,55 @@
                               "refresh-target": "source",
                             } %>
 
-  <% if show_notice? %>
+  <div
+    id="<%= alert_id %>"
+    data-refresh-target="notice"
+    role="alert"
+    aria-live="assertive"
+    aria-atomic="true"
+    class="fixed top-4 left-1/2 z-50 mx-auto hidden w-full max-w-xl -translate-x-1/2 px-4"
+  >
     <div
-      id="<%= alert_id %>"
-      data-refresh-target="notice"
-      role="alert"
-      aria-live="assertive"
-      aria-atomic="true"
-      class="fixed top-4 left-1/2 z-50 mx-auto hidden w-full max-w-xl -translate-x-1/2 px-4"
+      class="
+        flex items-center rounded-lg border border-slate-200 bg-white p-4 shadow-lg dark:border-slate-700
+        dark:bg-slate-800
+      "
     >
-      <div
-        class="
-          flex items-center rounded-lg border border-slate-200 bg-white p-4 shadow-lg dark:border-slate-700
-          dark:bg-slate-800
-        "
-      >
-        <!-- Icon -->
-        <div class="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900">
-          <%= icon(:info, color: :blue, size: :md) %>
-        </div>
+      <!-- Icon -->
+      <div class="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900">
+        <%= icon(:info, color: :blue, size: :md) %>
+      </div>
 
-        <!-- Message -->
-        <div class="ml-3 flex-1 text-sm font-medium text-slate-700 dark:text-slate-200"><%= message %></div>
+      <!-- Message -->
+      <div class="ml-3 flex-1 text-sm font-medium text-slate-700 dark:text-slate-200"><%= message %></div>
 
-        <!-- Actions -->
-        <div class="ml-auto flex items-center gap-3 pl-3">
-          <!-- Refresh Button -->
-          <button
-            type="button"
-            data-action="click->refresh#refresh"
-            class="
-              cursor-pointer px-3 py-1.5 text-sm font-medium text-primary-600 transition-colors duration-200
-              hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300
-            "
-          >
-            <%= link_text %>
-          </button>
+      <!-- Actions -->
+      <div class="ml-auto flex items-center gap-3 pl-3">
+        <!-- Refresh Button -->
+        <button
+          type="button"
+          data-action="click->refresh#refresh"
+          class="
+            cursor-pointer px-3 py-1.5 text-sm font-medium text-primary-600 transition-colors duration-200
+            hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300
+          "
+        >
+          <%= link_text %>
+        </button>
 
-          <!-- Dismiss Button -->
-          <button
-            type="button"
-            data-action="click->refresh#dismiss"
-            class="
-              inline-flex cursor-pointer items-center justify-center p-1 text-slate-400 transition-colors
-              duration-200 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300
-            "
-            aria-label="<%= I18n.t('general.screen_reader.close') %>"
-          >
-            <%= icon(:x, color: :subdued, size: :sm) %>
-          </button>
-        </div>
+        <!-- Dismiss Button -->
+        <button
+          type="button"
+          data-action="click->refresh#dismiss"
+          class="
+            inline-flex cursor-pointer items-center justify-center p-1 text-slate-400 transition-colors duration-200
+            hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300
+          "
+          aria-label="<%= I18n.t('general.screen_reader.close') %>"
+        >
+          <%= icon(:x, color: :subdued, size: :sm) %>
+        </button>
       </div>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/components/refresh_notice_component.rb
+++ b/app/components/refresh_notice_component.rb
@@ -66,11 +66,4 @@ class RefreshNoticeComponent < Component
   def alert_id
     @alert_id ||= "refresh-notice-#{object_id}"
   end
-
-  # Whether to show the notice UI (vs. auto-refreshing)
-  #
-  # @return [Boolean]
-  def show_notice?
-    Flipper.enabled?(:samples_refresh_notice, Current.user)
-  end
 end

--- a/app/controllers/concerns/workflow_execution_actions.rb
+++ b/app/controllers/concerns/workflow_execution_actions.rb
@@ -371,10 +371,8 @@ module WorkflowExecutionActions # rubocop:disable Metrics/ModuleLength
     search_params[:name_or_id_in] = params.dig(:q, :name_or_id_in)
     search_params[:sort] = params.dig(:q, :s)
 
-    if Flipper.enabled?(:workflow_execution_advanced_search)
-      groups_attributes = workflow_advanced_search_groups_attributes
-      search_params[:groups_attributes] = groups_attributes if groups_attributes.present?
-    end
+    groups_attributes = workflow_advanced_search_groups_attributes
+    search_params[:groups_attributes] = groups_attributes if groups_attributes.present?
 
     search_params.compact
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,8 +50,6 @@ class Project < ApplicationRecord
   def broadcast_refresh_later_to_samples_table
     broadcast_refresh_later_to self, :samples if self && !deleted?
 
-    return unless Flipper.enabled?(:samples_refresh_notice, Current.user)
-
     # Broadcast to all ancestor groups since they display samples from child projects/groups.
     # This ensures group sample views are notified of changes in nested projects.
     namespace.self_and_ancestors_of_type(Group.sti_name).each do |namespace|

--- a/app/services/base_sample_service.rb
+++ b/app/services/base_sample_service.rb
@@ -75,8 +75,6 @@ class BaseSampleService < BaseService
 
   # Broadcast all turbo broadcasts for sample services where the broadcasts were suppressed
   def broadcast_refresh_later_to_samples_table(old_namespaces, new_namespaces, old_project, new_project) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-    return unless Flipper.enabled?(:samples_refresh_notice, current_user)
-
     Turbo::StreamsChannel.broadcast_refresh_later_to old_project, :samples if old_project && !old_project.deleted?
 
     old_namespaces.each do |old_namespace|

--- a/app/services/workflow_executions/create_service.rb
+++ b/app/services/workflow_executions/create_service.rb
@@ -103,12 +103,8 @@ module WorkflowExecutions
     end
 
     def add_workflow_execution_tags
-      @workflow_execution.tags = if Flipper.enabled?(:wes_extended_metadata)
-                                   { createdBy: current_user.email, namespaceId: @workflow_execution.namespace.puid,
-                                     samplesCount: @samples_count.to_s }
-                                 else
-                                   { createdBy: current_user.email }
-                                 end
+      @workflow_execution.tags = { createdBy: current_user.email, namespaceId: @workflow_execution.namespace.puid,
+                                   samplesCount: @samples_count.to_s }
     end
 
     def sanitized_workflow_params

--- a/app/views/groups/workflow_executions/index.html.erb
+++ b/app/views/groups/workflow_executions/index.html.erb
@@ -50,9 +50,7 @@
       url: group_workflow_executions_path,
       total_count: @pagy.count,
       page_limit: @pagy.limit,
-      form_data: {
-        "search-field-selection-outlet": "#workflow-executions-table",
-      },
+      results_message: @results_message
     } %>
   </div>
 <% end %>

--- a/app/views/groups/workflow_executions/show.html.erb
+++ b/app/views/groups/workflow_executions/show.html.erb
@@ -9,11 +9,7 @@
 <%= render Viral::PageHeaderComponent.new(title: turbo_frame_tag('we_name_header') do @workflow_execution.name.blank? ? @workflow_execution.workflow.name :
    @workflow_execution.name end, id: @workflow_execution.id, id_color: find_pill_color_for_state(@workflow_execution.state)) do |component| %>
   <% component.with_buttons do %>
-    <div
-      class="
-        flex flex-col @xl:flex-row @lg:justify-between space-y-2 @lg:space-x-1 mb-2
-      "
-    >
+    <div class="mb-2 flex flex-col space-y-2 @lg:justify-between @lg:space-x-1 @xl:flex-row">
       <% if @allowed_to[:export_data] %>
         <% if @workflow_execution.completed? %>
           <%= button_to t("groups.workflow_executions.show.create_export_button"),
@@ -48,6 +44,7 @@
             "button button-default w-full pointer-events-none cursor-not-allowed bg-slate-100 text-slate-600 dark:bg-slate-600 dark:text-slate-300" %>
         <% end %>
       <% end %>
+
       <% if @workflow_execution.cancellable? && @allowed_to[:cancel] %>
         <%= button_to t("common.actions.cancel"),
         cancel_group_workflow_execution_path(@namespace, @workflow_execution.id),
@@ -59,6 +56,7 @@
         method: :put,
         class: "button button-default w-full" %>
       <% end %>
+
       <% if @allowed_to[:update] %>
         <%= button_to t("common.actions.edit"),
         edit_group_workflow_execution_path(@namespace, @workflow_execution),
@@ -68,6 +66,7 @@
         },
         class: "button button-default w-full" %>
       <% end %>
+
       <% if @workflow_execution.deletable? && @allowed_to[:destroy] %>
         <%= button_to t("common.actions.remove"),
         group_workflow_execution_path(@namespace, @workflow_execution, redirect: true),
@@ -152,6 +151,7 @@
   ) do %>
     <%= render partial: "workflow_executions/files",
     locals: {
+      allowed_to: @allowed_to,
       pagy: @pagy,
       q: @q,
       search_url: group_workflow_execution_path(@namespace, @workflow_execution),

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -1,9 +1,11 @@
+<%# locals: (allowed_to:, attachments:, has_attachments:, pagy:, sample:, q:) -%>
+
 <div id="sample-attachments">
-  <% if @has_attachments %>
+  <% if has_attachments %>
     <div class="mb-4 flex flex-wrap gap-2">
-      <% if @allowed_to[:update_sample] %>
+      <% if allowed_to[:update_sample] %>
         <%= render "shared/selection_buttons",
-        url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
+        url: select_namespace_project_sample_attachments_url(sample_id: sample.id),
         select_form_fields: {
           format: "turbo_stream",
           select: "on",
@@ -23,13 +25,13 @@
       <div class="max-sm:hidden sm:grow" role="presentation"></div>
 
       <%= render SearchComponent.new(
-              query: @q,
+              query: q,
               search_attribute: :puid_or_file_blob_filename_cont,
               label: t('common.controls.search'),
               placeholder: t(:".search.placeholder"),
-              value: @q.puid_or_file_blob_filename_cont,
+              value: q.puid_or_file_blob_filename_cont,
               url: namespace_project_sample_path,
-              total_count: @pagy.count,
+              total_count: pagy.count,
               class: "max-sm:grow",
               search_field_arguments: {
                 data: {
@@ -37,12 +39,12 @@
                 }
               }
               ) do %>
-        <%= hidden_field_tag :limit, @pagy.limit %>
+        <%= hidden_field_tag :limit, pagy.limit %>
       <% end %>
 
-      <% if @allowed_to[:update_sample] %>
+      <% if allowed_to[:update_sample] %>
         <%= button_to t("projects.samples.show.new_attachment_button"),
-        new_namespace_project_sample_attachment_path(sample_id: @sample.id),
+        new_namespace_project_sample_attachment_path(sample_id: sample.id),
         method: :get,
         data: {
           turbo_frame: "sample_modal",
@@ -51,7 +53,7 @@
         class: "button button-default max-sm:grow" %>
         <%= button_to t("projects.samples.show.concatenate_button"),
         new_namespace_project_sample_attachments_concatenation_path(
-          sample_id: @sample.id,
+          sample_id: sample.id,
         ),
         method: :get,
         data: {
@@ -62,7 +64,7 @@
         },
         class: "button button-default action-button max-sm:grow" %>
         <%= button_to t("projects.samples.show.delete_files_button"),
-        new_namespace_project_sample_attachments_deletion_path(sample_id: @sample.id),
+        new_namespace_project_sample_attachments_deletion_path(sample_id: sample.id),
         method: :get,
         data: {
           turbo_frame: "sample_modal",
@@ -79,28 +81,28 @@
 
   <div class="table-wrapper relative overflow-x-auto">
     <%= render Attachments::TableComponent.new(
-      @sample_attachments,
-      @pagy,
-      @q,
-      @sample,
-      @render_individual_attachments,
-      @has_attachments,
+      attachments,
+      pagy,
+      q,
+      sample,
+      render_individual_attachments,
+      has_attachments,
       abilities: {
-        select_attachments: @allowed_to[:update_sample],
+        select_attachments: allowed_to[:update_sample],
       },
       row_actions: {
-        preview: @allowed_to[:preview_attachment],
-        destroy: @allowed_to[:destroy_attachment],
+        preview: allowed_to[:preview_attachment],
+        destroy: allowed_to[:destroy_attachment],
       },
       empty:
-        if @allowed_to[:update_sample]
+        if allowed_to[:update_sample]
           {
             icon_name: Attachment.icon,
             title: t(".empty_state.title"),
             description: t(".empty_state.description"),
             action_text: t(".empty_state.action_text"),
             action_path:
-              new_namespace_project_sample_attachment_path(sample_id: @sample.id),
+              new_namespace_project_sample_attachment_path(sample_id: sample.id),
             action_method: :get,
             data: {
               turbo_frame: "sample_modal",

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (allowed_to:, attachments:, has_attachments:, pagy:, sample:, q:) -%>
+<%# locals: (allowed_to:, attachments:, has_attachments:, pagy:, render_individual_attachments:, sample:, q:) -%>
 
 <div id="sample-attachments">
   <% if has_attachments %>

--- a/app/views/projects/samples/attachments/_table.html.erb
+++ b/app/views/projects/samples/attachments/_table.html.erb
@@ -2,46 +2,42 @@
   <% if @has_attachments %>
     <div class="mb-4 flex flex-wrap gap-2">
       <% if @allowed_to[:update_sample] %>
-        <% if Flipper.enabled?(:sample_attachments_searching, current_user) %>
-          <%= render "shared/selection_buttons",
-          url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
-          select_form_fields: {
-            format: "turbo_stream",
-            select: "on",
-            "q[puid_or_file_blob_filename_cont]": params.dig(:q, :puid_or_file_blob_filename_cont),
-          },
-          deselect_form_fields: { format: "turbo_stream" },
-          select_button_options: {
-            title: t(".select_all_tooltip"),
-            aria: { label: t(".select_all_tooltip") },
-          },
-          deselect_button_options: {
-            title: t(".deselect_all_tooltip"),
-            aria: { label: t(".deselect_all_tooltip") },
-          } %>
-        <% end %>
+        <%= render "shared/selection_buttons",
+        url: select_namespace_project_sample_attachments_url(sample_id: @sample.id),
+        select_form_fields: {
+          format: "turbo_stream",
+          select: "on",
+          "q[puid_or_file_blob_filename_cont]": params.dig(:q, :puid_or_file_blob_filename_cont),
+        },
+        deselect_form_fields: { format: "turbo_stream" },
+        select_button_options: {
+          title: t(".select_all_tooltip"),
+          aria: { label: t(".select_all_tooltip") },
+        },
+        deselect_button_options: {
+          title: t(".deselect_all_tooltip"),
+          aria: { label: t(".deselect_all_tooltip") },
+        } %>
       <% end %>
 
       <div class="max-sm:hidden sm:grow" role="presentation"></div>
 
-      <% if Flipper.enabled?(:sample_attachments_searching, current_user) %>
-        <%= render SearchComponent.new(
-                query: @q,
-                search_attribute: :puid_or_file_blob_filename_cont,
-                label: t('common.controls.search'),
-                placeholder: t(:".search.placeholder"),
-                value: @q.puid_or_file_blob_filename_cont,
-                url: namespace_project_sample_path,
-                total_count: @pagy.count,
-                class: "max-sm:grow",
-                search_field_arguments: {
-                  data: {
-                    'search-field-selection-outlet': '#attachments-table'
-                  }
+      <%= render SearchComponent.new(
+              query: @q,
+              search_attribute: :puid_or_file_blob_filename_cont,
+              label: t('common.controls.search'),
+              placeholder: t(:".search.placeholder"),
+              value: @q.puid_or_file_blob_filename_cont,
+              url: namespace_project_sample_path,
+              total_count: @pagy.count,
+              class: "max-sm:grow",
+              search_field_arguments: {
+                data: {
+                  'search-field-selection-outlet': '#attachments-table'
                 }
-                ) do %>
-          <%= hidden_field_tag :limit, @pagy.limit %>
-        <% end %>
+              }
+              ) do %>
+        <%= hidden_field_tag :limit, @pagy.limit %>
       <% end %>
 
       <% if @allowed_to[:update_sample] %>

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -67,7 +67,13 @@
     ) do %>
       <%= render partial: "projects/samples/attachments/table",
       locals: {
+        allowed_to: @allowed_to,
         attachments: @sample_attachments,
+        has_attachments: @has_attachments,
+        pagy: @pagy,
+        sample: @sample,
+        q: @q,
+        render_individual_attachments: @render_individual_attachments
       } %>
     <% end %>
 

--- a/app/views/projects/workflow_executions/index.html.erb
+++ b/app/views/projects/workflow_executions/index.html.erb
@@ -13,7 +13,7 @@
   <%= component.with_buttons do %>
     <% if @has_workflow_executions && @render_workflow_actions %>
       <%= render DropdownComponent.new(label: t("shared.workflow_executions.actions_dropdown.label"), aria: { label: t('shared.workflow_executions.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
-        <% if allowed_to?(:cancel_workflow_executions?, @project.namespace) && Flipper.enabled?(:cancel_multiple_workflows, current_user) %>
+        <% if allowed_to?(:cancel_workflow_executions?, @project.namespace) %>
           <% dropdown.with_item(
             label:
               t("shared.workflow_executions.actions_dropdown.cancel_workflow_executions"),

--- a/app/views/projects/workflow_executions/index.html.erb
+++ b/app/views/projects/workflow_executions/index.html.erb
@@ -97,6 +97,7 @@
       url: namespace_project_workflow_executions_path,
       total_count: @pagy.count,
       page_limit: @pagy.limit,
+      results_message: @results_message
     } %>
   </div>
 <% end %>

--- a/app/views/projects/workflow_executions/show.html.erb
+++ b/app/views/projects/workflow_executions/show.html.erb
@@ -9,11 +9,7 @@
 <%= render Viral::PageHeaderComponent.new(title: turbo_frame_tag('we_name_header') do @workflow_execution.name.blank? ? @workflow_execution.workflow.name :
    @workflow_execution.name end, id: @workflow_execution.id, id_color: find_pill_color_for_state(@workflow_execution.state)) do |component| %>
   <% component.with_buttons do %>
-    <div
-      class="
-        flex flex-col @xl:flex-row @lg:justify-between space-y-2 @lg:space-x-1 mb-2
-      "
-    >
+    <div class="mb-2 flex flex-col space-y-2 @lg:justify-between @lg:space-x-1 @xl:flex-row">
       <% if @allowed_to[:export_data] %>
         <% if @workflow_execution.completed? %>
           <%= button_to t("projects.workflow_executions.show.create_export_button"),
@@ -49,6 +45,7 @@
           disabled: true %>
         <% end %>
       <% end %>
+
       <% if @workflow_execution.cancellable? && @allowed_to[:cancel] %>
         <%= button_to t("common.actions.cancel"),
         cancel_namespace_project_workflow_execution_path(
@@ -64,6 +61,7 @@
         method: :put,
         class: "button button-default w-full" %>
       <% end %>
+
       <% if @allowed_to[:update] %>
         <%= button_to t("common.actions.edit"),
         edit_namespace_project_workflow_execution_path(
@@ -77,6 +75,7 @@
         method: :get,
         class: "button button-default w-full" %>
       <% end %>
+
       <% if @workflow_execution.deletable? && @allowed_to[:destroy] %>
         <%= button_to t("common.actions.remove"),
         destroy_confirmation_namespace_project_workflow_execution_path(
@@ -183,6 +182,7 @@
   ) do %>
     <%= render partial: "workflow_executions/files",
     locals: {
+      allowed_to: @allowed_to,
       pagy: @pagy,
       q: @q,
       search_url:

--- a/app/views/workflow_executions/_files.html.erb
+++ b/app/views/workflow_executions/_files.html.erb
@@ -1,4 +1,5 @@
-<%# locals: (pagy:, q:, search_url:, attachments:, workflow_execution:, has_attachments: ) -%>
+<%# locals: (allowed_to:, pagy:, q:, search_url:, attachments:, workflow_execution:, has_attachments: ) -%>
+
 <div class="mb-2 flex justify-end">
   <%= render SearchComponent.new(
             query: q,
@@ -28,7 +29,7 @@
   abilities: {
   },
   row_actions: {
-    preview: @allowed_to[:preview],
+    preview: allowed_to[:preview],
   },
   empty: {
     icon_name: Attachment.icon,

--- a/app/views/workflow_executions/_files.html.erb
+++ b/app/views/workflow_executions/_files.html.erb
@@ -1,20 +1,18 @@
 <%# locals: (pagy:, q:, search_url:, attachments:, workflow_execution:, has_attachments: ) -%>
 <div class="mb-2 flex justify-end">
-  <% if Flipper.enabled?(:workflow_execution_attachments_searching, current_user) %>
-    <%= render SearchComponent.new(
-              query: q,
-              search_attribute: :puid_or_file_blob_filename_cont,
-              label: t('common.controls.search'),
-              placeholder: t("workflow_executions.files.search.placeholder"),
-              url: search_url,
-              total_count: pagy.count,
-              value: q.puid_or_file_blob_filename_cont,
-              class: "max-sm:grow",
-              data: {}
-            ) do %>
-      <%= hidden_field_tag :limit, pagy.limit %>
-      <%= hidden_field_tag :tab, "files" %>
-    <% end %>
+  <%= render SearchComponent.new(
+            query: q,
+            search_attribute: :puid_or_file_blob_filename_cont,
+            label: t('common.controls.search'),
+            placeholder: t("workflow_executions.files.search.placeholder"),
+            url: search_url,
+            total_count: pagy.count,
+            value: q.puid_or_file_blob_filename_cont,
+            class: "max-sm:grow",
+            data: {}
+          ) do %>
+    <%= hidden_field_tag :limit, pagy.limit %>
+    <%= hidden_field_tag :tab, "files" %>
   <% end %>
 </div>
 

--- a/app/views/workflow_executions/_table_filter.html.erb
+++ b/app/views/workflow_executions/_table_filter.html.erb
@@ -5,12 +5,10 @@
   { classes: "sm:min-w-[20rem]" }
 ).deep_merge(local_assigns.fetch(:search_field_arguments, {})) %>
 
-<% if workflow_advanced_search_enabled %>
-  <% base_form_data = base_form_data.merge(
-    controller: "filters",
-    "filters-selection-outlet": "#workflow-executions-table",
-  ) %>
-<% end %>
+<% base_form_data = base_form_data.merge(
+  controller: "filters",
+  "filters-selection-outlet": "#workflow-executions-table",
+) %>
 
 <div role="status" class="sr-only"><%= @results_message %></div>
 

--- a/app/views/workflow_executions/_table_filter.html.erb
+++ b/app/views/workflow_executions/_table_filter.html.erb
@@ -1,18 +1,8 @@
-<% workflow_advanced_search_fields = AdvancedSearch::Fields.for_workflow_executions %>
-<% base_form_data = { turbo_action: "replace" }.merge(local_assigns.fetch(:form_data, {})) %>
+<%# locals: (page_limit:, query:, results_message:, search:, total_count:, url:) -%>
 
-<% search_field_arguments = (
-  { classes: "sm:min-w-[20rem]" }
-).deep_merge(local_assigns.fetch(:search_field_arguments, {})) %>
+<div role="status" class="sr-only"><%= results_message %></div>
 
-<% base_form_data = base_form_data.merge(
-  controller: "filters",
-  "filters-selection-outlet": "#workflow-executions-table",
-) %>
-
-<div role="status" class="sr-only"><%= @results_message %></div>
-
-<%= form_with model: @query, html: { role: "search" }, scope: :q, url:, method: :get, data: base_form_data,
+<%= form_with model: search, html: { role: "search" }, scope: :q, url:, method: :get, data: {turbo_action: "replace", controller: "filters", "filters-selection-outlet": "#workflow-executions-table"},
               class: "filters contents" do |form| %>
   <div class="max-sm:grow">
     <% if query.present? && !query.sorts.empty? %>
@@ -28,19 +18,22 @@
       field_name: :name_or_id_cont,
       label: t("common.controls.search"),
       placeholder: t("shared.workflow_executions.index.search.placeholder"),
-      value: @query.name_or_id_cont,
+      value: search.name_or_id_cont,
       include_advanced_search_outlet: true,
-      **search_field_arguments,
+      data: {
+        "search-field-selection-outlet": "#workflow-executions-table",
+      },
+      classes: "sm:min-w-[20rem]"
     ) %>
   </div>
 
   <div class="max-sm:grow">
     <%= render AdvancedSearchComponent.new(
       form: form,
-      search: @query,
-      fields: workflow_advanced_search_fields,
-      open: @query.errors.any?,
-      status: @query.advanced_query?,
+      search: search,
+      fields: AdvancedSearch::Fields.for_workflow_executions,
+      open: search.errors.any?,
+      status: search.advanced_query?,
     ) %>
   </div>
 <% end %>

--- a/app/views/workflow_executions/_table_filter.html.erb
+++ b/app/views/workflow_executions/_table_filter.html.erb
@@ -1,9 +1,8 @@
-<% workflow_advanced_search_enabled = Flipper.enabled?(:workflow_execution_advanced_search) %>
-<% workflow_advanced_search_fields = workflow_advanced_search_enabled ? AdvancedSearch::Fields.for_workflow_executions : nil %>
+<% workflow_advanced_search_fields = AdvancedSearch::Fields.for_workflow_executions %>
 <% base_form_data = { turbo_action: "replace" }.merge(local_assigns.fetch(:form_data, {})) %>
 
 <% search_field_arguments = (
-  workflow_advanced_search_enabled ? { classes: "sm:min-w-[20rem]" } : {}
+  { classes: "sm:min-w-[20rem]" }
 ).deep_merge(local_assigns.fetch(:search_field_arguments, {})) %>
 
 <% if workflow_advanced_search_enabled %>
@@ -13,51 +12,37 @@
   ) %>
 <% end %>
 
-<% if workflow_advanced_search_enabled %>
-  <div role="status" class="sr-only"><%= @results_message %></div>
-  <%= form_with model: @query, html: { role: "search" }, scope: :q, url:, method: :get, data: base_form_data,
-                class: "filters contents" do |form| %>
-    <div class="max-sm:grow">
-      <% if query.present? && !query.sorts.empty? %>
-        <%= hidden_field_tag "q[s]", "#{query.sorts.first.name} #{query.sorts.first.dir}" %>
-      <% end %>
+<div role="status" class="sr-only"><%= @results_message %></div>
 
-      <% if local_assigns.fetch(:page_limit, nil).present? %>
-        <%= hidden_field_tag :limit, local_assigns[:page_limit] %>
-      <% end %>
+<%= form_with model: @query, html: { role: "search" }, scope: :q, url:, method: :get, data: base_form_data,
+              class: "filters contents" do |form| %>
+  <div class="max-sm:grow">
+    <% if query.present? && !query.sorts.empty? %>
+      <%= hidden_field_tag "q[s]", "#{query.sorts.first.name} #{query.sorts.first.dir}" %>
+    <% end %>
 
-      <%= render SearchFieldComponent.new(
-        form: form,
-        field_name: :name_or_id_cont,
-        label: t("common.controls.search"),
-        placeholder: t("shared.workflow_executions.index.search.placeholder"),
-        value: @query.name_or_id_cont,
-        include_advanced_search_outlet: true,
-        **search_field_arguments,
-      ) %>
-    </div>
+    <% if local_assigns.fetch(:page_limit, nil).present? %>
+      <%= hidden_field_tag :limit, local_assigns[:page_limit] %>
+    <% end %>
 
-    <div class="max-sm:grow">
-      <%= render AdvancedSearchComponent.new(
-        form: form,
-        search: @query,
-        fields: workflow_advanced_search_fields,
-        open: @query.errors.any?,
-        status: @query.advanced_query?,
-      ) %>
-    </div>
-  <% end %>
-<% else %>
-  <%= render SearchComponent.new(
-    query: query,
-    url: url,
-    search_attribute: :name_or_id_cont,
-    label: t("common.controls.search"),
-    placeholder: t("shared.workflow_executions.index.search.placeholder"),
-    value: query.name_or_id_cont,
-    total_count: total_count,
-    class: "max-sm:grow",
-    data: base_form_data,
-    search_field_arguments: search_field_arguments,
-  ) %>
+    <%= render SearchFieldComponent.new(
+      form: form,
+      field_name: :name_or_id_cont,
+      label: t("common.controls.search"),
+      placeholder: t("shared.workflow_executions.index.search.placeholder"),
+      value: @query.name_or_id_cont,
+      include_advanced_search_outlet: true,
+      **search_field_arguments,
+    ) %>
+  </div>
+
+  <div class="max-sm:grow">
+    <%= render AdvancedSearchComponent.new(
+      form: form,
+      search: @query,
+      fields: workflow_advanced_search_fields,
+      open: @query.errors.any?,
+      status: @query.advanced_query?,
+    ) %>
+  </div>
 <% end %>

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -10,21 +10,19 @@
   <%= component.with_buttons do %>
     <% if @has_workflow_executions %>
       <%= render DropdownComponent.new(label: t("shared.workflow_executions.actions_dropdown.label"), aria: { label: t('shared.workflow_executions.actions_dropdown.label') }, caret: true, classes: "font-normal button button-default") do |dropdown| %>
-        <% if Flipper.enabled?(:cancel_multiple_workflows, current_user) %>
-          <% dropdown.with_item(
-            label:
-              t("shared.workflow_executions.actions_dropdown.cancel_workflow_executions"),
-            url: cancel_multiple_confirmation_workflow_executions_path,
-            disableable: true,
-            data: {
-              turbo_stream: true,
-              controller: "action-button",
-              action_button_required_value: 1,
-            },
-            class:
-              "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white action-button cursor-pointer",
-          ) %>
-        <% end %>
+        <% dropdown.with_item(
+          label:
+            t("shared.workflow_executions.actions_dropdown.cancel_workflow_executions"),
+          url: cancel_multiple_confirmation_workflow_executions_path,
+          disableable: true,
+          data: {
+            turbo_stream: true,
+            controller: "action-button",
+            action_button_required_value: 1,
+          },
+          class:
+            "flex w-full items-center px-4 py-2 hover:bg-slate-100 dark:hover:bg-slate-600 dark:hover:text-white action-button cursor-pointer",
+        ) %>
 
         <% dropdown.with_item(
           label:

--- a/app/views/workflow_executions/index.html.erb
+++ b/app/views/workflow_executions/index.html.erb
@@ -88,11 +88,7 @@
       url: workflow_executions_path,
       total_count: @pagy.count,
       page_limit: @pagy.limit,
-      search_field_arguments: {
-        data: {
-          "search-field-selection-outlet": "#workflow-executions-table",
-        },
-      },
+      results_message: @results_message
     } %>
   </div>
 <% end %>

--- a/app/views/workflow_executions/show.html.erb
+++ b/app/views/workflow_executions/show.html.erb
@@ -144,6 +144,7 @@ end, id: @workflow_execution.id, id_color: find_pill_color_for_state(@workflow_e
   ) do %>
     <%= render partial: "workflow_executions/files",
     locals: {
+      allowed_to: @allowed_to,
       pagy: @pagy,
       q: @q,
       search_url: workflow_execution_path(@workflow_execution),

--- a/config/features.yml
+++ b/config/features.yml
@@ -28,16 +28,6 @@ features:
     name:
       en: "Advanced Search Autocomplete"
       fr: "Saisie semi-automatique de la recherche avancée"
-  cancel_multiple_workflows:
-    admin_manageable: true
-    description:
-      en: "Allow users to select and cancel multiple workflow executions at once."
-      fr: "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
-        \ de flux de travail à la fois."
-    enable_in_development: true
-    name:
-      en: "Cancel Multiple Workflows"
-      fr: "Annulation de plusieurs flux de travail"
   client_linelist_exports_v1:
     admin_manageable: true
     description:

--- a/config/features.yml
+++ b/config/features.yml
@@ -72,17 +72,6 @@ features:
   integration_access_token_generation:
     description: "Allow users to generate access tokens for API access."
     enable_in_development: true
-  samples_refresh_notice:
-    admin_manageable: true
-    description:
-      en: "Show a notice on the samples table when samples table is out of date due\
-        \ to additions, deletions, or updates."
-      fr: "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
-        \ après un ajout, une suppression ou une modification."
-    enable_in_development: true
-    name:
-      en: "Samples Refresh Notice"
-      fr: "Avis d'actualisation des échantillons"
   v2_dropdown:
     admin_manageable: true
     description:

--- a/config/features.yml
+++ b/config/features.yml
@@ -20,11 +20,9 @@ features:
   advanced_search_with_auto_complete:
     admin_manageable: true
     description:
-      en:
-        "Enable auto-complete suggestions for the field dropdown within the advanced\
+      en: "Enable auto-complete suggestions for the field dropdown within the advanced\
         \ search dialog."
-      fr:
-        "Activer les suggestions de saisie semi-automatique dans la liste des champs\
+      fr: "Activer les suggestions de saisie semi-automatique dans la liste des champs\
         \ de la recherche avancée."
     enable_in_development: true
     name:
@@ -34,8 +32,7 @@ features:
     admin_manageable: true
     description:
       en: "Allow users to select and cancel multiple workflow executions at once."
-      fr:
-        "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
+      fr: "Permettre aux utilisateurs de sélectionner et d'annuler plusieurs exécutions\
         \ de flux de travail à la fois."
     enable_in_development: true
     name:
@@ -60,8 +57,7 @@ features:
       en: "Client-Side Linelist Imports"
       fr: "Importations de listes linéaires côté client"
   compose_with_retry:
-    description:
-      "Exponentially backoff and retry failed compose operations. This\
+    description: "Exponentially backoff and retry failed compose operations. This\
       \ is intended to mitigate transient errors in the compose process."
     enable_in_development: true
   data_grid_samples_table:
@@ -77,8 +73,7 @@ features:
     admin_manageable: true
     description:
       en: "Enable groups to be marked as public so that all users have access"
-      fr:
-        "Permettre de marquer les groupes comme publics afin que tous les utilisateurs\
+      fr: "Permettre de marquer les groupes comme publics afin que tous les utilisateurs\
         \ y aient accès"
     enable_in_development: true
     name:
@@ -87,23 +82,12 @@ features:
   integration_access_token_generation:
     description: "Allow users to generate access tokens for API access."
     enable_in_development: true
-  sample_attachments_searching:
-    admin_manageable: true
-    description:
-      en: "Enable searching within the sample attachments table."
-      fr: "Activer la recherche dans le tableau des pièces jointes d'échantillons."
-    enable_in_development: true
-    name:
-      en: "Sample Attachment Search"
-      fr: "Recherche de pièces jointes d'échantillons"
   samples_refresh_notice:
     admin_manageable: true
     description:
-      en:
-        "Show a notice on the samples table when samples table is out of date due\
+      en: "Show a notice on the samples table when samples table is out of date due\
         \ to additions, deletions, or updates."
-      fr:
-        "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
+      fr: "Afficher un avis lorsque le tableau des échantillons n'est plus à jour\
         \ après un ajout, une suppression ou une modification."
     enable_in_development: true
     name:
@@ -130,8 +114,7 @@ features:
     admin_manageable: true
     description:
       en: "Enable the new v2 nextflow samplesheet display and submission process."
-      fr:
-        "Activer le nouvel affichage et le nouveau processus de soumission de la\
+      fr: "Activer le nouvel affichage et le nouveau processus de soumission de la\
         \ feuille d'échantillons Nextflow version 2."
     enable_in_development: true
     name:
@@ -147,29 +130,16 @@ features:
       en: "Version 2 Select"
       fr: "Sélecteur version 2"
   wes_extended_metadata:
-    description:
-      "Include additional metadata in WES submission, such as namespaceId\
+    description: "Include additional metadata in WES submission, such as namespaceId\
       \ and samplesCount."
     enable_in_development: true
   workflow_execution_advanced_search:
     admin_manageable: true
     description:
       en: "Enable the advanced search dialog for workflow executions."
-      fr:
-        "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
+      fr: "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
         \ flux de travail."
     enable_in_development: true
     name:
       en: "Workflow Execution Advanced Search"
       fr: "Recherche avancée des exécutions de flux de travail"
-  workflow_execution_attachments_searching:
-    admin_manageable: true
-    description:
-      en: "Enable searching within the workflow execution attachments table."
-      fr:
-        "Activer la recherche dans le tableau des pièces jointes des exécutions\
-        \ de flux de travail."
-    enable_in_development: true
-    name:
-      en: "Workflow Execution Attachment Search"
-      fr: "Recherche de pièces jointes des exécutions de flux de travail"

--- a/config/features.yml
+++ b/config/features.yml
@@ -129,17 +129,3 @@ features:
     name:
       en: "Version 2 Select"
       fr: "Sélecteur version 2"
-  wes_extended_metadata:
-    description: "Include additional metadata in WES submission, such as namespaceId\
-      \ and samplesCount."
-    enable_in_development: true
-  workflow_execution_advanced_search:
-    admin_manageable: true
-    description:
-      en: "Enable the advanced search dialog for workflow executions."
-      fr: "Activer la boîte de dialogue de recherche avancée pour les exécutions de\
-        \ flux de travail."
-    enable_in_development: true
-    name:
-      en: "Workflow Execution Advanced Search"
-      fr: "Recherche avancée des exécutions de flux de travail"

--- a/test/components/refresh_notice_component_test.rb
+++ b/test/components/refresh_notice_component_test.rb
@@ -6,12 +6,6 @@ class RefreshNoticeComponentTest < ViewComponentTestCase
   def setup
     super
     @project = namespaces_project_namespaces(:project1_namespace)
-    Flipper.enable(:samples_refresh_notice)
-  end
-
-  def teardown
-    Flipper.disable(:samples_refresh_notice)
-    super
   end
 
   # 🔄 BASIC RENDERING - Ensure component renders with required elements
@@ -129,20 +123,6 @@ class RefreshNoticeComponentTest < ViewComponentTestCase
 
     # The alert should have the hidden class initially
     assert_selector '.hidden', count: 1
-  end
-
-  test 'renders without notice UI when feature flag disabled' do
-    Flipper.disable(:samples_refresh_notice)
-
-    render_inline(RefreshNoticeComponent.new(streamable: @project, stream_name: :samples))
-
-    # Controller and turbo stream should still render for auto-refresh behavior
-    assert_selector '[data-controller="refresh"]', count: 1
-    assert_selector 'turbo-cable-stream-source', count: 1
-
-    # But the notice UI should not render
-    assert_no_selector '[data-refresh-target="notice"]'
-    assert_no_selector '[aria-live="assertive"]'
   end
 
   # 🧪 INTEGRATION - Test component structure

--- a/test/controllers/groups/workflow_executions_controller_test.rb
+++ b/test/controllers/groups/workflow_executions_controller_test.rb
@@ -71,30 +71,13 @@ module Groups
       assert_response :unauthorized
     end
 
-    test 'should ignore advanced search groups when workflow advanced-search feature flag is disabled' do
-      Flipper.disable(:workflow_execution_advanced_search)
-
-      get group_workflow_executions_path(@group),
-          params: workflow_advanced_search_params(state: 'completed').merge(limit: 100)
-
-      assert_response :success
-      assert_includes response.body, @workflow_execution_completed.id
-      assert_includes response.body, @workflow_execution_running.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
-    end
-
-    test 'should apply advanced search groups when workflow advanced-search feature flag is enabled' do
-      Flipper.enable(:workflow_execution_advanced_search)
-
+    test 'should apply advanced search groups' do
       get group_workflow_executions_path(@group),
           params: workflow_advanced_search_params(state: 'completed').merge(limit: 100)
 
       assert_response :success
       assert_includes response.body, @workflow_execution_completed.id
       assert_not_includes response.body, @workflow_execution_running.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
     end
 
     test 'should show workflow execution that was shared to group by the user' do

--- a/test/controllers/projects/workflow_executions_controller_test.rb
+++ b/test/controllers/projects/workflow_executions_controller_test.rb
@@ -78,30 +78,13 @@ module Projects
       assert_response :unauthorized
     end
 
-    test 'should ignore advanced search groups when workflow advanced-search feature flag is disabled' do
-      Flipper.disable(:workflow_execution_advanced_search)
-
-      get namespace_project_workflow_executions_path(@namespace, @project),
-          params: workflow_advanced_search_params(state: 'completed').merge(limit: 100)
-
-      assert_response :success
-      assert_includes response.body, @workflow_execution.id
-      assert_includes response.body, @workflow_execution_running.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
-    end
-
-    test 'should apply advanced search groups when workflow advanced-search feature flag is enabled' do
-      Flipper.enable(:workflow_execution_advanced_search)
-
+    test 'should apply advanced search groups' do
       get namespace_project_workflow_executions_path(@namespace, @project),
           params: workflow_advanced_search_params(state: 'completed').merge(limit: 100)
 
       assert_response :success
       assert_includes response.body, @workflow_execution.id
       assert_not_includes response.body, @workflow_execution_running.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
     end
 
     test 'should show workflow execution' do

--- a/test/controllers/workflow_executions_controller_test.rb
+++ b/test/controllers/workflow_executions_controller_test.rb
@@ -61,46 +61,24 @@ class WorkflowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal true, created_workflow_execution.shared_with_namespace
   end
 
-  test 'should ignore advanced search groups when workflow advanced-search feature flag is disabled' do
-    Flipper.disable(:workflow_execution_advanced_search)
-
-    get workflow_executions_path, params: workflow_advanced_search_params(state: 'completed').merge(limit: 100)
-
-    assert_response :success
-    assert_includes response.body, @workflow_execution_completed.id
-    assert_includes response.body, @workflow_execution_running.id
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
-  end
-
-  test 'should apply advanced search groups when workflow advanced-search feature flag is enabled' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
+  test 'should apply advanced search groups' do
     get workflow_executions_path, params: workflow_advanced_search_params(state: 'completed').merge(limit: 100)
 
     assert_response :success
     assert_includes response.body, @workflow_execution_completed.id
     assert_not_includes response.body, @workflow_execution_running.id
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'should apply advanced search groups when workflow advanced-search uses translated state labels' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
     get workflow_executions_path,
         params: workflow_advanced_search_params(state: I18n.t('workflow_executions.state.completed')).merge(limit: 100)
 
     assert_response :success
     assert_includes response.body, @workflow_execution_completed.id
     assert_not_includes response.body, @workflow_execution_running.id
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'should apply advanced search not_in state arrays when blank values are submitted' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
     get workflow_executions_path,
         params: workflow_advanced_search_params(
           operator: 'not_in',
@@ -111,8 +89,6 @@ class WorkflowExecutionsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, @workflow_execution_completed.id
     assert_not_includes response.body, @workflow_execution_running.id
     assert_not_includes response.body, @workflow_execution_new.id
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'should apply default sort and support sorting workflow executions' do

--- a/test/integration/sapporo/integration_sapporo_test.rb
+++ b/test/integration/sapporo/integration_sapporo_test.rb
@@ -7,7 +7,6 @@ class IntegrationSapporoTest < ActionDispatch::IntegrationTest
   include WorkflowExecutions
 
   def setup
-    Flipper.enable(:wes_extended_metadata)
     @workflow_execution = workflow_executions(:irida_next_example_end_to_end)
     Rails.configuration.ga4gh_wes_server_endpoint = ENV.fetch('GA4GH_WES_URL', 'http://localhost:1122/')
   end

--- a/test/lib/irida/experimental_feature_catalog_test.rb
+++ b/test/lib/irida/experimental_feature_catalog_test.rb
@@ -11,7 +11,6 @@ module Irida
         accessibility_statement
         advanced_search_metadata_operators
         advanced_search_with_auto_complete
-        cancel_multiple_workflows
         client_linelist_exports_v1
         client_linelist_imports_v1
         data_grid_samples_table

--- a/test/lib/irida/experimental_feature_catalog_test.rb
+++ b/test/lib/irida/experimental_feature_catalog_test.rb
@@ -21,7 +21,6 @@ module Irida
         v2_prefixed_select2
         v2_samplesheet
         v2_select2
-        workflow_execution_advanced_search
       ], entries.pluck(:key)
     end
 
@@ -30,7 +29,6 @@ module Irida
 
       assert_not_includes keys, 'compose_with_retry'
       assert_not_includes keys, 'integration_access_token_generation'
-      assert_not_includes keys, 'wes_extended_metadata'
     end
 
     test 'returns localized names and descriptions with english fallback' do

--- a/test/lib/irida/experimental_feature_catalog_test.rb
+++ b/test/lib/irida/experimental_feature_catalog_test.rb
@@ -15,7 +15,6 @@ module Irida
         client_linelist_imports_v1
         data_grid_samples_table
         global_groups
-        samples_refresh_notice
         v2_dropdown
         v2_prefixed_select2
         v2_samplesheet

--- a/test/lib/irida/experimental_feature_catalog_test.rb
+++ b/test/lib/irida/experimental_feature_catalog_test.rb
@@ -16,14 +16,12 @@ module Irida
         client_linelist_imports_v1
         data_grid_samples_table
         global_groups
-        sample_attachments_searching
         samples_refresh_notice
         v2_dropdown
         v2_prefixed_select2
         v2_samplesheet
         v2_select2
         workflow_execution_advanced_search
-        workflow_execution_attachments_searching
       ], entries.pluck(:key)
     end
 

--- a/test/models/sample_test.rb
+++ b/test/models/sample_test.rb
@@ -11,12 +11,10 @@ class SampleTest < ActiveSupport::TestCase
     @fastq_regex = '^\\S+\\.f(ast)?q(\\.gz)?$'
     # project1 is under group_one
     # project4 is under subgroup_one_group_three -> group_three (deeply nested)
-    Flipper.enable(:samples_refresh_notice)
     Flipper.enable(:v2_samplesheet)
   end
 
   def teardown
-    Flipper.disable(:samples_refresh_notice)
     Sample.suppressed_turbo_broadcasts = false
   end
 
@@ -436,58 +434,6 @@ class SampleTest < ActiveSupport::TestCase
     assert_equal expected_count, broadcast_calls.count
   end
 
-  test 'broadcasts only to project on sample create when flag disabled' do
-    Flipper.disable(:samples_refresh_notice)
-    project = @project1
-
-    broadcast_calls = count_broadcasts_for do
-      Sample.create!(name: 'New Sample No Flag', project: project)
-    end
-
-    # Only 1 broadcast (to project only, no ancestors)
-    assert_equal 1, broadcast_calls.count
-  end
-
-  test 'broadcasts only to project on sample update when flag disabled' do
-    Flipper.disable(:samples_refresh_notice)
-    sample = samples(:sample1)
-
-    broadcast_calls = count_broadcasts_for do
-      sample.update!(name: 'Updated Without Flag')
-    end
-
-    assert_equal 1, broadcast_calls.count
-  end
-
-  test 'broadcasts only to project on sample destroy when flag disabled' do
-    Flipper.disable(:samples_refresh_notice)
-    sample = samples(:sample2)
-
-    broadcast_calls = count_broadcasts_for do
-      sample.destroy
-    end
-
-    assert_equal 1, broadcast_calls.count
-  end
-
-  test 'broadcasts only to project on sample restore when flag disabled' do
-    Flipper.disable(:samples_refresh_notice)
-    sample = samples(:sample2)
-
-    # Destroy and restore to get a restored sample
-    sample.destroy
-    sample_id = sample.id
-    Sample.restore(sample_id, recursive: true)
-    restored_sample = Sample.find(sample_id)
-
-    # Test the broadcast method directly since Sample.restore doesn't trigger after_commit in tests
-    broadcast_calls = count_broadcasts_for do
-      restored_sample.send(:broadcast_refresh_later_to_samples_table)
-    end
-
-    assert_equal 1, broadcast_calls.count
-  end
-
   test 'broadcasts to both old and new projects when sample transferred with flag enabled' do
     sample = samples(:sample1)
     old_project = sample.project
@@ -502,18 +448,6 @@ class SampleTest < ActiveSupport::TestCase
     # Expected: 2 projects + old_ancestors + new_ancestors
     expected_count = 2 + old_ancestors.count + new_ancestors.count
     assert_equal expected_count, broadcast_calls.count
-  end
-
-  test 'broadcasts to both old and new projects when sample transferred with flag disabled' do
-    Flipper.disable(:samples_refresh_notice)
-    sample = samples(:sample2)
-
-    broadcast_calls = count_broadcasts_for do
-      sample.update!(project: @project4)
-    end
-
-    # Expected: 2 broadcasts (old project + new project), no ancestors
-    assert_equal 2, broadcast_calls.count
   end
 
   test 'handles sample transfer when old project is nil' do
@@ -587,22 +521,6 @@ class SampleTest < ActiveSupport::TestCase
     # Expected: 1 project + all ancestors
     expected_count = 1 + ancestors.count
     assert_equal expected_count, broadcast_calls.count
-  end
-
-  test 'broadcasts only to project in deeply nested namespace when flag disabled' do
-    Flipper.disable(:samples_refresh_notice)
-    project = @project4
-    ancestors = project.namespace.parent.self_and_ancestors
-
-    # Verify we have a deep hierarchy
-    assert ancestors.count >= 2, 'Test requires deeply nested namespace'
-
-    broadcast_calls = count_broadcasts_for do
-      Sample.create!(name: 'Deep Nested No Flag', project: project)
-    end
-
-    # Expected: 1 broadcast (project only, no ancestors)
-    assert_equal 1, broadcast_calls.count
   end
 
   test 'ancestor broadcasts include correct stream name and arguments' do

--- a/test/services/samples/group_batch_sample_import_service_test.rb
+++ b/test/services/samples/group_batch_sample_import_service_test.rb
@@ -24,11 +24,6 @@ module Samples
         sample_description_column: 'description',
         metadata_fields: %w[metadata1 metadata2]
       }
-      Flipper.enable(:samples_refresh_notice)
-    end
-
-    def teardown
-      Flipper.disable(:samples_refresh_notice)
     end
 
     test 'import samples with permission for group' do

--- a/test/services/samples/project_batch_sample_import_service_test.rb
+++ b/test/services/samples/project_batch_sample_import_service_test.rb
@@ -62,11 +62,6 @@ module Samples
         sample_description_column: 'description',
         metadata_fields: %w[metadata1 metadata2]
       }
-      Flipper.enable(:samples_refresh_notice)
-    end
-
-    def teardown
-      Flipper.disable(:samples_refresh_notice)
     end
 
     test 'import samples with permission for project namespace' do

--- a/test/services/workflow_executions/create_service_test.rb
+++ b/test/services/workflow_executions/create_service_test.rb
@@ -7,7 +7,6 @@ require 'webmock/minitest'
 module WorkflowExecutions
   class CreateServiceTest < ActiveStorageTestCase
     def setup
-      Flipper.enable(:wes_extended_metadata)
       @user = users(:john_doe)
       @project = projects(:project1)
       @sample = samples(:sample1)

--- a/test/system/groups/workflow_executions_test.rb
+++ b/test/system/groups/workflow_executions_test.rb
@@ -250,7 +250,6 @@ module Groups
     end
 
     test 'can search workflow execution files by puid & filename' do
-      Flipper.enable(:workflow_execution_attachments_searching)
       user = users(:joan_doe)
       login_as user
 

--- a/test/system/groups/workflow_executions_test.rb
+++ b/test/system/groups/workflow_executions_test.rb
@@ -85,29 +85,7 @@ module Groups
       end
     end
 
-    test 'workflow advanced search is hidden when workflow advanced-search feature flag is disabled' do
-      Flipper.disable(:workflow_execution_advanced_search)
-
-      visit group_workflow_executions_path(@group)
-
-      assert_no_button I18n.t(:'components.advanced_search_component.v1.title')
-
-      fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
-              with: @workflow_execution_group_shared1.id
-      find('input.t-search-component').send_keys(:return)
-
-      assert_text 'Displaying 1 item'
-      assert_selector 'table tbody tr', count: 1
-      assert_text @workflow_execution_group_shared1.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
-    end
-
-    test(
-      'workflow advanced search filters group workflow results when workflow advanced-search feature flag is ' \
-      'enabled'
-    ) do
-      Flipper.enable(:workflow_execution_advanced_search)
+    test 'workflow advanced search filters group workflow results' do
       workflow_execution_group_shared_completed = workflow_executions(:workflow_execution_group_shared_completed)
       workflow_execution_group_shared_running = workflow_executions(:workflow_execution_group_shared_running)
 
@@ -140,12 +118,9 @@ module Groups
       assert_selector "div[role='status']", text: /advanced search/, visible: false
       assert_text workflow_execution_group_shared_completed.id
       assert_no_text workflow_execution_group_shared_running.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
     end
 
-    test 'workflow advanced search clear removes group filter state when feature flag is enabled' do
-      Flipper.enable(:workflow_execution_advanced_search)
+    test 'workflow advanced search clear removes group filter state' do
       workflow_execution_group_shared_completed = workflow_executions(:workflow_execution_group_shared_completed)
       workflow_execution_group_shared_running = workflow_executions(:workflow_execution_group_shared_running)
 
@@ -180,8 +155,6 @@ module Groups
       assert_no_selector "button[aria-label='#{I18n.t(:'components.advanced_search_component.v1.clear_aria_label')}']"
       assert_text workflow_execution_group_shared_completed.id
       assert_text workflow_execution_group_shared_running.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
     end
 
     test 'should only include workflows that have been shared to the group' do

--- a/test/system/projects/samples/attachment_upload_progress_test.rb
+++ b/test/system/projects/samples/attachment_upload_progress_test.rb
@@ -6,7 +6,6 @@ module Projects
   module Samples
     class AttachmentUploadProgressTest < ApplicationSystemTestCase
       setup do
-        Flipper.enable(:sample_attachments_searching)
         @user = users(:john_doe)
         login_as @user
         @sample = samples(:sample2)

--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -8,7 +8,6 @@ module Projects
       include ActionView::Helpers::SanitizeHelper
 
       setup do
-        Flipper.enable(:sample_attachments_searching)
         @user = users(:john_doe)
         login_as @user
         @sample1 = samples(:sample1)

--- a/test/system/projects/workflow_executions_test.rb
+++ b/test/system/projects/workflow_executions_test.rb
@@ -23,8 +23,6 @@ module Projects
       @workflow_name_col = '5'
       @workflow_version_col = '6'
       @created_at_col = '7'
-
-      Flipper.enable(:cancel_multiple_workflows)
     end
 
     test 'should display a list of workflow executions' do

--- a/test/system/projects/workflow_executions_test.rb
+++ b/test/system/projects/workflow_executions_test.rb
@@ -386,30 +386,7 @@ module Projects
       end
     end
 
-    test 'workflow advanced search is hidden when workflow advanced-search feature flag is disabled' do
-      Flipper.disable(:workflow_execution_advanced_search)
-
-      visit namespace_project_workflow_executions_path(@namespace, @project)
-
-      assert_no_button I18n.t(:'components.advanced_search_component.v1.title')
-
-      fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
-              with: @workflow_execution1.id
-      find('input.t-search-component').send_keys(:return)
-
-      assert_text 'Displaying 1 item'
-      assert_selector 'table tbody tr', count: 1
-      assert_text @workflow_execution1.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
-    end
-
-    test(
-      'workflow advanced search filters project workflow results when workflow advanced-search feature flag is ' \
-      'enabled'
-    ) do
-      Flipper.enable(:workflow_execution_advanced_search)
-
+    test 'workflow advanced search filters project workflow results' do
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       assert_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -439,13 +416,9 @@ module Projects
       assert_selector "div[role='status']", text: /advanced search/, visible: false
       assert_text @workflow_execution1.id
       assert_no_text @workflow_execution3.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
     end
 
-    test 'workflow advanced search clear removes project filter state when feature flag is enabled' do
-      Flipper.enable(:workflow_execution_advanced_search)
-
+    test 'workflow advanced search clear removes project filter state' do
       visit namespace_project_workflow_executions_path(@namespace, @project)
 
       click_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -477,8 +450,6 @@ module Projects
       assert_no_selector "button[aria-label='#{I18n.t(:'components.advanced_search_component.v1.clear_aria_label')}']"
       assert_text @workflow_execution1.id
       assert_text @workflow_execution3.id
-    ensure
-      Flipper.disable(:workflow_execution_advanced_search)
     end
 
     test 'analyst or higher access can edit workflow execution post launch from workflow execution page' do

--- a/test/system/projects/workflow_executions_test.rb
+++ b/test/system/projects/workflow_executions_test.rb
@@ -549,7 +549,6 @@ module Projects
     end
 
     test 'can search workflow execution files by puid & filename' do
-      Flipper.enable(:workflow_execution_attachments_searching)
       workflow_execution = workflow_executions(:workflow_execution_shared2)
 
       visit namespace_project_workflow_execution_path(@namespace, @project, workflow_execution)

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -395,7 +395,6 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
   end
 
   test 'can search workflow execution files by puid & filename' do
-    Flipper.enable(:workflow_execution_attachments_searching)
     visit workflow_execution_path(@workflow_execution3)
 
     assert_text @workflow_execution3.id
@@ -1187,8 +1186,6 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
   end
 
   test 'can preview workflow execution files' do
-    Flipper.enable(:workflow_execution_attachments_searching)
-
     previewable_attachment = attachments(:samples_workflow_execution_completed_output_attachment)
 
     visit workflow_execution_path(@workflow_execution3)

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -551,61 +551,6 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'can filter by ID and name on workflow execution index page' do
-    visit workflow_executions_path
-
-    assert_text "Displaying items 1-#{PAGE_SIZE} of #{WORKFLOW_EXECUTION_COUNT} in total"
-    assert_selector 'table tbody tr', count: PAGE_SIZE
-
-    within('table tbody') do
-      assert_text @workflow_execution2.id
-      assert_text @workflow_execution2.name
-      assert_text @workflow_execution3.id
-      assert_text @workflow_execution3.name
-    end
-
-    fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
-            with: @workflow_execution2.id
-    find('input.t-search-component').send_keys(:return)
-
-    assert_text 'Displaying 1 item'
-    assert_selector 'table tbody tr', count: 1
-
-    within('table tbody') do
-      assert_text @workflow_execution2.id
-      assert_text @workflow_execution2.name
-      assert_no_text @workflow_execution3.id
-      assert_no_text @workflow_execution3.name
-    end
-
-    fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
-            with: ''
-    find('input.t-search-component').send_keys(:return)
-
-    assert_button I18n.t(:'components.search_field_component.clear_button')
-    assert_no_selector 'dialog[open] h1', text: I18n.t(:'components.advanced_search_component.v1.title')
-
-    assert_text "Displaying items 1-#{PAGE_SIZE} of #{WORKFLOW_EXECUTION_COUNT} in total"
-    assert_selector 'table tbody tr', count: PAGE_SIZE
-
-    fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
-            with: @workflow_execution3.name
-    find('input.t-search-component').send_keys(:return)
-
-    assert_button I18n.t(:'components.search_field_component.clear_button')
-    assert_no_selector 'dialog[open] h1', text: I18n.t(:'components.advanced_search_component.v1.title')
-
-    assert_text 'Displaying 1 item'
-    assert_selector 'table tbody tr', count: 1
-
-    within('table tbody') do
-      assert_no_text @workflow_execution2.id
-      assert_no_text @workflow_execution2.name
-      assert_text @workflow_execution3.id
-      assert_text @workflow_execution3.name
-    end
-  end
-
   test 'workflow advanced search filters results' do
     visit workflow_executions_path
 

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -23,8 +23,6 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     @workflow_name_col = '5'
     @workflow_version_col = '6'
     @created_at_col = '7'
-
-    Flipper.enable(:cancel_multiple_workflows)
   end
 
   test 'should display a list of workflow executions' do

--- a/test/system/workflow_executions_test.rb
+++ b/test/system/workflow_executions_test.rb
@@ -553,8 +553,7 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'can filter by ID and name on workflow execution index page when workflow advanced-search flag is enabled' do
-    Flipper.enable(:workflow_execution_advanced_search)
+  test 'can filter by ID and name on workflow execution index page' do
     visit workflow_executions_path
 
     assert_text "Displaying items 1-#{PAGE_SIZE} of #{WORKFLOW_EXECUTION_COUNT} in total"
@@ -607,31 +606,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       assert_text @workflow_execution3.id
       assert_text @workflow_execution3.name
     end
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
-  test 'workflow advanced search is hidden when workflow advanced-search feature flag is disabled' do
-    Flipper.disable(:workflow_execution_advanced_search)
-
-    visit workflow_executions_path
-
-    assert_no_button I18n.t(:'components.advanced_search_component.v1.title')
-
-    fill_in placeholder: I18n.t(:'shared.workflow_executions.index.search.placeholder'),
-            with: @workflow_execution1.id
-    find('input.t-search-component').send_keys(:return)
-
-    assert_text 'Displaying 1 item'
-    assert_selector 'table tbody tr', count: 1
-    assert_text @workflow_execution1.id
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
-  end
-
-  test 'workflow advanced search filters results when workflow advanced-search feature flag is enabled' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
+  test 'workflow advanced search filters results' do
     visit workflow_executions_path
 
     assert_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -665,13 +642,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_selector "div[role='status']", text: /advanced search/, visible: false
     assert_text @workflow_execution1.id
     assert_no_text @workflow_execution4.id
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'workflow advanced search returns no results for invalid enum state value' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
     visit workflow_executions_path
 
     click_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -697,13 +670,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       assert_selector "div[role='status']", text: /advanced search/, visible: false
       assert_text 'Displaying 0 items'
     end
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
-  test 'workflow quick search preserves active advanced search when feature flag is enabled' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
+  test 'workflow quick search preserves active advanced search' do
     visit workflow_executions_path
 
     click_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -745,13 +714,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
 
     assert_no_button I18n.t(:'components.search_field_component.clear_button')
     assert_button I18n.t(:'components.advanced_search_component.v1.clear_aria_label')
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'workflow advanced search keeps completed results visible when broadening state not_in filters' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
     visit workflow_executions_path
 
     click_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -790,13 +755,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     assert_text @workflow_execution1.id
     assert_no_text @workflow_execution4.id
     assert_no_text @workflow_execution5.id
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'workflow advanced search clears form on close when there is no active search' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
     visit workflow_executions_path
 
     click_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -828,13 +789,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
         assert_equal '', find("input[name$='[value]']", visible: :all).value
       end
     end
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'workflow advanced search retains applied state with multiple conditions when reopening dialog' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
     visit workflow_executions_path
 
     click_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -892,13 +849,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
         assert_equal 'my_run_id', find("input[name$='[value]']", visible: :visible).value
       end
     end
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'workflow advanced search resets to applied state on close when active search exists' do
-    Flipper.enable(:workflow_execution_advanced_search)
-
     visit workflow_executions_path
 
     click_button I18n.t(:'components.advanced_search_component.v1.title')
@@ -957,12 +910,9 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
       assert_no_selector "fieldset[data-advanced-search--v1-target='conditionsContainer'] input[value='draft_run_id']",
                          visible: :all
     end
-  ensure
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'workflow advanced search retains operator and value after reopen with autocomplete enabled' do
-    Flipper.enable(:workflow_execution_advanced_search)
     Flipper.enable(:advanced_search_with_auto_complete, @user)
 
     visit workflow_executions_path
@@ -999,7 +949,6 @@ class WorkflowExecutionsTest < ApplicationSystemTestCase
     end
   ensure
     Flipper.disable(:advanced_search_with_auto_complete, @user)
-    Flipper.disable(:workflow_execution_advanced_search)
   end
 
   test 'submitter can edit workflow execution post launch from workflow execution page' do


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Retired the following feature flags and made their behaviour the default:

* `cancel_multiple_workflows`
* `sample_attachments_searching`
* `samples_refresh_notice`
* `wes_extended_metadata`
* `workflow_execution_advanced_search`
* `workflow_execution_attachments_searching`

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Run server with `bin/setup`
2. Confirm that features that we're previously flagged behind feature flags are working as expected

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
