### PR TITLE
chore: Samples count propagation refactor

### DIFF
--- a/app/helpers/namespace_path_helper.rb
+++ b/app/helpers/namespace_path_helper.rb
@@ -3,7 +3,7 @@
 # Helper for namespace paths
 module NamespacePathHelper
   def namespace_path(namespace)
-    return if namespace.deleted?
+    return if namespace.nil? || namespace.deleted?
 
     if namespace&.group_namespace?
       helpers.group_path(namespace)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Namespace for Groups
-class Group < Namespace # rubocop:disable Metrics/ClassLength
+class Group < Namespace
   include History
 
   has_many :group_members, foreign_key: :namespace_id, inverse_of: :group,
@@ -118,23 +118,6 @@ class Group < Namespace # rubocop:disable Metrics/ClassLength
 
   def has_samples? # rubocop:disable Naming/PredicatePrefix
     samples_count.positive? || aggregated_samples_count.positive?
-  end
-
-  def add_to_samples_count(namespaces, addition_amount)
-    namespaces.each do |namespace|
-      Group.increment_counter(:samples_count, namespace.id, by: addition_amount) # rubocop:disable Rails/SkipsModelValidations
-    end
-  end
-
-  def subtract_from_samples_count(namespaces, subtraction_amount)
-    namespaces.each do |namespace|
-      Group.decrement_counter(:samples_count, namespace.id, by: subtraction_amount) # rubocop:disable Rails/SkipsModelValidations
-    end
-  end
-
-  # Delegates to namespace helper to propagate negative sample count changes through group ancestors.
-  def update_samples_count_by_destroy_service(deleted_samples_count)
-    propagate_samples_count_delta(-deleted_samples_count)
   end
 
   def validate_public_namespace_type

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -132,30 +132,9 @@ class Group < Namespace # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def update_samples_count_by_addition_services(added_samples_count = 1)
-    namespaces_to_update = self_and_ancestors.where(type: Group.sti_name)
-    add_to_samples_count(namespaces_to_update, added_samples_count)
-  end
-
+  # Delegates to namespace helper to propagate negative sample count changes through group ancestors.
   def update_samples_count_by_destroy_service(deleted_samples_count)
-    namespaces_to_update = self_and_ancestors.where(type: Group.sti_name)
-    subtract_from_samples_count(namespaces_to_update, deleted_samples_count)
-  end
-
-  def update_samples_count_by_transfer_service(destination, transferred_samples_count, destination_type = 'Project')
-    namespaces_to_update = self_and_ancestors_of_type(Group.sti_name)
-    subtract_from_samples_count(namespaces_to_update, transferred_samples_count)
-
-    case destination_type
-    when 'Project'
-      namespaces_to_update = destination.parent.self_and_ancestors.where(type: Group.sti_name)
-    when 'Group'
-      namespaces_to_update = destination.self_and_ancestors.where(type: Group.sti_name)
-    else
-      return
-    end
-
-    add_to_samples_count(namespaces_to_update, transferred_samples_count)
+    propagate_samples_count_delta(-deleted_samples_count)
   end
 
   def validate_public_namespace_type

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -28,7 +28,7 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
                            new_record? || expires_at_before_type_cast.present?
                          }
 
-  before_destroy :last_namespace_owner_member
+  before_destroy :last_namespace_owner_member, unless: :destroyed_by_association
 
   delegate :project, to: :project_namespace
 
@@ -147,8 +147,8 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   # Method to ensure we don't leave a group or project without an owner
-  def last_namespace_owner_member # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-    return if destroyed_by_association
+  def last_namespace_owner_member # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    return if destroyed_by_association || namespace.nil?
     return if access_level != Member::AccessLevel::OWNER
     return if namespace.parent&.user_namespace?
     return if Member.where(namespace:, access_level: Member::AccessLevel::OWNER).many?

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -74,6 +74,34 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
       select(Namespace.arel_table[:id])
     end
 
+    # Return common group ancestor IDs between two namespace parents.
+    # This can be reused by operations that need to skip shared ancestors.
+    # @param old_parent [Namespace, nil] the previous parent namespace
+    # @param new_parent [Namespace] the new parent namespace
+    # @return [Array<Integer>] group ancestor IDs shared by both parents
+    def common_group_ancestor_ids(old_parent, new_parent)
+      old_group_ids = old_parent&.group_ancestor_ids || []
+      new_group_ids = new_parent.group_ancestor_ids
+
+      old_group_ids & new_group_ids
+    end
+
+    # Transfer sample counts when a namespace moves from one parent to another.
+    # Subtracts from old parent's group ancestors and adds to new parent's group ancestors.
+    # @param old_parent [Namespace, nil] the old parent namespace
+    # @param new_parent [Namespace] the new parent namespace
+    # @param sample_count [Integer] the number of samples to transfer
+    def transfer_samples_count_delta(old_parent, new_parent, sample_count)
+      return if sample_count.nil? || sample_count.zero?
+
+      common_group_ids = common_group_ancestor_ids(old_parent, new_parent)
+
+      # Subtract from old parent ancestors except common ancestors.
+      old_parent&.propagate_samples_count_delta(-sample_count, except_group_ancestor_ids: common_group_ids)
+      # Add to new parent ancestors except common ancestors.
+      new_parent.propagate_samples_count_delta(sample_count, except_group_ancestor_ids: common_group_ids)
+    end
+
     # Return a relation containing this namespace (or namespaces from the
     # receiver relation) and all ancestor namespaces.
     #
@@ -606,10 +634,11 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # Propagate a positive or negative sample count delta to all group namespace ancestors.
   # This is called when a project's sample count changes or a project is transferred.
   # @param delta [Integer] positive or negative change in sample count
-  def propagate_samples_count_delta(delta)
+  # @param except_group_ancestor_ids [Array<Integer>] group ancestor IDs to skip
+  def propagate_samples_count_delta(delta, except_group_ancestor_ids: [])
     return if delta.zero?
 
-    group_ids = group_ancestor_ids
+    group_ids = group_ancestor_ids - except_group_ancestor_ids
     return if group_ids.empty?
 
     group_ids.each do |group_id|
@@ -619,25 +648,6 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
         Group.decrement_counter(:samples_count, group_id, by: delta.abs) # rubocop:disable Rails/SkipsModelValidations
       end
     end
