### PR TITLE
Attachment Download Fix

### DIFF
--- a/app/views/layouts/attachment.html.erb
+++ b/app/views/layouts/attachment.html.erb
@@ -42,6 +42,9 @@
         params: {
           disposition: :attachment,
         },
+        data: {
+          turbo: false,
+        },
         method: :get,
         class:
           "inline-flex items-center px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg hover:bg-gray-100 hover:text-blue-700 focus-visible:z-10 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" do %>

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -27,6 +27,9 @@ class AttachmentsTest < ApplicationSystemTestCase
     assert_button I18n.t('attachment.show.copy')
     assert_button I18n.t('common.actions.download')
 
+    download_button = find_button(I18n.t('common.actions.download'))
+    assert_equal 'false', download_button['data-turbo']
+
     assert_selector 'table', count: 1
     assert_selector 'thead th', count: 8
     assert_selector 'tbody tr', count: 10


### PR DESCRIPTION
## What does this PR do and why?
This PR addresses an issue where TSV attachments could not be downloaded from the preview page.
Fixes INC0030390.

## Screenshots or screen recordings
N/A

## How to set up and validate locally
1. Upload a TSV attachment.
2. Navigate to the preview page of the attachment.
3. Verify the `Download` button works.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
