### PR TITLE
Bug: Fix sample attachment selection count after deletion through row action link

### DIFF
--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -121,7 +121,7 @@ module Projects
       end
 
       def destroy_status(attachment, count)
-        return count == 2 ? :ok : :multi_status if attachment.associated_attachment
+        return count == 2 ? :ok : :multi_status if attachment.metadata.key?('associated_attachment_id')
 
         count == 1 ? :ok : :unprocessable_content
       end

--- a/app/controllers/projects/samples/attachments_controller.rb
+++ b/app/controllers/projects/samples/attachments_controller.rb
@@ -3,7 +3,7 @@
 module Projects
   module Samples
     # Controller actions for Project Samples Attachments
-    class AttachmentsController < Projects::Samples::ApplicationController
+    class AttachmentsController < Projects::Samples::ApplicationController # rubocop:disable Metrics/ClassLength
       include SampleAttachment
 
       before_action :attachment, only: %i[destroy]
@@ -121,9 +121,18 @@ module Projects
       end
 
       def destroy_status(attachment, count)
-        return count == 2 ? :ok : :multi_status if attachment.metadata.key?('associated_attachment_id')
-
-        count == 1 ? :ok : :unprocessable_content
+        if attachment.metadata.key?('associated_attachment_id')
+          case count
+          when 2
+            :ok
+          when 1
+            :multi_status
+          when 0
+            :unprocessable_content
+          end
+        else
+          count == 1 ? :ok : :unprocessable_content
+        end
       end
     end
   end

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -163,17 +163,15 @@ export default class extends Controller {
     } else {
       newStorageValue = newStorageValue.filter((value) => {
         try {
+          // parse potential stringified array for PE attachments being deleted
           const parsed = JSON.parse(value);
 
-          // If it's a nested array, remove it if ANY value matches
+          // if PE attachment, it will be a nested array value where the entire array must be removed
           if (Array.isArray(parsed)) {
             return !parsed.some((item) => values.includes(item));
           }
-
-          // Otherwise, treat it as a normal string
-          return !values.includes(value);
         } catch {
-          // Not JSON, so treat it as a normal string
+          // else remove the single attachment string value
           return !values.includes(value);
         }
       });

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -162,18 +162,20 @@ export default class extends Controller {
       newStorageValue = [...new Set([...newStorageValue, ...values])];
     } else {
       newStorageValue = newStorageValue.filter((value) => {
+        // exact match (single checkbox toggle / select-page store the raw value)
+        if (values.includes(value)) return false;
+        let parsed;
         try {
-          // parse potential stringified array for PE attachments being deleted
-          const parsed = JSON.parse(value);
-
-          // if PE attachment, it will be a nested array value where the entire array must be removed
-          if (Array.isArray(parsed)) {
-            return !parsed.some((item) => values.includes(item));
-          }
+          parsed = JSON.parse(value);
         } catch {
-          // else remove the single attachment string value
-          return !values.includes(value);
+          return true; // plain id that wasn't targeted
         }
+        // contained-id match (row-action delete passes a single id that may be
+        // part of a stored paired-end "[fwd, rev]" value)
+        if (Array.isArray(parsed)) {
+          return !parsed.some((item) => values.includes(item));
+        }
+        return true;
       });
     }
     this.update(newStorageValue, true, options);

--- a/app/javascript/controllers/selection_controller.js
+++ b/app/javascript/controllers/selection_controller.js
@@ -161,9 +161,22 @@ export default class extends Controller {
       // Use a Set to deduplicate values
       newStorageValue = [...new Set([...newStorageValue, ...values])];
     } else {
-      newStorageValue = newStorageValue.filter(
-        (value) => !values.includes(value),
-      );
+      newStorageValue = newStorageValue.filter((value) => {
+        try {
+          const parsed = JSON.parse(value);
+
+          // If it's a nested array, remove it if ANY value matches
+          if (Array.isArray(parsed)) {
+            return !parsed.some((item) => values.includes(item));
+          }
+
+          // Otherwise, treat it as a normal string
+          return !values.includes(value);
+        } catch {
+          // Not JSON, so treat it as a normal string
+          return !values.includes(value);
+        }
+      });
     }
     this.update(newStorageValue, true, options);
   }