-  end
-
-  # Transfer sample counts when a namespace moves from one parent to another.
-  # Subtracts from old parent's group ancestors and adds to new parent's group ancestors.
-  # @param old_parent [Namespace, nil] the old parent namespace
-  # @param new_parent [Namespace] the new parent namespace
-  # @param sample_count [Integer] the number of samples to transfer
-  def transfer_samples_count_delta(old_parent, new_parent, sample_count) # rubocop:disable Metrics/CyclomaticComplexity
-    return if sample_count.nil? || sample_count.zero?
-
-    # Subtract from old parent's group ancestors
-    if old_parent&.group_namespace? || old_parent&.project_namespace?
-      old_parent.propagate_samples_count_delta(-sample_count)
-    end
-
-    # Add to new parent's group ancestors
-    return unless new_parent.group_namespace? || new_parent.project_namespace?
-
-    new_parent.propagate_samples_count_delta(sample_count)
   end
 
   private
@@ -675,7 +685,7 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     old_parent_id, new_parent_id = saved_change_to_parent_id
     old_parent = old_parent_id ? Namespace.find(old_parent_id) : nil
     new_parent = Namespace.find(new_parent_id)
-    transfer_samples_count_delta(old_parent, new_parent, samples_count)
+    Namespace.transfer_samples_count_delta(old_parent, new_parent, samples_count)
   end
 
   def nullify_workflow_executions

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -24,6 +24,10 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   has_many :attachments, as: :attachable, dependent: :destroy
 
+  has_many :metadata_templates, dependent: :destroy
+
+  has_many :workflow_executions # rubocop:disable Rails/HasManyOrHasOneDependent
+
   validates :owner, presence: true, if: ->(n) { n.owner_required? }
   validates :name, presence: true, length: { minimum: 3, maximum: 255 }
   validates :name, uniqueness: { case_sensitive: false, scope: %i[type] }, if: -> { parent_id.blank? }
@@ -40,6 +44,8 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :validate_nesting_level, if: -> { new_record? || parent_id_changed? }
 
   scope :include_route, -> { includes(:route) }
+
+  before_real_destroy :nullify_workflow_executions
 
   after_restore :restore_routes
   after_destroy :propagate_destruction, unless: :destroyed_by_association
@@ -670,5 +676,9 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     old_parent = old_parent_id ? Namespace.find(old_parent_id) : nil
     new_parent = Namespace.find(new_parent_id)
     transfer_samples_count_delta(old_parent, new_parent, samples_count)
+  end
+
+  def nullify_workflow_executions
+    workflow_executions.update_all(namespace_id: nil) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -42,6 +42,9 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :include_route, -> { includes(:route) }
 
   after_restore :restore_routes
+  after_destroy :propagate_destruction, unless: :destroyed_by_association
+  after_restore :propagate_restoration
+  after_commit :propagate_parent_change, if: :saved_change_to_parent_id?
 
   class << self
     def sti_class_for(type_name)
@@ -589,10 +592,83 @@ class Namespace < ApplicationRecord # rubocop:disable Metrics/ClassLength
     MetadataTemplate.where(namespace: self)
   end
 
+  # Return IDs of group namespace ancestors (excluding user namespaces and project namespaces)
+  def group_ancestor_ids
+    self_and_ancestors_of_type(Group.sti_name).pluck(:id)
+  end
+
+  # Propagate a positive or negative sample count delta to all group namespace ancestors.
+  # This is called when a project's sample count changes or a project is transferred.
+  # @param delta [Integer] positive or negative change in sample count
+  def propagate_samples_count_delta(delta)
+    return if delta.zero?
+
+    group_ids = group_ancestor_ids
+    return if group_ids.empty?
+
+    group_ids.each do |group_id|
+      if delta.positive?
+        Group.increment_counter(:samples_count, group_id, by: delta) # rubocop:disable Rails/SkipsModelValidations
+      else
+        Group.decrement_counter(:samples_count, group_id, by: delta.abs) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+
+  # Transfer sample counts when a namespace moves from one parent to another.
+  # Subtracts from old parent's group ancestors and adds to new parent's group ancestors.
+  # @param old_parent [Namespace, nil] the old parent namespace
+  # @param new_parent [Namespace] the new parent namespace
+  # @param sample_count [Integer] the number of samples to transfer
+  def transfer_samples_count_delta(old_parent, new_parent, sample_count) # rubocop:disable Metrics/CyclomaticComplexity
+    return if sample_count.nil? || sample_count.zero?
+
+    # Subtract from old parent's group ancestors
+    if old_parent&.group_namespace? || old_parent&.project_namespace?
+      old_parent.propagate_samples_count_delta(-sample_count)
+    end
+
+    # Add to new parent's group ancestors
+    return unless new_parent.group_namespace? || new_parent.project_namespace?
+
+    new_parent.propagate_samples_count_delta(sample_count)
+  end
+
   private
 
   # Method to restore namespace routes when the namespace is restored
   def restore_routes
     Route.restore(Route.only_deleted.find_by(source_id: id)&.id, recursive: true)
+  end
+
+  # Propagate sample count decrements when namespace is soft-deleted.
+  # Only fires if this namespace is not being destroyed as part of a parent's cascade.
+  # This ensures we decrement at the top-level of the deletion tree, not at every level.
+  def propagate_destruction
+    return if parent.nil?
+
+    # Decrement group ancestors by this namespace's current sample count
+    parent.propagate_samples_count_delta(-samples_count) if samples_count.positive?
+  end
+
+  # Propagate sample count increments when namespace is restored.
+  # Restores the entire subtree and then increments parent's group ancestors.
+  def propagate_restoration
+    return if parent.nil?
+
+    # Increment group ancestors by this namespace's current sample count
+    parent.propagate_samples_count_delta(samples_count) if samples_count.positive?
+  end
+
+  # Transfer sample counts when namespace parent changes (e.g., project or group transfer).
+  # Moves the counts from old parent's group ancestors to new parent's group ancestors.
+  def propagate_parent_change
+    # Skip for ProjectNamespace during creation (project hasn't been associated yet)
+    return if is_a?(Namespaces::ProjectNamespace) && project.nil?
+
+    old_parent_id, new_parent_id = saved_change_to_parent_id
+    old_parent = old_parent_id ? Namespace.find(old_parent_id) : nil
+    new_parent = Namespace.find(new_parent_id)
+    transfer_samples_count_delta(old_parent, new_parent, samples_count)
   end
 end

--- a/app/models/namespace_group_link.rb
+++ b/app/models/namespace_group_link.rb
@@ -31,7 +31,7 @@ class NamespaceGroupLink < ApplicationRecord
                            new_record? || expires_at_before_type_cast.present?
                          }
 
-  after_destroy :send_access_revoked_emails
+  after_destroy :send_access_revoked_emails, unless: :destroyed_by_association
   after_save :send_access_granted_emails, if: :previously_new_record?
 
   scope :not_expired, -> { where('expires_at IS NULL OR expires_at > ?', Time.zone.now.beginning_of_day) }

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -16,6 +16,8 @@ module Namespaces
 
     has_many :bots, through: :namespace_bots, source: :user
 
