### PR TITLE
Bug: Advanced Search - Use metadata operators for metadata enum fields

### DIFF
--- a/app/components/advanced_search/v1/component.rb
+++ b/app/components/advanced_search/v1/component.rb
@@ -31,13 +31,17 @@ module AdvancedSearch
         enum_operators = {}
         if Flipper.enabled?(:advanced_search_metadata_operators)
           # flatten metadata operators to exclude optgroup labeling
-          metadata_operators = operation_options['metadata']
+          metadata_operators = @operations['metadata']
                                .values
                                .reduce({}, :merge)
-          enum_operators['metadata'] = metadata_operators.select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['metadata'].include?(value) }
+          enum_operators['metadata'] = metadata_operators.select do |_, value|
+            AdvancedSearch::ENUM_OPERATOR_VALUES['metadata'].include?(value)
+          end
         end
 
-        enum_operators['standard'] = operation_options['standard'].select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['standard'].include?(value) }
+        enum_operators['standard'] = @operations['standard'].select do |_, value|
+          AdvancedSearch::ENUM_OPERATOR_VALUES['standard'].include?(value)
+        end
         enum_operators
       end
 

--- a/app/components/advanced_search/v1/component.rb
+++ b/app/components/advanced_search/v1/component.rb
@@ -28,11 +28,18 @@ module AdvancedSearch
       end
 
       def enum_operation_options
-        operation_options['standard'].select { |_, value| enum_operation_values.include?(value) }
-      end
+        enum_operators = {}
+        if Flipper.enabled?(:advanced_search_metadata_operators) &&
+           Flipper.enabled?(:advanced_search_disable_standard_operators_for_metadata_in_graphql)
+          # flatten metadata operators to exclude optgroup labeling
+          metadata_operators = operation_options['metadata']
+                               .values
+                               .reduce({}, :merge)
+          enum_operators['metadata'] = metadata_operators.select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['metadata'].include?(value) }
+        end
 
-      def enum_operation_values
-        AdvancedSearch::ENUM_OPERATOR_VALUES
+        enum_operators['standard'] = operation_options['standard'].select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['standard'].include?(value) }
+        enum_operators
       end
 
       def operation_options # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/components/advanced_search/v1/component.rb
+++ b/app/components/advanced_search/v1/component.rb
@@ -29,8 +29,7 @@ module AdvancedSearch
 
       def enum_operation_options
         enum_operators = {}
-        if Flipper.enabled?(:advanced_search_metadata_operators) &&
-           Flipper.enabled?(:advanced_search_disable_standard_operators_for_metadata_in_graphql)
+        if Flipper.enabled?(:advanced_search_metadata_operators)
           # flatten metadata operators to exclude optgroup labeling
           metadata_operators = operation_options['metadata']
                                .values

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -92,7 +92,7 @@
     ) %>
   <% end %>
 
-  <button
+  <button <%# herb:disable html-no-title-attribute %>
     type="button"
     class="
       absolute -top-4 right-2 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-lg
@@ -100,6 +100,7 @@
       dark:hover:text-white
     "
     aria-label="<%= t("components.advanced_search_component.v1.remove_condition_aria_label") %>"
+    title="<%= t("components.advanced_search_component.v1.remove_condition_aria_label") %>"
     data-action="advanced-search--v1#removeCondition"
   >
     <%= icon(:x, size: :sm) %>

--- a/app/components/advanced_search/v1/condition_component.html.erb
+++ b/app/components/advanced_search/v1/condition_component.html.erb
@@ -15,15 +15,11 @@
     <% invalid_field = @condition.errors.include?(:field) %>
 
     <div class="form-field w-full <%= 'invalid' if invalid_field %>">
-      <% options = options_for_select(field_options, @condition.field).concat(
-        grouped_options_for_select(grouped_field_options, @condition.field),
-      ) %>
-
       <%= conditions_form.label :field, data: { required: true } %>
 
       <% unless Flipper.enabled?(:advanced_search_with_auto_complete, Current.user) %>
         <%= conditions_form.select :field,
