### PR TITLE
feat: ResetSamplesCountJob

### DIFF
--- a/app/jobs/reset_samples_count_job.rb
+++ b/app/jobs/reset_samples_count_job.rb
@@ -61,23 +61,14 @@ class ResetSamplesCountJob < ApplicationJob
   def scoped_projects(root_groups)
     return Project.all if root_groups.nil?
 
-    descendant_project_namespace_ids = descendant_namespace_ids(root_groups,
-                                                                Namespaces::ProjectNamespace.sti_name)
+    group_ids = scoped_groups(root_groups).select(:id)
 
-    Project.where(namespace_id: descendant_project_namespace_ids)
+    Project.joins(:namespace).where(namespace: { parent_id: group_ids })
   end
 
   def scoped_groups(root_groups)
     return Group.all if root_groups.nil?
 
-    descendant_group_ids = descendant_namespace_ids(root_groups, Group.sti_name)
-
-    Group.where(id: descendant_group_ids)
-  end
-
-  def descendant_namespace_ids(root_groups, type)
-    root_groups.find_each.flat_map do |root_group|
-      root_group.self_and_descendants_of_type(type).pluck(:id)
-    end.uniq
+    root_groups.self_and_descendants
   end
 end

--- a/app/jobs/reset_samples_count_job.rb
+++ b/app/jobs/reset_samples_count_job.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Recalculates persisted sample counters for projects and groups.
+#
+# Order is important:
+# 1) reset project counters from actual sample rows
+# 2) recalculate group counters from descendant projects
+class ResetSamplesCountJob < ApplicationJob
+  include ActiveJob::Continuable
+
+  queue_as :default
+  queue_with_priority 50
+
+  def perform(root_group_ids: nil)
+    @requested_root_group_ids = Array(root_group_ids).compact_blank
+    @root_groups = @requested_root_group_ids.empty? ? nil : Group.where(id: @requested_root_group_ids).distinct
+
+    if @root_groups&.none?
+      Rails.logger.warn("ResetSamplesCountJob skipped: no active groups found for root_group_ids=#{@requested_root_group_ids.inspect}") # rubocop:disable Layout/LineLength
+      return
+    end
+
+    step :reset_project_counts_step, start: 0
+    step :reset_group_counts_step, start: 0
+    step :log_completion
+  end
+
+  private
+
+  def reset_project_counts_step(step)
+    start_id = scoped_projects(@root_groups).order(:id).offset(step.cursor).first.id
+    scoped_projects(@root_groups).find_each(start: start_id) do |project|
+      Project.reset_counters(project.id, :samples)
+      step.advance!
+    end
+  end
+
+  def reset_group_counts_step(step)
+    start_id = scoped_groups(@root_groups).order(:id).offset(step.cursor).first.id
+    scoped_groups(@root_groups).find_each(start: start_id) do |group|
+      descendant_project_namespace_ids =
+        group.self_and_descendants_of_type(Namespaces::ProjectNamespace.sti_name).select(:id)
+      group_samples_count = Project.where(namespace_id: descendant_project_namespace_ids).sum(:samples_count)
+
+      group.update_columns(samples_count: group_samples_count) # rubocop:disable Rails/SkipsModelValidations
+      step.advance!
+    end
+  end
+
+  def log_completion
+    mode = @root_groups.nil? ? 'global' : 'root_scoped'
+    Rails.logger.info(
+      "ResetSamplesCountJob complete mode=#{mode} root_group_ids=#{@requested_root_group_ids.inspect}"
+    )
+  end
+
+  def scoped_projects(root_groups)
+    return Project.all if root_groups.nil?
+
+    descendant_project_namespace_ids = descendant_namespace_ids(root_groups,
+                                                                Namespaces::ProjectNamespace.sti_name)
+
+    Project.where(namespace_id: descendant_project_namespace_ids)
+  end
+
+  def scoped_groups(root_groups)
+    return Group.all if root_groups.nil?
+
+    descendant_group_ids = descendant_namespace_ids(root_groups, Group.sti_name)
+
+    Group.where(id: descendant_group_ids)
+  end
+
+  def descendant_namespace_ids(root_groups, type)
+    root_groups.find_each.flat_map do |root_group|
+      root_group.self_and_descendants_of_type(type).pluck(:id)
+    end.uniq
+  end
+end