+    has_many :namespace_group_links, inverse_of: :namespace, foreign_key: :namespace_id, dependent: :destroy
+
     has_many :shared_with_group_links, # rubocop:disable Rails/InverseOf
              lambda {
                where(namespace_type: Namespaces::ProjectNamespace.sti_name)

--- a/app/models/namespaces/project_namespace.rb
+++ b/app/models/namespaces/project_namespace.rb
@@ -5,7 +5,7 @@ module Namespaces
   class ProjectNamespace < Namespace
     include History
 
-    has_one :project, inverse_of: :namespace, foreign_key: :namespace_id, dependent: :destroy
+    has_one :project, -> { with_deleted }, inverse_of: :namespace, foreign_key: :namespace_id, dependent: :destroy
     has_many :project_members, foreign_key: :namespace_id, inverse_of: :project_namespace,
                                class_name: 'Member', dependent: :destroy
 
@@ -41,6 +41,8 @@ module Namespaces
 
     has_many :automated_workflow_executions, foreign_key: :namespace_id, inverse_of: :project_namespace,
                                              class_name: 'AutomatedWorkflowExecution', dependent: :destroy
+
+    delegate :samples_count, to: :project
 
     validate :validate_public_namespace_type, if: -> { public_changed? }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,6 +48,22 @@ class Project < ApplicationRecord
     :stack
   end
 
+  # Transfer sample count delta between two projects.
+  # @param old_project [Project] the source project
+  # @param new_project [Project] the target project
+  # @param transferred_samples_count [Integer] number of samples transferred
+  def self.transfer_samples_count_delta(old_project, new_project, transferred_samples_count)
+    return if transferred_samples_count.nil? || transferred_samples_count.zero?
+
+    # Update project counters directly without ancestor propagation.
+    Project.decrement_counter(:samples_count, old_project.id, by: transferred_samples_count) # rubocop:disable Rails/SkipsModelValidations
+    Project.increment_counter(:samples_count, new_project.id, by: transferred_samples_count) # rubocop:disable Rails/SkipsModelValidations
+
+    # Move ancestor counts once based on parent namespaces.
+    Namespace.transfer_samples_count_delta(old_project.namespace.parent, new_project.namespace.parent,
+                                           transferred_samples_count)
+  end
+
   def broadcast_refresh_later_to_samples_table
     broadcast_refresh_later_to self, :samples if self && !deleted?
 
@@ -58,21 +74,6 @@ class Project < ApplicationRecord
 
       broadcast_refresh_later_to namespace, :samples
     end
-  end
-
-  # Update the project's sample count by a given delta and propagate changes to ancestors.
-  # @param delta [Integer] positive or negative change in sample count
-  def update_samples_count_delta(delta)
-    return if delta.zero?
-
-    if delta.positive?
-      Project.increment_counter(:samples_count, id, by: delta) # rubocop:disable Rails/SkipsModelValidations
-    else
-      Project.decrement_counter(:samples_count, id, by: delta.abs) # rubocop:disable Rails/SkipsModelValidations
-    end
-
-    # Propagate the delta to group ancestors directly
-    namespace.propagate_samples_count_delta(delta)
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,7 @@ class Project < ApplicationRecord
 
   before_restore :restore_namespace
   after_destroy :destroy_namespace
+  after_commit :propagate_samples_count_change, if: :saved_change_to_samples_count?
 
   belongs_to :creator, class_name: 'User'
   belongs_to :namespace, autosave: true, class_name: 'Namespaces::ProjectNamespace'
@@ -59,6 +60,21 @@ class Project < ApplicationRecord
     end
   end
 
+  # Update the project's sample count by a given delta and propagate changes to ancestors.
+  # @param delta [Integer] positive or negative change in sample count
+  def update_samples_count_delta(delta)
+    return if delta.zero?
+
+    if delta.positive?
+      Project.increment_counter(:samples_count, id, by: delta) # rubocop:disable Rails/SkipsModelValidations
+    else
+      Project.decrement_counter(:samples_count, id, by: delta.abs) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    # Propagate the delta to group ancestors directly
+    namespace.propagate_samples_count_delta(delta)
+  end
+
   private
 
   def destroy_namespace
@@ -72,5 +88,13 @@ class Project < ApplicationRecord
     return if namespace_to_restore.nil?
 
     Namespace.restore(namespace_to_restore.id, recursive: true)
+  end
+
+  # Propagate sample count changes to group namespace ancestors.
+  # Called when samples_count is updated (e.g., via counter_cache on Sample creation/deletion).
+  def propagate_samples_count_change
+    old_count, new_count = saved_change_to_samples_count
+    delta = new_count - old_count
+    namespace.propagate_samples_count_delta(delta)
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -12,7 +12,11 @@ class Sample < ApplicationRecord
 
   belongs_to :project, counter_cache: true
 
+  after_destroy :propagate_samples_count_on_destroy
+  after_restore :propagate_samples_count_on_restore
   after_commit :broadcast_refresh_later_to_samples_table
+  after_commit :propagate_samples_count_on_create, on: :create
+  after_commit :propagate_samples_count_on_transfer, on: :update
 
   has_many :attachments, as: :attachable, dependent: :destroy
 
@@ -70,6 +74,40 @@ class Sample < ApplicationRecord
   end
 
   private
+
+  # Propagate samples_count increment when sample is created.
+  def propagate_samples_count_on_create
+    project&.namespace&.propagate_samples_count_delta(1)
+  end
+
+  # Propagate samples_count increment when sample is restored.
+  def propagate_samples_count_on_restore
+    project&.namespace&.propagate_samples_count_delta(1)
+  end
+
+  # Propagate samples_count transfer when sample is moved to a different project.
+  def propagate_samples_count_on_transfer # rubocop:disable Metrics/CyclomaticComplexity
+    return unless saved_change_to_project_id?
+
+    old_project_id = saved_change_to_project_id[0]
+    new_project_id = saved_change_to_project_id[1]
+
+    # Decrement old project's ancestors
+    old_project = Project.find(old_project_id) if old_project_id
+    old_project&.namespace&.propagate_samples_count_delta(-1)
+
+    # Increment new project's ancestors
+    new_project = Project.find(new_project_id) if new_project_id
+    new_project&.namespace&.propagate_samples_count_delta(1)
+  end
+
+  # Propagate samples_count decrement when sample is destroyed.
+  def propagate_samples_count_on_destroy
+    return if destroyed_by_association
+
+    # Decrement project's ancestors when sample is deleted
+    project&.namespace&.propagate_samples_count_delta(-1)
+  end
 
   def broadcast_refresh_later_to_samples_table # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     return if Sample.suppressed_turbo_broadcasts

--- a/app/services/base_sample_clone_service.rb
+++ b/app/services/base_sample_clone_service.rb
@@ -45,10 +45,6 @@ class BaseSampleCloneService < BaseSampleService
     ::Attachments::CreateService.new(current_user, clone, { files:, include_activity: false }).execute
   end
 
-  def update_samples_count(cloned_samples_count)
-    @new_project.parent.update_samples_count_by_addition_services(cloned_samples_count)
-  end
-
   def create_project_level_activity(cloned_samples_data, old_project_namespace) # rubocop:disable Metrics/MethodLength
     cloned_samples_count = cloned_samples_data.count
     ext_details = ExtendedDetail.create!(details: { cloned_samples_count: cloned_samples_count,

--- a/app/services/base_sample_destroy_service.rb
+++ b/app/services/base_sample_destroy_service.rb
@@ -23,10 +23,6 @@ class BaseSampleDestroyService < BaseService
     sample.project.namespace.update_metadata_summary_by_sample_deletion(sample)
   end
 
-  def update_samples_count(project_namespace, samples_deleted_count)
-    project_namespace.parent.update_samples_count_by_destroy_service(samples_deleted_count)
-  end
-
   def create_project_activity(project_namespace, deleted_samples_data)
     ext_details = ExtendedDetail.create!(details: { samples_deleted_count: deleted_samples_data.size,
                                                     deleted_samples_data: deleted_samples_data })

--- a/app/services/groups/destroy_service.rb
+++ b/app/services/groups/destroy_service.rb
@@ -8,7 +8,6 @@ module Groups
     def initialize(group, user = nil, params = {})
       super(user, params.except(:group, :group_id))
       @group = group
-      @deleted_samples_count = @group.samples_count
     end
 
     def execute
@@ -27,15 +26,9 @@ module Groups
                                         removed_group_puid: @group.puid,
                                         action: 'group_subgroup_destroy'
                                       }
-
-        update_samples_count
       end
 
       group.update_metadata_summary_by_namespace_deletion
-    end
-
-    def update_samples_count
-      @group.update_samples_count_by_destroy_service(@deleted_samples_count)
     end
   end
 end

--- a/app/services/groups/samples/clone_service.rb
+++ b/app/services/groups/samples/clone_service.rb
@@ -9,7 +9,7 @@ module Groups
 
       private
 
-      def clone_samples(sample_ids, broadcast_target) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      def clone_samples(sample_ids, broadcast_target)
         @cloned_samples_data = { project_data: {}, group_data: [] }
         cloned_sample_ids = {}
         filtered_samples = filter_sample_ids(sample_ids, 'clone')
@@ -24,10 +24,7 @@ module Groups
           update_progress_bar(index, total_sample_count, broadcast_target)
         end
 
-        unless @cloned_samples_data[:project_data].empty?
-          update_samples_count(cloned_sample_ids.count) if @new_project.parent.group_namespace?
-          create_activities
-        end
+        create_activities unless @cloned_samples_data[:project_data].empty?
 
         cloned_sample_ids
       end

--- a/app/services/groups/samples/destroy_service.rb
+++ b/app/services/groups/samples/destroy_service.rb
@@ -34,7 +34,6 @@ module Groups
 
           project_namespace = Namespaces::ProjectNamespace.find_by(puid: project_puid)
 
-          update_samples_count(project_namespace, samples_deleted_count) if project_namespace.parent.group_namespace?
           create_project_activity(project_namespace, @deleted_samples_data[:project_data][project_puid])
 
           total_deleted_samples_count += samples_deleted_count

--- a/app/services/groups/transfer_service.rb
+++ b/app/services/groups/transfer_service.rb
@@ -2,7 +2,7 @@
 
 module Groups
   # Service used to Transfer Groups
-  class TransferService < BaseGroupService # rubocop:disable Metrics/ClassLength
+  class TransferService < BaseGroupService
     def initialize(group, user = nil, transfer_form = nil)
       super(group, user)
       @transfer_form = transfer_form
@@ -41,8 +41,6 @@ module Groups
         create_activities(old_namespace, new_namespace)
 
         UpdateMembershipsJob.perform_later(new_namespace_member_ids)
-
-        update_samples_count(old_namespace, new_namespace)
 
         new_namespace.update_metadata_summary_by_namespace_transfer(@group, old_namespace)
 
@@ -120,17 +118,6 @@ module Groups
                                  new_namespace: new_namespace.puid,
                                  action: 'group_namespace_transfer'
                                }
-      end
-    end
-
-    def update_samples_count(old_namespace, new_namespace)
-      transferred_samples_count = Project.joins(:namespace).where(namespace: { parent_id: @group.self_and_descendants })
-                                         .select(:samples_count).pluck(:samples_count).sum
-      if old_namespace
-        old_namespace.update_samples_count_by_transfer_service(new_namespace, transferred_samples_count,
-                                                               new_namespace.type)
-      elsif new_namespace.type == 'Group'
-        new_namespace.update_samples_count_by_addition_services(transferred_samples_count)
       end
     end
   end

--- a/app/services/projects/destroy_service.rb
+++ b/app/services/projects/destroy_service.rb
@@ -3,10 +3,8 @@
 module Projects
   # Service used to Delete Projects
   class DestroyService < BaseProjectService
-    def execute # rubocop:disable Metrics/AbcSize
+    def execute
       authorize! project, to: :destroy?
-
-      deleted_samples_count = @project.samples.size
 
       project.namespace.destroy!
 
@@ -14,7 +12,6 @@ module Projects
 
       return unless project.namespace.deleted? && @project.parent.type == 'Group'
 
-      update_samples_count(deleted_samples_count)
       project.namespace.update_metadata_summary_by_namespace_deletion
     end
 
@@ -30,10 +27,6 @@ module Projects
                                                   project_puid: @project.namespace.puid,
                                                   action: 'group_project_destroy'
                                                 }
