### PR TITLE
Bug: Fix devenv.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,8 +2,6 @@
 
 export DIRENV_WARN_TIMEOUT=20s
 
-export LD_LIBRARY_PATH=~/.nix-profile/lib
-
 eval "$(devenv direnvrc)"
 
 # `use devenv` supports the same options as the `devenv shell` command.

--- a/devenv.nix
+++ b/devenv.nix
@@ -141,9 +141,8 @@ lib.mkMerge [
     # See full reference at https://devenv.sh/reference/options/
   }
   (lib.mkIf pkgs.stdenv.isLinux {
-    # Additional Linux packages
-    packages = [ pkgs.sssd ];
-
-    env.LD_LIBRARY_PATH = "${pkgs.sssd}/lib";
+    enterShell = ''
+      export NIX_LDFLAGS="-L/lib64 -L/usr/lib64 $NIX_LDFLAGS"
+    '';
   })
 ]


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a potential bug after the recent `devenv` update where access to this repo was denied unless `direnv deny` was run.

## Screenshots or screen recordings

[Screencast from 2026-07-29 13-59-42.webm](https://github.com/user-attachments/assets/83155c51-c8de-4bf4-a309-c1fca4bbf35c)

## How to set up and validate locally
1. To recreate the problem, checkout `main`, pull, and follow the steps described in [PR2134](https://github.com/phac-nml/irida-next/pull/2134) to update your local environment.
2. Afterwards, with direnv allow, try to access the remote `irida-next` repo, and see if there's a loss of access.
3. If so, run `direnv deny` and you should be able to pull again
4. Run `direnv allow` and checkout this branch and try pulling. Pulling should be possible once again.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