-                               options,
+                               field_options_for_select,
                                { include_blank: true },
                                {
                                  "data-action": "change->advanced-search--v1#handleFieldChange",
@@ -35,7 +31,7 @@
         <%= render ComboboxComponent.new(
           form: conditions_form,
           field: :field,
-          options: options,
+          options: field_options_for_select,
           data: {
             action: "change->advanced-search--v1#handleFieldChange",
           },
@@ -104,7 +100,6 @@
       dark:hover:text-white
     "
     aria-label="<%= t("components.advanced_search_component.v1.remove_condition_aria_label") %>"
-    title="<%= t("components.advanced_search_component.v1.remove_condition_aria_label") %>"
     data-action="advanced-search--v1#removeCondition"
   >
     <%= icon(:x, size: :sm) %>

--- a/app/components/advanced_search/v1/condition_component.rb
+++ b/app/components/advanced_search/v1/condition_component.rb
@@ -62,9 +62,7 @@ module AdvancedSearch
       end
 
       def enum_operator_options
-        if Flipper.enabled?(:advanced_search_metadata_operators) &&
-           Flipper.enabled?(:advanced_search_disable_standard_operators_for_metadata_in_graphql) &&
-           selected_field.starts_with?('metadata')
+        if Flipper.enabled?(:advanced_search_metadata_operators) && selected_field.starts_with?('metadata')
           # flatten metadata operators to exclude optgroup labeling
           metadata_operators = @operations['metadata']
                                .values

--- a/app/components/advanced_search/v1/condition_component.rb
+++ b/app/components/advanced_search/v1/condition_component.rb
@@ -62,12 +62,14 @@ module AdvancedSearch
       end
 
       def enum_operator_options
-        if Flipper.enabled?(:advanced_search_metadata_operators) && selected_field.starts_with?('metadata')
+        if Flipper.enabled?(:advanced_search_metadata_operators) && selected_field.starts_with?('metadata.')
           # flatten metadata operators to exclude optgroup labeling
-          metadata_operators = @operations['metadata']
-                               .values
-                               .reduce({}, :merge)
-          metadata_operators.select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['metadata'].include?(value) }
+          flattened_metadata_operators = @operations['metadata']
+                                         .values
+                                         .reduce({}, :merge)
+          flattened_metadata_operators.select do |_, value|
+            AdvancedSearch::ENUM_OPERATOR_VALUES['metadata'].include?(value)
+          end
         else
           @operations['standard'].select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['standard'].include?(value) }
         end

--- a/app/components/advanced_search/v1/condition_component.rb
+++ b/app/components/advanced_search/v1/condition_component.rb
@@ -70,7 +70,6 @@ module AdvancedSearch
           metadata_operators.select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['metadata'].include?(value) }
         else
           @operations['standard'].select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['standard'].include?(value) }
-
         end
       end
 

--- a/app/components/advanced_search/v1/condition_component.rb
+++ b/app/components/advanced_search/v1/condition_component.rb
@@ -62,11 +62,24 @@ module AdvancedSearch
       end
 
       def enum_operator_options
-        @operations['standard'].select { |_, value| enum_operator_values.include?(value) }
+        if Flipper.enabled?(:advanced_search_metadata_operators) &&
+           Flipper.enabled?(:advanced_search_disable_standard_operators_for_metadata_in_graphql) &&
+           selected_field.starts_with?('metadata')
+          # flatten metadata operators to exclude optgroup labeling
+          metadata_operators = @operations['metadata']
+                               .values
+                               .reduce({}, :merge)
+          metadata_operators.select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['metadata'].include?(value) }
+        else
+          @operations['standard'].select { |_, value| AdvancedSearch::ENUM_OPERATOR_VALUES['standard'].include?(value) }
+
+        end
       end
 