-    end
-
-    def update_samples_count(deleted_samples_count)
-      @project.parent.update_samples_count_by_destroy_service(deleted_samples_count)
     end
   end
 end

--- a/app/services/projects/samples/clone_service.rb
+++ b/app/services/projects/samples/clone_service.rb
@@ -6,7 +6,7 @@ module Projects
     class CloneService < BaseSampleCloneService
       private
 
-      def clone_samples(sample_ids, broadcast_target) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      def clone_samples(sample_ids, broadcast_target)
         cloned_sample_ids = {}
         cloned_samples_data = []
         filtered_samples = filter_sample_ids(sample_ids, 'clone')
@@ -23,10 +23,7 @@ module Projects
           update_progress_bar(index, total_sample_count, broadcast_target)
         end
 
-        if cloned_sample_ids.any?
-          update_samples_count(cloned_sample_ids.count) if @new_project.parent.group_namespace?
-          create_project_level_activity(cloned_samples_data, @namespace)
-        end
+        create_project_level_activity(cloned_samples_data, @namespace) if cloned_sample_ids.any?
 
         cloned_sample_ids
       end

--- a/app/services/projects/samples/destroy_service.rb
+++ b/app/services/projects/samples/destroy_service.rb
@@ -6,7 +6,7 @@ module Projects
     class DestroyService < BaseSampleDestroyService
       private
 
