### PR TITLE
chore(devenv): Pin to nextflow 25.10.2 and fix linux overrides for sssd

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1785435900,
-        "narHash": "sha256-t+Cm2LICKr8eDNM/ruPJBqmCpybZWRgHpgiIuMLt0ww=",
+        "lastModified": 1785772008,
+        "narHash": "sha256-xVVP8WR9/yQ0AvvVQMeMQbHrHXJTKBq7dqcPyphXDek=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d0ea5226b162f4611e3541cc45547d210e83ae03",
+        "rev": "9d93b838def889d5bcff302cac49c9322d34d33c",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1785318976,
-        "narHash": "sha256-2/0aIcE9GEVvdzizcVUImPWG6R3vVtJo/01DNXv2R/w=",
+        "lastModified": 1785435900,
+        "narHash": "sha256-t+Cm2LICKr8eDNM/ruPJBqmCpybZWRgHpgiIuMLt0ww=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "81ab9b8fffc8ec352f4a72eb49b41ef93766aceb",
+        "rev": "d0ea5226b162f4611e3541cc45547d210e83ae03",
         "type": "github"
       },
       "original": {
@@ -48,6 +48,22 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nextflow-pin": {
+      "locked": {
+        "lastModified": 1782485202,
+        "narHash": "sha256-CNLRQnboC3eN4/l8Pf7JX5VrQyzRiajkU8Rnzg6FIt4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1f6deaff6d3c8546398eadc710c3fb6fbcaf45e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1f6deaff6d3c8546398eadc710c3fb6fbcaf45e4",
         "type": "github"
       }
     },
@@ -112,6 +128,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "nextflow-pin": "nextflow-pin",
         "nixpkgs": "nixpkgs",
         "nixpkgs-ruby": "nixpkgs-ruby"
       }

--- a/devenv.nix
+++ b/devenv.nix
@@ -70,9 +70,9 @@ lib.mkMerge [
     processes.sapporo-service = {
       ports.http.allocate = 1122;
       exec = ''
-        SKIP_CHOWN_OUTPUTS=True SAPPORO_HOST=0.0.0.0 SAPPORO_PORT=${toString config.processes.sapporo-service.ports.http.value} SAPPORO_DEBUG=True SAPPORO_RUN_SH=${config.git.root}/.devenv/sapporo-service/sapporo/run_irida_next.sh poetry run sapporo
+        SKIP_CHOWN_OUTPUTS=True SAPPORO_HOST=0.0.0.0 SAPPORO_PORT=${toString config.processes.sapporo-service.ports.http.value} SAPPORO_DEBUG=True SAPPORO_RUN_SH=${config.devenv.state}/sapporo-service/sapporo/run_irida_next.sh poetry run sapporo
       '';
-      cwd = "${config.git.root}/.devenv/sapporo-service/sapporo";
+      cwd = "${config.devenv.state}/sapporo-service/sapporo";
     };
 
     # https://devenv.sh/services/
@@ -149,7 +149,7 @@ lib.mkMerge [
         mkdir -p sapporo/runs/.nextflow
         printf "docker {\n\tenabled = true\n\trunOptions = '--network host'\n}" > sapporo/runs/.nextflow/config
       '';
-      cwd = "${config.git.root}/.devenv";
+      cwd = "${config.devenv.state}";
       before = [ "devenv:processes:sapporo-service" ];
     };
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,6 +6,15 @@ lib.mkMerge [
     env.PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright.passthru.browsers}";
     env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS="true";
 
+    # pin nextflow to 25.10.2
+    overlays = [
+      (final: prev: {
+        nextflow = (import inputs.nextflow-pin {
+          system = prev.stdenv.system;
+        }).nextflow;
+      })
+    ];
+
     # https://devenv.sh/packages/
     packages = with pkgs; [
       pkg-config
@@ -142,7 +151,11 @@ lib.mkMerge [
   }
   (lib.mkIf pkgs.stdenv.isLinux {
     enterShell = ''
-      export NIX_LDFLAGS="-L/lib64 -L/usr/lib64 $NIX_LDFLAGS"
+      # add libnss_sss.so.2 to LD_PRELOAD if it exists, to avoid issues with SSSD and NSS
+      LIBNSS_SSS_PATH=$(find /lib /usr/lib /lib64 /usr/lib64 -name "libnss_sss.so.2" 2>/dev/null | head -n 1)
+      if [ -n "$LIBNSS_SSS_PATH" ]; then
+        export LD_PRELOAD="$LIBNSS_SSS_PATH"
+      fi
     '';
   })
 ]

--- a/devenv.nix
+++ b/devenv.nix
@@ -5,13 +5,25 @@ lib.mkMerge [
     env.GA4GH_WES_URL = "http://localhost:1122";
     env.PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright.passthru.browsers}";
     env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS="true";
+    env.POETRY_DATA_DIR = "${config.devenv.state}/poetry/data";
+    env.POETRY_CACHE_DIR = "${config.devenv.state}/poetry/cache";
 
     # pin nextflow to 25.10.2
     overlays = [
       (final: prev: {
-        nextflow = (import inputs.nextflow-pin {
+        nextflow = inputs.nextflow-pin.legacyPackages.${prev.system}.nextflow.overrideAttrs (oldAttrs: {
           system = prev.stdenv.system;
-        }).nextflow;
+          postPatch = ''
+            # Nextflow invokes the constant "/bin/bash" (not as a shebang) at
+            # several locations so we fix that globally. However, when running inside
+            # a container, we actually *want* "/bin/bash". Thus the global fix needs
+            # to be reverted for this specific use case.
+            substituteInPlace modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy \
+              --replace-fail "['/bin/bash'," "['${prev.bash}/bin/bash'," \
+              --replace-fail "if( containerBuilder ) {" "if( containerBuilder ) {
+                        launcher = launcher.replaceFirst(\"/nix/store/.*/bin/bash\", \"/bin/bash\")"
+          '';
+        });
       })
     ];
 

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,4 +1,6 @@
 inputs:
+  nextflow-pin:
+    url: github:nixos/nixpkgs/1f6deaff6d3c8546398eadc710c3fb6fbcaf45e4
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling
   nixpkgs-ruby:


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR updates the devenv config to use a pinned version of Nextflow (25.10.2). Additionally linux config in devenv.nix has been updated to set LD_PRELOAD instead of NIX_LDFLAGS which fixes an issue with being able to create postgres directories.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Ensure no running server and services
2. Delete postgres state directory `rm -rf .devenv/state/postgres`
3. Reload direnv with `direnv reload`
4. Start up services with `devenv up` and confirm no errors from postgres related to uid
5. Make sure git commands work with `git pull` shouldn't raise an error
6. Run the following to confirm that nextflow 25.10.2 is installed `nextflow -version`
7. Start up the server with `bin/setup`
8. Login as user of choice and launch `IRIDA Next Example 1.0.3` and confirm that it runs without any errors

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