--- a/app/jobs/reset_samples_count_job.rb
+++ b/app/jobs/reset_samples_count_job.rb
@@ -28,7 +28,9 @@ class ResetSamplesCountJob < ApplicationJob
   private
 
   def reset_project_counts_step(step)
-    start_id = scoped_projects(@root_groups).order(:id).offset(step.cursor).first.id
+    start_id = scoped_projects(@root_groups).order(:id).offset(step.cursor).first&.id
+    return if start_id.nil?
+
     scoped_projects(@root_groups).find_each(start: start_id) do |project|
       Project.reset_counters(project.id, :samples)
       step.advance!
@@ -36,7 +38,9 @@ class ResetSamplesCountJob < ApplicationJob
   end
 
   def reset_group_counts_step(step)
-    start_id = scoped_groups(@root_groups).order(:id).offset(step.cursor).first.id
+    start_id = scoped_groups(@root_groups).order(:id).offset(step.cursor).first&.id
+    return if start_id.nil?
+
     scoped_groups(@root_groups).find_each(start: start_id) do |group|
       descendant_project_namespace_ids =
         group.self_and_descendants_of_type(Namespaces::ProjectNamespace.sti_name).select(:id)

--- a/test/jobs/reset_samples_count_job_test.rb
+++ b/test/jobs/reset_samples_count_job_test.rb
@@ -193,6 +193,26 @@ class ResetSamplesCountJobTest < ActiveJob::TestCase
                  'Root group passed as root_group_id should be reset'
   end
 
+  test 'resets group with no descendant projects to zero' do
+    # Find a group that has no descendant projects
+    group_without_projects = groups(:group_eight)
+
+    # Ensure the group has no descendant projects (for this test to be valid)
+    expected_count = expected_group_samples_count(group_without_projects)
+    skip "Test group must have no descendant projects, but has #{expected_count}" unless expected_count.zero?
+
+    # Corrupt sample count
+    group_without_projects.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+
+    ResetSamplesCountJob.perform_now
+
+    group_without_projects.reload
+
+    # Group with no descendant projects should have samples_count of 0
+    assert_equal 0, group_without_projects.samples_count,
+                 'Group with no descendant projects should have samples_count reset to 0'
+  end
+
   test 'resets projects before groups' do
     ResetSamplesCountJob.perform_later
 
@@ -213,6 +233,8 @@ class ResetSamplesCountJobTest < ActiveJob::TestCase
 
   def expected_group_samples_count(group)
     descendant_project_namespace_ids = group.self_and_descendants_of_type(Namespaces::ProjectNamespace.sti_name).select(:id)
-    Project.where(namespace_id: descendant_project_namespace_ids).sum { |project| project.samples.count }
+    Sample.joins(:project)
+          .where(projects: { namespace_id: descendant_project_namespace_ids })
+          .count
   end
 end