-      def destroy_samples # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def destroy_samples
         samples = Sample.where(id: @sample_ids).where(project_id: @namespace.project.id)
         samples_deleted_puids = []
         deleted_samples_data = []
@@ -21,11 +21,7 @@ module Projects
         end
 
         deleted_samples_count = samples_deleted_puids.count
-        if deleted_samples_count.positive?
-          update_samples_count(@namespace, deleted_samples_count) if @namespace.parent.group_namespace?
-
-          create_project_activity(@namespace, deleted_samples_data)
-        end
+        create_project_activity(@namespace, deleted_samples_data) if deleted_samples_count.positive?
         deleted_samples_count
       end
     end

--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -24,8 +24,6 @@ module Projects
 
       @new_namespace.update_metadata_summary_by_namespace_transfer(@project.namespace, @old_namespace)
 
-      update_samples_count
-
       true
     end
 
@@ -95,16 +93,6 @@ module Projects
       end
 
       params
-    end
-
-    def update_samples_count
-      transferred_samples_count = @project.samples.size
-      if @old_namespace.type == 'Group'
-        @old_namespace.update_samples_count_by_transfer_service(@new_namespace, transferred_samples_count,
-                                                                @new_namespace.type)
-      elsif @new_namespace.type == 'Group'
-        @new_namespace.update_samples_count_by_addition_services(transferred_samples_count)
-      end
     end
   end
 end

--- a/app/services/samples/create_service.rb
+++ b/app/services/samples/create_service.rb
@@ -15,27 +15,18 @@ module Samples
     def execute
       authorize! @project, to: :create_sample? unless @project.nil?
 
-      if sample.save
-
-        update_samples_count if @project.parent.group_namespace?
-
-        if @include_activity
-          @project.namespace.create_activity key: 'namespaces_project_namespace.samples.create',
-                                             owner: current_user,
-                                             parameters:
-                                               {
-                                                 sample_id: sample.id,
-                                                 sample_puid: sample.puid,
-                                                 action: 'sample_create'
-                                               }
-        end
+      if sample.save && @include_activity
+        @project.namespace.create_activity key: 'namespaces_project_namespace.samples.create',
+                                           owner: current_user,
+                                           parameters:
+                                             {
+                                               sample_id: sample.id,
+                                               sample_puid: sample.puid,
+                                               action: 'sample_create'
+                                             }
       end
 
       sample
-    end
-
-    def update_samples_count
-      @project.parent.update_samples_count_by_addition_services
     end
   end
 end

--- a/app/services/samples/transfer_service.rb
+++ b/app/services/samples/transfer_service.rb
@@ -84,19 +84,6 @@ module Samples
       project_namespace.self_and_ancestors_of_type([Namespaces::ProjectNamespace.sti_name, Group.sti_name])
     end
 
-    # Update sample counts on projects after transfer.
-    #
-    # Decrements the source project's count and increments the target project's count.
-    # If either project belongs to a group, also updates the group's metadata summary.
-    #
-    # @param old_project [Project] the source project
-    # @param new_project [Project] the target project
-    # @param transferred_samples_count [Integer] number of samples transferred
-    def update_samples_count(old_project, new_project, transferred_samples_count)
-      old_project.update_samples_count_delta(-transferred_samples_count)
-      new_project.update_samples_count_delta(transferred_samples_count)
-    end
-
     # Update metadata summaries for all namespaces affected by the transfer.
     #
     # For each source project, collects the metadata keys and counts from samples
@@ -342,7 +329,7 @@ module Samples
         old_project = Project.find(old_project_id)
         data = fetch_transferred_sample_data(sample_ids)
 
-        update_samples_count(old_project, new_project, sample_ids.size)
+        Project.transfer_samples_count_delta(old_project, new_project, sample_ids.size)
 
         process_project_transfer_activity(old_project, new_project, data, group_activity_data)
 

--- a/app/services/samples/transfer_service.rb
+++ b/app/services/samples/transfer_service.rb
@@ -93,13 +93,8 @@ module Samples
     # @param new_project [Project] the target project
     # @param transferred_samples_count [Integer] number of samples transferred
     def update_samples_count(old_project, new_project, transferred_samples_count)
-      Project.decrement_counter(:samples_count, old_project.id, by: transferred_samples_count) # rubocop:disable Rails/SkipsModelValidations
-      Project.increment_counter(:samples_count, new_project.id, by: transferred_samples_count) # rubocop:disable Rails/SkipsModelValidations
-      if old_project.parent.type == 'Group'
-        old_project.parent.update_samples_count_by_transfer_service(new_project, transferred_samples_count)
-      elsif new_project.parent.type == 'Group'
-        new_project.parent.update_samples_count_by_addition_services(transferred_samples_count)
-      end
+      old_project.update_samples_count_delta(-transferred_samples_count)
+      new_project.update_samples_count_delta(transferred_samples_count)
     end
 
     # Update metadata summaries for all namespaces affected by the transfer.

--- a/test/components/projects/sample_clone_activity_component_test.rb
+++ b/test/components/projects/sample_clone_activity_component_test.rb
@@ -74,7 +74,9 @@ module Projects
       project_namespace = namespaces_project_namespaces(:project2_namespace)
       project1 = projects(:project1)
 
-      project1.really_destroy!
+      project_namespace_to_destroy = project1.namespace
+      project_namespace_to_destroy.destroy!
+      project_namespace_to_destroy.really_destroy!
 
       activities = project_namespace.human_readable_activity(project_namespace.retrieve_project_activity).reverse
 
@@ -107,7 +109,9 @@ module Projects
       project_namespace = namespaces_project_namespaces(:project1_namespace)
       project2 = projects(:project2)
 
-      project2.really_destroy!
+      project_namespace_to_destroy = project2.namespace
+      project_namespace_to_destroy.destroy!
+      project_namespace_to_destroy.really_destroy!
 
       activities = project_namespace.human_readable_activity(project_namespace.retrieve_project_activity).reverse
 

--- a/test/components/projects/sample_transfer_activity_component_test.rb
+++ b/test/components/projects/sample_transfer_activity_component_test.rb
@@ -74,7 +74,9 @@ module Projects
       project_namespace = namespaces_project_namespaces(:project2_namespace)
       project1 = projects(:project1)
 
