### PR TITLE
Bug: Advanced Search - Add list value input for text_in and text_not_in

### DIFF
--- a/app/components/advanced_search/v1/value_component.html.erb
+++ b/app/components/advanced_search/v1/value_component.html.erb
@@ -12,7 +12,7 @@
 >
   <%= @conditions_form.label :value, data: { required: true } %>
 
-  <% if %w[in not_in].include?(@condition.operator) %>
+  <% if %w[in not_in text_in text_not_in].include?(@condition.operator) %>
     <% if @options.nil? %>
       <div
         data-controller="list-input"

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -193,7 +193,12 @@ export default class AdvancedSearchController extends Controller {
     } else {
       const selectedField = this.#selectedConditionField(condition);
       if (Object.hasOwn(this.enumFieldsValue, selectedField)) {
-        const templateTarget = ["in", "not_in"].includes(operator)
+        const templateTarget = [
+          "in",
+          "not_in",
+          "text_in",
+          "text_not_in",
+        ].includes(operator)
           ? this.listSelectValueTemplateTarget
           : this.selectValueTemplateTarget;
         value.outerHTML = templateTarget.innerHTML
@@ -210,7 +215,12 @@ export default class AdvancedSearchController extends Controller {
           operator,
         );
       } else {
-        const templateTarget = ["in", "not_in"].includes(operator)
+        const templateTarget = [
+          "in",
+          "not_in",
+          "text_in",
+          "text_not_in",
+        ].includes(operator)
           ? this.listValueTemplateTarget
           : this.valueTemplateTarget;
         value.outerHTML = templateTarget.innerHTML
@@ -488,7 +498,9 @@ export default class AdvancedSearchController extends Controller {
       return;
     }
 
-    const listOperator = ["in", "not_in"].includes(operator);
+    const listOperator = ["in", "not_in", "text_in", "text_not_in"].includes(
+      operator,
+    );
     const select = listOperator
       ? valueContainer.querySelector("select[name$='[value][]']")
       : valueContainer.querySelector("select[name$='[value]']");

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -420,4 +420,35 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test 'text_in and text_not_in render list input' do
+    Flipper.enable(:advanced_search_metadata_operators)
+    visit('rails/view_components/advanced_search_component/empty')
+    within 'div[data-controller-connected="true"]' do
+      click_button I18n.t(:'components.advanced_search_component.v1.title')
+
+      assert_selector 'dialog h1', text: I18n.t(:'components.advanced_search_component.v1.title')
+      within 'dialog' do
+        assert_accessible
+        assert_selector 'h1', text: I18n.t(:'components.advanced_search_component.v1.title')
+        assert_selector ".dialog--header button[aria-label='#{I18n.t('components.dialog.close')}']"
+        within all("fieldset[data-advanced-search--v1-target='groupsContainer']")[0] do
+          within all("fieldset[data-advanced-search--v1-target='conditionsContainer']")[0] do
+            assert_no_selector 'div[data-controller="list-input"]'
+            find("input[id$='field']").send_keys('age', :enter)
+            find("select[name$='[operator]']").find("option[value='text_in']").select_option
+            assert_selector 'div[data-controller="list-input"]'
+
+            find("select[name$='[operator]']").find("option[value='text_equals']").select_option
+            assert_no_selector 'div[data-controller="list-input"]'
+
+            find("select[name$='[operator]']").find("option[value='text_not_in']").select_option
+            assert_selector 'div[data-controller="list-input"]'
+          end
+        end
+      end
+    end
+  ensure
+    Flipper.enable(:advanced_search_with_auto_complete)
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where `text_in` and `text_not_in` didn't render the expected list value input (only rendered standard text input).

## Screenshots or screen recordings
Before:
<img width="1582" height="1614" alt="image" src="https://github.com/user-attachments/assets/b8e40107-5ec0-4772-84b1-7f1d695f0d25" />

Now:
<img width="1582" height="1614" alt="image" src="https://github.com/user-attachments/assets/4c078951-58f1-43b6-9987-e25a6f4f3ea0" />

## How to set up and validate locally
1. Enable feature flag `Flipper.enable(:advanced_search_metadata_operators)`
2. Navigate to project samples where samples have metadata
3. Create an advanced search and select a metadata field within the field selection, and then `text_in` or `text_not_in` for operator.
4. Verify the value input renders the list value input, and enter a couple valid inputs
5. Verify the advanced search filters as expected for both operators
6. Re-open the advanced search dialog and verify the value input is still the list value input and still contains the entered values

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