-      def enum_operator_values
-        AdvancedSearch::ENUM_OPERATOR_VALUES
+      def field_options_for_select
+        options_for_select(field_options, @condition.field).concat(
+          grouped_options_for_select(grouped_field_options, @condition.field)
+        )
       end
 
       def enum_field_config

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -328,9 +328,22 @@ export default class AdvancedSearchController extends Controller {
     blankOption.value = "";
     blankOption.text = "";
     operator.appendChild(blankOption);
-
+    console.log(this.enumOperationsValue);
     if (this.#enumHasValues(enumConfig)) {
-      this.#createOperatorOptions(this.enumOperationsValue, operator);
+      if (
+        selectedField.startsWith("metadata.") &&
+        Object.hasOwn(this.operationsValue, "metadata")
+      ) {
+        this.#createOperatorOptions(
+          this.enumOperationsValue["metadata"],
+          operator,
+        );
+      } else {
+        this.#createOperatorOptions(
+          this.enumOperationsValue["standard"],
+          operator,
+        );
+      }
     } else if (
       selectedField.startsWith("metadata.") &&
       Object.hasOwn(this.operationsValue, "metadata")

--- a/app/javascript/controllers/advanced_search/v1_controller.js
+++ b/app/javascript/controllers/advanced_search/v1_controller.js
@@ -328,7 +328,7 @@ export default class AdvancedSearchController extends Controller {
     blankOption.value = "";
     blankOption.text = "";
     operator.appendChild(blankOption);
-    console.log(this.enumOperationsValue);
+
     if (this.#enumHasValues(enumConfig)) {
       if (
         selectedField.startsWith("metadata.") &&

--- a/app/models/advanced_search/fields.rb
+++ b/app/models/advanced_search/fields.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module AdvancedSearch
-  ENUM_OPERATOR_VALUES = %w[= != in not_in].freeze
+  ENUM_OPERATOR_VALUES = {
+    'metadata' => %w[text_equals text_not_equals text_in text_not_in],
+    'standard' => %w[= != in not_in]
+  }.freeze
 
   # Builds field option payloads for advanced-search UI rendering.
   class Fields

--- a/test/components/advanced_search_component_test.rb
+++ b/test/components/advanced_search_component_test.rb
@@ -451,4 +451,46 @@ class AdvancedSearchComponentTest < ApplicationSystemTestCase
   ensure
     Flipper.enable(:advanced_search_with_auto_complete)
   end
+
+  test 'standard and metadata operators based on enum field type' do
+    Flipper.enable(:advanced_search_metadata_operators)
+
+    visit('rails/view_components/advanced_search_component/workflow')
+    within 'div[data-controller-connected="true"]' do
+      click_button I18n.t(:'components.advanced_search_component.v1.title')
+
+      assert_selector 'dialog h1', text: I18n.t(:'components.advanced_search_component.v1.title')
+      within 'dialog' do
+        within all("fieldset[data-advanced-search--v1-target='groupsContainer']")[0] do
+          within all("fieldset[data-advanced-search--v1-target='conditionsContainer']")[0] do
+            find("input[id$='field']").send_keys([:ctrl, 'a'], :delete, 'state', :enter)
+            within "select[name$='[operator]']" do
+              assert_selector 'option[value="="]'
+              assert_selector 'option[value="!="]'
+              assert_selector 'option[value="in"]'
+              assert_selector 'option[value="not_in"]'
+              assert_no_selector 'option[value="text_equals"]'
+              assert_no_selector 'option[value="text_not_equals"]'
+              assert_no_selector 'option[value="text_in"]'
+              assert_no_selector 'option[value="text_not_in"]'
+            end
+
+            find("input[id$='field']").send_keys([:ctrl, 'a'], :delete, 'workflow name', :enter)
+            within "select[name$='[operator]']" do
+              assert_no_selector 'option[value="="]'
+              assert_no_selector 'option[value="!="]'
+              assert_no_selector 'option[value="in"]'
+              assert_no_selector 'option[value="not_in"]'
+              assert_selector 'option[value="text_equals"]'
+              assert_selector 'option[value="text_not_equals"]'
+              assert_selector 'option[value="text_in"]'
+              assert_selector 'option[value="text_not_in"]'
+            end
+          end
+        end
+      end
+    end
+  ensure
+    Flipper.disable(:advanced_search_metadata_operators)
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where once the metadata operator feature flags are enabled and metadata fields must use metadata operators, metadata enum fields (namely workflow name and ver) would error through the UI as they still utilized standard operators (=, !=, in, not_in)
Now, enum operators populate based on whether the selected field is standard or metadata.

## Screenshots or screen recordings

Before:

[Screencast from 2026-08-07 12-12-19.webm](https://github.com/user-attachments/assets/363b5286-0772-4962-88db-a74bf440a059)

Now:

[Screencast from 2026-08-07 12-13-41.webm](https://github.com/user-attachments/assets/77b22993-e84f-4e0a-a4b9-cc2c365c63e8)

## How to set up and validate locally
1. Enable feature flag `Flipper.enable(:advanced_search_metadata_operators)`
2. Navigate to a Workflow Executions page, and ensure you have some workflows to filter through.
3. Select a standard field that is not State, and verify the normal standard operators populate
4. First, select both `State` and `Workflow Name` fields and verify the enum operators populate (State should have `=, !=, in, not_in`, and workflow name should have `text_equals, text_not_equals, text_in, text_not_in`.)
5. Create a search for `State`  and verify the search filters as expected. Re-open the `Advanced Search` dialog, and verify the search conditions are populated as expected.
6. Repeat the above for `Workflow Name`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