-      project1.really_destroy!
+      project_namespace_to_destroy = project1.namespace
+      project_namespace_to_destroy.destroy!
+      project_namespace_to_destroy.really_destroy!
 
       activities = project_namespace.human_readable_activity(project_namespace.retrieve_project_activity).reverse
 
@@ -107,7 +109,9 @@ module Projects
       project_namespace = namespaces_project_namespaces(:project1_namespace)
       project2 = projects(:project2)
 
-      project2.really_destroy!
+      project_namespace_to_destroy = project2.namespace
+      project_namespace_to_destroy.destroy!
+      project_namespace_to_destroy.really_destroy!
 
       activities = project_namespace.human_readable_activity(project_namespace.retrieve_project_activity).reverse
 

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -365,13 +365,6 @@ class GroupTest < ActiveSupport::TestCase
     assert_equal group.samples_count, group.aggregated_samples_count
   end
 
-  test 'update samples_count by sample deletion' do
-    assert_difference -> { @group_three.reload.samples_count } => -1,
-                      -> { @group_three_subgroup1.reload.samples_count } => -1 do
-      @group_three_subgroup1.update_samples_count_by_destroy_service(1)
-    end
-  end
-
   test 'samples_count for each group fixture should be correct' do
     # If you've added samples to fixtures, update the sample_count to the corresponding project/groups
     Group.find_each do |group|

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -365,25 +365,10 @@ class GroupTest < ActiveSupport::TestCase
     assert_equal group.samples_count, group.aggregated_samples_count
   end
 
-  test 'update samples_count by sample transfer' do
-    project = projects(:project22)
-    assert_difference -> { @group_three.reload.samples_count } => -1,
-                      -> { @group_three_subgroup1.reload.samples_count } => -1 do
-      @group_three_subgroup1.update_samples_count_by_transfer_service(project, 1)
-    end
-  end
-
   test 'update samples_count by sample deletion' do
     assert_difference -> { @group_three.reload.samples_count } => -1,
                       -> { @group_three_subgroup1.reload.samples_count } => -1 do
       @group_three_subgroup1.update_samples_count_by_destroy_service(1)
-    end
-  end
-
-  test 'update samples_count by sample addition' do
-    assert_difference -> { @group_three.reload.samples_count } => 1,
-                      -> { @group_three_subgroup1.reload.samples_count } => 1 do
-      @group_three_subgroup1.update_samples_count_by_addition_services(1)
     end
   end
 

--- a/test/models/namespace_test.rb
+++ b/test/models/namespace_test.rb
@@ -119,4 +119,56 @@ class NamespaceTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test '#common_group_ancestor_ids with overlapping ancestors' do
+    old_parent = groups(:subgroup_twelve_a_a)
+    new_parent = groups(:subgroup_twelve_b)
+
+    common_group_ids = Namespace.common_group_ancestor_ids(old_parent, new_parent)
+
+    assert_equal [groups(:group_twelve).id], common_group_ids
+  end
+
+  test '#common_group_ancestor_ids with nil old parent' do
+    new_parent = groups(:subgroup_twelve_b)
+
+    common_group_ids = Namespace.common_group_ancestor_ids(nil, new_parent)
+
+    assert_equal [], common_group_ids
+  end
+
+  test '#common_group_ancestor_ids with non-overlapping ancestors' do
+    old_parent = groups(:subgroup_twelve_a_a)
+    new_parent = groups(:group_two)
+
+    common_group_ids = Namespace.common_group_ancestor_ids(old_parent, new_parent)
+
+    assert_equal [], common_group_ids
+  end
+
+  test '#propagate_samples_count_delta skips except_group_ancestor_ids' do
+    namespace = namespaces_project_namespaces(:project31_namespace)
+    excluded_group_id = groups(:group_twelve).id
+
+    Group.expects(:increment_counter).with(:samples_count, groups(:subgroup_twelve_a_a).id, by: 1).once
+    Group.expects(:increment_counter).with(:samples_count, groups(:subgroup_twelve_a).id, by: 1).once
+    Group.expects(:increment_counter).with(:samples_count, excluded_group_id, by: 1).never
+
+    namespace.propagate_samples_count_delta(1, except_group_ancestor_ids: [excluded_group_id])
+  end
+
+  test '#transfer_samples_count_delta updates only non-common ancestors' do
+    old_parent = groups(:subgroup_twelve_a_a)
+    new_parent = groups(:subgroup_twelve_b)
+    sample_count = 2
+
+    Group.expects(:decrement_counter).with(:samples_count, groups(:subgroup_twelve_a_a).id, by: sample_count).once
+    Group.expects(:decrement_counter).with(:samples_count, groups(:subgroup_twelve_a).id, by: sample_count).once
+    Group.expects(:decrement_counter).with(:samples_count, groups(:group_twelve).id, by: sample_count).never
+
+    Group.expects(:increment_counter).with(:samples_count, groups(:subgroup_twelve_b).id, by: sample_count).once
+    Group.expects(:increment_counter).with(:samples_count, groups(:group_twelve).id, by: sample_count).never
+
+    Namespace.transfer_samples_count_delta(old_parent, new_parent, sample_count)
+  end
 end

--- a/test/models/sample_test.rb
+++ b/test/models/sample_test.rb
@@ -543,4 +543,209 @@ class SampleTest < ActiveSupport::TestCase
     expected_count = 1 + ancestors.count
     assert_equal expected_count, broadcast_calls.count
   end