--- a/test/jobs/reset_samples_count_job_test.rb
+++ b/test/jobs/reset_samples_count_job_test.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require 'active_job/continuation/test_helper'
+require 'test_helper'
+
+class ResetSamplesCountJobTest < ActiveJob::TestCase
+  include ActiveJob::Continuation::TestHelper
+
+  test 'resets project and group counters globally' do
+    project = projects(:project1)
+    group = groups(:group_one)
+
+    project.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+    group.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+
+    ResetSamplesCountJob.perform_now
+
+    assert_equal project.samples.count, project.reload.samples_count
+    assert_equal expected_group_samples_count(group), group.reload.samples_count
+  end
+
+  test 'resets only descendants when root_group_ids are provided' do
+    root_group = groups(:group_twelve)
+    in_scope_project = projects(:project29)
+    out_of_scope_project = projects(:project1)
+    in_scope_group = groups(:subgroup_twelve_a)
+    out_of_scope_group = groups(:group_one)
+
+    in_scope_project.update_columns(samples_count: 900) # rubocop:disable Rails/SkipsModelValidations
+    out_of_scope_project.update_columns(samples_count: 800) # rubocop:disable Rails/SkipsModelValidations
+    in_scope_group.update_columns(samples_count: 700) # rubocop:disable Rails/SkipsModelValidations
+    out_of_scope_group.update_columns(samples_count: 600) # rubocop:disable Rails/SkipsModelValidations
+
+    ResetSamplesCountJob.perform_now(root_group_ids: [root_group.id])
+
+    assert_equal in_scope_project.samples.count, in_scope_project.reload.samples_count
+    assert_equal expected_group_samples_count(in_scope_group), in_scope_group.reload.samples_count
+
+    assert_equal 800, out_of_scope_project.reload.samples_count
+    assert_equal 600, out_of_scope_group.reload.samples_count
+  end
+
+  test 'is idempotent in global mode' do
+    project = projects(:project4)
+    group = groups(:group_three)
+
+    project.update_columns(samples_count: 500) # rubocop:disable Rails/SkipsModelValidations
+    group.update_columns(samples_count: 500) # rubocop:disable Rails/SkipsModelValidations
+
+    ResetSamplesCountJob.perform_now
+
+    assert_no_changes -> { project.reload.samples_count } do
+      assert_no_changes -> { group.reload.samples_count } do
+        ResetSamplesCountJob.perform_now
+      end
+    end
+  end
+
+  test 'job resumes from correct step after interruption' do
+    project = projects(:project1)
+    group = groups(:group_one)
+
+    project.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+    group.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+
+    ResetSamplesCountJob.perform_later
+
+    # Interrupt after project counts are reset but before group counts
+    interrupt_job_after_step(ResetSamplesCountJob, :reset_project_counts_step) do
+      perform_enqueued_jobs(only: ResetSamplesCountJob)
+    end
+
+    project.reload
+    group.reload
+
+    # Project counts should be reset
+    assert_equal project.samples.count, project.samples_count
+
+    # Group counts should still be incorrect (not reset yet)
+    assert_equal 999, group.samples_count
+
+    # Resume the job
+    perform_enqueued_jobs(only: ResetSamplesCountJob)
+
+    project.reload
+    group.reload
+
+    # Both should now be correct
+    assert_equal project.samples.count, project.samples_count
+    assert_equal expected_group_samples_count(group), group.samples_count
+  end
+
+  test 'does not reprocess records after cursor on resumption' do
+    # Use a specific root group to have a known, limited set of projects
+    root_group = groups(:group_twelve)
+    projects_to_reset = root_group.self_and_descendants_of_type(Namespaces::ProjectNamespace.sti_name)
+                                  .map(&:project)
+                                  .compact
+                                  .sort_by(&:id)
+    skip 'Need at least 3 projects in test group for this test' if projects_to_reset.count < 3
+
+    projects_to_reset.each do |project|
+      project.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    first_project = projects_to_reset.first
+    first_project_sample_count = first_project.samples.count
+
+    # Interrupt after the first project (cursor position 1 means skip first record)
+    interrupt_job_during_step(ResetSamplesCountJob, :reset_project_counts_step, cursor: 1) do
+      ResetSamplesCountJob.perform_later(root_group_ids: [root_group.id])
+      perform_enqueued_jobs(only: ResetSamplesCountJob)
+    end
+
+    first_project.reload
+
+    # First project should have been reset to correct count
+    assert_equal first_project_sample_count, first_project.samples_count,
+                 'First project should have been reset during first execution'
+
+    # Now manually set the first project back to an incorrect count to verify it won't be reset again
+    first_project.update_columns(samples_count: 888) # rubocop:disable Rails/SkipsModelValidations
+
+    # Resume the job - should only process remaining projects, not the first one again
+    perform_enqueued_jobs(only: ResetSamplesCountJob)
+
+    first_project.reload
+
+    # First project count should still be 888 (not reset again), proving the cursor worked
+    assert_equal 888, first_project.samples_count,
+                 'First project should NOT have been reprocessed (cursor should skip it)'
+
+    # Verify remaining projects were processed correctly
+    projects_to_reset[1..].each do |project|
+      assert_equal project.samples.count, project.reload.samples_count
+    end
+  end
+
+  test 'does not reprocess groups after cursor on resumption' do
+    # Use a specific root group to have a known, limited set of groups
+    root_group = groups(:group_twelve)
+    groups_to_reset = root_group.self_and_descendants_of_type(Group.sti_name).sort_by(&:id)
+    skip 'Need at least 3 groups in test hierarchy for this test' if groups_to_reset.count < 3
+
+    groups_to_reset.each do |group|
+      group.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    first_group = groups_to_reset.first
+    first_group_expected_sample_count = expected_group_samples_count(first_group)
+
+    # Interrupt after the first group (cursor position 1 means skip first record)
+    interrupt_job_during_step(ResetSamplesCountJob, :reset_group_counts_step, cursor: 1) do
+      ResetSamplesCountJob.perform_later(root_group_ids: [root_group.id])
+      perform_enqueued_jobs(only: ResetSamplesCountJob)
+    end
+
+    first_group.reload
+
+    # First group should have been reset to correct count
+    assert_equal first_group_expected_sample_count, first_group.samples_count,
+                 'First group should have been reset during first execution'
+
+    # Now manually set the first group back to an incorrect count to verify it won't be reset again
+    first_group.update_columns(samples_count: 777) # rubocop:disable Rails/SkipsModelValidations
+
+    # Resume the job - should only process remaining groups, not the first one again
+    perform_enqueued_jobs(only: ResetSamplesCountJob)
+
+    first_group.reload
+
+    # First group count should still be 777 (not reset again), proving the cursor worked
+    assert_equal 777, first_group.samples_count,
+                 'First group should NOT have been reprocessed (cursor should skip it)'
+
+    # Verify remaining groups were processed correctly
+    groups_to_reset[1..].each do |group|
+      assert_equal expected_group_samples_count(group), group.reload.samples_count
+    end
+  end
+
+  test 'resets projects before groups' do
+    ResetSamplesCountJob.perform_later
+
+    interrupt_job_after_step(ResetSamplesCountJob, :reset_project_counts_step) do
+      perform_enqueued_jobs(only: ResetSamplesCountJob)
+    end
+
+    # After interrupting after project step, should still have job enqueued
+    assert_enqueued_jobs(1, only: ResetSamplesCountJob)
+
+    # After completing, should move to group step
+    perform_enqueued_jobs(only: ResetSamplesCountJob)
+
+    assert_performed_jobs(2, only: ResetSamplesCountJob)
+  end
+
+  private
+
+  def expected_group_samples_count(group)
+    descendant_project_namespace_ids = group.self_and_descendants_of_type(Namespaces::ProjectNamespace.sti_name).select(:id)
+    Project.where(namespace_id: descendant_project_namespace_ids).sum { |project| project.samples.count }
+  end
+end