@@ -182,7 +195,6 @@ export default class extends Controller {
       this.rowSelectionTargets.forEach((row) => {
         row.checked = ids.indexOf(row.value) > -1;
       });
-
       this.#updateActionButtons(ids.length);
       this.#updateCounts(ids.length, announce);
       this.#setSelectPageCheckboxValue(

--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -761,6 +761,77 @@ module Projects
           assert_selector 'strong[data-selection-target="selected"]', text: '0'
         end
       end
+
+      test 'selecting and de-selecting attachments updates selection count' do
+        login_as users(:jeff_doe)
+        project = projects(:projectA)
+        sample = samples(:sampleC)
+        namespace = namespaces_user_namespaces(:jeff_doe_namespace)
+        pe_fwd_attachment = attachments(:attachmentPEFWD4)
+        non_pe_attachment = attachments(:attachmentG)
+
+        visit namespace_project_sample_url(namespace, project, sample)
+
+        # no attachments selected/checked
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 8
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 0
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 8"
+          assert_selector 'strong[data-selection-target="selected"]', text: '0'
+        end
+
+        assert_selector '#sample-attachments table #attachments-table-body tr', count: 8
+
+        check "checkbox_attachment_#{pe_fwd_attachment.id}"
+
+        # verify selection counts
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 8
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 1
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 8"
+          assert_selector 'strong[data-selection-target="selected"]', text: '1'
+        end
+
+        check "checkbox_attachment_#{non_pe_attachment.id}"
+
+        # verify selection counts
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 8
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 2
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 8"
+          assert_selector 'strong[data-selection-target="selected"]', text: '2'
+        end
+
+        uncheck "checkbox_attachment_#{pe_fwd_attachment.id}"
+
+        # verify selection counts
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 8
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 1
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 8"
+          assert_selector 'strong[data-selection-target="selected"]', text: '1'
+        end
+
+        uncheck "checkbox_attachment_#{non_pe_attachment.id}"
+
+        # verify selection counts
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 8
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 0
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 8"
+          assert_selector 'strong[data-selection-target="selected"]', text: '0'
+        end
+      end
     end
   end
 end

--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -685,6 +685,82 @@ module Projects
         assert_text I18n.t('projects.samples.attachments.table.empty_state.title')
         assert_text I18n.t('projects.samples.attachments.table.empty_state.description')
       end
+
+      test 'deleting by delete row action link selected pe and non-pe attachments updates selection count' do
+        login_as users(:jeff_doe)
+        project = projects(:projectA)
+        sample = samples(:sampleC)
+        namespace = namespaces_user_namespaces(:jeff_doe_namespace)
+        pe_fwd_attachment = attachments(:attachmentPEFWD4)
+        non_pe_attachment = attachments(:attachmentG)
+
+        visit namespace_project_sample_url(namespace, project, sample)
+
+        # no attachments selected/checked
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 8
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 0
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 8"
+          assert_selector 'strong[data-selection-target="selected"]', text: '0'
+        end
+
+        # select a pe and non-pe attachment
+        within '#sample-attachments' do
+          assert_selector 'table #attachments-table-body tr', count: 8
+          check "checkbox_attachment_#{pe_fwd_attachment.id}"
+          check "checkbox_attachment_#{non_pe_attachment.id}"
+        end
+
+        # verify selection counts
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 8
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 2
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 8"
+          assert_selector 'strong[data-selection-target="selected"]', text: '2'
+        end
+
+        # delete pe attachment
+        within "#attachment_#{pe_fwd_attachment.id}" do
+          click_button I18n.t('common.actions.delete')
+        end
+
+        within 'dialog' do
+          click_button I18n.t('common.controls.confirm')
+        end
+
+        # verify updated count
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 7
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 1
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 7"
+          assert_selector 'strong[data-selection-target="selected"]', text: '1'
+        end
+
+        # delete non pe attachment
+        within "#attachment_#{non_pe_attachment.id}" do
+          click_button I18n.t('common.actions.delete')
+        end
+
+        within 'dialog' do
+          click_button I18n.t('common.controls.confirm')
+        end
+
+        # verify updated attachment counts
+        within 'tbody' do
+          assert_selector 'input[name="attachment_ids[]"]', count: 6
+          assert_selector 'input[name="attachment_ids[]"]:checked', count: 0
+        end
+        within 'tfoot' do
+          assert_text "#{I18n.t('components.attachments.table_component.counts.attachments')}: 6"
+          assert_selector 'strong[data-selection-target="selected"]', text: '0'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes two bugs that were found when deleting attachments by the delete row action link.
1. Successful PE file deletion led to a `:multi_status` status, rather than to `:success`
2. Successful PE file deletion, when selected, did not update the selected count correctly.

## Screenshots or screen recordings
Before:

[Screencast from 2026-08-11 15-04-57.webm](https://github.com/user-attachments/assets/8d7ae43d-820e-4c36-a71b-64bb62d5ead4)

Now:

[Screencast from 2026-08-11 15-05-34.webm](https://github.com/user-attachments/assets/0db463a8-71a5-4361-8339-acd2b69d36e0)

## How to set up and validate locally
1. Navigate to sample attachments page, and upload some files, including PE files.
2. Select any number of attachments, and delete a selected PE file, and verify the selected count updates as expected
3. Repeat the above with a non-PE file, and using the `Delete Files` button, and verify the selected count updates as expected.
4. Test that selection counts still update correctly elsewhere in the application (like workflows and sample tables).

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