+
+  test 'creating a sample propagates samples_count to project and group ancestors' do
+    # Hierarchy: group_twelve -> subgroup_twelve_a -> subgroup_twelve_a_a -> project31
+    project31 = projects(:project31)
+    subgroup12aa = groups(:subgroup_twelve_a_a)
+    subgroup12a = groups(:subgroup_twelve_a)
+    group12 = groups(:group_twelve)
+
+    # Reset counts
+    [project31.namespace, subgroup12aa, subgroup12a, group12].each do |ns|
+      ns.update(samples_count: 0)
+    end
+
+    assert_difference(-> { project31.reload.samples_count } => 1,
+                      -> { subgroup12aa.reload.samples_count } => 1,
+                      -> { subgroup12a.reload.samples_count } => 1,
+                      -> { group12.reload.samples_count } => 1) do
+      Sample.create!(name: 'Test Sample Create', project: project31)
+    end
+  end
+
+  test 'deleting a sample propagates samples_count decrement to project and group ancestors' do
+    # Hierarchy: group_twelve -> subgroup_twelve_a -> subgroup_twelve_a_a -> project31
+    project31 = projects(:project31)
+    subgroup12aa = groups(:subgroup_twelve_a_a)
+    subgroup12a = groups(:subgroup_twelve_a)
+    group12 = groups(:group_twelve)
+
+    # Create a sample first
+    sample = Sample.create!(name: 'Test Sample Delete', project: project31)
+
+    # Reload all to get current counts
+    project31.reload
+    subgroup12aa.reload
+    subgroup12a.reload
+    group12.reload
+
+    # Verify sample was created and counts incremented
+    assert project31.samples_count.positive?
+    assert subgroup12a.samples_count.positive?
+    assert subgroup12aa.samples_count.positive?
+    assert group12.samples_count.positive?
+
+    # Now delete and verify counts decrement
+    assert_difference(-> { project31.reload.samples_count } => -1,
+                      -> { subgroup12aa.reload.samples_count } => -1,
+                      -> { subgroup12a.reload.samples_count } => -1,
+                      -> { group12.reload.samples_count } => -1) do
+      sample.destroy
+    end
+  end
+
+  test 'restoring a deleted sample propagates samples_count increment to project and group ancestors' do
+    # Hierarchy: group_twelve -> subgroup_twelve_a -> subgroup_twelve_a_a -> project31
+    project31 = projects(:project31)
+    subgroup12aa = groups(:subgroup_twelve_a_a)
+    subgroup12a = groups(:subgroup_twelve_a)
+    group12 = groups(:group_twelve)
+
+    # Create a sample
+    sample = Sample.create!(name: 'Test Sample Restore', project: project31)
+    sample_id = sample.id
+
+    # Reload to get accurate counts after creation
+    project31.reload
+    subgroup12aa.reload
+    subgroup12a.reload
+    group12.reload
+
+    project_count_after_create = project31.samples_count
+    subgroup12a_count_after_create = subgroup12a.samples_count
+    subgroup12aa_count_after_create = subgroup12aa.samples_count
+    group12_count_after_create = group12.samples_count
+
+    # Delete the sample
+    sample.destroy
+    project31.reload
+    subgroup12aa.reload
+    subgroup12a.reload
+    group12.reload
+
+    # Verify counts decremented after delete
+    assert_equal project_count_after_create - 1, project31.samples_count
+    assert_equal subgroup12a_count_after_create - 1, subgroup12a.samples_count
+    assert_equal subgroup12aa_count_after_create - 1, subgroup12aa.samples_count
+    assert_equal group12_count_after_create - 1, group12.samples_count
+
+    # Restore the sample and verify counts increment
+    assert_difference(-> { project31.reload.samples_count } => 1,
+                      -> { subgroup12aa.reload.samples_count } => 1,
+                      -> { subgroup12a.reload.samples_count } => 1,
+                      -> { group12.reload.samples_count } => 1) do
+      Sample.restore(sample_id, recursive: true)
+    end
+  end
+
+  test 'transferring a sample between projects in different hierarchies propagates counts correctly' do
+    # Transfer from project31 (group_twelve -> subgroup_twelve_a -> subgroup_twelve_a_a)
+    # to project1 (group_one)
+    project31 = projects(:project31)
+    project1 = projects(:project1)
+    subgroup12aa = groups(:subgroup_twelve_a_a)
+    subgroup12a = groups(:subgroup_twelve_a)
+    group12 = groups(:group_twelve)
+    group_one = groups(:group_one)
+
+    # Create sample in project31
+    sample = Sample.create!(name: 'Test Sample Transfer', project: project31)
+
+    # Reload all to get current counts
+    project31.reload
+    project1.reload
+    subgroup12aa.reload
+    subgroup12a.reload
+    group12.reload
+    group_one.reload
+
+    # Store counts before transfer
+    project31_count_before = project31.samples_count
+    project1_count_before = project1.samples_count
+    group12_count_before = group12.samples_count
+    group_one_count_before = group_one.samples_count
+
+    # Transfer sample to project1
+    sample.update(project: project1)
+
+    # Verify old hierarchy decremented
+    assert_equal project31_count_before - 1, project31.reload.samples_count
+    assert_equal group12_count_before - 1, group12.reload.samples_count
+
+    # Verify new hierarchy incremented
+    assert_equal project1_count_before + 1, project1.reload.samples_count
+    assert_equal group_one_count_before + 1, group_one.reload.samples_count
+  end
+
+  test 'transferring a sample within same project hierarchy does not change ancestor counts' do
+    # Both projects under group_one, so transfers should only move count within same hierarchy
+    project1 = projects(:project1)
+    project5 = projects(:project5)
+    group_one = groups(:group_one)
+
+    # Create sample in project1
+    sample = Sample.create!(name: 'Test Sample Transfer Within', project: project1)
+
+    project1.reload
+    project5.reload
+    group_one.reload
+
+    # Store counts before transfer
+    group_one_count_before = group_one.samples_count
+
+    # Transfer sample to project5 (same group)
+    sample.update(project: project5)
+
+    # Group one count should remain same (decrement from project1, increment to project5)
+    assert_equal group_one_count_before, group_one.reload.samples_count
+
+    # Project counts should be updated correctly
+    assert project1.reload.samples_count < (project1.samples.count + 1)
+    assert project5.reload.samples_count > (project5.samples.count - 1)
+  end
+
+  test 'multiple samples creation and deletion maintains correct hierarchy counts' do
+    # Test with multiple samples to ensure counts stay accurate
+    project31 = projects(:project31)
+    subgroup12a = groups(:subgroup_twelve_a)
+    group12 = groups(:group_twelve)
+
+    # NOTE: project31 already has 2 samples in the fixture (sample34, sample35)
+    initial_project_count = project31.samples_count
+    initial_subgroup_count = subgroup12a.samples_count
+    initial_group_count = group12.samples_count
+
+    # Create 3 additional samples
+    samples = []
+    3.times do |i|
+      samples << Sample.create!(name: "Multi Sample #{i}", project: project31)
+    end
+
+    project31.reload
+    subgroup12a.reload
+    group12.reload
+
+    # Verify all 3 new samples were counted
+    assert_equal initial_project_count + 3, project31.samples_count
+    assert_equal initial_subgroup_count + 3, subgroup12a.samples_count
+    assert_equal initial_group_count + 3, group12.samples_count
+
+    # Delete 2 of the new samples
+    samples[0].destroy
+    samples[1].destroy
+
+    # Verify counts decremented by 2
+    assert_equal initial_project_count + 1, project31.reload.samples_count
+    assert_equal initial_subgroup_count + 1, subgroup12a.reload.samples_count
+    assert_equal initial_group_count + 1, group12.reload.samples_count
+
+    # Restore one
+    Sample.restore(samples[0].id, recursive: true)
+
+    # Verify count incremented by 1 again
+    assert_equal initial_project_count + 2, project31.reload.samples_count
+    assert_equal initial_subgroup_count + 2, subgroup12a.reload.samples_count
+    assert_equal initial_group_count + 2, group12.reload.samples_count
+  end
 end