--- a/test/jobs/reset_samples_count_job_test.rb
+++ b/test/jobs/reset_samples_count_job_test.rb
@@ -179,6 +179,20 @@ class ResetSamplesCountJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'resets root group itself when root_group_ids are provided' do
+    # Verify that the root group passed as root_group_ids is reset, not just its descendants
+    root_group = groups(:group_twelve)
+    root_group.update_columns(samples_count: 999) # rubocop:disable Rails/SkipsModelValidations
+
+    ResetSamplesCountJob.perform_now(root_group_ids: [root_group.id])
+
+    root_group.reload
+
+    # Root group itself should have been reset to correct count
+    assert_equal expected_group_samples_count(root_group), root_group.samples_count,
+                 'Root group passed as root_group_id should be reset'
+  end
+
   test 'resets projects before groups' do
     ResetSamplesCountJob.perform_later
 


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Added in `ResetSamplesCountJob` which recalculates Project and Group `samples_count` columns. Optionally an array of `root_group_ids` can be passed which limit the joib to only process Projects and Groups that are descendants of the passed in `root_group_ids`, otherwise all Projects and Groups are processed. This job is idempotent and can be resumed from interruption without reprocessing already processed Projects and Groups.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Ensure services are running (e.g. `devenv up`)
2. Run targetted tests with `bin/rails test test/jobs/reset_samples_count_job_test.rb`
3. Expect all tests to pass
4. Optionally run broader test suite
5. Optionally run job from rails console

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