--- a/test/services/samples/transfer_service_test.rb
+++ b/test/services/samples/transfer_service_test.rb
@@ -690,5 +690,125 @@ module Samples
       missing_sample1.destroy
       missing_sample2.destroy
     end
+
+    test 'transferring samples updates project and group ancestor counts - different hierarchies' do
+      # Hierarchy: group_twelve -> subgroup_twelve_a -> subgroup_twelve_a_a -> project31
+      # and: group_twelve -> subgroup_twelve_b -> project30
+      service = Samples::TransferService.new(@project31.namespace, @john_doe)
+
+      # Store initial counts
+      project31_count_before = @project31.samples_count
+      project30_count_before = @project30.samples_count
+      subgroup12aa_count_before = @subgroup12aa.samples_count
+      subgroup12b_count_before = @subgroup12b.samples_count
+      group12_count_before = @group12.samples_count
+
+      # Transfer sample34 and sample35 from project31 to project30
+      transferred_ids = service.execute(@project30.id, [@sample34.id, @sample35.id])
+
+      # Verify transfers succeeded
+      assert_equal 2, transferred_ids.count
+
+      # Reload all groups to get updated counts
+      @project31.reload
+      @project30.reload
+      @subgroup12aa.reload
+      @subgroup12b.reload
+      @group12.reload
+
+      # Verify source project count decreased
+      assert_equal project31_count_before - 2, @project31.samples_count
+
+      # Verify destination project count increased
+      assert_equal project30_count_before + 2, @project30.samples_count
+
+      # Verify source subgroup count decreased
+      assert_equal subgroup12aa_count_before - 2, @subgroup12aa.samples_count
+
+      # Verify destination subgroup count increased
+      assert_equal subgroup12b_count_before + 2, @subgroup12b.samples_count
+
+      # Verify group count stayed the same (both are under group12)
+      assert_equal group12_count_before, @group12.samples_count
+    end
+
+    test 'transferring samples between different groups updates both groups and their ancestors' do
+      # Transfer from project31 (group_twelve hierarchy) to project1 (group_one)
+      project1 = projects(:project1)
+      group_one = groups(:group_one)
+      group12 = @group12
+
+      service = Samples::TransferService.new(@project31.namespace, @john_doe)
+
+      # Store initial counts
+      project31_count_before = @project31.samples_count
+      project1_count_before = project1.samples_count
+      group12_count_before = group12.samples_count
+      group_one_count_before = group_one.samples_count
+
+      # Transfer samples from project31 to project1
+      transferred_ids = service.execute(project1.id, [@sample34.id, @sample35.id])
+
+      assert_equal 2, transferred_ids.count
+
+      # Reload all
+      @project31.reload
+      project1.reload
+      group12.reload
+      group_one.reload
+
+      # Verify source project and group decreased
+      assert_equal project31_count_before - 2, @project31.samples_count
+      assert_equal group12_count_before - 2, group12.samples_count
+
+      # Verify destination project and group increased
+      assert_equal project1_count_before + 2, project1.samples_count
+      assert_equal group_one_count_before + 2, group_one.samples_count
+    end
+
+    test 'transferring single sample updates counts correctly' do
+      service = Samples::TransferService.new(@project31.namespace, @john_doe)
+
+      project31_count_before = @project31.samples_count
+      project30_count_before = @project30.samples_count
+
+      # Transfer just one sample
+      transferred_ids = service.execute(@project30.id, [@sample34.id])
+
+      assert_equal 1, transferred_ids.count
+
+      @project31.reload
+      @project30.reload
+
+      # Verify counts changed by 1
+      assert_equal project31_count_before - 1, @project31.samples_count
+      assert_equal project30_count_before + 1, @project30.samples_count
+    end
+
+    test 'transferring samples with conflicts does not affect untransferred sample counts' do
+      # Create a sample in project30 with same name as sample34
+      # This will prevent sample34 from being transferred due to conflict
+      Sample.create!(name: @sample34.name, project: @project30)
+
+      service = Samples::TransferService.new(@project31.namespace, @john_doe)
+
+      project31_count_before = @project31.samples_count
+      project30_count_before = @project30.samples_count
+
+      # Attempt to transfer both samples
+      # sample34 will conflict, sample35 should transfer
+      transferred_ids = service.execute(@project30.id, [@sample34.id, @sample35.id])
+
+      # Only sample35 should be transferred (sample34 conflicts)
+      assert_equal 1, transferred_ids.count
+      assert transferred_ids.include?(@sample35.id)
+
+      @project31.reload
+      @project30.reload
+
+      # Verify only 1 sample was counted in transfers
+      assert_equal project31_count_before - 1, @project31.samples_count
+      assert_equal project30_count_before + 1, @project30.samples_count
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This pr refactors samples_count propagation so hierarchy updates are handled in model callbacks and shared propagation helpers, rather than being repeated in multiple services. The main goal is to make count propagation more reliable, reduce duplication, and avoid unnecessary ancestor updates during transfers.

What changed

1. Centralized ancestor propagation in Namespace
   * Added class-level transfer logic that moves ancestor counts between old and new parents.
   * Added common ancestor detection so shared ancestors are excluded from transfer updates.
   * Added support to propagate delta while explicitly excluding selected ancestor ids.
   * Added lifecycle callback handling on namespace parent changes, deletion, and restoration so propagation happens automatically when namespace relationships change.
2. Updated Project transfer behavior
   * Introduced project-level transfer helper for samples_count movement between projects.
   * Project transfer now updates project counters directly, then calls namespace transfer propagation once for ancestor movement.
   * This prevents double propagation and ensures a single authoritative path for ancestor updates.
   * Shifted sample lifecycle propagation to model callbacks
   * Added propagation hooks for sample create, transfer, destroy, and restore.
   * This makes project and group ancestor updates occur consistently based on lifecycle events, independent of service call paths.
3. Simplified service layer
   * Removed explicit samples_count propagation code from project transfer, group transfer, project destroy, group destroy, and sample destroy/transfer paths where model callbacks now own the responsibility.
   * Kept services focused on orchestration, authorization, and activity/metadata concerns.
   * Removed obsolete Group propagation helpers
   * Deleted now-unused group helper methods that manually added/subtracted/transferred ancestor counts.
   * Cleaned up related lint directives that became unnecessary.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Ensure services are running (e.g. `devenv up`)
2. Run targetted tests with `bin/rails test test/models/namespace_test.rb test/services/projects/transfer_service_test.rb test/services/groups/transfer_service_test.rb test/services/samples/transfer_service_test.rb`
3. Expect all tests to pass
4. Optionally run broader test suite

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
