### PR TITLE
Remove viral_* view helpers in favor of explicit component renders

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -10,7 +10,7 @@
 # Docs: https://herb-tools.dev/configuration
 # Linter: https://herb-tools.dev/projects/linter
 
-version: 0.10.2
+version: 0.10.3
 
 framework: actionview
 template_engine: erubi
@@ -65,8 +65,18 @@ linter:
       enabled: true
     erb-strict-locals-required:
       enabled: true
+      # Hint until partials are migrated off instance variables. Declaring
+      # locals without converting call sites would raise at render time.
+      severity: hint
+    erb-no-instance-variables-in-partials:
+      severity: hint
+    erb-no-duplicate-branch-elements:
+      severity: hint
+    html-no-underscores-in-attribute-names:
+      # Stimulus identifiers must match controller file names (underscores).
+      severity: hint
     erb-no-unused-expressions:
-      enabled: false
+      enabled: true
     html-navigation-has-label:
       enabled: true
     html-no-block-inside-inline:

--- a/app/components/activities/dialogs/activity_list_dialog_component.html.erb
+++ b/app/components/activities/dialogs/activity_list_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(title: @title) %>
 
   <div
@@ -6,7 +6,7 @@
     data-activities--extended-details-activity-type-value="<%= activity_type %>"
   >
     <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
-      <%= viral_pill(text: helpers.local_time(activity[:created_at]), color: :green) %>
+      <%= render Viral::PillComponent.new(text: helpers.local_time(activity[:created_at]), color: :green) %>
 
       <p class="mt-2 dark:text-slate-400">
         <%= @description %>

--- a/app/components/activities/dialogs/activity_table_listing_dialog_component.html.erb
+++ b/app/components/activities/dialogs/activity_table_listing_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :extra_large) do |dialog| %>
   <% dialog.with_header(title: @title) %>
 
   <div
@@ -7,7 +7,7 @@
     data-activities--extended-details-num-cols-value="<%= @column_headers.length %>"
   >
     <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">
-      <%= viral_pill(text: helpers.local_time(activity[:created_at]), color: :green) %>
+      <%= render Viral::PillComponent.new(text: helpers.local_time(activity[:created_at]), color: :green) %>
 
       <p class="mt-2 dark:text-slate-400">
         <%= @description %>

--- a/app/components/advanced_search/v1/component.html.erb
+++ b/app/components/advanced_search/v1/component.html.erb
@@ -13,7 +13,7 @@
     "advanced-search--v1-operations-value": json_escape_data(operation_options),
   },
 ) do %>
-  <%= viral_dialog(id: 'advanced-search-dialog', size: :large, open: @open) do |dialog| %>
+  <%= render Viral::DialogComponent.new(id: 'advanced-search-dialog', size: :large, open: @open) do |dialog| %>
     <% dialog.with_trigger do %>
       <div class="flex w-full grow flex-row rounded-lg" role="group">
         <button
@@ -61,7 +61,7 @@
       <div class="space-y-4" data-advanced-search--v1-target="searchGroupsContainer"></div>
 
       <div class="flex justify-end space-x-2">
-        <%= viral_button(data: { action: "advanced-search--v1#addGroup" }) do %>
+        <%= render Viral::ButtonComponent.new(data: { action: "advanced-search--v1#addGroup" }) do %>
           <%= t("components.advanced_search_component.v1.add_group_button") %>
         <% end %>
       </div>
@@ -86,7 +86,7 @@
     ) { t("components.advanced_search_component.v1.apply_filter_button") } %>
 
     <% dialog.with_secondary_action do %>
-      <%= viral_button(data: { action: "advanced-search--v1#clearForm viral--dialog#close filters#submit" }) do %>
+      <%= render Viral::ButtonComponent.new(data: { action: "advanced-search--v1#clearForm viral--dialog#close filters#submit" }) do %>
         <%= t("components.advanced_search_component.v1.clear_filter_button") %>
       <% end %>
     <% end %>

--- a/app/components/advanced_search/v1/group_component.html.erb
+++ b/app/components/advanced_search/v1/group_component.html.erb
@@ -24,11 +24,11 @@
   <% end %>
 
   <div class="my-4 flex justify-end">
-    <%= viral_button(data: { action: "advanced-search--v1#addCondition" }) do %>
+    <%= render Viral::ButtonComponent.new(data: { action: "advanced-search--v1#addCondition" }) do %>
       <%= t("components.advanced_search_component.v1.add_condition_button") %>
     <% end %>
 
-    <%= viral_button(classes: class_names("ml-2", "hidden": !@show_remove_group_button), data: { action: "advanced-search--v1#removeGroup" }) do %>
+    <%= render Viral::ButtonComponent.new(classes: class_names("ml-2", "hidden": !@show_remove_group_button), data: { action: "advanced-search--v1#removeGroup" }) do %>
       <%= t("components.advanced_search_component.v1.remove_group_button") %>
     <% end %>
   </div>

--- a/app/components/attachments/dialogs/delete_attachment_component.html.erb
+++ b/app/components/attachments/dialogs/delete_attachment_component.html.erb
@@ -1,14 +1,11 @@
-<%= viral_dialog(open: @open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: @open, size: :large) do |dialog| %>
   <% dialog.with_header(
     title: t("components.attachments.dialogs.delete_attachment_component.title"),
   ) %>
+
   <%= helpers.turbo_frame_tag("deletion-alert") %>
 
-  <div
-    class="
-      mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
-    "
-  >
+  <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4">
       <% if @attachment.associated_attachment %>
         <%= t(
@@ -25,6 +22,7 @@
         ) %>
       <% end %>
     </p>
+
     <%= form_for(:deletion, url: destroy_path, method: :delete) do |form| %>
       <%= form.submit t(
                     "components.attachments.dialogs.delete_attachment_component.submit_button",

--- a/app/components/attachments/dialogs/new_attachment_component.html.erb
+++ b/app/components/attachments/dialogs/new_attachment_component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: @open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: @open) do |dialog| %>
   <% dialog.with_header(
     title:
       t("components.attachments.dialogs.new_attachment_component.upload_files"),
@@ -16,7 +16,7 @@
       data-attachment-upload-error-fallback-text-value="<%= t('common.upload.failed') %>"
       data-attachment-upload-fastq-pairing-patterns-value="<%= helpers.attachment_upload_fastq_pairing_data_attributes[:attachment_upload_fastq_pairing_patterns_value].to_json %>"
     >
-      <%= viral_alert(
+      <%= render Viral::AlertComponent.new(
         message: t("common.upload.upload_failed_retry"),
         type: :danger,
         data: { "attachment-upload-target": "uploadErrorAlert" },
@@ -24,7 +24,7 @@
         aria: { live: "assertive", role: "alert" }
       ) %>
 
-      <%= viral_alert(
+      <%= render Viral::AlertComponent.new(
         message: t("common.upload.form_submit_failed"),
         type: :danger,
         data: { "attachment-upload-target": "formErrorAlert" },
@@ -59,7 +59,7 @@
                         class:
                           "block w-full mb-5 text-xs text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 disabled:opacity-50 disabled:cursor-not-allowed" %>
 
-        <%= viral_alert(message: t('components.attachments.dialogs.new_attachment_component.files_ignored'), type: :alert, data: { "file-upload-target": "alert" }, classes: "hidden", aria: {
+        <%= render Viral::AlertComponent.new(message: t('components.attachments.dialogs.new_attachment_component.files_ignored'), type: :alert, data: { "file-upload-target": "alert" }, classes: "hidden", aria: {
             live: "assertive",
           }) do %>
           <ul class="mt-4 max-w-md list-inside list-disc space-y-1" data-file-upload-target="error"></ul>

--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -230,7 +230,7 @@
                         <% end %>
                       </div>
                     <% elsif column == :format || column == :type %>
-                      <%= viral_pill(
+                      <%= render Viral::PillComponent.new(
                         text: attachment.metadata[column.to_s],
                         color: helpers.find_pill_color_for_attachment(attachment, column.to_s),
                       ) %>
@@ -337,5 +337,5 @@
     ) %>
   <% end %>
 <% else %>
-  <div class="empty_state_message"><%= viral_empty(**@empty) %></div>
+  <div class="empty_state_message"><%= render Viral::EmptyStateComponent.new(**@empty) %></div>
 <% end %>

--- a/app/components/bots/table_component.html.erb
+++ b/app/components/bots/table_component.html.erb
@@ -1,6 +1,6 @@
 <%= helpers.turbo_frame_tag "bots-table-section" do %>
   <% if @bot_accounts.count.positive? %>
-    <%= viral_data_table(@bot_accounts, id: "bots-table") do |table| %>
+    <%= render Viral::DataTableComponent.new(@bot_accounts, id: "bots-table") do |table| %>
       <% table.with_column(t("bots.index.table.header.username")) do |row| %>
         <%= row.user.email %>
       <% end %>
@@ -102,7 +102,7 @@
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: t("bots.index.pagy_item")) %>
   <% else %>
     <div class="empty_state_message">
-      <%= viral_empty(
+      <%= render Viral::EmptyStateComponent.new(
       title: t("bots.index.table.empty_state.title"),
       description: t("bots.index.table.empty_state.description"),
       icon_name: NamespaceBot.icon,

--- a/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
+++ b/app/components/data_exports/linelist_export_dialog/v2/component.html.erb
@@ -15,7 +15,7 @@
   "linelist-export-created-records-message-value": t("data_exports.new_linelist_export_dialog.created_records")
 } %>
 
-<%= viral_dialog(open: @open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: @open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("data_exports.new_linelist_export_dialog.title")) %>
 
   <%= tag.div class: "font-normal text-slate-500 dark:text-slate-400", data: linelist_data do %>

--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -64,9 +64,9 @@
                 <% status_text = t("common.statuses.#{data_export.status}").upcase %>
 
                 <% if data_export.status == 'ready' %>
-                  <%= viral_pill(text: status_text, color: :green) %>
+                  <%= render Viral::PillComponent.new(text: status_text, color: :green) %>
                 <% else %>
-                  <%= viral_pill(text: status_text, color: :slate) %>
+                  <%= render Viral::PillComponent.new(text: status_text, color: :slate) %>
                 <% end %>
               </td>
 
@@ -139,7 +139,7 @@
   <% end %>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: @empty[:title],
       description: @empty[:description],
       icon_name: DataExport.icon,

--- a/app/components/data_imports/linelist_import_dialog/v2/component.html.erb
+++ b/app/components/data_imports/linelist_import_dialog/v2/component.html.erb
@@ -18,7 +18,7 @@
   "linelist-import-error-message-value": t(".error_message"),
 } %>
 
-<%= viral_dialog(open: true, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("shared.samples.metadata.file_imports.dialog.title")) %>
   <%= helpers.turbo_stream_from @broadcast_target %>
 
@@ -34,14 +34,14 @@
       <% end %>
 
       <template data-linelist-import-target="flashTemplate">
-        <%= viral_flash(
+        <%= render Viral::FlashComponent.new(
         type: :success,
         data: t("shared.samples.metadata.file_imports.success.description"),
       ) %>
       </template>
 
       <template data-linelist-import-target="alertTemplate">
-        <%= viral_alert(
+        <%= render Viral::AlertComponent.new(
                 type: :danger,
                 message: "PLACEHOLDER",
                 classes: class_names("mb-4"),
@@ -50,7 +50,7 @@
       </template>
 
       <template data-linelist-import-target="dialogTemplate">
-        <%= viral_dialog(
+        <%= render Viral::DialogComponent.new(
           size: :large,
           open: false,
           closable: false,
@@ -63,7 +63,7 @@
             <div id="error-messages"></div>
 
             <div>
-              <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+              <%= render Viral::ButtonComponent.new(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
                 <%= t("shared.samples.metadata.file_imports.errors.ok_button") %>
               <% end %>
             </div>

--- a/app/components/form_error_summary_component.html.erb
+++ b/app/components/form_error_summary_component.html.erb
@@ -1,4 +1,4 @@
-<%= viral_alert(**alert_system_arguments) do %>
+<%= render Viral::AlertComponent.new(**alert_system_arguments) do %>
   <div class="outline-hidden" data-controller="form-error-summary" tabindex="-1">
     <h2 id="<%= heading_id %>" class="text-sm font-semibold">
       <%= title_text %>

--- a/app/components/groups/table_component.html.erb
+++ b/app/components/groups/table_component.html.erb
@@ -43,7 +43,7 @@
 
             <td class="px-6 py-4">
               <% if namespace_group_link_source.key?(:inherited_namespace_path) %>
-                <%= pathogen_link(href: namespace_group_link_source[:inherited_namespace_path], data: {
+                <%= render Pathogen::Link.new(href: namespace_group_link_source[:inherited_namespace_path], data: {
                   turbo_frame: "_top",
                 }) do |component| %>
                   <% component.with_tooltip(text: t(:"projects.group_links.index.inherited_from")) %>
@@ -122,7 +122,7 @@
   <% end %>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: t(:"#{@namespace.type.downcase}s.group_links.index.empty_state.title"),
       description:
         t(

--- a/app/components/history_component.html.erb
+++ b/app/components/history_component.html.erb
@@ -29,7 +29,7 @@
           <% end %>
 
           <% if index == 0 %>
-            <%= viral_pill(
+            <%= render Viral::PillComponent.new(
               text: t(:"components.history.latest"),
               color: :green,
               classes: "ml-2",

--- a/app/components/layout/sidebar/item_component.html.erb
+++ b/app/components/layout/sidebar/item_component.html.erb
@@ -19,20 +19,20 @@
     ) do %>
       <% if avatar %>
         <span class="rounded-lg bg-white">
-          <%= viral_avatar(name: label, colour_string: "#{label}-#{url}", size: :xs) %>
+          <%= render Viral::AvatarComponent.new(name: label, colour_string: "#{label}-#{url}", size: :xs) %>
         </span>
       <% else %>
         <%= create_icon %>
       <% end %>
     <% end %>
 
-    <span class="line-clamp-2 text-sm font-medium transition-opacity duration-200 ease-in-out" title="<%= label %>">
+    <div class="line-clamp-2 text-sm font-medium transition-opacity duration-200 ease-in-out">
       <% if avatar %>
         <turbo-frame id="namespace_name"><%= label %></turbo-frame>
       <% else %>
         <%= label %>
       <% end %>
-    </span>
+    </div>
 
     <% if defined?(badge) && badge.present? %>
       <span

--- a/app/components/layout_component.html.erb
+++ b/app/components/layout_component.html.erb
@@ -105,7 +105,7 @@
 
       <div id="flashes" class="fixed top-5 right-6 z-50 flex flex-col">
         <% flash.each do |key, value| %>
-          <%= viral_flash(type: key, data: value) %>
+          <%= render Viral::FlashComponent.new(type: key, data: value) %>
         <% end %>
       </div>
 

--- a/app/components/list_input_component.html.erb
+++ b/app/components/list_input_component.html.erb
@@ -1,5 +1,5 @@
 <template data-list-input-target="template">
-  <%= viral_pill(color: :blue, classes: "search-tag inline-flex items-center filter-item mb-1 mr-1 py-1.5", style: "content-visibility: auto;") do %>
+  <%= render Viral::PillComponent.new(color: :blue, classes: "search-tag inline-flex items-center filter-item mb-1 mr-1 py-1.5", style: "content-visibility: auto;") do %>
     <input type="hidden" data-turbo-temporary name="<%= list_input_form_name %>">
     <span class="label mr-1 font-mono text-sm font-semibold"></span>
 
@@ -20,7 +20,7 @@
 <div class="space-y-4">
   <% if @show_description %>
     <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
-      <%= raw t(:"components.list_input.description") %>
+      <%= sanitize t(:"components.list_input.description"), tags: %w[kbd] %>
     </p>
   <% end %>
 
@@ -44,7 +44,6 @@
         "
         data-action="click->list-input#clear"
         aria-label="<%= t(:'components.list_input.clear') %>"
-        title="<%= t(:'components.list_input.clear') %>"
       >
         <%= icon(:x, size: :sm) %>
       </button>

--- a/app/components/members/table_component.html.erb
+++ b/app/components/members/table_component.html.erb
@@ -51,7 +51,7 @@
                 <%= member.user.email %>
 
                 <% if @current_user == member.user %>
-                  <%= viral_pill(
+                  <%= render Viral::PillComponent.new(
                     text: t("activerecord.models.member.its_you"),
                     color: :green,
                     border: :green,
@@ -59,7 +59,7 @@
                   ) %>
                 <% else %>
                   <% if !member.user.human? %>
-                    <%= viral_pill(
+                    <%= render Viral::PillComponent.new(
                       text: t("activerecord.models.member.bot"),
                       color: :transparent,
                       border: :true,
@@ -78,7 +78,7 @@
               <% if !member_source.key?(:inherited_namespace_path) %>
                 <div class="text-sm font-normal text-slate-500 dark:text-slate-400"><%= member_source[:label] %></div>
               <% else %>
-                <%= pathogen_link(href: member_source[:inherited_namespace_path], data: {
+                <%= render Pathogen::Link.new(href: member_source[:inherited_namespace_path], data: {
                   turbo_frame: "_top",
                 }) do |component| %>
                   <% component.with_tooltip(text: t(".inherited_from")) %>
@@ -145,7 +145,7 @@ member.access_level <= @access_levels.values.last) && !member_source.key?(:inher
   <% end %>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: t(:"#{@namespace.type.downcase}s.members.index.empty_state.title"),
       description:
         t(:"#{@namespace.type.downcase}s.members.index.empty_state.description"),

--- a/app/components/metadata_templates/table_component.html.erb
+++ b/app/components/metadata_templates/table_component.html.erb
@@ -52,7 +52,7 @@
     </table>
   <% else %>
     <div class="empty_state_message">
-      <%= viral_empty(
+      <%= render Viral::EmptyStateComponent.new(
         title:
           t(
             :"metadata_templates.table.empty.title",

--- a/app/components/namespace_row/contents_component.html.erb
+++ b/app/components/namespace_row/contents_component.html.erb
@@ -1,7 +1,7 @@
 <span class="mt-3 mr-2 inline-block h-8 shrink-0"><%= avatar_icon %></span>
 
 <div class="flex grow flex-wrap place-content-start items-center gap-2">
-  <%= viral_avatar(
+  <%= render Viral::AvatarComponent.new(
     name: @namespace.name,
     size: @icon_size,
     colour_string: "#{@namespace.name}-#{@namespace.id}",
@@ -28,7 +28,7 @@
   <%= render PuidComponent.new(puid: @namespace.puid) %>
 
   <div class="grow">
-    <%= viral_pill(
+    <%= render Viral::PillComponent.new(
       text:
         t(
           :"members.access_levels.level_#{Member.effective_access_level(@namespace, Current.user)}",
@@ -41,7 +41,7 @@
   <div class="mr-2 ml-auto flex flex-col items-end">
     <div class="flex flex-row flex-wrap gap-2 text-slate-500 dark:text-slate-400">
       <% if @namespace.group_namespace? %>
-        <%= pathogen_link(href: namespace_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.subnamespaces.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= render Pathogen::Link.new(href: namespace_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.subnamespaces.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -61,7 +61,7 @@
             <%= @namespace.children.count %>
           </span>
         <% end %>
-        <%= pathogen_link(href: namespace_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.projects.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= render Pathogen::Link.new(href: namespace_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.projects.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -81,7 +81,7 @@
             <%= @namespace.project_namespaces.count %>
           </span>
         <% end %>
-        <%= pathogen_link(href: helpers.group_samples_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= render Pathogen::Link.new(href: helpers.group_samples_path(@namespace), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -93,7 +93,7 @@
           tag: :div,
         ) %>
 
-          <span id="<%= "#{dom_id(@namespace)}-samples-count" %>" class="<%= count_pill_classes(:samples) %>">
+          <span id="<%= dom_id(@namespace) %>-samples-count" class="<%= count_pill_classes(:samples) %>">
             <%= icon Sample.icon,
           size: :sm,
           class: "mr-0.5 text-blue-700 dark:text-blue-200" %>
@@ -104,7 +104,7 @@
       <% end %>
 
       <% if @namespace.project_namespace? %>
-        <%= pathogen_link(href: helpers.namespace_project_samples_path(@namespace.parent, @namespace.project), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
+        <%= render Pathogen::Link.new(href: helpers.namespace_project_samples_path(@namespace.parent, @namespace.project), data: top_frame_link_data, 'aria-label': t(:"components.namespace_row.contents_component.samples.aria-label", namespace_type: @namespace.model_name.human.downcase, namespace_puid: @namespace.puid), class: "group pill-focus-reset") do |component| %>
           <% component.with_tooltip(
           text:
             t(
@@ -116,7 +116,7 @@
           tag: :div,
         ) %>
 
-          <span id="<%= "#{dom_id(@namespace.project)}-samples-count" %>" class="<%= count_pill_classes(:samples) %>">
+          <span id="<%= dom_id(@namespace.project) %>-samples-count" class="<%= count_pill_classes(:samples) %>">
             <%= icon Sample.icon,
           size: :sm,
           class: "mr-0.5 text-blue-700 dark:text-blue-200" %>

--- a/app/components/nextflow/shared/workflow_param_property_component.html.erb
+++ b/app/components/nextflow/shared/workflow_param_property_component.html.erb
@@ -1,10 +1,10 @@
 <div>
-  <% help_text_id = fields.field_id(name, "help") %>
+  <% help_text_id = fields.field_id(name, "help") %> <%# herb:disable actionview-no-silent-helper %>
 
   <% if property[:type] != "boolean" %>
     <% if (property[:format] == "path" || property[:format] == "file-path") && !property[:enum].present? %>
-      <% legend_id = fields.field_id(name, "legend") %>
-      <% prefix_id = fields.field_id(name, "prefix") %>
+      <% legend_id = fields.field_id(name, "legend") %> <%# herb:disable actionview-no-silent-helper %>
+      <% prefix_id = fields.field_id(name, "prefix") %> <%# herb:disable actionview-no-silent-helper %>
       <% describedby_ids = [prefix_id] %>
       <% describedby_ids << help_text_id if property[:help_text].present? %>
       <fieldset class="m-0 border-0 p-0">
@@ -12,7 +12,7 @@
           <%= property[:description] %>
 
           <% if property[:required] %>
-            <%= viral_pill(text: t(:"components.nextflow.required"), color: :primary) %>
+            <%= render Viral::PillComponent.new(text: t(:"components.nextflow.required"), color: :primary) %>
           <% end %>
         </legend>
       </fieldset>
@@ -65,14 +65,14 @@
         <%= property[:description] %>
 
         <% if property[:required] %>
-          <%= viral_pill(text: t(:"components.nextflow.required"), color: :primary) %>
+          <%= render Viral::PillComponent.new(text: t(:"components.nextflow.required"), color: :primary) %>
         <% end %>
       <% end %>
       <%= form_input(fields, name, property, property[:required], instance) %>
     <% end %>
   <% else %>
     <% value = instance.present? ? instance["workflow_params"][name.to_s] : property[:default] %>
-    <%= viral_prefixed_boolean(form: fields, name:, value: ActiveModel::Type::Boolean.new.cast(value)) do |input| %>
+    <%= render Viral::Form::Prefixed::BooleanComponent.new(form: fields, name:, value: ActiveModel::Type::Boolean.new.cast(value)) do |input| %>
       <%= input.with_prefix do %>
         <%= format_name_as_arg(name) %>
       <% end %>
@@ -81,14 +81,14 @@
         <%= property[:description] %>
 
         <% if property[:required] %>
-          <%= viral_pill(text: t(:"components.nextflow.required"), color: :primary) %>
+          <%= render Viral::PillComponent.new(text: t(:"components.nextflow.required"), color: :primary) %>
         <% end %>
       <% end %>
     <% end %>
   <% end %>
 
   <% if property[:help_text].present? %>
-    <%= viral_help_text(id: help_text_id) do %>
+    <%= render Viral::Form::HelpTextComponent.new(id: help_text_id) do %>
       <%= property[:help_text] %>
     <% end %>
   <% end %>

--- a/app/components/nextflow/v1/component.html.erb
+++ b/app/components/nextflow/v1/component.html.erb
@@ -68,7 +68,7 @@
                                 "bg-slate-50 border border-slate-300 text-slate-900 text-sm rounded-lg block w-full p-2.5  dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white" %>
 
           <div id="workflow_execution_name_error" class="mt-2 text-sm">
-            <%= viral_help_text(state: :error, classes: "hidden") %>
+            <%= render Viral::Form::HelpTextComponent.new(state: :error, classes: "hidden") %>
           </div>
 
           <p

--- a/app/components/nextflow/v2/component.html.erb
+++ b/app/components/nextflow/v2/component.html.erb
@@ -64,7 +64,7 @@
                                 "bg-slate-50 border border-slate-300 text-slate-900 text-sm rounded-lg block w-full p-2.5  dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white" %>
 
           <div id="workflow_execution_name_error" class="mt-2 text-sm">
-            <%= viral_help_text(state: :error, classes: "hidden") %>
+            <%= render Viral::Form::HelpTextComponent.new(state: :error, classes: "hidden") %>
           </div>
 
           <p id="<%= form.field_id("workflow_execution_name", "hint") %>" class="field-hint">
@@ -90,7 +90,7 @@
               <% if item == :input_output_options && property[:format] == "file-path" %>
                 <% unless @automated_workflow %>
                   <div id="samplesheet_message" data-nextflow--v2--samplesheet-target="samplesheetMessagesContainer">
-                    <%= viral_alert(
+                    <%= render Viral::AlertComponent.new(
                       message:
                         t(
                           "components.nextflow_component.loading_samplesheet",
@@ -252,6 +252,7 @@
       <%= form_with(
       url: helpers.samplesheet_workflow_executions_submissions_path,
     ) do |f| %>
+        <!-- Samplesheet params form is cloned client-side. -->
       <% end %>
     </template>
   <% end %>
@@ -259,7 +260,7 @@
   <div class="sr-only" aria-live="assertive" data-nextflow--v2--samplesheet-target="ariaLive"></div>
 
   <template data-nextflow--v2--samplesheet-target="samplesheetReadyTemplate">
-    <%= viral_alert(
+    <%= render Viral::AlertComponent.new(
       type: "success",
       message:
         t(

--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -1,12 +1,12 @@
 <% if @personal_access_tokens.size.positive? %>
-  <%= viral_data_table(@personal_access_tokens, id: "access-tokens-table") do |table| %>
+  <%= render Viral::DataTableComponent.new(@personal_access_tokens, id: "access-tokens-table") do |table| %>
     <% table.with_column(t("personal_access_tokens.table.header.name")) do |row| %>
       <%= row[:name] %>
     <% end %>
 
     <% table.with_column(t("personal_access_tokens.table.header.status")) do |row| %>
       <% row_status = row_token_status(row) %>
-      <%= viral_pill(color: row_status[:color], text: row_status[:text], classes: "token-status") %>
+      <%= render Viral::PillComponent.new(color: row_status[:color], text: row_status[:text], classes: "token-status") %>
     <% end %>
 
     <% table.with_column(t("personal_access_tokens.table.header.scopes")) do |row| %>
@@ -87,7 +87,7 @@
   <% end %>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: @empty[:title],
       description: @empty[:description],
       icon_name: PersonalAccessToken.icon,

--- a/app/components/samples/table/v1/component.html.erb
+++ b/app/components/samples/table/v1/component.html.erb
@@ -1,7 +1,7 @@
 <% if @has_samples %>
   <% if @show_metadata_fields_size_warning %>
     <div class="mb-4" role="status" aria-live="polite">
-      <%= viral_alert do %>
+      <%= render Viral::AlertComponent.new do %>
         <span class="inline"><%= @metadata_fields_size_warning_message %></span>
       <% end %>
     </div>
@@ -209,37 +209,37 @@
       </template>
       <div id="editable-cell-form-container" class="invisible" data-editable-cell-target="formContainer"></div>
       <template data-editable-cell-target="confirmDialogTemplate">
-        <%= viral_dialog(open: false) do |dialog| %>
+        <%= render Viral::DialogComponent.new(open: false) do |dialog| %>
           <% dialog.with_header(
             title: t("shared.samples.metadata.editing_field_cell.dialog.title"),
           ) %>
 
           <p class="text-base leading-8 text-wrap text-slate-900 dark:text-white">
             <span data-message-type="wov" class="hidden">
-              <%= raw t(
+              <%= sanitize t(
                 "shared.samples.metadata.editing_field_cell.dialog.description_with_new_value.with_original_value",
-              ) %>
+              ), tags: %w[kbd span], attributes: %w[class] %>
             </span>
 
             <span data-message-type="woov" class="hidden">
-              <%= raw t(
+              <%= sanitize t(
                 "shared.samples.metadata.editing_field_cell.dialog.description_with_new_value.without_original_value",
-              ) %>
+              ), tags: %w[kbd span], attributes: %w[class] %>
             </span>
 
             <span data-message-type="wonv" class="hidden">
-              <%= raw t(
+              <%= sanitize t(
                 "shared.samples.metadata.editing_field_cell.dialog.description_without_new_value",
-              ) %>
+              ), tags: %w[kbd span], attributes: %w[class] %>
             </span>
           </p>
 
           <% dialog.with_secondary_action do %>
-            <%= viral_button(value: "confirm", state: :primary) do
+            <%= render Viral::ButtonComponent.new(value: "confirm", state: :primary) do
               t("shared.samples.metadata.editing_field_cell.dialog.confirm_button")
             end %>
 
-            <%= viral_button(value: "cancel", state: :default) do
+            <%= render Viral::ButtonComponent.new(value: "cancel", state: :default) do
               t("shared.samples.metadata.editing_field_cell.dialog.discard_button")
             end %>
           <% end %>
@@ -250,7 +250,7 @@
   <% end %>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: @empty[:title],
       description: @empty[:description],
       icon_name: Sample.icon,

--- a/app/components/samples/table/v2/component.html.erb
+++ b/app/components/samples/table/v2/component.html.erb
@@ -1,6 +1,6 @@
 <% if empty_state? %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: @empty[:title],
       description: @empty[:description],
       icon_name: Sample.icon,

--- a/app/components/viral/form/file_input_component.html.erb
+++ b/app/components/viral/form/file_input_component.html.erb
@@ -1,13 +1,9 @@
 <%= render Viral::BaseComponent.new(tag: 'div', classes: class_names('hidden': hidden)) do %>
-  <label
-    for="<%= @name %>"
-    class="block mb-2 text-sm font-medium text-slate-900 dark:text-white"
-  >
-    <%= label %>
-  </label>
+  <label for="<%= @name %>" class="mb-2 block text-sm font-medium text-slate-900 dark:text-white"><%= label %></label>
   <%= file_field_tag @name, **system_arguments %>
+
   <% if help_text.present? %>
-    <%= viral_help_text do %>
+    <%= render Viral::Form::HelpTextComponent.new do %>
       <%= help_text %>
     <% end %>
   <% end %>

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -141,7 +141,7 @@
                         ) %>
                       <% end %>
                     <% elsif column == :state %>
-                      <%= viral_pill(
+                      <%= render Viral::PillComponent.new(
                         text: t(:"workflow_executions.state.#{workflow_execution[column]}"),
                         color: helpers.find_pill_color_for_state(workflow_execution[column]),
                         border: true,
@@ -282,7 +282,7 @@
   <% end %>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: @empty[:title],
       description: @empty[:description],
       icon_name: WorkflowExecution.icon,

--- a/app/helpers/nextflow_helper.rb
+++ b/app/helpers/nextflow_helper.rb
@@ -2,12 +2,12 @@
 
 # Helper to render a Nextflow pipeline form
 module NextflowHelper
-  def form_input(container, name, property, required, instance) # rubocop:disable Metrics/MethodLength
+  def form_input(container, name, property, required, instance) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
     value = instance.present? ? instance['workflow_params'][name.to_s] : property[:default]
 
     if property[:enum].present?
-      return viral_prefixed_select(form: container, name:, options: property[:enum],
-                                   selected_value: value) do |select|
+      return render(Viral::Form::Prefixed::SelectComponent.new(form: container, name:, options: property[:enum],
+                                                               selected_value: value)) do |select|
                select.with_prefix do
                  format_name_as_arg(name)
                end
@@ -16,8 +16,8 @@ module NextflowHelper
 
     data = { 'metadata-header-name': name.to_s.remove('_header') } if metadata_header?(name.to_s)
 
-    viral_prefixed_text_input(form: container, name:, required:, pattern: property[:pattern],
-                              value:, data:) do |input|
+    render(Viral::Form::Prefixed::TextInputComponent.new(form: container, name:, required:, pattern: property[:pattern],
+                                                         value:, data:)) do |input|
       input.with_prefix do
         format_name_as_arg(name)
       end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -2,34 +2,6 @@
 
 # ViewHelper for user interface components
 module ViewHelper
-  VIRAL_HELPERS = {
-    alert: 'Viral::AlertComponent',
-    avatar: 'Viral::AvatarComponent',
-    button: 'Viral::ButtonComponent',
-    card: 'Viral::CardComponent',
-    dialog: 'Viral::DialogComponent',
-    empty: 'Viral::EmptyStateComponent',
-    data_table: 'Viral::DataTableComponent',
-    file_input: 'Viral::Form::FileInputComponent',
-    flash: 'Viral::FlashComponent',
-    help_text: 'Viral::Form::HelpTextComponent',
-    icon: 'Viral::IconComponent',
-    pageheader: 'Viral::PageHeaderComponent',
-    prefixed_boolean: 'Viral::Form::Prefixed::BooleanComponent',
-    prefixed_select: 'Viral::Form::Prefixed::SelectComponent',
-    prefixed_text_input: 'Viral::Form::Prefixed::TextInputComponent',
-    pill: 'Viral::PillComponent',
-    select: 'Viral::Form::SelectComponent',
-    text_input: 'Viral::Form::TextInputComponent',
-    tooltip: 'Viral::TooltipComponent'
-  }.freeze
-
-  VIRAL_HELPERS.each do |name, component|
-    define_method "viral_#{name}" do |*args, **kwargs, &block|
-      render component.constantize.new(*args, **kwargs), &block
-    end
-  end
-
   def combobox_datepicker(*, **, &)
     render(ComboboxDatepickerComponent.new(*, **), &)
   end

--- a/app/views/dashboard/groups/index.html.erb
+++ b/app/views/dashboard/groups/index.html.erb
@@ -55,7 +55,7 @@
       <% if @pagy.count.positive? %>
         <div class="flex flex-row-reverse"><%= render Viral::Pagy::PaginationComponent.new(@pagy) %></div>
       <% else %>
-        <%= viral_empty(
+        <%= render Viral::EmptyStateComponent.new(
           icon_name: :magnifying_glass,
           title: t("components.viral.pagy.empty_state.title"),
           description: t("components.viral.pagy.empty_state.description"),
@@ -64,7 +64,7 @@
     </div>
   <% else %>
     <div class="empty_state_message">
-      <%= viral_empty(
+      <%= render Viral::EmptyStateComponent.new(
         icon_name: Group.icon,
         title: t(".no_groups_title"),
         description: t(".no_groups_description"),

--- a/app/views/dashboard/projects/_projects_list.html.erb
+++ b/app/views/dashboard/projects/_projects_list.html.erb
@@ -50,7 +50,7 @@
         item: t("dashboard.projects.index.pagy_item"),
       ) %>
     <% else %>
-      <%= viral_empty(
+      <%= render Viral::EmptyStateComponent.new(
         icon_name: :magnifying_glass,
         title: t("components.viral.pagy.empty_state.title"),
         description: t("components.viral.pagy.empty_state.description"),
@@ -59,7 +59,7 @@
   </div>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       icon_name: Project.icon,
       title: t("dashboard.projects.index.no_projects"),
       description: t("dashboard.projects.index.no_projects_description"),

--- a/app/views/data_exports/_new_analysis_export_dialog.html.erb
+++ b/app/views/data_exports/_new_analysis_export_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
 
   <div
@@ -19,7 +19,7 @@
 
     <div class="grid gap-4">
       <div data-controller="collapsible">
-        <h2 id="<%= "accordion-collapse-heading-workflows" %>">
+        <h2 id="accordion-collapse-heading-workflows">
           <button
             type="button"
             class="
@@ -43,10 +43,10 @@
 
         <div
           data-collapsible-target="item"
-          id="<%= "accordion-collapse-body-workflows" %>"
+          id="accordion-collapse-body-workflows"
           class="hidden"
           role="region"
-          aria-labelledby="<%= "accordion-collapse-heading-workflows" %>"
+          aria-labelledby="accordion-collapse-heading-workflows"
         >
           <div class="border border-t-0 border-slate-200 p-2.5 text-base leading-relaxed dark:border-slate-700">
             <span data-infinite-scroll-target="summary">

--- a/app/views/data_exports/_new_linelist_export_dialog.html.erb
+++ b/app/views/data_exports/_new_linelist_export_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
 
   <%= turbo_frame_tag "sample_export_dialog_content" do %>
@@ -25,7 +25,7 @@
 
       <div class="grid gap-4">
         <div data-controller="collapsible">
-          <h2 id="<%= "accordion-collapse-heading-samples" %>">
+          <h2 id="accordion-collapse-heading-samples">
             <button
               type="button"
               class="
@@ -49,10 +49,10 @@
 
           <div
             data-collapsible-target="item"
-            id="<%= "accordion-collapse-body-samples" %>"
+            id="accordion-collapse-body-samples"
             class="hidden"
             role="region"
-            aria-labelledby="<%= "accordion-collapse-heading-samples" %>"
+            aria-labelledby="accordion-collapse-heading-samples"
           >
             <div
               class="

--- a/app/views/data_exports/_new_sample_export_dialog.html.erb
+++ b/app/views/data_exports/_new_sample_export_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
 
   <%= turbo_frame_tag "sample_export_dialog_content" do %>
@@ -23,7 +23,7 @@
 
       <div class="grid gap-4">
         <div data-controller="collapsible">
-          <h2 id="<%= "accordion-collapse-heading-samples" %>">
+          <h2 id="accordion-collapse-heading-samples">
             <button
               type="button"
               class="
@@ -47,10 +47,10 @@
 
           <div
             data-collapsible-target="item"
-            id="<%= "accordion-collapse-body-samples" %>"
+            id="accordion-collapse-body-samples"
             class="hidden"
             role="region"
-            aria-labelledby="<%= "accordion-collapse-heading-samples" %>"
+            aria-labelledby="accordion-collapse-heading-samples"
           >
             <div
               class="

--- a/app/views/data_exports/_new_single_analysis_export_dialog.html.erb
+++ b/app/views/data_exports/_new_single_analysis_export_dialog.html.erb
@@ -1,10 +1,10 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(:"data_exports.new_analysis_export_dialog.title")) %>
 
   <div class="font-normal text-slate-500 dark:text-slate-400">
     <div class="grid gap-4">
       <div data-controller="collapsible">
-        <h2 id="<%= "accordion-collapse-heading-workflows" %>">
+        <h2 id="accordion-collapse-heading-workflows">
           <button
             type="button"
             class="
@@ -28,10 +28,10 @@
 
         <div
           data-collapsible-target="item"
-          id="<%= "accordion-collapse-body-workflows" %>"
+          id="accordion-collapse-body-workflows"
           class="hidden"
           role="region"
-          aria-labelledby="<%= "accordion-collapse-heading-workflows" %>"
+          aria-labelledby="accordion-collapse-heading-workflows"
         >
           <div
             class="

--- a/app/views/data_exports/_preview.html.erb
+++ b/app/views/data_exports/_preview.html.erb
@@ -1,5 +1,5 @@
 <div class="mt-2">
-  <%= viral_card do |card| %>
+  <%= render Viral::CardComponent.new do |card| %>
     <% card.with_header(title: "#{@data_export.file.filename}", classes: "pb-0") %>
 
     <% card.with_section do %>

--- a/app/views/data_exports/_summary.html.erb
+++ b/app/views/data_exports/_summary.html.erb
@@ -1,49 +1,60 @@
 <div class="px-4 py-4">
-  <dl
-    class="
-      max-w-md text-slate-900 divide-y divide-slate-200 dark:text-white
-      dark:divide-slate-700
-    "
-  >
+  <dl class="max-w-md divide-y divide-slate-200 text-slate-900 dark:divide-slate-700 dark:text-white">
     <div class="flex flex-col pb-3">
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".id") %></dt>
       <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= @data_export.id %></dd>
     </div>
+
     <% unless @data_export.name.nil? %>
       <div class="flex flex-col py-3">
         <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t('common.labels.name') %></dt>
         <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= @data_export.name %></dd>
       </div>
     <% end %>
+
     <div class="flex flex-col py-3">
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".type") %></dt>
-      <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= t(:"data_exports.types.#{@data_export.export_type}") %></dd>
+
+      <dd class="text-lg font-semibold text-slate-900 dark:text-white">
+        <%= t(:"data_exports.types.#{@data_export.export_type}") %>
+      </dd>
     </div>
+
     <% if @data_export.export_type == 'linelist' %>
       <div class="flex flex-col py-3">
         <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".format") %></dt>
-        <dd class="text-lg font-semibold text-slate-900 dark:text-white"><%= @data_export.export_parameters["linelist_format"] %></dd>
+
+        <dd class="text-lg font-semibold text-slate-900 dark:text-white">
+          <%= @data_export.export_parameters["linelist_format"] %>
+        </dd>
       </div>
     <% end %>
+
     <div class="flex flex-col py-3">
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".status") %></dt>
+
       <dd class="text-lg font-semibold text-slate-900 dark:text-white">
         <% status_text = t("common.statuses.#{@data_export.status}").upcase %>
+
         <% if @data_export.status == 'ready' %>
-          <%= viral_pill(text: status_text, color: :green) %>
+          <%= render Viral::PillComponent.new(text: status_text, color: :green) %>
         <% else %>
-          <%= viral_pill(text: status_text, color: :slate) %>
+          <%= render Viral::PillComponent.new(text: status_text, color: :slate) %>
         <% end %>
       </dd>
     </div>
+
     <div class="flex flex-col py-3">
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t('common.labels.created') %></dt>
+
       <dd class="text-lg font-semibold text-slate-900 dark:text-white">
         <%= local_date(@data_export.created_at, :long) %>
       </dd>
     </div>
+
     <div class="flex flex-col pt-3">
       <dt class="mb-1 text-slate-500 md:text-lg dark:text-slate-400"><%= t(:".expires_at") %></dt>
+
       <dd class="text-lg font-semibold text-slate-900 dark:text-white">
         <% if @data_export.expires_at.nil? %>
           <%= t(:".once_ready") %>

--- a/app/views/data_exports/create.turbo_stream.erb
+++ b/app/views/data_exports/create.turbo_stream.erb
@@ -1,10 +1,9 @@
 <% if export_type == 'analysis' %>
-  <%= turbo_stream.update "export_dialog" do %>
-  <% end %>
+  <%= turbo_stream.update "export_dialog", "" %>
 <% else %>
-  <%= turbo_stream.update "samples_dialog" do %>
-  <% end %>
+  <%= turbo_stream.update "samples_dialog", "" %>
 <% end %>
+
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>

--- a/app/views/data_exports/destroy.turbo_stream.erb
+++ b/app/views/data_exports/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -66,7 +66,7 @@
         class="hidden max-w-md list-inside text-sm text-slate-500 dark:text-slate-400"
       >
         <li>
-          <%= viral_help_text(state: :error) %>
+          <%= render Viral::Form::HelpTextComponent.new(state: :error) %>
         </li>
       </ul>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -31,9 +31,9 @@
                     class: "button button-default w-full" do %>
             <span class="inline-flex items-center text-center">
               <% if Rails.configuration.auth_config["#{provider}_icon"] %>
-                <%= viral_icon(name: "#{provider}_icon", classes: "w-4 h-4 mr-2 -ml-1") %>
+                <%= render Viral::IconComponent.new(name: "#{provider}_icon", classes: "w-4 h-4 mr-2 -ml-1") %>
               <% else %>
-                <%= viral_icon(name: provider, classes: "w-4 h-4 mr-2 -ml-1") %>
+                <%= render Viral::IconComponent.new(name: provider, classes: "w-4 h-4 mr-2 -ml-1") %>
               <% end %>
 
               <% if Rails.configuration.auth_config["#{provider}_text"] %>

--- a/app/views/groups/_edit_advanced_delete.html.erb
+++ b/app/views/groups/_edit_advanced_delete.html.erb
@@ -1,4 +1,4 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: t(:"groups.edit.advanced.delete.title")) %>
 
   <% card.with_section do %>

--- a/app/views/groups/_edit_advanced_path.html.erb
+++ b/app/views/groups/_edit_advanced_path.html.erb
@@ -1,4 +1,4 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: t(:"groups.edit.advanced.path.title")) %>
 
   <% card.with_section do %>
@@ -25,7 +25,8 @@
                   text-sm font-medium text-ellipsis whitespace-nowrap text-slate-700 @md:!rounded-r-none
                   @md:border-r-0 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300
                 "
-                title="<%= "#{root_url}#{@group&.parent&.full_path}" %>"
+                aria-label="<%= root_url %><%= @group&.parent&.full_path %>"
+                role="group"
               >
                 <% if @group.parent %>
                   <%= root_url %>

--- a/app/views/groups/_edit_advanced_transfer.html.erb
+++ b/app/views/groups/_edit_advanced_transfer.html.erb
@@ -1,4 +1,4 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: t("groups.edit.advanced.transfer.title")) %>
 
   <% card.with_section do %>

--- a/app/views/groups/_edit_change_visibility.html.erb
+++ b/app/views/groups/_edit_change_visibility.html.erb
@@ -1,4 +1,4 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: t("groups.edit.advanced.change_visibility.title")) %>
 
   <% card.with_section do %>

--- a/app/views/groups/_shared_namespaces.html.erb
+++ b/app/views/groups/_shared_namespaces.html.erb
@@ -21,13 +21,13 @@
     <% end %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: t(".pagy.item")) %>
   <% elsif @has_namespaces %>
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       icon_name: :magnifying_glass,
       title: t("components.viral.pagy.empty_state.title"),
       description: t("components.viral.pagy.empty_state.description"),
     ) %>
   <% else %>
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: t(:"groups.show.shared_namespaces.no_shared.title"),
       description: t(:"groups.show.shared_namespaces.no_shared.description"),
       icon_name: Group.icon,

--- a/app/views/groups/_subgroups_and_projects.html.erb
+++ b/app/views/groups/_subgroups_and_projects.html.erb
@@ -21,13 +21,13 @@
     <% end %>
     <%= render Viral::Pagy::FullComponent.new(@pagy, item: t(".pagy.item")) %>
   <% elsif @has_namespaces %>
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       icon_name: :magnifying_glass,
       title: t("components.viral.pagy.empty_state.title"),
       description: t("components.viral.pagy.empty_state.description"),
     ) %>
   <% else %>
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: t(:"groups.show.subgroups.no_subgroups.title"),
       description: t(:"groups.show.subgroups.no_subgroups.description"),
       icon_name: Group.icon,

--- a/app/views/groups/attachments/create.turbo_stream.erb
+++ b/app/views/groups/attachments/create.turbo_stream.erb
@@ -1,14 +1,14 @@
 <% attachments&.each do |attachment| %>
   <% if attachment.persisted? %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :success,
         data: t(".success", filename: attachment.file.filename),
       ) %>
     <% end %>
   <% else %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :error,
         data:
           t(
@@ -20,6 +20,7 @@
     <% end %>
   <% end %>
 <% end %>
+
 <%= turbo_stream.update "attachment_modal",
                     partial: "new_attachment_modal",
                     locals: {

--- a/app/views/groups/attachments/destroy.turbo_stream.erb
+++ b/app/views/groups/attachments/destroy.turbo_stream.erb
@@ -9,7 +9,7 @@
 
   <% destroyed_attachments.each do |attachment| %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :success,
         data: t(".success", filename: attachment.file.filename),
       ) %>
@@ -17,9 +17,8 @@
   <% end %>
 
   <turbo-stream action="refresh"></turbo-stream>
-
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type: :error, data: message) %>
+    <%= render Viral::FlashComponent.new(type: :error, data: message) %>
   <% end %>
 <% end %>

--- a/app/views/groups/bots/_bot_modal.html.erb
+++ b/app/views/groups/bots/_bot_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(
     title: t("groups.bots.index.bot_listing.new_bot_modal.title"),
   ) %>

--- a/app/views/groups/bots/_destroy_confirmation_modal.html.erb
+++ b/app/views/groups/bots/_destroy_confirmation_modal.html.erb
@@ -1,16 +1,13 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t("bots.destroy_confirmation.title")) %>
 
   <%= turbo_frame_tag("deletion-alert") %>
 
-  <div
-    class="
-      mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
-    "
-  >
+  <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4">
       <%= t("bots.destroy_confirmation.description", bot_name: bot_account.user.email) %>
     </p>
+
     <%= form_for(:deletion, url: group_bot_path(id: bot_account.id), method: :delete,
             data: {
               turbo_frame: "_top",

--- a/app/views/groups/bots/create.turbo_stream.erb
+++ b/app/views/groups/bots/create.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <% if @bot_account.persisted? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <%= turbo_stream.replace "access-token-section",
                        partial: "access_token_section",

--- a/app/views/groups/bots/destroy.turbo_stream.erb
+++ b/app/views/groups/bots/destroy.turbo_stream.erb
@@ -1,6 +1,7 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
+
 <% if @bot_account.deleted? %>
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/groups/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/groups/bots/personal_access_tokens/_personal_access_token_listing_modal.html.erb
+++ b/app/views/groups/bots/personal_access_tokens/_personal_access_token_listing_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, id: 'bot_tokens_dialog', size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, id: 'bot_tokens_dialog', size: :extra_large) do |dialog| %>
   <% dialog.with_header(
     title: t("groups.bots.index.personal_access_tokens_listing_modal.title"),
   ) %>

--- a/app/views/groups/bots/personal_access_tokens/_revoke_confirmation_modal.html.erb
+++ b/app/views/groups/bots/personal_access_tokens/_revoke_confirmation_modal.html.erb
@@ -1,13 +1,9 @@
-<%= viral_dialog(open: open, id: 'revoke_confirmation_dialog') do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, id: 'revoke_confirmation_dialog') do |dialog| %>
   <% dialog.with_header(title: t("personal_access_tokens.revoke_confirmation.title")) %>
 
   <%= turbo_frame_tag("deletion-alert") %>
 
-  <div
-    class="
-      mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
-    "
-  >
+  <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4">
       <%= t(
         "personal_access_tokens.revoke_confirmation.description",
@@ -15,6 +11,7 @@
         bot_name: bot_account.user.email,
       ) %>
     </p>
+
     <%= form_for(:deletion, url: revoke_group_bot_personal_access_token_path(
           bot_id: @bot_account.id,
           id: personal_access_token.id

--- a/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/groups/bots/personal_access_tokens/create.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <% if @personal_access_token.persisted? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <%= turbo_stream.replace "access-token-section",
                        partial: "groups/bots/access_token_section",

--- a/app/views/groups/bots/personal_access_tokens/revoke.turbo_stream.erb
+++ b/app/views/groups/bots/personal_access_tokens/revoke.turbo_stream.erb
@@ -1,8 +1,9 @@
-<%= turbo_stream.update "personal-access-token-alert", viral_alert(type:, message:) %>
+<%= turbo_stream.update "personal-access-token-alert", render(Viral::AlertComponent.new(type:, message:)) %>
 
 <%= turbo_stream.replace "personal_access_tokens",
                      partial: "table",
                      locals: {
                        personal_access_tokens: @personal_access_tokens,
                      } %>
+
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="grid gap-4">
     <%= render Viral::PageHeaderComponent.new(title: t(".details.title")) %>
 
-    <%= viral_card do |card| %>
+    <%= render Viral::CardComponent.new do |card| %>
       <% card.with_header(title: t(:"groups.edit.details.subtitle")) %>
 
       <% card.with_section do %>

--- a/app/views/groups/group_links/_edit_modal.html.erb
+++ b/app/views/groups/group_links/_edit_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(id: 'edit-group-link-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'edit-group-link-dialog', open: open) do |dialog| %>
   <% dialog.with_header(title: t(:"groups.group_links.edit.title")) %>
 
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">

--- a/app/views/groups/group_links/_invite_group_modal.html.erb
+++ b/app/views/groups/group_links/_invite_group_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(id: 'new-group-link-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'new-group-link-dialog', open: open) do |dialog| %>
   <% dialog.with_trigger do %>
     <button class="button w-full button-default" data-action="viral--dialog#open">
       <%= I18n.t("groups.members.index.invite_group") %>

--- a/app/views/groups/group_links/create.turbo_stream.erb
+++ b/app/views/groups/group_links/create.turbo_stream.erb
@@ -18,7 +18,7 @@
 
   <% if @created_namespace_group_link.errors.none? %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(type:, data: message) %>
+      <%= render Viral::FlashComponent.new(type:, data: message) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/groups/group_links/destroy.turbo_stream.erb
+++ b/app/views/groups/group_links/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <% if @namespace_group_link&.deleted? %>

--- a/app/views/groups/group_links/update.turbo_stream.erb
+++ b/app/views/groups/group_links/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @namespace_group_link.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/groups/history/_group_history_modal.html.erb
+++ b/app/views/groups/history/_group_history_modal.html.erb
@@ -1,13 +1,15 @@
-<%= viral_dialog(open: true, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(
     title: t(".version_number", version_number: log_data[:version]),
   ) %>
+
   <div>
     <%= render partial: "group_history_modal_description", locals: { log_data: } %>
     <%= render HistoryVersionComponent.new(log_data: log_data) %>
   </div>
+
   <% dialog.with_secondary_action do %>
-    <%= viral_button(data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(data: { action: 'click->viral--dialog#close' }) do %>
       <%= t(".close") %>
     <% end %>
   <% end %>

--- a/app/views/groups/members/_create_modal.html.erb
+++ b/app/views/groups/members/_create_modal.html.erb
@@ -1,10 +1,12 @@
-<%= viral_dialog(id: 'new-member-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'new-member-dialog', open: open) do |dialog| %>
   <% dialog.with_trigger do %>
-    <button class="button button-primary w-full" data-action="viral--dialog#open">
+    <button class="button w-full button-primary" data-action="viral--dialog#open">
       <%= I18n.t("groups.members.index.add") %>
     </button>
   <% end %>
+
   <% dialog.with_header(title: t(:"groups.members.new.title")) %>
+
   <% if @new_member&.invalid? %>
     <%= render partial: "form" %>
   <% else %>

--- a/app/views/groups/members/_edit_modal.html.erb
+++ b/app/views/groups/members/_edit_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(id: 'edit-member-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'edit-member-dialog', open: open) do |dialog| %>
   <% dialog.with_header(title: t(:"groups.members.edit.title")) %>
 
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">

--- a/app/views/groups/members/create.turbo_stream.erb
+++ b/app/views/groups/members/create.turbo_stream.erb
@@ -8,7 +8,7 @@
 
 <% if @new_member.persisted? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 
   <%= turbo_stream.replace "members" do %>

--- a/app/views/groups/members/destroy.turbo_stream.erb
+++ b/app/views/groups/members/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <% if member.deleted? %>

--- a/app/views/groups/members/update.turbo_stream.erb
+++ b/app/views/groups/members/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @member.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Viral::PageHeaderComponent.new(title: @group.name, id: @group.puid) do |component| %>
   <%= component.icon do %>
-    <%= viral_avatar(
+    <%= render Viral::AvatarComponent.new(
       name: @group.name,
       colour_string: "#{@group.name}-#{@group.id}",
       size: :large,

--- a/app/views/groups/update.turbo_stream.erb
+++ b/app/views/groups/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @group.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 

--- a/app/views/groups/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/groups/workflow_executions/_edit_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/groups/workflow_executions/cancel.turbo_stream.erb
+++ b/app/views/groups/workflow_executions/cancel.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/groups/workflow_executions/destroy.turbo_stream.erb
+++ b/app/views/groups/workflow_executions/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/groups/workflow_executions/update.turbo_stream.erb
+++ b/app/views/groups/workflow_executions/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @workflow_execution.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 

--- a/app/views/integration_access_token/create.turbo_stream.erb
+++ b/app/views/integration_access_token/create.turbo_stream.erb
@@ -1,16 +1,19 @@
 <% if new_personal_access_token %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(
+    <%= render Viral::FlashComponent.new(
       type: :success,
       data: t("integration_access_tokens.create.success", name: new_personal_access_token.name),
     ) %>
   <% end %>
   <%= turbo_stream.update "access-token-data-frame" do %>
-    <div data-controller="integration-access-token" data-integration-access-token-token-value="<%= encoded_token %>" data-integration-access-token-target-value="<%= target_host %>" >
-    </div>
+    <div
+      data-controller="integration-access-token"
+      data-integration-access-token-token-value="<%= encoded_token %>"
+      data-integration-access-token-target-value="<%= target_host %>"
+    ></div>
   <% end %>
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type: :error, data: message) %>
+    <%= render Viral::FlashComponent.new(type: :error, data: message) %>
   <% end %>
 <% end %>

--- a/app/views/integration_access_token/index.html.erb
+++ b/app/views/integration_access_token/index.html.erb
@@ -1,21 +1,22 @@
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+
 <%= render Viral::PageHeaderComponent.new(
   title: t("integration_access_tokens.index.title"),
   subtitle: t("integration_access_tokens.index.subtitle"),
 ) %>
 
-<div class="grid gap-4 grid-cols-1" data-turbo="true">
+<div class="grid grid-cols-1 gap-4" data-turbo="true">
   <%= turbo_frame_tag "access-token-data-frame" %>
 
   <%= turbo_frame_tag "integration_access_token_form" do %>
     <%= form_with() do |f| %>
-        <%= f.submit t("integration_access_tokens.create.submit"), class: "button button-primary" %>
-      <% end %>
+      <%= f.submit t("integration_access_tokens.create.submit"), class: "button button-primary" %>
+    <% end %>
   <% end %>
 
-  <div id="flashes" class="fixed flex flex-col top-5 right-6 z-50">
-  <% flash.each do |key, value| %>
-    <%= viral_flash(type: key, data: value) %>
-  <% end %>
+  <div id="flashes" class="fixed top-5 right-6 z-50 flex flex-col">
+    <% flash.each do |key, value| %>
+      <%= render Viral::FlashComponent.new(type: key, data: value) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -54,7 +54,7 @@
             </div>
 
             <% flash.each do |type, msg| %>
-              <%= viral_alert(type: type, message: msg) %>
+              <%= render Viral::AlertComponent.new(type: type, message: msg) %>
             <% end %>
 
             <%= yield %>

--- a/app/views/profiles/experimental_features/show.html.erb
+++ b/app/views/profiles/experimental_features/show.html.erb
@@ -8,7 +8,7 @@
   class="sr-only"
 ></div>
 
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_section(border_bottom: true, border_top: true) do %>
     <p class="text-sm text-slate-500 dark:text-slate-400"><%= t(".description") %></p>
   <% end %>

--- a/app/views/profiles/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/profiles/personal_access_tokens/create.turbo_stream.erb
@@ -14,7 +14,7 @@
                        } %>
   <%= turbo_stream.update "new-token-form", "" %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(
+    <%= render Viral::FlashComponent.new(
       type: :success,
       data: t(".success", name: new_personal_access_token.name),
     ) %>

--- a/app/views/profiles/personal_access_tokens/new.turbo_stream.erb
+++ b/app/views/profiles/personal_access_tokens/new.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update "new-token-form" do %>
-  <%= viral_card(title: t(:"profiles.personal_access_tokens.create.title"), subtitle: t(:"profiles.personal_access_tokens.create.subtitle")) do %>
+  <%= render Viral::CardComponent.new(title: t(:"profiles.personal_access_tokens.create.title"), subtitle: t(:"profiles.personal_access_tokens.create.subtitle")) do %>
     <%= render partial: "form",
     locals: {
       personal_access_token: @personal_access_token,

--- a/app/views/profiles/personal_access_tokens/revoke.turbo_stream.erb
+++ b/app/views/profiles/personal_access_tokens/revoke.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type: :success, data: message) %>
+  <%= render Viral::FlashComponent.new(type: :success, data: message) %>
 <% end %>
 
 <%= turbo_stream.replace "token-information-component" do %>

--- a/app/views/profiles/personal_access_tokens/rotate.turbo_stream.erb
+++ b/app/views/profiles/personal_access_tokens/rotate.turbo_stream.erb
@@ -17,6 +17,6 @@
   <% end %>
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type: :error, data: message) %>
+    <%= render Viral::FlashComponent.new(type: :error, data: message) %>
   <% end %>
 <% end %>

--- a/app/views/profiles/preferences/show.html.erb
+++ b/app/views/profiles/preferences/show.html.erb
@@ -1,6 +1,6 @@
 <%= render Viral::PageHeaderComponent.new(title: t(".preferences")) %>
 
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_section(border_bottom: true, border_top: true) do %>
     <%= tag.div(
       role: "radiogroup",
@@ -15,12 +15,7 @@
         dark_text: t("theme.modes.dark")
       }
     ) do %>
-      <div
-        id="theme-legend"
-        class="
-          mb-2 text-sm font-semibold text-slate-800 dark:text-white uppercase
-        "
-      >
+      <div id="theme-legend" class="mb-2 text-sm font-semibold text-slate-800 uppercase dark:text-white">
         <%= t(".theme_title") %>
       </div>
 
@@ -65,6 +60,7 @@
       ) %>
     <% end %>
   <% end %>
+
   <% card.with_section do %>
     <%= render "locale_form", user: @user %>
   <% end %>

--- a/app/views/profiles/preferences/update.turbo_stream.erb
+++ b/app/views/profiles/preferences/update.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,6 @@
 <%= render Viral::PageHeaderComponent.new(title: t(".title")) %>
-<%= viral_card do %>
+
+<%= render Viral::CardComponent.new do %>
   <%= render "form", user: @user if @user.provider == nil %>
   <%= render "domain_user", user: @user if @user.provider != nil %>
 <% end %>

--- a/app/views/projects/_change_path.html.erb
+++ b/app/views/projects/_change_path.html.erb
@@ -1,4 +1,4 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: t(:"projects.edit.advanced.path.title")) %>
 
   <% card.with_section do %>
@@ -26,7 +26,8 @@
                     py-2 text-sm font-medium text-ellipsis whitespace-nowrap text-slate-700 @md:!rounded-r-none
                     @md:border-r-0 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300
                   "
-                  title="<%= "#{root_url}#{@project&.parent&.full_path}" %>"
+                  aria-label="<%= root_url %><%= @project&.parent&.full_path %>"
+                  role="group"
                 >
                   <% if @project.parent %>
                     <%= root_url %>

--- a/app/views/projects/_destroy.html.erb
+++ b/app/views/projects/_destroy.html.erb
@@ -1,4 +1,4 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: t(:"projects.edit.advanced.destroy.title")) %>
 
   <% card.with_section do %>

--- a/app/views/projects/_transfer.html.erb
+++ b/app/views/projects/_transfer.html.erb
@@ -1,4 +1,4 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: t(:"projects.edit.advanced.transfer.title")) %>
 
   <% card.with_section do %>

--- a/app/views/projects/attachments/create.turbo_stream.erb
+++ b/app/views/projects/attachments/create.turbo_stream.erb
@@ -1,14 +1,14 @@
 <% attachments&.each do |attachment| %>
   <% if attachment.persisted? %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :success,
         data: t(".success", filename: attachment.file.filename),
       ) %>
     <% end %>
   <% else %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :error,
         data:
           t(
@@ -20,6 +20,7 @@
     <% end %>
   <% end %>
 <% end %>
+
 <%= turbo_stream.update "attachment_modal",
                     partial: "new_attachment_modal",
                     locals: {

--- a/app/views/projects/attachments/destroy.turbo_stream.erb
+++ b/app/views/projects/attachments/destroy.turbo_stream.erb
@@ -9,7 +9,7 @@
 
   <% destroyed_attachments.each do |attachment| %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :success,
         data: t(".success", filename: attachment.file.filename),
       ) %>
@@ -17,9 +17,8 @@
   <% end %>
 
   <turbo-stream action="refresh"></turbo-stream>
-
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type: :error, data: message) %>
+    <%= render Viral::FlashComponent.new(type: :error, data: message) %>
   <% end %>
 <% end %>

--- a/app/views/projects/automated_workflow_executions/_edit_dialog.html.erb
+++ b/app/views/projects/automated_workflow_executions/_edit_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :extra_large) do |dialog| %>
   <% workflow_name =
     (
       if @automated_workflow_execution.name.empty?

--- a/app/views/projects/automated_workflow_executions/_new_automated_workflow_execution_modal.html.erb
+++ b/app/views/projects/automated_workflow_executions/_new_automated_workflow_execution_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :extra_large) do |dialog| %>
   <% dialog.with_header(title: t(:".title", workflow: @workflow.name)) %>
 
   <% if Flipper.enabled?(:v2_samplesheet, current_user) %>

--- a/app/views/projects/automated_workflow_executions/_pipeline_selection_modal.html.erb
+++ b/app/views/projects/automated_workflow_executions/_pipeline_selection_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t(:".title")) %>
 
   <ul>
@@ -22,7 +22,7 @@
                   <%= workflow.name %>
                 </span>
 
-                <%= viral_pill(text: workflow.version, color: :primary) %>
+                <%= render Viral::PillComponent.new(text: workflow.version, color: :primary) %>
               </span>
 
               <span class="truncate text-sm font-normal text-slate-500 group-hover:text-slate-200 dark:text-slate-400">

--- a/app/views/projects/automated_workflow_executions/_table.html.erb
+++ b/app/views/projects/automated_workflow_executions/_table.html.erb
@@ -1,32 +1,39 @@
 <% if @automated_workflow_executions.count.positive? %>
-  <%= viral_data_table(@automated_workflow_executions, id: "automated_workflow_executions") do |table| %>
+  <%= render Viral::DataTableComponent.new(@automated_workflow_executions, id: "automated_workflow_executions") do |table| %>
     <% table.with_column(t(".headers.id"),
       sticky_key: :left
     ) do |row| %>
       <%= row[:id] %>
     <% end %>
+
     <% table.with_column(t(".headers.name")) do |row| %>
       <%= row[:name] %>
     <% end %>
+
     <% table.with_column(t(".headers.workflow_name")) do |row| %>
       <%= row.workflow.name %>
     <% end %>
+
     <% table.with_column(t(".headers.workflow_version")) do |row| %>
       <%= row.metadata["workflow_version"] %>
     <% end %>
+
     <% table.with_column(t(".headers.created_at")) do |row| %>
       <%= local_date(row[:created_at], :long) %>
     <% end %>
+
     <% table.with_column(t(".headers.updated_at")) do |row| %>
       <%= local_time_ago(row[:updated_at]) %>
     <% end %>
+
     <% table.with_column(t(".headers.status")) do |row| %>
       <% if row[:disabled] %>
-        <%= viral_pill(text: t("common.statuses.disabled").upcase, color: "red") %>
+        <%= render Viral::PillComponent.new(text: t("common.statuses.disabled").upcase, color: "red") %>
       <% else %>
-        <%= viral_pill(text: t("common.statuses.enabled"), color: "green") %>
+        <%= render Viral::PillComponent.new(text: t("common.statuses.enabled"), color: "green") %>
       <% end %>
     <% end %>
+
     <% table.with_column(t(".headers.actions"),
         classes: "flex justify-start"
       ) do |row| %>
@@ -51,6 +58,7 @@
         class:
           "font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer mr-2" %>
       <% end %>
+
       <%= button_to t("common.actions.delete"),
       namespace_project_automated_workflow_execution_path(
         @project.parent,
@@ -76,7 +84,7 @@
   <% end %>
 <% else %>
   <div class="empty_state_message">
-    <%= viral_empty(
+    <%= render Viral::EmptyStateComponent.new(
       title: t(:".empty.title"),
       description: t(:".empty.description"),
       icon_name: AutomatedWorkflowExecution.icon,

--- a/app/views/projects/automated_workflow_executions/create.turbo_stream.erb
+++ b/app/views/projects/automated_workflow_executions/create.turbo_stream.erb
@@ -1,9 +1,11 @@
 <%= turbo_stream.replace "automated_workflow_execution_modal" do %>
   <%= turbo_frame_tag "automated_workflow_execution_modal" %>
 <% end %>
+
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
+
 <%= turbo_stream.replace "automated_workflow_executions_table" do %>
   <%= turbo_frame_tag "automated_workflow_executions_table",
   src: namespace_project_automated_workflow_executions_path(format: :turbo_stream) %>

--- a/app/views/projects/automated_workflow_executions/destroy.turbo_stream.erb
+++ b/app/views/projects/automated_workflow_executions/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <% if @automated_workflow_execution.destroyed? %>

--- a/app/views/projects/automated_workflow_executions/edit.turbo_stream.erb
+++ b/app/views/projects/automated_workflow_executions/edit.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% if @automated_workflow_execution.disabled %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% else %>
   <%= turbo_stream.update(

--- a/app/views/projects/bots/_bot_modal.html.erb
+++ b/app/views/projects/bots/_bot_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(
     title: t("projects.bots.index.bot_listing.new_bot_modal.title"),
   ) %>

--- a/app/views/projects/bots/_destroy_confirmation_modal.html.erb
+++ b/app/views/projects/bots/_destroy_confirmation_modal.html.erb
@@ -1,15 +1,12 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t("bots.destroy_confirmation.title")) %>
   <%= turbo_frame_tag("deletion-alert") %>
 
-  <div
-    class="
-      mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
-    "
-  >
+  <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4">
       <%= t("bots.destroy_confirmation.description", bot_name: bot_account.user.email) %>
     </p>
+
     <%= form_for(:deletion, url: namespace_project_bot_path(id: bot_account.id), method: :delete,
             data: {
               turbo_frame: "_top",

--- a/app/views/projects/bots/create.turbo_stream.erb
+++ b/app/views/projects/bots/create.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <% if @bot_account.persisted? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <%= turbo_stream.replace "access-token-section",
                        partial: "access_token_section",

--- a/app/views/projects/bots/destroy.turbo_stream.erb
+++ b/app/views/projects/bots/destroy.turbo_stream.erb
@@ -1,6 +1,7 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
+
 <% if @bot_account.deleted? %>
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
+++ b/app/views/projects/bots/personal_access_tokens/_generate_personal_access_token_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/projects/bots/personal_access_tokens/_personal_access_token_listing_modal.html.erb
+++ b/app/views/projects/bots/personal_access_tokens/_personal_access_token_listing_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, id: 'bot_tokens_dialog', size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, id: 'bot_tokens_dialog', size: :extra_large) do |dialog| %>
   <% dialog.with_header(
     title: t("projects.bots.index.personal_access_tokens_listing_modal.title"),
   ) %>

--- a/app/views/projects/bots/personal_access_tokens/_revoke_confirmation_modal.html.erb
+++ b/app/views/projects/bots/personal_access_tokens/_revoke_confirmation_modal.html.erb
@@ -1,12 +1,8 @@
-<%= viral_dialog(open: open, id: 'revoke_confirmation_dialog') do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, id: 'revoke_confirmation_dialog') do |dialog| %>
   <% dialog.with_header(title: t("personal_access_tokens.revoke_confirmation.title")) %>
   <%= turbo_frame_tag("deletion-alert") %>
 
-  <div
-    class="
-      mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400
-    "
-  >
+  <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4">
       <%= t(
         "personal_access_tokens.revoke_confirmation.description",
@@ -14,6 +10,7 @@
         bot_name: bot_account.user.email,
       ) %>
     </p>
+
     <%= form_for(:deletion, url: revoke_namespace_project_bot_personal_access_token_path(
           bot_id: bot_account.id,
           id: personal_access_token.id

--- a/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
+++ b/app/views/projects/bots/personal_access_tokens/create.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <% if @personal_access_token.persisted? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <%= turbo_stream.replace "access-token-section",
                        partial: "projects/bots/access_token_section",

--- a/app/views/projects/bots/personal_access_tokens/revoke.turbo_stream.erb
+++ b/app/views/projects/bots/personal_access_tokens/revoke.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.update "personal-access-token-alert", viral_alert(type:, message:) %>
+<%= turbo_stream.update "personal-access-token-alert", render(Viral::AlertComponent.new(type:, message:)) %>
 
 <%= turbo_stream.replace "personal_access_tokens",
                      partial: "table",

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -2,8 +2,9 @@
   <div class="grid gap-4">
     <%= render Viral::PageHeaderComponent.new(title: t(".general.title")) %>
 
-    <%= viral_card do |card| %>
+    <%= render Viral::CardComponent.new do |card| %>
       <% card.with_header(title: t(".general.heading")) %>
+
       <% card.with_section do %>
         <%= turbo_frame_tag("project_name_and_description_form") do %>
           <%= render partial: "edit_name_and_description_form", locals: { project: @project } %>

--- a/app/views/projects/group_links/_edit_modal.html.erb
+++ b/app/views/projects/group_links/_edit_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(id: 'edit-group-link-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'edit-group-link-dialog', open: open) do |dialog| %>
   <% dialog.with_header(title: t(:"projects.group_links.edit.title")) %>
 
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">

--- a/app/views/projects/group_links/_invite_group_modal.html.erb
+++ b/app/views/projects/group_links/_invite_group_modal.html.erb
@@ -1,10 +1,12 @@
-<%= viral_dialog(id: 'new-group-link-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'new-group-link-dialog', open: open) do |dialog| %>
   <% dialog.with_header(title: I18n.t("projects.group_links.new.title")) %>
+
   <% dialog.with_trigger do %>
-    <button class="button button-default w-full" data-action="viral--dialog#open">
+    <button class="button w-full button-default" data-action="viral--dialog#open">
       <%= I18n.t("projects.members.index.invite_group") %>
     </button>
   <% end %>
+
   <% if defined?(new_group_link) && new_group_link&.invalid? %>
     <%= render partial: "form", locals: { new_group_link: new_group_link } %>
   <% else %>

--- a/app/views/projects/group_links/create.turbo_stream.erb
+++ b/app/views/projects/group_links/create.turbo_stream.erb
@@ -18,7 +18,7 @@
 
   <% if @created_namespace_group_link.errors.none? %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(type:, data: message) %>
+      <%= render Viral::FlashComponent.new(type:, data: message) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/projects/group_links/destroy.turbo_stream.erb
+++ b/app/views/projects/group_links/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <% if @namespace_group_link&.deleted? %>

--- a/app/views/projects/group_links/update.turbo_stream.erb
+++ b/app/views/projects/group_links/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @namespace_group_link.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/projects/history/_project_history_modal.html.erb
+++ b/app/views/projects/history/_project_history_modal.html.erb
@@ -1,13 +1,15 @@
-<%= viral_dialog(open: true, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(
     title: t(".version_number", version_number: log_data[:version]),
   ) %>
+
   <div>
     <%= render partial: "project_history_modal_description", locals: { log_data: } %>
     <%= render HistoryVersionComponent.new(log_data: log_data) %>
   </div>
+
   <% dialog.with_secondary_action do %>
-    <%= viral_button(data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(data: { action: 'click->viral--dialog#close' }) do %>
       <%= t(".close") %>
     <% end %>
   <% end %>

--- a/app/views/projects/members/_create_modal.html.erb
+++ b/app/views/projects/members/_create_modal.html.erb
@@ -1,10 +1,12 @@
-<%= viral_dialog(id: 'new-member-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'new-member-dialog', open: open) do |dialog| %>
   <% dialog.with_header(title: t(:"projects.members.new.title")) %>
+
   <% dialog.with_trigger do %>
-    <button class="button button-primary w-full" data-action="viral--dialog#open">
+    <button class="button w-full button-primary" data-action="viral--dialog#open">
       <%= I18n.t("projects.members.index.add") %>
     </button>
   <% end %>
+
   <% if @new_member&.invalid? %>
     <%= render partial: "form" %>
   <% else %>

--- a/app/views/projects/members/_edit_modal.html.erb
+++ b/app/views/projects/members/_edit_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(id: 'edit-member-dialog', open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: 'edit-member-dialog', open: open) do |dialog| %>
   <% dialog.with_header(title: t(:"projects.members.edit.title")) %>
 
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">

--- a/app/views/projects/members/create.turbo_stream.erb
+++ b/app/views/projects/members/create.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <% if @new_member.persisted? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 
   <%= turbo_stream.replace "members" do %>

--- a/app/views/projects/members/destroy.turbo_stream.erb
+++ b/app/views/projects/members/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <% if member.deleted? %>

--- a/app/views/projects/members/update.turbo_stream.erb
+++ b/app/views/projects/members/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @member.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -74,14 +74,14 @@
   <% end %>
 
   <td class="px-6 py-4">
-    <%= viral_pill(
+    <%= render Viral::PillComponent.new(
       text: attachment.metadata["format"],
       color: find_pill_color_for_attachment(attachment, "format"),
     ) %>
   </td>
 
   <td class="px-6 py-4">
-    <%= viral_pill(
+    <%= render Viral::PillComponent.new(
       text: attachment.metadata["type"],
       color: find_pill_color_for_attachment(attachment, "type"),
     ) %>

--- a/app/views/projects/samples/attachments/_delete_attachment_modal.html.erb
+++ b/app/views/projects/samples/attachments/_delete_attachment_modal.html.erb
@@ -1,18 +1,17 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
   <%= turbo_frame_tag("deletion-alert") %>
 
   <div
     data-controller="selection"
     data-selection-delete-id-param="<%= @attachment.id %>"
-    data-selection-storage-key-value='<%="files-#{@sample.id}" %>'
-    class="
-      mb-4 font-normal text-slate-500 dark:text-slate-400 overflow-x-visible
-    "
+    data-selection-storage-key-value="files-<%= @sample.id %>"
+    class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400"
   >
     <p class="mb-4">
       <%= t(".description") %>
     </p>
+
     <%= form_for(:deletion, url: namespace_project_sample_attachment_path(id: @attachment.id), method: :delete) do |form| %>
       <%= form.submit t(".submit_button"),
                   class:

--- a/app/views/projects/samples/attachments/_form.html.erb
+++ b/app/views/projects/samples/attachments/_form.html.erb
@@ -10,7 +10,7 @@
     data-attachment-upload-error-fallback-text-value="<%= t('common.upload.failed') %>"
     data-attachment-upload-fastq-pairing-patterns-value="<%= attachment_upload_fastq_pairing_data_attributes[:attachment_upload_fastq_pairing_patterns_value].to_json %>"
   >
-    <%= viral_alert(
+    <%= render Viral::AlertComponent.new(
       message: t("common.upload.upload_failed_retry"),
       type: :danger,
       data: { "attachment-upload-target": "uploadErrorAlert" },
@@ -18,7 +18,7 @@
       aria: { live: "assertive", role: "alert" }
     ) %>
 
-    <%= viral_alert(
+    <%= render Viral::AlertComponent.new(
       message: t("common.upload.form_submit_failed"),
       type: :danger,
       data: { "attachment-upload-target": "formErrorAlert" },
@@ -53,7 +53,7 @@
                       class:
                         "block w-full mb-5 text-xs text-slate-900 border border-slate-300 rounded-lg cursor-pointer bg-slate-50 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 disabled:opacity-50 disabled:cursor-not-allowed" %>
 
-      <%= viral_alert(message: t(:'projects.samples.show.files_ignored'), type: :alert, data: { "file-upload-target": "alert" }, classes: "hidden", aria: {
+      <%= render Viral::AlertComponent.new(message: t(:'projects.samples.show.files_ignored'), type: :alert, data: { "file-upload-target": "alert" }, classes: "hidden", aria: {
             live: "assertive",
           }) do %>
         <ul class="mt-4 max-w-md list-inside list-disc space-y-1" data-file-upload-target="error"></ul>

--- a/app/views/projects/samples/attachments/_new_attachment_modal.html.erb
+++ b/app/views/projects/samples/attachments/_new_attachment_modal.html.erb
@@ -1,5 +1,6 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t("projects.samples.show.upload_files")) %>
+
   <%= render partial: "projects/samples/attachments/form",
   locals: {
     attachment: attachment,

--- a/app/views/projects/samples/attachments/concatenations/_modal.html.erb
+++ b/app/views/projects/samples/attachments/concatenations/_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
 
   <%= form_with(model: @concatenation_form, url: namespace_project_sample_attachments_concatenation_path,
@@ -20,6 +20,7 @@
 
         <%= tag.div class: "mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400",
                     tabindex: 0,
+                    role: "group",
                     aria: {
                       label: form.field_id(:attachment_ids),
                       describedby: (invalid_attachment_ids ? form.field_id(:attachment_ids, "error") : nil)

--- a/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/concatenations/create.turbo_stream.erb
@@ -8,7 +8,7 @@
 
 <% unless @concatenation_form.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <turbo-stream action="refresh"></turbo-stream>
 <% end %>

--- a/app/views/projects/samples/attachments/create.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/create.turbo_stream.erb
@@ -1,15 +1,14 @@
 <% attachments&.each do |attachment| %>
   <% if attachment.persisted? %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :success,
         data: t(".success", filename: attachment.file.filename),
       ) %>
     <% end %>
-
   <% else %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :error,
         data:
           t(
@@ -21,6 +20,7 @@
     <% end %>
   <% end %>
 <% end %>
+
 <%= turbo_stream.update "sample_modal",
                     partial: "new_attachment_modal",
                     locals: {

--- a/app/views/projects/samples/attachments/deletions/_modal.html.erb
+++ b/app/views/projects/samples/attachments/deletions/_modal.html.erb
@@ -1,15 +1,12 @@
-<%= viral_dialog(open: open, size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :extra_large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
   <%= turbo_frame_tag("deletion-alert") %>
 
-  <div
-    class="
-      mb-4 font-normal text-slate-500 dark:text-slate-400 overflow-x-visible
-    "
-  >
+  <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4"><%= t(".description") %></p>
+
     <div
-      class="overflow-auto scrollbar"
+      class="scrollbar overflow-auto"
       data-controller="projects--samples--attachments--files"
       data-projects--samples--attachments--files-target="field"
     ></div>
@@ -22,7 +19,6 @@
       'projects--samples--attachments--selected-attachments-storage-key-value': "files-#{@sample.id}",
       action: 'turbo:submit-end->projects--samples--attachments--selected-attachments#clear'
     }, method: :delete) do |form| %>
-
     <div data-projects--samples--attachments--selected-attachments-target="field"></div>
 
     <div>

--- a/app/views/projects/samples/attachments/deletions/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/deletions/destroy.turbo_stream.erb
@@ -2,14 +2,14 @@
 
 <% unless message.nil? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 
 <% unless not_deleted_attachments.nil? %>
   <% not_deleted_attachments.each do |attachment| %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :error,
         data:
           t(

--- a/app/views/projects/samples/attachments/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/attachments/destroy.turbo_stream.erb
@@ -7,7 +7,7 @@
 
   <% destroyed_attachments.each do |attachment| %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(
+      <%= render Viral::FlashComponent.new(
         type: :success,
         data: t(".success", filename: attachment.file.filename),
       ) %>
@@ -15,9 +15,8 @@
   <% end %>
 
   <turbo-stream action="refresh"></turbo-stream>
-
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type: :error, data: message) %>
+    <%= render Viral::FlashComponent.new(type: :error, data: message) %>
   <% end %>
 <% end %>

--- a/app/views/projects/samples/history/_sample_history_modal.html.erb
+++ b/app/views/projects/samples/history/_sample_history_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(
     title:
       t(
@@ -6,15 +6,18 @@
         version: log_data[:version],
       ),
   ) %>
+
   <div>
     <%= render partial: "projects/samples/history/sample_history_modal_description",
     locals: {
       log_data:,
     } %>
+
     <%= render HistoryVersionComponent.new(log_data: log_data) %>
   </div>
+
   <% dialog.with_secondary_action do %>
-    <%= viral_button(data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(data: { action: 'click->viral--dialog#close' }) do %>
       Close
     <% end %>
   <% end %>

--- a/app/views/projects/samples/metadata/_form.html.erb
+++ b/app/views/projects/samples/metadata/_form.html.erb
@@ -66,7 +66,7 @@
                     id="sample_key_PLACEHOLDER_error"
                     class="invisible relative z-0 mt-1 min-h-[1.5rem] w-full text-sm"
                   >
-                    <%= viral_help_text(state: :error, classes: "hidden") %>
+                    <%= render Viral::Form::HelpTextComponent.new(state: :error, classes: "hidden") %>
                   </div>
                 </div>
 
@@ -94,7 +94,7 @@
                     id="sample_value_PLACEHOLDER_error"
                     class="invisible relative z-0 mt-1 min-h-[1.5rem] w-full text-sm"
                   >
-                    <%= viral_help_text(state: :error, classes: "hidden") %>
+                    <%= render Viral::Form::HelpTextComponent.new(state: :error, classes: "hidden") %>
                   </div>
                 </div>
               </div>

--- a/app/views/projects/samples/metadata/_new_metadata_modal.html.erb
+++ b/app/views/projects/samples/metadata/_new_metadata_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
   <%= render partial: "projects/samples/metadata/form" %>
 <% end %>

--- a/app/views/projects/samples/metadata/_update_metadata_modal.html.erb
+++ b/app/views/projects/samples/metadata/_update_metadata_modal.html.erb
@@ -1,7 +1,8 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(
     title: t("projects.samples.show.metadata.update.update_metadata"),
   ) %>
+
   <%= render partial: "projects/samples/metadata/update_form",
   locals: {
     key:,

--- a/app/views/projects/samples/metadata/deletions/_modal.html.erb
+++ b/app/views/projects/samples/metadata/deletions/_modal.html.erb
@@ -1,20 +1,19 @@
-<%= viral_dialog(open: open, classes: ["overflow-x-visible"]) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, classes: ["overflow-x-visible"]) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
   <%= turbo_frame_tag("deletion-alert") %>
 
   <div class="mb-4 font-normal text-slate-500 dark:text-slate-400">
     <p class="mb-4"><%= t(".description") %></p>
-    <div
-      data-controller="projects--samples--metadata--delete-listing"
-      class="overflow-auto scrollbar"
-    >
-      <table class="w-full text-sm text-left text-slate-500 dark:text-slate-400 mb-4">
-        <thead class="text-slate-700 bg-slate-50 dark:bg-slate-900 dark:text-slate-400">
+
+    <div data-controller="projects--samples--metadata--delete-listing" class="scrollbar overflow-auto">
+      <table class="mb-4 w-full text-left text-sm text-slate-500 dark:text-slate-400">
+        <thead class="bg-slate-50 text-slate-700 dark:bg-slate-900 dark:text-slate-400">
           <tr>
             <th class="px-6 py-4"><%= t(".key_header") %></th>
             <th class="px-6 py-4"><%= t(".value_header") %></th>
           </tr>
         </thead>
+
         <tbody data-projects--samples--metadata--delete-listing-target="tableBody"></tbody>
       </table>
     </div>
@@ -27,6 +26,7 @@
       action: 'turbo:submit-end->projects--samples--metadata--destroy#clear'
     }, method: :delete) do |form| %>
     <div data-projects--samples--metadata--destroy-target="field"></div>
+
     <div>
       <%= form.submit t("common.actions.delete"),
                   id: "destroy-metadata-button",

--- a/app/views/projects/samples/metadata/deletions/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/metadata/deletions/destroy.turbo_stream.erb
@@ -2,12 +2,12 @@
 
 <% messages.each do |message| %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type: message[:type], data: message[:message]) %>
+    <%= render Viral::FlashComponent.new(type: message[:type], data: message[:message]) %>
   <% end %>
 <% end %>
 
 <%= turbo_stream.replace "sample-metadata" do %>
-  <% render partial: "projects/samples/metadata/table",
+  <%= render partial: "projects/samples/metadata/table",
   locals: {
     sample_metadata: @sample.metadata_with_provenance,
   } %>

--- a/app/views/projects/samples/metadata/destroy.turbo_stream.erb
+++ b/app/views/projects/samples/metadata/destroy.turbo_stream.erb
@@ -1,17 +1,17 @@
 <% if @sample.errors.any? %>
   <%= turbo_stream.update "update-alert",
-                      viral_alert(
+                      render(Viral::AlertComponent.new(
                         type: "alert",
                         message: error_message(@sample),
                         classes: "mb-4",
-                      ) %>
+                      )) %>
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 
   <%= turbo_stream.replace "sample-metadata" do %>
-    <% render partial: "projects/samples/metadata/table",
+    <%= render partial: "projects/samples/metadata/table",
     locals: {
       sample: @sample,
       sample_metadata: @sample.metadata_with_provenance,

--- a/app/views/projects/samples/show.html.erb
+++ b/app/views/projects/samples/show.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag "samples_dialog" %>
 
 <%= render Viral::PageHeaderComponent.new(title: @sample.name, id: @sample.puid, subtitle: @sample.description) do |component| %>
-  <%= viral_pill(text: @sample.puid, color: :blue) %>
+  <%= render Viral::PillComponent.new(text: @sample.puid, color: :blue) %>
 
   <% component.with_buttons do %>
     <% if @allowed_to[:update_sample] %>

--- a/app/views/projects/update.turbo_stream.erb
+++ b/app/views/projects/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @project.namespace.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 

--- a/app/views/projects/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/projects/workflow_executions/_edit_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(
     title:
       t(

--- a/app/views/projects/workflow_executions/cancel.turbo_stream.erb
+++ b/app/views/projects/workflow_executions/cancel.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/projects/workflow_executions/destroy.turbo_stream.erb
+++ b/app/views/projects/workflow_executions/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <%= turbo_stream.update "workflow_execution_dialog",

--- a/app/views/projects/workflow_executions/destroy_multiple.turbo_stream.erb
+++ b/app/views/projects/workflow_executions/destroy_multiple.turbo_stream.erb
@@ -1,12 +1,12 @@
 <% if defined?(messages) %>
   <% messages.each do |message| %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(type: message[:type], data: message[:message]) %>
+      <%= render Viral::FlashComponent.new(type: message[:type], data: message[:message]) %>
     <% end %>
   <% end %>
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 

--- a/app/views/projects/workflow_executions/update.turbo_stream.erb
+++ b/app/views/projects/workflow_executions/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @workflow_execution.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 

--- a/app/views/samples/clones/_dialog.html.erb
+++ b/app/views/samples/clones/_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large, closable: closable) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large, closable: closable) do |dialog| %>
   <% dialog.with_header(title: t("samples.clones.dialog.title")) %>
   <%= turbo_stream_from @broadcast_target %>
 

--- a/app/views/samples/deletions/_destroy_multiple_confirmation_dialog.html.erb
+++ b/app/views/samples/deletions/_destroy_multiple_confirmation_dialog.html.erb
@@ -2,7 +2,7 @@
 
 <% sample_deletion_reason_enabled = Flipper.enabled?(:sample_deletion_reason, current_user) %>
 
-<%= viral_dialog(id: "multiple-deletions-dialog", open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(id: "multiple-deletions-dialog", open: open) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
 
   <div

--- a/app/views/samples/deletions/_destroy_single_confirmation_dialog.html.erb
+++ b/app/views/samples/deletions/_destroy_single_confirmation_dialog.html.erb
@@ -2,7 +2,7 @@
 
 <% sample_deletion_reason_enabled = Flipper.enabled?(:sample_deletion_reason, current_user) %>
 
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
   <%= turbo_frame_tag("deletion-alert") %>
 

--- a/app/views/samples/metadata/bulk_create.turbo_stream.erb
+++ b/app/views/samples/metadata/bulk_create.turbo_stream.erb
@@ -1,11 +1,11 @@
 <% if @sample.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% else %>
   <% @messages.each do |message| %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(type: message[:type], data: message[:message]) %>
+      <%= render Viral::FlashComponent.new(type: message[:type], data: message[:message]) %>
     <% end %>
   <% end %>
 <% end %>
@@ -17,7 +17,7 @@
                     } %>
 
 <%= turbo_stream.replace "sample-metadata" do %>
-  <% render partial: "projects/samples/metadata/table",
+  <%= render partial: "projects/samples/metadata/table",
   locals: {
     sample: @sample,
     sample_metadata: @sample.metadata_with_provenance,

--- a/app/views/samples/metadata/bulk_update.turbo_stream.erb
+++ b/app/views/samples/metadata/bulk_update.turbo_stream.erb
@@ -10,18 +10,18 @@
 
 <% if @sample.errors.any? %>
   <%= turbo_stream.update "update-alert",
-                      viral_alert(
+                      render(Viral::AlertComponent.new(
                         type: "alert",
                         message: error_message(@sample),
                         classes: "mb-4",
-                      ) %>
+                      )) %>
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 
   <%= turbo_stream.replace "sample-metadata" do %>
-    <% render partial: "projects/samples/metadata/table",
+    <%= render partial: "projects/samples/metadata/table",
     locals: {
       sample: @sample,
       sample_metadata: @sample.metadata_with_provenance,

--- a/app/views/samples/transfers/_dialog.html.erb
+++ b/app/views/samples/transfers/_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large, closable: closable) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large, closable: closable) do |dialog| %>
   <% dialog.with_header(title: t("samples.transfers.dialog.title")) %>
   <%= turbo_stream_from @broadcast_target %>
 

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.prepend 'flashes' do %>
-  <%= viral_flash(type: type, data: message) %>
+  <%= render Viral::FlashComponent.new(type: type, data: message) %>
 <% end %>

--- a/app/views/shared/error/not_authorized.turbo_stream.erb
+++ b/app/views/shared/error/not_authorized.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type: "alert", data: authorization_message) %>
+  <%= render Viral::FlashComponent.new(type: "alert", data: authorization_message) %>
 <% end %>

--- a/app/views/shared/error/not_found.turbo_stream.erb
+++ b/app/views/shared/error/not_found.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type: "alert", data: message) %>
+  <%= render Viral::FlashComponent.new(type: "alert", data: message) %>
 <% end %>
 
 <%= turbo_stream.append "personal-access-token-revoke-errors",
-                    viral_alert(type:, message:) %>
+                    render(Viral::AlertComponent.new(type:, message:)) %>

--- a/app/views/shared/form/_field_errors.html.erb
+++ b/app/views/shared/form/_field_errors.html.erb
@@ -1,9 +1,10 @@
 <%# locals: (id: nil, errors:) -%>
+
 <% if defined? errors %>
   <%= tag.ul id: id, class: "max-w-md text-sm text-slate-500 list-inside dark:text-slate-400" do %>
     <% errors.each do |error_message| %>
       <li>
-        <%= viral_help_text(state: :error) do %>
+        <%= render Viral::Form::HelpTextComponent.new(state: :error) do %>
           <%= error_message %>
         <% end %>
       </li>

--- a/app/views/shared/metadata_templates/_create.turbo_stream.erb
+++ b/app/views/shared/metadata_templates/_create.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <% if @metadata_template.persisted? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <%= turbo_stream.replace "metadata-templates-table" do %>
     <%= turbo_frame_tag "metadata-templates-table", src: index_path do %>

--- a/app/views/shared/metadata_templates/_destroy.turbo_stream.erb
+++ b/app/views/shared/metadata_templates/_destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <%= turbo_stream.replace "metadata-templates-table" do %>

--- a/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_edit_template_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("metadata_templates.edit_template_dialog.title")) %>
 
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>

--- a/app/views/shared/metadata_templates/_new_template_dialog.html.erb
+++ b/app/views/shared/metadata_templates/_new_template_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large) do |dialog| %>
   <% dialog.with_header(title: t("metadata_templates.new_template_dialog.title")) %>
 
   <%= turbo_frame_tag "metadata_template_dialog_content" do %>

--- a/app/views/shared/metadata_templates/_update.turbo_stream.erb
+++ b/app/views/shared/metadata_templates/_update.turbo_stream.erb
@@ -7,7 +7,7 @@
 
 <% if !@metadata_template.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
   <%= turbo_stream.replace @metadata_template, method: :morph do %>
     <%= render MetadataTemplates::RowComponent.new(

--- a/app/views/shared/personal_access_tokens/_rotate.turbo_stream.erb
+++ b/app/views/shared/personal_access_tokens/_rotate.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.update "personal-access-token-alert", viral_alert(type:, message:) %>
+<%= turbo_stream.update "personal-access-token-alert", render(Viral::AlertComponent.new(type:, message:)) %>
 
 <% if local_assigns[:personal_access_token] %>
   <%= turbo_stream.update "rotate-access-token-section",

--- a/app/views/shared/personal_access_tokens/_rotate_confirmation_modal.html.erb
+++ b/app/views/shared/personal_access_tokens/_rotate_confirmation_modal.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, id: 'rotate_confirmation_dialog') do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, id: 'rotate_confirmation_dialog') do |dialog| %>
   <% dialog.with_header(title: t("personal_access_tokens.rotate_confirmation.title")) %>
 
   <div class="mb-4 overflow-x-visible font-normal text-slate-500 dark:text-slate-400">

--- a/app/views/shared/samples/_errors.html.erb
+++ b/app/views/shared/samples/_errors.html.erb
@@ -25,7 +25,7 @@
   </ul>
 
   <div class="mt-4 flex justify-end">
-    <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
       <%= t(".ok_button") %>
     <% end %>
   </div>

--- a/app/views/shared/samples/_success.html.erb
+++ b/app/views/shared/samples/_success.html.erb
@@ -6,7 +6,7 @@
 
   <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= message %></p>
 
-  <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+  <%= render Viral::ButtonComponent.new(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
     <%= t(".ok_button") %>
   <% end %>
 </div>

--- a/app/views/shared/samples/metadata/file_imports/_dialog.html.erb
+++ b/app/views/shared/samples/metadata/file_imports/_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
   <%= turbo_stream_from broadcast_target %>
 

--- a/app/views/shared/samples/metadata/file_imports/_errors.html.erb
+++ b/app/views/shared/samples/metadata/file_imports/_errors.html.erb
@@ -33,7 +33,7 @@
   </ul>
 
   <div class="mt-4 flex">
-    <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
       <%= t(".ok_button") %>
     <% end %>
   </div>

--- a/app/views/shared/samples/metadata/file_imports/_success.html.erb
+++ b/app/views/shared/samples/metadata/file_imports/_success.html.erb
@@ -11,7 +11,7 @@
 
   <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= t(".description") %></p>
 
-  <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+  <%= render Viral::ButtonComponent.new(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
     <%= t(".ok_button") %>
   <% end %>
 </div>

--- a/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open, size: :large, closable: closable) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, size: :large, closable: closable) do |dialog| %>
   <% dialog.with_header(title: t("shared.samples.spreadsheet_imports.dialog.title")) %>
   <%= turbo_stream_from @broadcast_target %>
 

--- a/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_errors.html.erb
@@ -1,15 +1,12 @@
-<div
-  data-controller="projects--samples--complete"
-  data-projects--samples--complete-filters-outlet=".filters"
->
+<div data-controller="projects--samples--complete" data-projects--samples--complete-filters-outlet=".filters">
   <p class="mb-4 dark:text-white"><%= t(".description") %></p>
 
   <% errors.each do |error| %>
-    <%= viral_alert(type:, message: error, classes: "mb-4") %>
+    <%= render Viral::AlertComponent.new(type:, message: error, classes: "mb-4") %>
   <% end %>
 
   <div class="mt-2">
-    <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
       <%= t(".ok_button") %>
     <% end %>
   </div>

--- a/app/views/shared/samples/spreadsheet_imports/_success.html.erb
+++ b/app/views/shared/samples/spreadsheet_imports/_success.html.erb
@@ -9,10 +9,11 @@
   <% unless problems.empty? %>
     <p class="mb-4 text-lg font-semibold text-slate-900 dark:text-white"><%= t(".problems") %></p>
 
-    <%= viral_data_table(problems, id: 'problems_table') do |table| %>
+    <%= render Viral::DataTableComponent.new(problems, id: 'problems_table') do |table| %>
       <% table.with_column("Sample Name") do |row| %>
         <%= row[:sample_name] %>
       <% end %>
+
       <% table.with_column("Messages") do |row| %>
         <% row[:message].each do |msg| %>
           <%= t(
@@ -23,10 +24,10 @@
         <% end %>
       <% end %>
     <% end %>
-
   <% end %>
+
   <div class="mt-2">
-    <%= viral_button(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(state: :primary, data: { action: 'click->viral--dialog#close' }) do %>
       <%= t(".ok_button") %>
     <% end %>
   </div>

--- a/app/views/shared/workflow_executions/_cancel_multiple.turbo_stream.erb
+++ b/app/views/shared/workflow_executions/_cancel_multiple.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% messages.each do |message| %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type: message[:type], data: message[:message]) %>
+    <%= render Viral::FlashComponent.new(type: message[:type], data: message[:message]) %>
   <% end %>
 <% end %>
 

--- a/app/views/shared/workflow_executions/_cancel_multiple_confirmation_dialog.html.erb
+++ b/app/views/shared/workflow_executions/_cancel_multiple_confirmation_dialog.html.erb
@@ -1,8 +1,9 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
+
   <div
     data-controller="infinite-scroll"
-    data-infinite-scroll-selection-outlet='#workflow-executions-table'
+    data-infinite-scroll-selection-outlet="#workflow-executions-table"
     data-infinite-scroll-paged-field-name-value="workflow_execution_ids[]"
     data-infinite-scroll-singular-description-value="<%= t(".description.singular") %>"
     data-infinite-scroll-plural-description-value="<%= t(".description.plural") %>"
@@ -15,19 +16,20 @@
     <% end %>
 
     <div class="grid gap-4">
-      <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400 "><span data-infinite-scroll-target="summary">
-          <%= t(".description.zero") %>
-        </span>
+      <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
+        <span data-infinite-scroll-target="summary"><%= t(".description.zero") %></span>
         <span><%= t(".state_warning_html") %></span>
       </p>
+
       <div>
-        <div class="block mb-1 text-sm font-medium text-slate-900 dark:text-white">
+        <div class="mb-1 block text-sm font-medium text-slate-900 dark:text-white">
           <%= t(".workflow_executions") %>
         </div>
+
         <div
           class="
-            overflow-y-auto max-h-[300px] border border-slate-300 rounded-lg block w-full
-            p-2.5 dark:bg-slate-800 dark:border-slate-600
+            block max-h-[300px] w-full overflow-y-auto rounded-lg border border-slate-300 p-2.5
+            dark:border-slate-600 dark:bg-slate-800
           "
           data-action="scroll->infinite-scroll#scroll"
           data-infinite-scroll-target="scrollable"
@@ -39,6 +41,7 @@
           </ul>
         </div>
       </div>
+
       <%= form_for(:cancel, url: @cancel_path, method: :delete,
           data: {
             controller: "form--json-submission",

--- a/app/views/shared/workflow_executions/_destroy_confirmation_dialog.html.erb
+++ b/app/views/shared/workflow_executions/_destroy_confirmation_dialog.html.erb
@@ -1,14 +1,13 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
+
   <div class="grid gap-4">
-    <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400 ">
+    <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
       <%= t(".description") %>
     </p>
+
     <div class="grid gap-4">
-      <div
-        data-controller="selection"
-        data-selection-storage-key-value="<%= "#{request.base_url}#{@index_path}" %>"
-      >
+      <div data-controller="selection" data-selection-storage-key-value="<%= request.base_url %><%= @index_path %>">
         <%= button_to t(".submit_button"),
         @destroy_path,
         method: :delete,

--- a/app/views/shared/workflow_executions/_destroy_multiple_confirmation_dialog.html.erb
+++ b/app/views/shared/workflow_executions/_destroy_multiple_confirmation_dialog.html.erb
@@ -1,8 +1,9 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t(".title")) %>
+
   <div
     data-controller="infinite-scroll"
-    data-infinite-scroll-selection-outlet='#workflow-executions-table'
+    data-infinite-scroll-selection-outlet="#workflow-executions-table"
     data-infinite-scroll-paged-field-name-value="workflow_execution_ids[]"
     data-infinite-scroll-singular-description-value="<%= t(".description.singular") %>"
     data-infinite-scroll-plural-description-value="<%= t(".description.plural") %>"
@@ -15,19 +16,20 @@
     <% end %>
 
     <div class="grid gap-4">
-      <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400 "><span data-infinite-scroll-target="summary">
-          <%= t(".description.zero") %>
-        </span>
+      <p class="text-base leading-relaxed text-slate-500 dark:text-slate-400">
+        <span data-infinite-scroll-target="summary"><%= t(".description.zero") %></span>
         <span><%= t(".state_warning_html") %></span>
       </p>
+
       <div>
-        <div class="block mb-1 text-sm font-medium text-slate-900 dark:text-white">
+        <div class="mb-1 block text-sm font-medium text-slate-900 dark:text-white">
           <%= t(".workflow_executions") %>
         </div>
+
         <div
           class="
-            overflow-y-auto max-h-[300px] border border-slate-300 rounded-lg block w-full
-            p-2.5 dark:bg-slate-800 dark:border-slate-600
+            block max-h-[300px] w-full overflow-y-auto rounded-lg border border-slate-300 p-2.5
+            dark:border-slate-600 dark:bg-slate-800
           "
           data-action="scroll->infinite-scroll#scroll"
           data-infinite-scroll-target="scrollable"
@@ -39,6 +41,7 @@
           </ul>
         </div>
       </div>
+
       <%= form_for(:destroy, url: @destroy_path, method: :delete,
           data: {
             controller: "form--json-submission",

--- a/app/views/workflow_executions/_edit_dialog.html.erb
+++ b/app/views/workflow_executions/_edit_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: open) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open) do |dialog| %>
   <% dialog.with_header(title: t("workflow_executions.edit_dialog.title")) %>
 
   <div class="mb-6 text-lg font-normal text-slate-500 dark:text-slate-400">

--- a/app/views/workflow_executions/_error_dialog.html.erb
+++ b/app/views/workflow_executions/_error_dialog.html.erb
@@ -1,13 +1,16 @@
-<%= viral_dialog(open: open, id: 'workflow_execution_error_dialog', size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, id: 'workflow_execution_error_dialog', size: :large) do |dialog| %>
   <% dialog.with_header(title: t("shared.workflow_executions.error_dialog.title")) %>
 
-  <%= viral_alert(message:, type: :alert, classes: "mb-4 h-30 overflow-y-auto", dismissible: false) do %>
-    <ul class="mt-1.5 ml-4 list-disc list-inside">
+  <%= render Viral::AlertComponent.new(message:, type: :alert, classes: "mb-4 h-30 overflow-y-auto", dismissible: false) do %>
+    <ul class="mt-1.5 ml-4 list-inside list-disc">
       <% errors.each do |error| %>
         <%- error_parts = error.split(":") %>
+
         <%- if error_parts.length > 1 %>
-          <li><%= error_parts[0] %>
-            <ul class="mt-1.5 ml-4 list-disc list-inside">
+          <li>
+            <%= error_parts[0] %>
+
+            <ul class="mt-1.5 ml-4 list-inside list-disc">
               <li><%= error_parts[1] %></li>
             </ul>
           </li>

--- a/app/views/workflow_executions/_samplesheet.html.erb
+++ b/app/views/workflow_executions/_samplesheet.html.erb
@@ -1,36 +1,26 @@
 <% if @samplesheet_headers.blank? || @samplesheet_rows.blank? %>
-  <%= viral_alert(message: t(:"workflow_executions.samples.empty"), type: :info) %>
+  <%= render Viral::AlertComponent.new(message: t(:"workflow_executions.samples.empty"), type: :info) %>
 <% else %>
   <div class="relative overflow-x-auto">
-    <table
-      class="
-        w-full text-sm text-left text-slate-500 rtl:text-right dark:text-slate-400
-      "
-    >
-      <thead
-        class="
-          text-xs uppercase text-slate-700 bg-slate-50 dark:bg-slate-900
-          dark:text-slate-400
-        "
-      >
+    <table class="w-full text-left text-sm text-slate-500 rtl:text-right dark:text-slate-400">
+      <thead class="bg-slate-50 text-xs text-slate-700 uppercase dark:bg-slate-900 dark:text-slate-400">
         <tr>
           <% @samplesheet_headers.each do |header| %>
             <th scope="col" class="px-6 py-3">
               <%= header %>
             </th>
           <% end %>
-
         </tr>
       </thead>
+
       <tbody>
         <% @samplesheet_rows.each do |sample| %>
-          <tr class="bg-white border-b dark:bg-slate-800 dark:border-slate-700">
+          <tr class="border-b bg-white dark:border-slate-700 dark:bg-slate-800">
             <% @samplesheet_headers.each do |header| %>
               <% if header == "sample" %>
                 <th class="px-6 py-4">
                   <div class="font-semibold text-slate-900 dark:text-white"><%= sample[header] %></div>
                 </th>
-
               <% else %>
                 <% if sample[header].is_a?(Hash) %>
                   <td class="px-6 py-4">

--- a/app/views/workflow_executions/cancel.turbo_stream.erb
+++ b/app/views/workflow_executions/cancel.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <turbo-stream action="refresh"></turbo-stream>

--- a/app/views/workflow_executions/destroy.turbo_stream.erb
+++ b/app/views/workflow_executions/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append "flashes" do %>
-  <%= viral_flash(type:, data: message) %>
+  <%= render Viral::FlashComponent.new(type:, data: message) %>
 <% end %>
 
 <%= turbo_stream.update "workflow_execution_dialog",

--- a/app/views/workflow_executions/destroy_multiple.turbo_stream.erb
+++ b/app/views/workflow_executions/destroy_multiple.turbo_stream.erb
@@ -1,12 +1,12 @@
 <% if defined?(messages) %>
   <% messages.each do |message| %>
     <%= turbo_stream.append "flashes" do %>
-      <%= viral_flash(type: message[:type], data: message[:message]) %>
+      <%= render Viral::FlashComponent.new(type: message[:type], data: message[:message]) %>
     <% end %>
   <% end %>
 <% else %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 

--- a/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
+++ b/app/views/workflow_executions/file_selector/_file_selector_dialog.html.erb
@@ -1,8 +1,9 @@
-<%= viral_dialog(open: open, id: "file_selector_form_dialog", size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: open, id: "file_selector_form_dialog", size: :extra_large) do |dialog| %>
   <% dialog.with_header(title: t(".select_file")) %>
+
   <% if @listing_attachments.empty? %>
-    <div class="mb-2 empty_state_message">
-      <%= viral_empty(
+    <div class="empty_state_message mb-2">
+      <%= render Viral::EmptyStateComponent.new(
         title: t(".empty.title"),
         description: t(".empty.description"),
         icon_name: Attachment.icon,
@@ -10,54 +11,47 @@
     </div>
   <% else %>
     <%= form_with id: 'file_selector_form', url: workflow_executions_file_selector_index_path(file_selector: file_selector_params), method: :post do |form| %>
-      <input type="hidden" name="format" value="turbo_stream"/>
-      <div class="flex flex-col min-h-0 mb-2 table-container shrink">
-        <div class="overflow-auto scrollbar">
+      <input type="hidden" name="format" value="turbo_stream">
+
+      <div class="table-container mb-2 flex min-h-0 shrink flex-col">
+        <div class="scrollbar overflow-auto">
           <fieldset>
             <legend class="sr-only"><%= t(".select_file") %></legend>
-            <table
-              class='
-                w-full text-sm text-left rtl:text-right text-slate-500 dark:text-slate-400
-                whitespace-nowrap
-              '
-            >
+
+            <table class="w-full text-left text-sm whitespace-nowrap text-slate-500 rtl:text-right dark:text-slate-400">
               <thead
-                class='
-                  sticky top-0 z-10 text-xs uppercase border text-slate-700 bg-slate-50
-                  dark:bg-slate-700 dark:text-slate-300 border-slate-200 dark:border-slate-700
-                '
+                class="
+                  sticky top-0 z-10 border border-slate-200 bg-slate-50 text-xs text-slate-700 uppercase
+                  dark:border-slate-700 dark:bg-slate-700 dark:text-slate-300
+                "
               >
                 <tr>
-                  <th scope="col" class="pr-3 pl-10.5 py-3 bg-slate-50 dark:bg-slate-700">
+                  <th scope="col" class="bg-slate-50 py-3 pr-3 pl-10.5 dark:bg-slate-700">
                     <%= t(".headers.filename") %>
                   </th>
+
                   <th scope="col" class="p-3">
                     <%= t(".headers.format") %>
                   </th>
+
                   <th scope="col" class="p-3">
                     <%= t(".headers.type") %>
                   </th>
+
                   <th scope="col" class="p-3">
                     <%= t(".headers.size") %>
                   </th>
+
                   <th scope="col" class="p-3">
                     <%= t(".headers.created_at") %>
                   </th>
                 </tr>
               </thead>
-              <tbody
-                class='
-                  overflow-y-auto bg-white border dark:bg-slate-800 border-slate-200
-                  dark:border-slate-700
-                '
-              >
+
+              <tbody class="overflow-y-auto border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
                 <% @listing_attachments.each do |attachment| %>
-                  <tr
-                    class="
-                      bg-white border-b border-slate-200 dark:bg-slate-800 dark:border-slate-700
-                    "
-                  >
-                    <td class="p-3 bg-white dark:bg-slate-800">
+                  <tr class="border-b border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+                    <td class="bg-white p-3 dark:bg-slate-800">
                       <%= form.radio_button "attachment_id",
                                         attachment[:id],
                                         label: attachment[:filename],
@@ -65,25 +59,34 @@
                                           file_selector_params["selected_id"] &&
                                             file_selector_params["selected_id"] == attachment[:id] %>
                     </td>
-                    <td class="p-3"><%= viral_pill(
+
+                    <td class="p-3">
+                      <%= render Viral::PillComponent.new(
                         text: attachment[:metadata]["format"],
                         color: find_pill_color_for_attachment(attachment, "format"),
-                      ) %></td>
-                    <td class="p-3"><%= viral_pill(
+                      ) %>
+                    </td>
+
+                    <td class="p-3">
+                      <%= render Viral::PillComponent.new(
                         text: attachment[:metadata]["type"],
                         color: find_pill_color_for_attachment(attachment, "type"),
-                      ) %></td>
+                      ) %>
+                    </td>
+
                     <td class="p-3">
                       <%= number_to_human_size(attachment[:byte_size]) %>
                     </td>
+
                     <td class="p-3">
                       <%= local_time_ago(attachment[:created_at]) %>
                     </td>
                   </tr>
                 <% end %>
+
                 <% unless file_selector_params["required_properties"].present? && file_selector_params["required_properties"].include?(file_selector_params["property"]) %>
-                  <tr class="bg-white border-b dark:bg-slate-800 dark:border-slate-700">
-                    <td class="p-3 bg-white dark:bg-slate-800">
+                  <tr class="border-b bg-white dark:border-slate-700 dark:bg-slate-800">
+                    <td class="bg-white p-3 dark:bg-slate-800">
                       <%= form.radio_button "attachment_id",
                                         "no_attachment",
                                         label: t(".no_file"),
@@ -96,11 +99,11 @@
           </fieldset>
         </div>
       </div>
+
       <% unless @listing_attachments.empty? %>
         <%= form.submit t(".submit_button"),
                     class:
                       "inline-flex items-center justify-center text-sm border cursor-pointer sm:w-auto text-white bg-primary-700 hover:bg-primary-800 rounded-lg px-5 py-3 dark:text-white dark:bg-primary-600 dark:hover:bg-primary-700 dark:border-primary-900 dark:hover:bg-primary-700" %>
-
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
+++ b/app/views/workflow_executions/submissions/_pipeline_selection_dialog.html.erb
@@ -1,4 +1,4 @@
-<%= viral_dialog(open: true) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true) do |dialog| %>
   <% dialog.with_header(
     title: t(:"workflow_executions.submissions.pipeline_selection.title"),
   ) %>
@@ -54,7 +54,7 @@
               <span class="min-w-0 flex-1 text-left group-hover:stroke-slate-100">
                 <span class="flex items-center space-x-2">
                   <span class="truncate font-medium text-slate-900 dark:text-white"><%= workflow.name %></span>
-                  <%= viral_pill(text: workflow.version, color: :primary) %>
+                  <%= render Viral::PillComponent.new(text: workflow.version, color: :primary) %>
                 </span>
 
                 <span class="text-sm font-normal text-wrap text-slate-500 dark:text-slate-400">

--- a/app/views/workflow_executions/submissions/create.turbo_stream.erb
+++ b/app/views/workflow_executions/submissions/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update "samples_dialog" do %>
-  <%= viral_dialog(open: true, size: :extra_large) do |dialog| %>
+  <%= render Viral::DialogComponent.new(open: true, size: :extra_large) do |dialog| %>
     <% dialog.with_header(title: t(:".title", workflow: @workflow.name)) %>
 
     <% if Flipper.enabled?(:v2_samplesheet, current_user) %>

--- a/app/views/workflow_executions/update.turbo_stream.erb
+++ b/app/views/workflow_executions/update.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% unless @workflow_execution.errors.any? %>
   <%= turbo_stream.append "flashes" do %>
-    <%= viral_flash(type:, data: message) %>
+    <%= render Viral::FlashComponent.new(type:, data: message) %>
   <% end %>
 <% end %>
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2066,8 +2066,8 @@ fr:
           dialog:
             confirm_button: Enregistrer
             description_with_new_value:
-              with_original_value: Cliquez sur <kbd>Enregistrer<kbd> pour mettre à jour la valeur <span class='font-bold underline'>NEW_VALUE</span> ou sur <kbd>Abandonner</kbd> pour annuler et revenir à la valeur précédente de <span class='font-bold underline'>ORIGINAL_VALUE</span>.
-              without_original_value: Cliquez sur <kbd>Enregistrer<kbd> pour mettre à jour la valeur <span class='font-bold underline'>NEW_VALUE</span> ou sur <kbd>Abandonner</kbd> pour annuler et revenir à la valeur vide précédente.
+              with_original_value: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur <span class='font-bold underline'>NEW_VALUE</span> ou sur <kbd>Abandonner</kbd> pour annuler et revenir à la valeur précédente de <span class='font-bold underline'>ORIGINAL_VALUE</span>.
+              without_original_value: Cliquez sur <kbd>Enregistrer</kbd> pour mettre à jour la valeur <span class='font-bold underline'>NEW_VALUE</span> ou sur <kbd>Abandonner</kbd> pour annuler et revenir à la valeur vide précédente.
             description_without_new_value: Cliquez sur <kbd>Enregistrer</kbd> pour supprimer la valeur actuelle ou sur <kbd>Abandonner</kbd> pour annuler et revenir à la valeur précédente de <span class='font-bold underline'>ORIGINAL_VALUE</span>.
             discard_button: Abandonner
             title: Confirmation requise

--- a/test/components/previews/clipboard_component_preview/custom_content.html.erb
+++ b/test/components/previews/clipboard_component_preview/custom_content.html.erb
@@ -2,5 +2,5 @@
   value: "Different value",
   title: 'Copy to clipboard value: "Different value"',
 ) do %>
-  <%= viral_pill(text: "INXT_GRP_AYJFZ42CTQ", color: "orange", classes: "ml-2") %>
+  <%= render Viral::PillComponent.new(text: "INXT_GRP_AYJFZ42CTQ", color: "orange", classes: "ml-2") %>
 <% end %>

--- a/test/components/previews/confirmation_component_preview/custom_content.html.erb
+++ b/test/components/previews/confirmation_component_preview/custom_content.html.erb
@@ -4,7 +4,7 @@
 <%# ------------------------------------------ %>
 
 <div id="confirmation-content" class="hidden">
-  <%= viral_alert(message: "This is some custom content") %>
+  <%= render Viral::AlertComponent.new(message: "This is some custom content") %>
 </div>
 
 <%= button_to "Confirmation",

--- a/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
+++ b/test/components/previews/confirmation_component_preview/with_confirm_value.html.erb
@@ -4,7 +4,7 @@
 <%# ------------------------------------------ %>
 
 <div class="custom-content hidden">
-  <%= viral_alert(
+  <%= render Viral::AlertComponent.new(
     message: "You are about to delete this project.  This cannot be undone.",
     type: :alert,
   ) %>

--- a/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
+++ b/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
@@ -14,7 +14,7 @@
     >
 
     <ul id="user_email_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= viral_help_text(state: :error) { "Email can't be blank" } %></li>
+      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { "Email can't be blank" } %></li>
     </ul>
   </div>
 
@@ -31,7 +31,7 @@
     >
 
     <ul id="namespace_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= viral_help_text(state: :error) { 'Namespace required' } %></li>
+      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { 'Namespace required' } %></li>
     </ul>
   </div>
 
@@ -48,7 +48,7 @@
     >
 
     <ul id="expires_at_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= viral_help_text(state: :error) { "Expiration date can't be blank" } %></li>
+      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { "Expiration date can't be blank" } %></li>
     </ul>
   </div>
 
@@ -84,7 +84,7 @@
     </fieldset>
 
     <ul id="personal_access_token_scopes_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= viral_help_text(state: :error) { "Scopes can't be blank" } %></li>
+      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { "Scopes can't be blank" } %></li>
     </ul>
   </div>
 </div>

--- a/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
+++ b/test/components/previews/form_error_summary_component_preview/focus_demo.html.erb
@@ -14,7 +14,7 @@
     >
 
     <ul id="user_email_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { "Email can't be blank" } %></li>
+      <li><%= render(Viral::Form::HelpTextComponent.new(state: :error)) { "Email can't be blank" } %></li>
     </ul>
   </div>
 
@@ -31,7 +31,7 @@
     >
 
     <ul id="namespace_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { 'Namespace required' } %></li>
+      <li><%= render(Viral::Form::HelpTextComponent.new(state: :error)) { 'Namespace required' } %></li>
     </ul>
   </div>
 
@@ -48,7 +48,7 @@
     >
 
     <ul id="expires_at_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { "Expiration date can't be blank" } %></li>
+      <li><%= render(Viral::Form::HelpTextComponent.new(state: :error)) { "Expiration date can't be blank" } %></li>
     </ul>
   </div>
 
@@ -84,7 +84,7 @@
     </fieldset>
 
     <ul id="personal_access_token_scopes_error" class="max-w-md list-inside text-sm text-slate-500 dark:text-slate-400">
-      <li><%= render Viral::Form::HelpTextComponent.new(state: :error) { "Scopes can't be blank" } %></li>
+      <li><%= render(Viral::Form::HelpTextComponent.new(state: :error)) { "Scopes can't be blank" } %></li>
     </ul>
   </div>
 </div>

--- a/test/components/previews/viral_alert_component_preview/accessibility_demo.html.erb
+++ b/test/components/previews/viral_alert_component_preview/accessibility_demo.html.erb
@@ -19,80 +19,87 @@
 <div class="space-y-6">
   <!-- Screen Reader Support -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📢 Screen Reader Support
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "This alert is announced to screen readers with 'aria-live' and 'aria-atomic'", type: :info) %>
-      <%= viral_alert(message: "When dismissed, screen readers announce 'Alert dismissed'", type: :success, dismissible: true) %>
-      <%= viral_alert(message: "Progress bars are announced as they update during auto-dismiss", type: :warning, auto_dismiss: true) %>
+      <%= render Viral::AlertComponent.new(message: "This alert is announced to screen readers with 'aria-live' and 'aria-atomic'", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "When dismissed, screen readers announce 'Alert dismissed'", type: :success, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Progress bars are announced as they update during auto-dismiss", type: :warning, auto_dismiss: true) %>
     </div>
   </div>
 
   <!-- Keyboard Navigation -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ⌨️  Keyboard Navigation
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ⌨️ Keyboard Navigation
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Press Tab to focus this alert, then Enter or Space to dismiss", dismissible: true) %>
-      <%= viral_alert(message: "Press Escape anywhere to dismiss dismissible alerts", type: :info, dismissible: true) %>
-      <%= viral_alert(message: "Use Tab to navigate between multiple alerts", type: :warning, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Press Tab to focus this alert, then Enter or Space to dismiss", dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Press Escape anywhere to dismiss dismissible alerts", type: :info, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Use Tab to navigate between multiple alerts", type: :warning, dismissible: true) %>
     </div>
   </div>
 
   <!-- ARIA Attributes -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      🏷️  ARIA Attributes
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      🏷️ ARIA Attributes
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "This alert has role='alert' for screen readers", type: :info) %>
-      <%= viral_alert(message: "aria-live='assertive' ensures immediate announcement", type: :warning) %>
-      <%= viral_alert(message: "aria-atomic='true' announces the entire alert content", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "This alert has role='alert' for screen readers", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "aria-live='assertive' ensures immediate announcement", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "aria-atomic='true' announces the entire alert content", type: :success) %>
     </div>
   </div>
 
   <!-- Focus Management -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🎯 Focus Management
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Dismissible alerts are focusable with tabindex='-1'", dismissible: true) %>
-      <%= viral_alert(message: "Close button has proper focus indicators", type: :info, dismissible: true) %>
-      <%= viral_alert(message: "Focus moves logically through the interface", type: :warning, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Dismissible alerts are focusable with tabindex='-1'", dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Close button has proper focus indicators", type: :info, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Focus moves logically through the interface", type: :warning, dismissible: true) %>
     </div>
   </div>
 
   <!-- Semantic Structure -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      🏗️  Semantic Structure
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      🏗️ Semantic Structure
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Proper heading hierarchy and landmark roles", type: :info) %>
-      <%= viral_alert(message: "Meaningful button labels and descriptions", type: :success, dismissible: true) %>
-      <%= viral_alert(message: "Logical content flow for assistive technology", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "Proper heading hierarchy and landmark roles", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "Meaningful button labels and descriptions", type: :success, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Logical content flow for assistive technology", type: :warning) %>
     </div>
   </div>
 
   <!-- Interactive Accessibility -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🎮 Interactive Accessibility
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Hover and focus states are clearly visible", type: :info, dismissible: true) %>
-      <%= viral_alert(message: "Progress bars update smoothly for all users", type: :warning, auto_dismiss: true) %>
-      <%= viral_alert(message: "All interactive elements are keyboard accessible", type: :success, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Hover and focus states are clearly visible", type: :info, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Progress bars update smoothly for all users", type: :warning, auto_dismiss: true) %>
+      <%= render Viral::AlertComponent.new(message: "All interactive elements are keyboard accessible", type: :success, dismissible: true) %>
     </div>
   </div>
 
   <!-- Accessibility Features Overview -->
-  <div class="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-    <h4 class="font-semibold text-blue-900 dark:text-blue-100 mb-2">♿ Built-in Accessibility Features</h4>
-    <ul class="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+  <div class="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+    <h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-100">♿ Built-in Accessibility Features</h4>
+
+    <ul class="space-y-1 text-sm text-blue-700 dark:text-blue-300">
       <li>• <strong>ARIA Live Regions</strong> - automatic screen reader announcements</li>
       <li>• <strong>Role Attributes</strong> - proper semantic meaning for assistive technology</li>
       <li>• <strong>Keyboard Navigation</strong> - full keyboard accessibility</li>
@@ -102,31 +109,49 @@
   </div>
 
   <!-- Keyboard Shortcuts -->
-  <div class="mt-6 p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800">
-    <h4 class="font-semibold text-green-900 dark:text-green-100 mb-2">⌨️  Keyboard Shortcuts</h4>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-green-700 dark:text-green-300">
+  <div class="mt-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+    <h4 class="mb-2 font-semibold text-green-900 dark:text-green-100">⌨️ Keyboard Shortcuts</h4>
+
+    <div class="grid grid-cols-1 gap-4 text-sm text-green-700 md:grid-cols-2 dark:text-green-300">
       <div>
-        <h5 class="font-semibold mb-2">Navigation</h5>
+        <h5 class="mb-2 font-semibold">Navigation</h5>
+
         <ul class="space-y-1">
-          <li>• <kbd class="px-2 py-1 bg-green-200 dark:bg-green-800 rounded text-xs">Tab</kbd> - Navigate between alerts</li>
-          <li>• <kbd class="px-2 py-1 bg-green-200 dark:bg-green-800 rounded text-xs">Shift+Tab</kbd> - Navigate backwards</li>
+          <li>
+            • <kbd class="rounded bg-green-200 px-2 py-1 text-xs dark:bg-green-800">Tab</kbd> - Navigate between alerts
+          </li>
+
+          <li>
+            • <kbd class="rounded bg-green-200 px-2 py-1 text-xs dark:bg-green-800">Shift+Tab</kbd> - Navigate backwards
+          </li>
         </ul>
       </div>
+
       <div>
-        <h5 class="font-semibold mb-2">Actions</h5>
+        <h5 class="mb-2 font-semibold">Actions</h5>
+
         <ul class="space-y-1">
-          <li>• <kbd class="px-2 py-1 bg-green-200 dark:bg-green-800 rounded text-xs">Escape</kbd> - Dismiss alert</li>
-          <li>• <kbd class="px-2 py-1 bg-green-200 dark:bg-green-800 rounded text-xs">Enter</kbd> - Activate focused element</li>
-          <li>• <kbd class="px-2 py-1 bg-green-200 dark:bg-green-800 rounded text-xs">Space</kbd> - Activate focused element</li>
+          <li>• <kbd class="rounded bg-green-200 px-2 py-1 text-xs dark:bg-green-800">Escape</kbd> - Dismiss alert</li>
+
+          <li>
+            • <kbd class="rounded bg-green-200 px-2 py-1 text-xs dark:bg-green-800">Enter</kbd> - Activate focused
+            element
+          </li>
+
+          <li>
+            • <kbd class="rounded bg-green-200 px-2 py-1 text-xs dark:bg-green-800">Space</kbd> - Activate focused
+            element
+          </li>
         </ul>
       </div>
     </div>
   </div>
 
   <!-- Testing Accessibility -->
-  <div class="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">🧪 Testing Accessibility</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">🧪 Testing Accessibility</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
       <li>• <strong>Screen Reader Testing</strong> - Test with NVDA, JAWS, or VoiceOver</li>
       <li>• <strong>Keyboard Navigation</strong> - Navigate using only Tab, Enter, and Space</li>
       <li>• <strong>Focus Indicators</strong> - Ensure focus is clearly visible</li>
@@ -136,9 +161,10 @@
   </div>
 
   <!-- WCAG Compliance -->
-  <div class="mt-6 p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200 dark:border-purple-800">
-    <h4 class="font-semibold text-purple-900 dark:text-purple-100 mb-2">✅ WCAG 2.1 AA Compliance</h4>
-    <ul class="text-sm text-purple-700 dark:text-purple-300 space-y-1">
+  <div class="mt-6 rounded-lg border border-purple-200 bg-purple-50 p-4 dark:border-purple-800 dark:bg-purple-900/20">
+    <h4 class="mb-2 font-semibold text-purple-900 dark:text-purple-100">✅ WCAG 2.1 AA Compliance</h4>
+
+    <ul class="space-y-1 text-sm text-purple-700 dark:text-purple-300">
       <li>• <strong>1.3.1 Info and Relationships</strong> - Proper semantic structure</li>
       <li>• <strong>2.1.1 Keyboard</strong> - Full keyboard accessibility</li>
       <li>• <strong>2.4.3 Focus Order</strong> - Logical tab navigation</li>

--- a/test/components/previews/viral_alert_component_preview/auto_dismiss_alert.html.erb
+++ b/test/components/previews/viral_alert_component_preview/auto_dismiss_alert.html.erb
@@ -13,46 +13,51 @@
   - Perfect for temporary notifications
 
   Usage:
-  viral_alert(message: "Message", auto_dismiss: true)
+  render Viral::AlertComponent.new(message: "Message", auto_dismiss: true)
 -->
 
 <div class="space-y-6">
   <!-- Basic Auto-dismiss Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ⏰ Basic Auto-dismiss Alert
     </h3>
-    <%= viral_alert(message: "This alert will automatically disappear in 5 seconds. Watch the progress bar at the bottom!", auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "This alert will automatically disappear in 5 seconds. Watch the progress bar at the bottom!", auto_dismiss: true) %>
   </div>
 
   <!-- Auto-dismiss Info Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ℹ️  Auto-dismiss Info Alert
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ℹ️ Auto-dismiss Info Alert
     </h3>
-    <%= viral_alert(message: "New message received from John Doe. This notification will auto-dismiss shortly.", type: :info, auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "New message received from John Doe. This notification will auto-dismiss shortly.", type: :info, auto_dismiss: true) %>
   </div>
 
   <!-- Auto-dismiss Success Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ✅ Auto-dismiss Success Alert
     </h3>
-    <%= viral_alert(message: "File uploaded successfully! This confirmation will disappear automatically.", type: :success, auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "File uploaded successfully! This confirmation will disappear automatically.", type: :success, auto_dismiss: true) %>
   </div>
 
   <!-- Auto-dismiss Warning Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ⚠️  Auto-dismiss Warning Alert
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ⚠️ Auto-dismiss Warning Alert
     </h3>
-    <%= viral_alert(message: "Your session will expire soon. Please save your work. This reminder will auto-dismiss.", type: :warning, auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "Your session will expire soon. Please save your work. This reminder will auto-dismiss.", type: :warning, auto_dismiss: true) %>
   </div>
 
   <!-- Interactive Demo Note -->
-  <div class="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-    <h4 class="font-semibold text-blue-900 dark:text-blue-100 mb-2">🎭 Interactive Features</h4>
-    <ul class="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+  <div class="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+    <h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-100">🎭 Interactive Features</h4>
+
+    <ul class="space-y-1 text-sm text-blue-700 dark:text-blue-300">
       <li>• <strong>Hover over any alert</strong> to pause the countdown</li>
       <li>• <strong>Move your mouse away</strong> to resume the countdown</li>
       <li>• <strong>Focus on any alert</strong> to pause (Tab navigation)</li>
@@ -62,9 +67,10 @@
   </div>
 
   <!-- Technical Details -->
-  <div class="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">⚙️  Technical Details</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">⚙️ Technical Details</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
       <li>• <strong>Duration:</strong> 5 seconds (5000ms)</li>
       <li>• <strong>Update interval:</strong> 50ms for smooth progress bar</li>
       <li>• <strong>Pause events:</strong> mouseenter, focusin</li>

--- a/test/components/previews/viral_alert_component_preview/custom_styling.html.erb
+++ b/test/components/previews/viral_alert_component_preview/custom_styling.html.erb
@@ -13,82 +13,90 @@
   - Maintains all accessibility and functionality
 
   Usage:
-  viral_alert(message: "Message", classes: "custom-class bg-purple-100 border-purple-300")
+  render Viral::AlertComponent.new(message: "Message", classes: "custom-class bg-purple-100 border-purple-300")
 -->
 
 <div class="space-y-6">
   <!-- Custom Background Colors -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🎨 Custom Background Colors
     </h3>
-    <%= viral_alert(message: "Custom purple background", classes: "bg-purple-100 border-purple-300 text-purple-800") %>
 
-    <%= viral_alert(message: "Custom indigo background", classes: "bg-indigo-100 border-indigo-300 text-indigo-800") %>
+    <%= render Viral::AlertComponent.new(message: "Custom purple background", classes: "bg-purple-100 border-purple-300 text-purple-800") %>
 
-    <%= viral_alert(message: "Custom emerald background", classes: "bg-emerald-100 border-emerald-300 text-emerald-800") %>
+    <%= render Viral::AlertComponent.new(message: "Custom indigo background", classes: "bg-indigo-100 border-indigo-300 text-indigo-800") %>
+
+    <%= render Viral::AlertComponent.new(message: "Custom emerald background", classes: "bg-emerald-100 border-emerald-300 text-emerald-800") %>
   </div>
 
   <!-- Custom Styling with Icons -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🖼️ Custom Styling with Icons
     </h3>
-    <%= viral_alert(message: "Premium feature available", type: :success, classes: "bg-gradient-to-r from-green-50 to-emerald-50 border-green-300 shadow-lg") %>
 
-    <%= viral_alert(message: "Limited time offer", type: :warning, classes: "bg-gradient-to-r from-amber-50 to-orange-50 border-amber-300 shadow-md") %>
+    <%= render Viral::AlertComponent.new(message: "Premium feature available", type: :success, classes: "bg-gradient-to-r from-green-50 to-emerald-50 border-green-300 shadow-lg") %>
+
+    <%= render Viral::AlertComponent.new(message: "Limited time offer", type: :warning, classes: "bg-gradient-to-r from-amber-50 to-orange-50 border-amber-300 shadow-md") %>
   </div>
 
   <!-- Custom Layout Modifications -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📐 Custom Layout Modifications
     </h3>
-    <%= viral_alert(message: "Large padding and rounded corners", classes: "p-6 rounded-xl shadow-lg") %>
 
-    <%= viral_alert(message: "Compact design with custom spacing", classes: "p-2 rounded-md mx-4") %>
+    <%= render Viral::AlertComponent.new(message: "Large padding and rounded corners", classes: "p-6 rounded-xl shadow-lg") %>
+
+    <%= render Viral::AlertComponent.new(message: "Compact design with custom spacing", classes: "p-2 rounded-md mx-4") %>
   </div>
 
   <!-- Brand-Specific Styling -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🏷️ Brand-Specific Styling
     </h3>
-    <%= viral_alert(message: "Company announcement", classes: "bg-slate-800 text-white border-slate-600 shadow-xl") %>
 
-    <%= viral_alert(message: "Partner notification", classes: "bg-blue-900 text-blue-100 border-blue-700") %>
+    <%= render Viral::AlertComponent.new(message: "Company announcement", classes: "bg-slate-800 text-white border-slate-600 shadow-xl") %>
+
+    <%= render Viral::AlertComponent.new(message: "Partner notification", classes: "bg-blue-900 text-blue-100 border-blue-700") %>
   </div>
 
   <!-- Interactive Custom Styling -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔘 Interactive Custom Styling
     </h3>
-    <%= viral_alert(message: "Custom dismissible alert", dismissible: true, classes: "bg-rose-50 border-rose-300 text-rose-800 hover:bg-rose-100 transition-colors") %>
 
-    <%= viral_alert(message: "Custom auto-dismiss alert", auto_dismiss: true, classes: "bg-violet-50 border-violet-300 text-violet-800") %>
+    <%= render Viral::AlertComponent.new(message: "Custom dismissible alert", dismissible: true, classes: "bg-rose-50 border-rose-300 text-rose-800 hover:bg-rose-100 transition-colors") %>
+
+    <%= render Viral::AlertComponent.new(message: "Custom auto-dismiss alert", auto_dismiss: true, classes: "bg-violet-50 border-violet-300 text-violet-800") %>
   </div>
 
   <!-- Advanced Custom Styling -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ⚡ Advanced Custom Styling
     </h3>
-    <%= viral_alert(message: "Premium notification", type: :success, classes: "bg-gradient-to-r from-yellow-50 via-amber-50 to-orange-50 border-amber-300 text-amber-900 shadow-lg transform hover:scale-105 transition-transform") %>
 
-    <%= viral_alert(message: "System status update", type: :info, classes: "bg-gradient-to-r from-blue-50 to-cyan-50 border-blue-300 text-blue-900 backdrop-blur-sm") %>
+    <%= render Viral::AlertComponent.new(message: "Premium notification", type: :success, classes: "bg-gradient-to-r from-yellow-50 via-amber-50 to-orange-50 border-amber-300 text-amber-900 shadow-lg transform hover:scale-105 transition-transform") %>
+
+    <%= render Viral::AlertComponent.new(message: "System status update", type: :info, classes: "bg-gradient-to-r from-blue-50 to-cyan-50 border-blue-300 text-blue-900 backdrop-blur-sm") %>
   </div>
 
   <!-- Design System Integration -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🎯 Design System Integration
     </h3>
-    <div class="bg-slate-50 dark:bg-slate-800 p-4 rounded-lg">
-      <h4 class="text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
+
+    <div class="rounded-lg bg-slate-50 p-4 dark:bg-slate-800">
+      <h4 class="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
         Design System Guidelines
       </h4>
-      <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
+
+      <ul class="space-y-2 text-sm text-slate-600 dark:text-slate-400">
         <li>• Use consistent color palettes from your design system</li>
         <li>• Maintain proper contrast ratios for accessibility</li>
         <li>• Keep custom styling within brand guidelines</li>
@@ -100,29 +108,37 @@
 
   <!-- Technical Implementation -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔧 Technical Implementation
     </h3>
-    <div class="bg-slate-50 dark:bg-slate-800 p-4 rounded-lg">
-      <h4 class="text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
+
+    <div class="rounded-lg bg-slate-50 p-4 dark:bg-slate-800">
+      <h4 class="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
         How to Use Custom Styling
       </h4>
-      <div class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
+
+      <div class="space-y-2 text-sm text-slate-600 dark:text-slate-400">
         <p><strong>Basic Usage:</strong></p>
-        <code class="block bg-slate-100 dark:bg-slate-700 p-2 rounded text-xs font-mono">
-          viral_alert(message: "Message", classes: "custom-class")
+
+        <code class="block rounded bg-slate-100 p-2 font-mono text-xs dark:bg-slate-700">
+          render Viral::AlertComponent.new(message: "Message", classes: "custom-class")
         </code>
 
         <p class="mt-3"><strong>Advanced Usage:</strong></p>
-        <code class="block bg-slate-100 dark:bg-slate-700 p-2 rounded text-xs font-mono">
-          viral_alert(message: "Message", type: :info, classes: "bg-purple-100 border-purple-300 text-purple-800 p-6 rounded-xl shadow-lg")
+
+        <code class="block rounded bg-slate-100 p-2 font-mono text-xs dark:bg-slate-700">
+          render Viral::AlertComponent.new(message: "Message", type: :info, classes: "bg-purple-100 border-purple-300
+          text-purple-800 p-6 rounded-xl shadow-lg")
         </code>
 
         <p class="mt-3"><strong>With Content Block:</strong></p>
-        <code class="block bg-slate-100 dark:bg-slate-700 p-2 rounded text-xs font-mono">
-          viral_alert(message: "Message", classes: "custom-styling") do
-          <br>&nbsp;&nbsp;div "Additional content"
-          <br>end
+
+        <code class="block rounded bg-slate-100 p-2 font-mono text-xs dark:bg-slate-700">
+          render Viral::AlertComponent.new(message: "Message", classes: "custom-styling") do
+          <br>
+          &nbsp;&nbsp;div "Additional content"
+          <br>
+          end
         </code>
       </div>
     </div>
@@ -130,14 +146,16 @@
 
   <!-- Best Practices -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       💡 Best Practices
     </h3>
-    <div class="bg-slate-50 dark:bg-slate-800 p-4 rounded-lg">
-      <h4 class="text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
+
+    <div class="rounded-lg bg-slate-50 p-4 dark:bg-slate-800">
+      <h4 class="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
         Custom Styling Guidelines
       </h4>
-      <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
+
+      <ul class="space-y-2 text-sm text-slate-600 dark:text-slate-400">
         <li>• <strong>Accessibility First:</strong> Always maintain proper contrast ratios</li>
         <li>• <strong>Consistency:</strong> Use your established color palette</li>
         <li>• <strong>Responsiveness:</strong> Test custom styles on all screen sizes</li>

--- a/test/components/previews/viral_alert_component_preview/danger_alert.html.erb
+++ b/test/components/previews/viral_alert_component_preview/danger_alert.html.erb
@@ -12,39 +12,43 @@
   - Perfect for critical errors and failures
 
   Usage:
-  viral_alert(message: "Error message", type: :danger)
+  render Viral::AlertComponent.new(message: "Error message", type: :danger)
 -->
 
 <div class="space-y-6">
   <!-- Basic Danger Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🚨 Basic Danger Alert
     </h3>
-    <%= viral_alert(message: "Failed to save your changes. Please check your connection and try again.", type: :danger) %>
+
+    <%= render Viral::AlertComponent.new(message: "Failed to save your changes. Please check your connection and try again.", type: :danger) %>
   </div>
 
   <!-- Danger with Error Details -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ❌ Error Details
     </h3>
-    <%= viral_alert(message: "Database connection failed. Error code: DB_CONN_001. Contact system administrator immediately.", type: :danger) %>
+
+    <%= render Viral::AlertComponent.new(message: "Database connection failed. Error code: DB_CONN_001. Contact system administrator immediately.", type: :danger) %>
   </div>
 
   <!-- Danger with Security Warning -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔒 Security Warning
     </h3>
-    <%= viral_alert(message: "Multiple failed login attempts detected. Your account has been temporarily locked for security.", type: :danger) %>
+
+    <%= render Viral::AlertComponent.new(message: "Multiple failed login attempts detected. Your account has been temporarily locked for security.", type: :danger) %>
   </div>
 
   <!-- Danger with System Failure -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       💥 System Failure
     </h3>
-    <%= viral_alert(message: "Critical system error detected. Some services may be unavailable. Engineers have been notified.", type: :danger) %>
+
+    <%= render Viral::AlertComponent.new(message: "Critical system error detected. Some services may be unavailable. Engineers have been notified.", type: :danger) %>
   </div>
 </div>

--- a/test/components/previews/viral_alert_component_preview/dismissible_alert.html.erb
+++ b/test/components/previews/viral_alert_component_preview/dismissible_alert.html.erb
@@ -12,49 +12,62 @@
   - Perfect for important but not critical messages
 
   Usage:
-  viral_alert(message: "Message", dismissible: true)
+  render Viral::AlertComponent.new(message: "Message", dismissible: true)
 -->
 
 <div class="space-y-6">
   <!-- Basic Dismissible Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🚪 Basic Dismissible Alert
     </h3>
-    <%= viral_alert(message: "This alert can be dismissed by clicking the X button or pressing Escape.", dismissible: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "This alert can be dismissed by clicking the X button or pressing Escape.", dismissible: true) %>
   </div>
 
   <!-- Dismissible Info Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ℹ️  Dismissible Info Alert
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ℹ️ Dismissible Info Alert
     </h3>
-    <%= viral_alert(message: "Your profile has been updated. You can dismiss this message when you're ready.", type: :info, dismissible: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "Your profile has been updated. You can dismiss this message when you're ready.", type: :info, dismissible: true) %>
   </div>
 
   <!-- Dismissible Success Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ✅ Dismissible Success Alert
     </h3>
-    <%= viral_alert(message: "Changes saved successfully! Click the X to dismiss this confirmation.", type: :success, dismissible: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "Changes saved successfully! Click the X to dismiss this confirmation.", type: :success, dismissible: true) %>
   </div>
 
   <!-- Dismissible Warning Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ⚠️  Dismissible Warning Alert
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ⚠️ Dismissible Warning Alert
     </h3>
-    <%= viral_alert(message: "Please review your settings before proceeding. Dismiss when you're ready.", type: :warning, dismissible: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "Please review your settings before proceeding. Dismiss when you're ready.", type: :warning, dismissible: true) %>
   </div>
 
   <!-- Accessibility Note -->
-  <div class="mt-8 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">♿ Accessibility Features</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
-      <li>• Press <kbd class="px-2 py-1 bg-slate-200 dark:bg-slate-700 rounded text-xs">Escape</kbd> to dismiss</li>
-      <li>• Use <kbd class="px-2 py-1 bg-slate-200 dark:bg-slate-700 rounded text-xs">Tab</kbd> to focus the close button</li>
-      <li>• Press <kbd class="px-2 py-1 bg-slate-200 dark:bg-slate-700 rounded text-xs">Enter</kbd> or <kbd class="px-2 py-1 bg-slate-200 dark:bg-slate-700 rounded text-xs">Space</kbd> to activate</li>
+  <div class="mt-8 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">♿ Accessibility Features</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
+      <li>• Press <kbd class="rounded bg-slate-200 px-2 py-1 text-xs dark:bg-slate-700">Escape</kbd> to dismiss</li>
+
+      <li>
+        • Use <kbd class="rounded bg-slate-200 px-2 py-1 text-xs dark:bg-slate-700">Tab</kbd> to focus the close button
+      </li>
+
+      <li>
+        • Press <kbd class="rounded bg-slate-200 px-2 py-1 text-xs dark:bg-slate-700">Enter</kbd> or
+        <kbd class="rounded bg-slate-200 px-2 py-1 text-xs dark:bg-slate-700">Space</kbd> to activate
+      </li>
+
       <li>• Screen readers announce when alerts are dismissed</li>
     </ul>
   </div>

--- a/test/components/previews/viral_alert_component_preview/dismissible_with_auto_dismiss.html.erb
+++ b/test/components/previews/viral_alert_component_preview/dismissible_with_auto_dismiss.html.erb
@@ -13,47 +13,53 @@
   - Perfect balance of user control and automation
 
   Usage:
-  viral_alert(message: "Message", dismissible: true, auto_dismiss: true)
+  render Viral::AlertComponent.new(message: "Message", dismissible: true, auto_dismiss: true)
 -->
 
 <div class="space-y-6">
   <!-- Basic Combination Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🎭 Basic Combination Alert
     </h3>
-    <%= viral_alert(message: "This alert gives you the best of both worlds - close it now or wait for auto-dismiss!", dismissible: true, auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "This alert gives you the best of both worlds - close it now or wait for auto-dismiss!", dismissible: true, auto_dismiss: true) %>
   </div>
 
   <!-- Info Combination Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ℹ️  Info with Options
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ℹ️ Info with Options
     </h3>
-    <%= viral_alert(message: "New updates available. You can review them now or dismiss this message to check later.", type: :info, dismissible: true, auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "New updates available. You can review them now or dismiss this message to check later.", type: :info, dismissible: true, auto_dismiss: true) %>
   </div>
 
   <!-- Success Combination Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ✅ Success with Options
     </h3>
-    <%= viral_alert(message: "Your preferences have been saved! This confirmation will auto-dismiss, or you can close it now.", type: :success, dismissible: true, auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "Your preferences have been saved! This confirmation will auto-dismiss, or you can close it now.", type: :success, dismissible: true, auto_dismiss: true) %>
   </div>
 
   <!-- Warning Combination Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ⚠️  Warning with Options
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ⚠️ Warning with Options
     </h3>
-    <%= viral_alert(message: "Please review your recent changes. This reminder will auto-dismiss, or you can acknowledge it now.", type: :warning, dismissible: true, auto_dismiss: true) %>
+
+    <%= render Viral::AlertComponent.new(message: "Please review your recent changes. This reminder will auto-dismiss, or you can acknowledge it now.", type: :warning, dismissible: true, auto_dismiss: true) %>
   </div>
 
   <!-- User Choice Explanation -->
-  <div class="mt-8 p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800">
-    <h4 class="font-semibold text-green-900 dark:text-green-100 mb-2">🤔 User Choice Options</h4>
-    <div class="text-sm text-green-700 dark:text-green-300 space-y-2">
+  <div class="mt-8 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+    <h4 class="mb-2 font-semibold text-green-900 dark:text-green-100">🤔 User Choice Options</h4>
+
+    <div class="space-y-2 text-sm text-green-700 dark:text-green-300">
       <p><strong>Option 1: Close Now</strong></p>
+
       <ul class="ml-4 space-y-1">
         <li>• Click the X button</li>
         <li>• Press Escape key</li>
@@ -61,6 +67,7 @@
       </ul>
 
       <p class="mt-3"><strong>Option 2: Wait for Auto-dismiss</strong></p>
+
       <ul class="ml-4 space-y-1">
         <li>• Do nothing - disappears in 5 seconds</li>
         <li>• Hover to pause the countdown</li>
@@ -70,9 +77,10 @@
   </div>
 
   <!-- Use Case Examples -->
-  <div class="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">💡 Perfect Use Cases</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">💡 Perfect Use Cases</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
       <li>• <strong>Feature announcements</strong> - users can read now or dismiss</li>
       <li>• <strong>Success confirmations</strong> - acknowledge or let disappear</li>
       <li>• <strong>Reminders</strong> - act now or dismiss for later</li>

--- a/test/components/previews/viral_alert_component_preview/info_alert.html.erb
+++ b/test/components/previews/viral_alert_component_preview/info_alert.html.erb
@@ -11,7 +11,7 @@
   - Responsive design that works on all devices
 
   Usage:
-  viral_alert(message: "Your message here", type: :info)
+  render Viral::AlertComponent.new(message: "Your message here", type: :info)
 -->
 
 <div class="space-y-6">
@@ -21,7 +21,7 @@
       📋 Basic Info Alert
     </h3>
 
-    <%= viral_alert(message: "Your profile has been updated successfully. All changes have been saved to your account.") %>
+    <%= render Viral::AlertComponent.new(message: "Your profile has been updated successfully. All changes have been saved to your account.") %>
   </div>
 
   <!-- Info Alert with Custom Message -->
@@ -30,7 +30,7 @@
       ✏️ Custom Message
     </h3>
 
-    <%= viral_alert(message: "New features are available! Check out our latest updates in the dashboard.") %>
+    <%= render Viral::AlertComponent.new(message: "New features are available! Check out our latest updates in the dashboard.") %>
   </div>
 
   <!-- Info Alert with Long Message -->
@@ -39,6 +39,6 @@
       📖 Long Message
     </h3>
 
-    <%= viral_alert(message: "We've made several improvements to the system based on your feedback. The new interface is more intuitive, loads faster, and includes additional features that will make your workflow more efficient. These changes will be rolled out gradually over the next few days.") %>
+    <%= render Viral::AlertComponent.new(message: "We've made several improvements to the system based on your feedback. The new interface is more intuitive, loads faster, and includes additional features that will make your workflow more efficient. These changes will be rolled out gradually over the next few days.") %>
   </div>
 </div>

--- a/test/components/previews/viral_alert_component_preview/multiple_alerts.html.erb
+++ b/test/components/previews/viral_alert_component_preview/multiple_alerts.html.erb
@@ -13,88 +13,95 @@
   - Demonstrates best practices for multiple alerts
 
   Usage:
-  Multiple viral_alert components can be rendered in sequence
+  Multiple Viral::AlertComponent instances can be rendered in sequence
 -->
 
 <div class="space-y-6">
   <!-- Multiple Alert Types -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🎨 Multiple Alert Types
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "System maintenance completed successfully!", type: :success) %>
-      <%= viral_alert(message: "New features are now available in your dashboard.", type: :info) %>
-      <%= viral_alert(message: "Please review your recent changes before proceeding.", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "System maintenance completed successfully!", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "New features are now available in your dashboard.", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "Please review your recent changes before proceeding.", type: :warning) %>
     </div>
   </div>
 
   <!-- Mixed Configurations -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔧 Mixed Configurations
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Profile updated successfully!", type: :success, dismissible: true) %>
-      <%= viral_alert(message: "This notification will auto-dismiss in 5 seconds.", type: :info, auto_dismiss: true) %>
-      <%= viral_alert(message: "You have 3 unread messages.", type: :warning, dismissible: true, auto_dismiss: true) %>
+      <%= render Viral::AlertComponent.new(message: "Profile updated successfully!", type: :success, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "This notification will auto-dismiss in 5 seconds.", type: :info, auto_dismiss: true) %>
+      <%= render Viral::AlertComponent.new(message: "You have 3 unread messages.", type: :warning, dismissible: true, auto_dismiss: true) %>
     </div>
   </div>
 
   <!-- Sequential Information -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📋 Sequential Information
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Step 1: Data validation completed", type: :success) %>
-      <%= viral_alert(message: "Step 2: Processing files...", type: :info) %>
-      <%= viral_alert(message: "Step 3: Uploading to server...", type: :info) %>
-      <%= viral_alert(message: "Step 4: Finalizing...", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "Step 1: Data validation completed", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "Step 2: Processing files...", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "Step 3: Uploading to server...", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "Step 4: Finalizing...", type: :info) %>
     </div>
   </div>
 
   <!-- Error Recovery Flow -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔄 Error Recovery Flow
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Connection failed. Attempting to reconnect...", type: :danger) %>
-      <%= viral_alert(message: "Reconnection successful! Syncing data...", type: :warning) %>
-      <%= viral_alert(message: "All data synchronized successfully!", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "Connection failed. Attempting to reconnect...", type: :danger) %>
+      <%= render Viral::AlertComponent.new(message: "Reconnection successful! Syncing data...", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "All data synchronized successfully!", type: :success) %>
     </div>
   </div>
 
   <!-- User Action Required -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📋 User Action Required
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Please complete your profile setup", type: :warning, dismissible: true) %>
-      <%= viral_alert(message: "2 of 5 required fields are incomplete", type: :info) %>
-      <%= viral_alert(message: "Profile completion will unlock additional features", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "Please complete your profile setup", type: :warning, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "2 of 5 required fields are incomplete", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "Profile completion will unlock additional features", type: :success) %>
     </div>
   </div>
 
   <!-- System Status Overview -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📊 System Status Overview
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "✅ Database: Online and healthy", type: :success) %>
-      <%= viral_alert(message: "✅ File Storage: 85% capacity used", type: :warning) %>
-      <%= viral_alert(message: "✅ API Services: All endpoints responding", type: :success) %>
-      <%= viral_alert(message: "⚠️  Backup System: Last backup 23 hours ago", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "✅ Database: Online and healthy", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "✅ File Storage: 85% capacity used", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "✅ API Services: All endpoints responding", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "⚠️  Backup System: Last backup 23 hours ago", type: :warning) %>
     </div>
   </div>
 
   <!-- Multiple Alerts Best Practices -->
-  <div class="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-    <h4 class="font-semibold text-blue-900 dark:text-blue-100 mb-2">🎯 Multiple Alerts Best Practices</h4>
-    <ul class="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+  <div class="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+    <h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-100">🎯 Multiple Alerts Best Practices</h4>
+
+    <ul class="space-y-1 text-sm text-blue-700 dark:text-blue-300">
       <li>• <strong>Limit to 5-7 alerts</strong> - too many can overwhelm users</li>
       <li>• <strong>Use consistent spacing</strong> - maintain visual rhythm</li>
       <li>• <strong>Group related alerts</strong> - show logical relationships</li>
@@ -104,9 +111,10 @@
   </div>
 
   <!-- When to Use Multiple Alerts -->
-  <div class="mt-6 p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800">
-    <h4 class="font-semibold text-green-900 dark:text-green-100 mb-2">💡 Perfect Use Cases</h4>
-    <ul class="text-sm text-green-700 dark:text-green-300 space-y-1">
+  <div class="mt-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+    <h4 class="mb-2 font-semibold text-green-900 dark:text-green-100">💡 Perfect Use Cases</h4>
+
+    <ul class="space-y-1 text-sm text-green-700 dark:text-green-300">
       <li>• <strong>Multi-step processes</strong> - show progress and status</li>
       <li>• <strong>System overviews</strong> - display multiple status indicators</li>
       <li>• <strong>User onboarding</strong> - guide through setup steps</li>
@@ -116,9 +124,10 @@
   </div>
 
   <!-- Accessibility Considerations -->
-  <div class="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">♿ Accessibility Considerations</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">♿ Accessibility Considerations</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
       <li>• <strong>Screen reader order</strong> - alerts are announced in DOM order</li>
       <li>• <strong>Focus management</strong> - ensure logical tab order</li>
       <li>• <strong>Dismissal patterns</strong> - consistent behavior across all alerts</li>

--- a/test/components/previews/viral_alert_component_preview/responsive_demo.html.erb
+++ b/test/components/previews/viral_alert_component_preview/responsive_demo.html.erb
@@ -19,56 +19,61 @@
 <div class="space-y-6">
   <!-- Responsive Layout -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📱 Responsive Layout
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "This alert adapts to your screen size automatically", type: :info) %>
-      <%= viral_alert(message: "On mobile, buttons and spacing adjust for touch", type: :success, dismissible: true) %>
-      <%= viral_alert(message: "Content flows naturally on all devices", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "This alert adapts to your screen size automatically", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "On mobile, buttons and spacing adjust for touch", type: :success, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Content flows naturally on all devices", type: :warning) %>
     </div>
   </div>
 
   <!-- Mobile Touch Targets -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       👆 Mobile Touch Targets
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Close button is sized for easy tapping on mobile", type: :info, dismissible: true) %>
-      <%= viral_alert(message: "Progress bars are touch-friendly", type: :warning, auto_dismiss: true) %>
-      <%= viral_alert(message: "All interactive elements meet accessibility guidelines", type: :success, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Close button is sized for easy tapping on mobile", type: :info, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Progress bars are touch-friendly", type: :warning, auto_dismiss: true) %>
+      <%= render Viral::AlertComponent.new(message: "All interactive elements meet accessibility guidelines", type: :success, dismissible: true) %>
     </div>
   </div>
 
   <!-- Adaptive Spacing -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📏 Adaptive Spacing
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Padding and margins adjust for different screen sizes", type: :info) %>
-      <%= viral_alert(message: "Text remains readable on all devices", type: :success) %>
-      <%= viral_alert(message: "Icons scale appropriately for each viewport", type: :warning) %>
+      <%= render Viral::AlertComponent.new(message: "Padding and margins adjust for different screen sizes", type: :info) %>
+      <%= render Viral::AlertComponent.new(message: "Text remains readable on all devices", type: :success) %>
+      <%= render Viral::AlertComponent.new(message: "Icons scale appropriately for each viewport", type: :warning) %>
     </div>
   </div>
 
   <!-- Cross-Device Behavior -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔄 Cross-Device Behavior
     </h3>
+
     <div class="space-y-3">
-      <%= viral_alert(message: "Same functionality works on desktop and mobile", type: :info, dismissible: true, auto_dismiss: true) %>
-      <%= viral_alert(message: "Keyboard shortcuts work on all platforms", type: :success, dismissible: true) %>
-      <%= viral_alert(message: "Touch and mouse interactions are consistent", type: :warning, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Same functionality works on desktop and mobile", type: :info, dismissible: true, auto_dismiss: true) %>
+      <%= render Viral::AlertComponent.new(message: "Keyboard shortcuts work on all platforms", type: :success, dismissible: true) %>
+      <%= render Viral::AlertComponent.new(message: "Touch and mouse interactions are consistent", type: :warning, dismissible: true) %>
     </div>
   </div>
 
   <!-- Responsive Guidelines -->
-  <div class="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-    <h4 class="font-semibold text-blue-900 dark:text-blue-100 mb-2">📱 Responsive Design Principles</h4>
-    <ul class="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+  <div class="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+    <h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-100">📱 Responsive Design Principles</h4>
+
+    <ul class="space-y-1 text-sm text-blue-700 dark:text-blue-300">
       <li>• <strong>Mobile-first approach</strong> - designed for small screens first</li>
       <li>• <strong>Touch-friendly targets</strong> - minimum 44px touch targets</li>
       <li>• <strong>Adaptive spacing</strong> - margins and padding scale with screen size</li>
@@ -78,9 +83,10 @@
   </div>
 
   <!-- Device Testing -->
-  <div class="mt-6 p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800">
-    <h4 class="font-semibold text-green-900 dark:text-green-100 mb-2">🧪 Device Testing Checklist</h4>
-    <ul class="text-sm text-green-700 dark:text-green-300 space-y-1">
+  <div class="mt-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+    <h4 class="mb-2 font-semibold text-green-900 dark:text-green-100">🧪 Device Testing Checklist</h4>
+
+    <ul class="space-y-1 text-sm text-green-700 dark:text-green-300">
       <li>• <strong>Mobile devices</strong> - test on various screen sizes (320px - 768px)</li>
       <li>• <strong>Tablets</strong> - test landscape and portrait orientations</li>
       <li>• <strong>Desktop</strong> - test on different monitor sizes and resolutions</li>
@@ -90,9 +96,10 @@
   </div>
 
   <!-- Performance Considerations -->
-  <div class="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">⚡ Performance Considerations</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">⚡ Performance Considerations</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
       <li>• <strong>Efficient rendering</strong> - minimal DOM manipulation</li>
       <li>• <strong>Smooth animations</strong> - 60fps transitions on all devices</li>
       <li>• <strong>Memory management</strong> - proper cleanup prevents leaks</li>

--- a/test/components/previews/viral_alert_component_preview/simple_message.html.erb
+++ b/test/components/previews/viral_alert_component_preview/simple_message.html.erb
@@ -12,54 +12,60 @@
   - Responsive and accessible
 
   Usage:
-  viral_alert(message: "Your simple message here")
+  render Viral::AlertComponent.new(message: "Your simple message here")
 -->
 
 <div class="space-y-6">
   <!-- Basic Simple Message -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       💬 Basic Simple Message
     </h3>
-    <%= viral_alert(message: "Your profile has been updated.") %>
+
+    <%= render Viral::AlertComponent.new(message: "Your profile has been updated.") %>
   </div>
 
   <!-- Short Status Update -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📊 Status Update
     </h3>
-    <%= viral_alert(message: "Processing complete.", type: :success) %>
+
+    <%= render Viral::AlertComponent.new(message: "Processing complete.", type: :success) %>
   </div>
 
   <!-- Quick Notification -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔔 Quick Notification
     </h3>
-    <%= viral_alert(message: "New message received.", type: :info) %>
+
+    <%= render Viral::AlertComponent.new(message: "New message received.", type: :info) %>
   </div>
 
   <!-- Simple Warning -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ⚠️  Simple Warning
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ⚠️ Simple Warning
     </h3>
-    <%= viral_alert(message: "Please save your work.", type: :warning) %>
+
+    <%= render Viral::AlertComponent.new(message: "Please save your work.", type: :warning) %>
   </div>
 
   <!-- Error Message -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ❌ Error Message
     </h3>
-    <%= viral_alert(message: "Connection failed.", type: :danger) %>
+
+    <%= render Viral::AlertComponent.new(message: "Connection failed.", type: :danger) %>
   </div>
 
   <!-- Design Principles -->
-  <div class="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-    <h4 class="font-semibold text-blue-900 dark:text-blue-100 mb-2">🎨 Design Principles</h4>
-    <ul class="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+  <div class="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+    <h4 class="mb-2 font-semibold text-blue-900 dark:text-blue-100">🎨 Design Principles</h4>
+
+    <ul class="space-y-1 text-sm text-blue-700 dark:text-blue-300">
       <li>• <strong>Keep it short</strong> - one line, under 60 characters</li>
       <li>• <strong>Be specific</strong> - what happened, not how it happened</li>
       <li>• <strong>Use active voice</strong> - "Updated" not "Has been updated"</li>
@@ -69,9 +75,10 @@
   </div>
 
   <!-- Best Practices -->
-  <div class="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">💡 Best Practices</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">💡 Best Practices</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
       <li>• <strong>Use for:</strong> confirmations, status updates, quick notifications</li>
       <li>• <strong>Avoid for:</strong> complex instructions, detailed explanations, user actions</li>
       <li>• <strong>Test length:</strong> ensure messages fit on mobile devices</li>

--- a/test/components/previews/viral_alert_component_preview/success_alert.html.erb
+++ b/test/components/previews/viral_alert_component_preview/success_alert.html.erb
@@ -12,39 +12,43 @@
   - Great for celebrating achievements
 
   Usage:
-  viral_alert(message: "Success message", type: :success)
+  render Viral::AlertComponent.new(message: "Success message", type: :success)
 -->
 
 <div class="space-y-6">
   <!-- Basic Success Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🎉 Basic Success Alert
     </h3>
-    <%= viral_alert(message: "Your changes have been saved successfully!", type: :success) %>
+
+    <%= render Viral::AlertComponent.new(message: "Your changes have been saved successfully!", type: :success) %>
   </div>
 
   <!-- Success with Achievement -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🏆 Achievement Unlocked
     </h3>
-    <%= viral_alert(message: "Congratulations! You've completed all the required training modules.", type: :success) %>
+
+    <%= render Viral::AlertComponent.new(message: "Congratulations! You've completed all the required training modules.", type: :success) %>
   </div>
 
   <!-- Success with Action Confirmation -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ✅ Action Confirmed
     </h3>
-    <%= viral_alert(message: "Sample uploaded successfully. 1,247 records were processed and imported into the database.", type: :success) %>
+
+    <%= render Viral::AlertComponent.new(message: "Sample uploaded successfully. 1,247 records were processed and imported into the database.", type: :success) %>
   </div>
 
   <!-- Success with Time Information -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ⏱️  Process Completed
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ⏱️ Process Completed
     </h3>
-    <%= viral_alert(message: "Backup completed in 2 minutes 34 seconds. All data has been securely stored.", type: :success) %>
+
+    <%= render Viral::AlertComponent.new(message: "Backup completed in 2 minutes 34 seconds. All data has been securely stored.", type: :success) %>
   </div>
 </div>

--- a/test/components/previews/viral_alert_component_preview/warning_alert.html.erb
+++ b/test/components/previews/viral_alert_component_preview/warning_alert.html.erb
@@ -12,39 +12,43 @@
   - Great for drawing attention to important information
 
   Usage:
-  viral_alert(message: "Warning message", type: :warning)
+  render Viral::AlertComponent.new(message: "Warning message", type: :warning)
 -->
 
 <div class="space-y-6">
   <!-- Basic Warning Alert -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
-      ⚠️  Basic Warning Alert
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
+      ⚠️ Basic Warning Alert
     </h3>
-    <%= viral_alert(message: "Your session will expire in 15 minutes. Please save your work.", type: :warning) %>
+
+    <%= render Viral::AlertComponent.new(message: "Your session will expire in 15 minutes. Please save your work.", type: :warning) %>
   </div>
 
   <!-- Warning with Recommendation -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       💡 Recommendation
     </h3>
-    <%= viral_alert(message: "Consider enabling two-factor authentication for enhanced account security.", type: :warning) %>
+
+    <%= render Viral::AlertComponent.new(message: "Consider enabling two-factor authentication for enhanced account security.", type: :warning) %>
   </div>
 
   <!-- Warning with System Notice -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔧 System Notice
     </h3>
-    <%= viral_alert(message: "Scheduled maintenance will occur tonight from 2:00 AM to 4:00 AM. Some features may be temporarily unavailable.", type: :warning) %>
+
+    <%= render Viral::AlertComponent.new(message: "Scheduled maintenance will occur tonight from 2:00 AM to 4:00 AM. Some features may be temporarily unavailable.", type: :warning) %>
   </div>
 
   <!-- Warning with Action Required -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📋 Action Required
     </h3>
-    <%= viral_alert(message: "Please review and update your profile information. Some fields are incomplete or outdated.", type: :warning) %>
+
+    <%= render Viral::AlertComponent.new(message: "Please review and update your profile information. Some fields are incomplete or outdated.", type: :warning) %>
   </div>
 </div>

--- a/test/components/previews/viral_alert_component_preview/with_actions.html.erb
+++ b/test/components/previews/viral_alert_component_preview/with_actions.html.erb
@@ -1,250 +1,171 @@
-<!-- 🔘 ALERTS WITH ACTIONS - Interactive elements within alerts Action alerts
-include interactive elements like buttons, links, or forms within the alert
-content. Perfect for alerts that require user decisions or immediate actions.
-Features: - Interactive elements within the alert - Buttons, links, forms, or
-other controls - Maintains alert styling and behavior - Perfect for user
-decisions and actions - Can combine with dismissible/auto-dismiss Usage:
-viral_alert(message: "Message") do div class: "flex gap-2 mt-3" do button
-"Action", class: "btn btn-primary" button "Cancel", class: "btn btn-secondary"
-end end -->
+<!--
+  🔘 ALERTS WITH ACTIONS - Interactive elements within alerts Action alerts
+  include interactive elements like buttons, links, or forms within the alert
+  content. Perfect for alerts that require user decisions or immediate actions.
+  Features: - Interactive elements within the alert - Buttons, links, forms, or
+  other controls - Maintains alert styling and behavior - Perfect for user
+  decisions and actions - Can combine with dismissible/auto-dismiss Usage:
+  render Viral::AlertComponent.new(message: "Message") do div class: "flex gap-2 mt-3" do button
+  "Action", class: "btn btn-primary" button "Cancel", class: "btn btn-secondary"
+  end end
+-->
 <div class="space-y-6">
   <!-- Basic Action Buttons -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       🔘 Basic Action Buttons
     </h3>
-    <%= viral_alert(message: "Do you want to save your changes?", type: :info) do %>
-      <div class="flex gap-2 mt-3">
-        <button
-          class="
-            px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors
-          "
-        >
+
+    <%= render Viral::AlertComponent.new(message: "Do you want to save your changes?", type: :info) do %>
+      <div class="mt-3 flex gap-2">
+        <button class="rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700">
           💾 Save Changes
         </button>
-        <button
-          class="
-            px-4 py-2 bg-slate-200 text-slate-700 rounded-lg hover:bg-slate-300
-            transition-colors
-          "
-        >
+
+        <button class="rounded-lg bg-slate-200 px-4 py-2 text-slate-700 transition-colors hover:bg-slate-300">
           ❌ Discard
         </button>
       </div>
     <% end %>
   </div>
+
   <!-- Success with Action -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ✅ Success with Action
     </h3>
-    <%= viral_alert(message: "Your profile has been updated successfully!", type: :success) do %>
-      <div class="flex gap-2 mt-3">
-        <button
-          class="
-            px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700
-            transition-colors
-          "
-        >
+
+    <%= render Viral::AlertComponent.new(message: "Your profile has been updated successfully!", type: :success) do %>
+      <div class="mt-3 flex gap-2">
+        <button class="rounded-lg bg-green-600 px-4 py-2 text-white transition-colors hover:bg-green-700">
           👁️ View Profile
         </button>
-        <button
-          class="
-            px-4 py-2 bg-slate-200 text-slate-700 rounded-lg hover:bg-slate-300
-            transition-colors
-          "
-        >
+
+        <button class="rounded-lg bg-slate-200 px-4 py-2 text-slate-700 transition-colors hover:bg-slate-300">
           ✏️ Edit More
         </button>
       </div>
     <% end %>
   </div>
+
   <!-- Warning with Decision -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ⚠️ Warning with Decision
     </h3>
-    <%= viral_alert(message: "You have unsaved changes. What would you like to do?", type: :warning) do %>
-      <div class="flex gap-2 mt-3">
-        <button
-          class="
-            px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700
-            transition-colors
-          "
-        >
-          💾 Save & Continue
+
+    <%= render Viral::AlertComponent.new(message: "You have unsaved changes. What would you like to do?", type: :warning) do %>
+      <div class="mt-3 flex gap-2">
+        <button class="rounded-lg bg-amber-600 px-4 py-2 text-white transition-colors hover:bg-amber-700">
+          💾 Save &amp; Continue
         </button>
-        <button
-          class="
-            px-4 py-2 bg-slate-200 text-slate-700 rounded-lg hover:bg-slate-300
-            transition-colors
-          "
-        >
+
+        <button class="rounded-lg bg-slate-200 px-4 py-2 text-slate-700 transition-colors hover:bg-slate-300">
           ⏸️ Save Later
         </button>
-        <button
-          class="
-            px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors
-          "
-        >
+
+        <button class="rounded-lg bg-red-600 px-4 py-2 text-white transition-colors hover:bg-red-700">
           ❌ Discard Changes
         </button>
       </div>
     <% end %>
   </div>
+
   <!-- Error with Recovery Actions -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ❌ Error with Recovery Actions
     </h3>
-    <%= viral_alert(message: "Failed to upload file. Please try one of these solutions:", type: :danger) do %>
-      <div class="space-y-3 mt-3">
+
+    <%= render Viral::AlertComponent.new(message: "Failed to upload file. Please try one of these solutions:", type: :danger) do %>
+      <div class="mt-3 space-y-3">
         <div class="text-sm text-slate-600 dark:text-slate-400">
           <p class="mb-2">The file upload failed. Here are your options:</p>
         </div>
+
         <div class="flex gap-2">
-          <button
-            class="
-              px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors
-            "
-          >
+          <button class="rounded-lg bg-red-600 px-4 py-2 text-white transition-colors hover:bg-red-700">
             🔄 Try Again
           </button>
-          <button
-            class="
-              px-4 py-2 bg-slate-200 text-slate-700 rounded-lg hover:bg-slate-300
-              transition-colors
-            "
-          >
+
+          <button class="rounded-lg bg-slate-200 px-4 py-2 text-slate-700 transition-colors hover:bg-slate-300">
             📁 Choose Different File
           </button>
-          <button
-            class="
-              px-4 py-2 bg-slate-200 text-slate-700 rounded-lg hover:bg-slate-300
-              transition-colors
-            "
-          >
+
+          <button class="rounded-lg bg-slate-200 px-4 py-2 text-slate-700 transition-colors hover:bg-slate-300">
             🆘 Get Help
           </button>
         </div>
       </div>
     <% end %>
   </div>
+
   <!-- Info with Multiple Actions -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ℹ️ Info with Multiple Actions
     </h3>
-    <%= viral_alert(message: "New features are available! Explore what's new:", type: :info) do %>
-      <div class="space-y-3 mt-3">
+
+    <%= render Viral::AlertComponent.new(message: "New features are available! Explore what's new:", type: :info) do %>
+      <div class="mt-3 space-y-3">
         <div class="text-sm text-slate-600 dark:text-slate-400">
           <p>We've added several new features to improve your workflow:</p>
         </div>
+
         <div class="grid grid-cols-2 gap-2">
-          <button
-            class="
-              px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors
-              text-sm
-            "
-          >
+          <button class="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white transition-colors hover:bg-blue-700">
             📊 Analytics
           </button>
-          <button
-            class="
-              px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors
-              text-sm
-            "
-          >
+
+          <button class="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white transition-colors hover:bg-blue-700">
             🔍 Search
           </button>
-          <button
-            class="
-              px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors
-              text-sm
-            "
-          >
+
+          <button class="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white transition-colors hover:bg-blue-700">
             📱 Mobile
           </button>
-          <button
-            class="
-              px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors
-              text-sm
-            "
-          >
+
+          <button class="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white transition-colors hover:bg-blue-700">
             ⚙️ Settings
           </button>
         </div>
+
         <div class="flex gap-2">
-          <button
-            class="
-              px-4 py-2 bg-slate-200 text-slate-700 rounded-lg hover:bg-slate-300
-              transition-colors
-            "
-          >
+          <button class="rounded-lg bg-slate-200 px-4 py-2 text-slate-700 transition-colors hover:bg-slate-300">
             📖 Read More
           </button>
-          <button
-            class="
-              px-4 py-2 bg-slate-200 text-slate-700 rounded-lg hover:bg-slate-300
-              transition-colors
-            "
-          >
+
+          <button class="rounded-lg bg-slate-200 px-4 py-2 text-slate-700 transition-colors hover:bg-slate-300">
             ⏰ Remind Later
           </button>
         </div>
       </div>
     <% end %>
   </div>
+
   <!-- Action Guidelines -->
-  <div
-    class="
-      mt-8 p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200
-      dark:border-purple-800
-    "
-  >
-    <h4 class="font-semibold text-purple-900 dark:text-purple-100 mb-2">🎯 Action Design Guidelines</h4>
-    <ul class="text-sm text-purple-700 dark:text-purple-300 space-y-1">
-      <li>•
-        <strong>Primary action first</strong>
-        - most important button should be most prominent</li>
-      <li>•
-        <strong>Limit to 3-4 actions</strong>
-        - too many choices can overwhelm users</li>
-      <li>•
-        <strong>Use clear button text</strong>
-        - "Save Changes" not "OK"</li>
-      <li>•
-        <strong>Consider button hierarchy</strong>
-        - primary, secondary, and destructive actions</li>
-      <li>•
-        <strong>Group related actions</strong>
-        - use visual grouping for better organization</li>
+  <div class="mt-8 rounded-lg border border-purple-200 bg-purple-50 p-4 dark:border-purple-800 dark:bg-purple-900/20">
+    <h4 class="mb-2 font-semibold text-purple-900 dark:text-purple-100">🎯 Action Design Guidelines</h4>
+
+    <ul class="space-y-1 text-sm text-purple-700 dark:text-purple-300">
+      <li>• <strong>Primary action first</strong> - most important button should be most prominent</li>
+      <li>• <strong>Limit to 3-4 actions</strong> - too many choices can overwhelm users</li>
+      <li>• <strong>Use clear button text</strong> - "Save Changes" not "OK"</li>
+      <li>• <strong>Consider button hierarchy</strong> - primary, secondary, and destructive actions</li>
+      <li>• <strong>Group related actions</strong> - use visual grouping for better organization</li>
     </ul>
   </div>
+
   <!-- Best Practices -->
-  <div
-    class="
-      mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200
-      dark:border-slate-700
-    "
-  >
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">💡 Best Practices</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
-      <li>•
-        <strong>Use for:</strong>
-        user decisions, immediate actions, multi-step processes</li>
-      <li>•
-        <strong>Avoid for:</strong>
-        simple notifications, status updates, read-only information</li>
-      <li>•
-        <strong>Keep actions relevant</strong>
-        - only include actions that make sense in context</li>
-      <li>•
-        <strong>Consider mobile</strong>
-        - ensure buttons are large enough to tap easily</li>
-      <li>•
-        <strong>Test user flow</strong>
-        - make sure the actions lead to logical next steps</li>
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">💡 Best Practices</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
+      <li>• <strong>Use for:</strong> user decisions, immediate actions, multi-step processes</li>
+      <li>• <strong>Avoid for:</strong> simple notifications, status updates, read-only information</li>
+      <li>• <strong>Keep actions relevant</strong> - only include actions that make sense in context</li>
+      <li>• <strong>Consider mobile</strong> - ensure buttons are large enough to tap easily</li>
+      <li>• <strong>Test user flow</strong> - make sure the actions lead to logical next steps</li>
     </ul>
   </div>
 </div>

--- a/test/components/previews/viral_alert_component_preview/with_rich_content.html.erb
+++ b/test/components/previews/viral_alert_component_preview/with_rich_content.html.erb
@@ -1,36 +1,43 @@
-<!-- 📚 RICH CONTENT ALERTS - Additional context and information Rich content
-alerts use the content block to provide additional information, context, or
-details that complement the main message. Perfect for complex notifications
-that need more explanation. Features: - Main message with additional content
-below - Content block for extra details - Flexible content (text, links, lists,
-etc.) - Maintains clean visual hierarchy - Perfect for detailed explanations
-Usage: viral_alert(message: "Main message") do div "Additional content goes
-here" end -->
+<!--
+  📚 RICH CONTENT ALERTS - Additional context and information Rich content
+  alerts use the content block to provide additional information, context, or
+  details that complement the main message. Perfect for complex notifications
+  that need more explanation. Features: - Main message with additional content
+  below - Content block for extra details - Flexible content (text, links, lists,
+  etc.) - Maintains clean visual hierarchy - Perfect for detailed explanations
+  Usage: render Viral::AlertComponent.new(message: "Main message") do div "Additional content goes
+  here" end
+-->
 <div class="space-y-6">
   <!-- Basic Rich Content -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       📚 Basic Rich Content
     </h3>
-    <%= viral_alert(message: "System maintenance scheduled") do %>
+
+    <%= render Viral::AlertComponent.new(message: "System maintenance scheduled") do %>
       <div class="text-slate-600 dark:text-slate-400">
-        <p class="mb-2">We'll be performing routine maintenance to improve system
-          performance.</p>
-        <p><strong>Duration:</strong>
-          2 hours<br>
-          <strong>Impact:</strong>
-          Minimal - some features may be slower than usual</p>
+        <p class="mb-2">
+          We'll be performing routine maintenance to improve system performance.
+        </p>
+
+        <p>
+          <strong>Duration:</strong> 2 hours<br>
+          <strong>Impact:</strong> Minimal - some features may be slower than usual
+        </p>
       </div>
     <% end %>
   </div>
+
   <!-- Success with Details -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ✅ Success with Details
     </h3>
-    <%= viral_alert(message: "Data import completed successfully!", type: :success) do %>
+
+    <%= render Viral::AlertComponent.new(message: "Data import completed successfully!", type: :success) do %>
       <div class="text-slate-600 dark:text-slate-400">
-        <ul class="list-disc list-inside space-y-1">
+        <ul class="list-inside list-disc space-y-1">
           <li>1,247 records imported</li>
           <li>3 duplicate records skipped</li>
           <li>Processing time: 2 minutes 34 seconds</li>
@@ -38,21 +45,19 @@ here" end -->
       </div>
     <% end %>
   </div>
+
   <!-- Warning with Instructions -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ⚠️ Warning with Instructions
     </h3>
-    <%= viral_alert(message: "Action required: Review pending changes", type: :warning) do %>
+
+    <%= render Viral::AlertComponent.new(message: "Action required: Review pending changes", type: :warning) do %>
       <div class="text-slate-600 dark:text-slate-400">
         <p class="mb-2">You have 5 pending changes that require your review:</p>
-        <div
-          class="
-            bg-amber-50 dark:bg-amber-900/20 p-3 rounded border border-amber-200
-            dark:border-amber-800
-          "
-        >
-          <ul class="text-sm space-y-1">
+
+        <div class="rounded border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
+          <ul class="space-y-1 text-sm">
             <li>• Profile information update</li>
             <li>• Security settings change</li>
             <li>• Notification preferences</li>
@@ -63,53 +68,40 @@ here" end -->
       </div>
     <% end %>
   </div>
+
   <!-- Info with Links -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ℹ️ Info with Links
     </h3>
-    <%= viral_alert(message: "New features available in your dashboard", type: :info) do %>
+
+    <%= render Viral::AlertComponent.new(message: "New features available in your dashboard", type: :info) do %>
       <div class="text-slate-600 dark:text-slate-400">
         <p class="mb-2">We've added several new features to help you work more efficiently:</p>
+
         <div class="space-y-2">
-          <a
-            href="#"
-            class="
-              text-blue-600 dark:text-blue-400 underline hover:decoration-2 block
-            "
-          >📊 Enhanced Analytics Dashboard</a>
-          <a
-            href="#"
-            class="
-              text-blue-600 dark:text-blue-400 underline hover:decoration-2 block
-            "
-          >🔍 Advanced Search Filters</a>
-          <a
-            href="#"
-            class="
-              text-blue-600 dark:text-blue-400 underline hover:decoration-2 block
-            "
-          >📱 Mobile App Updates</a>
+          <a href="/" class="block text-blue-600 underline hover:decoration-2 dark:text-blue-400">📊 Enhanced Analytics Dashboard</a>
+          <a href="/" class="block text-blue-600 underline hover:decoration-2 dark:text-blue-400">🔍 Advanced Search Filters</a>
+          <a href="/" class="block text-blue-600 underline hover:decoration-2 dark:text-blue-400">📱 Mobile App Updates</a>
         </div>
       </div>
     <% end %>
   </div>
+
   <!-- Error with Solutions -->
   <div>
-    <h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-3">
+    <h3 class="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
       ❌ Error with Solutions
     </h3>
-    <%= viral_alert(message: "Unable to process your request", type: :danger) do %>
+
+    <%= render Viral::AlertComponent.new(message: "Unable to process your request", type: :danger) do %>
       <div class="text-slate-600 dark:text-slate-400">
-        <p class="mb-2">The system encountered an error while processing your request. Here
-          are some solutions to try:</p>
-        <div
-          class="
-            bg-red-50 dark:bg-red-900/20 p-3 rounded border border-red-200
-            dark:border-red-800
-          "
-        >
-          <ol class="list-decimal list-inside space-y-1 text-sm">
+        <p class="mb-2">
+          The system encountered an error while processing your request. Here are some solutions to try:
+        </p>
+
+        <div class="rounded border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+          <ol class="list-inside list-decimal space-y-1 text-sm">
             <li>Refresh the page and try again</li>
             <li>Check your internet connection</li>
             <li>Clear your browser cache</li>
@@ -119,56 +111,30 @@ here" end -->
       </div>
     <% end %>
   </div>
+
   <!-- Content Guidelines -->
-  <div
-    class="
-      mt-8 p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200
-      dark:border-green-800
-    "
-  >
-    <h4 class="font-semibold text-green-900 dark:text-green-100 mb-2">📝 Content Guidelines</h4>
-    <ul class="text-sm text-green-700 dark:text-green-300 space-y-1">
-      <li>•
-        <strong>Keep main message short</strong>
-        - under 60 characters</li>
-      <li>•
-        <strong>Use content block for details</strong>
-        - don't cram everything in the message</li>
-      <li>•
-        <strong>Structure content clearly</strong>
-        - use lists, paragraphs, and visual hierarchy</li>
-      <li>•
-        <strong>Include actionable information</strong>
-        - what should users do next?</li>
-      <li>•
-        <strong>Use appropriate formatting</strong>
-        - links, bold text, and spacing for readability</li>
+  <div class="mt-8 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+    <h4 class="mb-2 font-semibold text-green-900 dark:text-green-100">📝 Content Guidelines</h4>
+
+    <ul class="space-y-1 text-sm text-green-700 dark:text-green-300">
+      <li>• <strong>Keep main message short</strong> - under 60 characters</li>
+      <li>• <strong>Use content block for details</strong> - don't cram everything in the message</li>
+      <li>• <strong>Structure content clearly</strong> - use lists, paragraphs, and visual hierarchy</li>
+      <li>• <strong>Include actionable information</strong> - what should users do next?</li>
+      <li>• <strong>Use appropriate formatting</strong> - links, bold text, and spacing for readability</li>
     </ul>
   </div>
+
   <!-- When to Use Rich Content -->
-  <div
-    class="
-      mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200
-      dark:border-slate-700
-    "
-  >
-    <h4 class="font-semibold text-slate-900 dark:text-white mb-2">🎯 Perfect Use Cases</h4>
-    <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-1">
-      <li>•
-        <strong>Complex notifications</strong>
-        - need more context or explanation</li>
-      <li>•
-        <strong>Actionable alerts</strong>
-        - include next steps or instructions</li>
-      <li>•
-        <strong>Detailed confirmations</strong>
-        - show what was accomplished</li>
-      <li>•
-        <strong>System announcements</strong>
-        - provide comprehensive information</li>
-      <li>•
-        <strong>Error explanations</strong>
-        - help users understand and resolve issues</li>
+  <div class="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+    <h4 class="mb-2 font-semibold text-slate-900 dark:text-white">🎯 Perfect Use Cases</h4>
+
+    <ul class="space-y-1 text-sm text-slate-600 dark:text-slate-400">
+      <li>• <strong>Complex notifications</strong> - need more context or explanation</li>
+      <li>• <strong>Actionable alerts</strong> - include next steps or instructions</li>
+      <li>• <strong>Detailed confirmations</strong> - show what was accomplished</li>
+      <li>• <strong>System announcements</strong> - provide comprehensive information</li>
+      <li>• <strong>Error explanations</strong> - help users understand and resolve issues</li>
     </ul>
   </div>
 </div>

--- a/test/components/previews/viral_avatar_component_preview/default.html.erb
+++ b/test/components/previews/viral_avatar_component_preview/default.html.erb
@@ -1,4 +1,4 @@
-<%= viral_avatar(
+<%= render Viral::AvatarComponent.new(
       name: "Outbreak 2021",
       colour_string: "Streptococcus / Streptococcus pyogenes / Outbreak 2021"
     ) %>

--- a/test/components/previews/viral_avatar_component_preview/large.html.erb
+++ b/test/components/previews/viral_avatar_component_preview/large.html.erb
@@ -1,1 +1,1 @@
-<%= viral_avatar(name: "Outbreak 2021", colour_string: "Streptococcus / Streptococcus pyogenes / Outbreak 2021", size: :large) %>
+<%= render Viral::AvatarComponent.new(name: "Outbreak 2021", colour_string: "Streptococcus / Streptococcus pyogenes / Outbreak 2021", size: :large) %>

--- a/test/components/previews/viral_avatar_component_preview/small.html.erb
+++ b/test/components/previews/viral_avatar_component_preview/small.html.erb
@@ -1,4 +1,4 @@
-<%= viral_avatar(
+<%= render Viral::AvatarComponent.new(
   name: "Outbreak 2021",
   colour_string: "Streptococcus / Streptococcus pyogenes / Outbreak 2021",
   size: :small

--- a/test/components/previews/viral_avatar_component_preview/with_link.html.erb
+++ b/test/components/previews/viral_avatar_component_preview/with_link.html.erb
@@ -1,4 +1,4 @@
-<%= viral_avatar(
+<%= render Viral::AvatarComponent.new(
   name: "Outbreak 2021",
   url: "https://www.google.com",
   colour_string: "Streptococcus / Streptococcus pyogenes / Outbreak 2021",

--- a/test/components/previews/viral_button_component_preview/basic.html.erb
+++ b/test/components/previews/viral_button_component_preview/basic.html.erb
@@ -1,1 +1,1 @@
-<%= viral_button { "Create user" } %>
+<%= render Viral::ButtonComponent.new { "Create user" } %>

--- a/test/components/previews/viral_button_component_preview/basic.html.erb
+++ b/test/components/previews/viral_button_component_preview/basic.html.erb
@@ -1,1 +1,1 @@
-<%= render Viral::ButtonComponent.new { "Create user" } %>
+<%= render(Viral::ButtonComponent.new) { "Create user" } %>

--- a/test/components/previews/viral_button_component_preview/destructive.html.erb
+++ b/test/components/previews/viral_button_component_preview/destructive.html.erb
@@ -1,1 +1,1 @@
-<%= viral_button(state: :destructive) { "Remove user" } %>
+<%= render Viral::ButtonComponent.new(state: :destructive) { "Remove user" } %>

--- a/test/components/previews/viral_button_component_preview/destructive.html.erb
+++ b/test/components/previews/viral_button_component_preview/destructive.html.erb
@@ -1,1 +1,1 @@
-<%= render Viral::ButtonComponent.new(state: :destructive) { "Remove user" } %>
+<%= render(Viral::ButtonComponent.new(state: :destructive)) { "Remove user" } %>

--- a/test/components/previews/viral_button_component_preview/disclosure.html.erb
+++ b/test/components/previews/viral_button_component_preview/disclosure.html.erb
@@ -1,6 +1,6 @@
 <div>
-  <%= viral_button(disclosure: true, classes: "mb-2") { "Organism" } %>
-  <%= viral_button(disclosure: :down, classes: "mb-2") { "Organism" } %>
-  <%= viral_button(disclosure: :up, classes: "mb-2") { "Organism" } %>
-  <%= viral_button(disclosure: :right) { "Organism" } %>
+  <%= render Viral::ButtonComponent.new(disclosure: true, classes: "mb-2") { "Organism" } %>
+  <%= render Viral::ButtonComponent.new(disclosure: :down, classes: "mb-2") { "Organism" } %>
+  <%= render Viral::ButtonComponent.new(disclosure: :up, classes: "mb-2") { "Organism" } %>
+  <%= render Viral::ButtonComponent.new(disclosure: :right) { "Organism" } %>
 </div>

--- a/test/components/previews/viral_button_component_preview/disclosure.html.erb
+++ b/test/components/previews/viral_button_component_preview/disclosure.html.erb
@@ -1,6 +1,6 @@
 <div>
-  <%= render Viral::ButtonComponent.new(disclosure: true, classes: "mb-2") { "Organism" } %>
-  <%= render Viral::ButtonComponent.new(disclosure: :down, classes: "mb-2") { "Organism" } %>
-  <%= render Viral::ButtonComponent.new(disclosure: :up, classes: "mb-2") { "Organism" } %>
-  <%= render Viral::ButtonComponent.new(disclosure: :right) { "Organism" } %>
+  <%= render(Viral::ButtonComponent.new(disclosure: true, classes: "mb-2")) { "Organism" } %>
+  <%= render(Viral::ButtonComponent.new(disclosure: :down, classes: "mb-2")) { "Organism" } %>
+  <%= render(Viral::ButtonComponent.new(disclosure: :up, classes: "mb-2")) { "Organism" } %>
+  <%= render(Viral::ButtonComponent.new(disclosure: :right)) { "Organism" } %>
 </div>

--- a/test/components/previews/viral_button_component_preview/full_width.html.erb
+++ b/test/components/previews/viral_button_component_preview/full_width.html.erb
@@ -1,3 +1,3 @@
 <div style="width: 300px">
-  <%= viral_button(full_width: true) { "Create user" } %>
+  <%= render Viral::ButtonComponent.new(full_width: true) { "Create user" } %>
 </div>

--- a/test/components/previews/viral_button_component_preview/full_width.html.erb
+++ b/test/components/previews/viral_button_component_preview/full_width.html.erb
@@ -1,3 +1,3 @@
 <div style="width: 300px">
-  <%= render Viral::ButtonComponent.new(full_width: true) { "Create user" } %>
+  <%= render(Viral::ButtonComponent.new(full_width: true)) { "Create user" } %>
 </div>

--- a/test/components/previews/viral_button_component_preview/large.html.erb
+++ b/test/components/previews/viral_button_component_preview/large.html.erb
@@ -1,1 +1,1 @@
-<%= viral_button(size: :large) { "Create user" } %>
+<%= render Viral::ButtonComponent.new(size: :large) { "Create user" } %>

--- a/test/components/previews/viral_button_component_preview/large.html.erb
+++ b/test/components/previews/viral_button_component_preview/large.html.erb
@@ -1,1 +1,1 @@
-<%= render Viral::ButtonComponent.new(size: :large) { "Create user" } %>
+<%= render(Viral::ButtonComponent.new(size: :large)) { "Create user" } %>

--- a/test/components/previews/viral_button_component_preview/primary.html.erb
+++ b/test/components/previews/viral_button_component_preview/primary.html.erb
@@ -1,1 +1,1 @@
-<%= render Viral::ButtonComponent.new(state: :primary) { "Create user" } %>
+<%= render(Viral::ButtonComponent.new(state: :primary)) { "Create user" } %>

--- a/test/components/previews/viral_button_component_preview/primary.html.erb
+++ b/test/components/previews/viral_button_component_preview/primary.html.erb
@@ -1,1 +1,1 @@
-<%= viral_button(state: :primary) { "Create user" } %>
+<%= render Viral::ButtonComponent.new(state: :primary) { "Create user" } %>

--- a/test/components/previews/viral_button_component_preview/small.html.erb
+++ b/test/components/previews/viral_button_component_preview/small.html.erb
@@ -1,1 +1,1 @@
-<%= viral_button(size: :small) { "Create user" } %>
+<%= render Viral::ButtonComponent.new(size: :small) { "Create user" } %>

--- a/test/components/previews/viral_button_component_preview/small.html.erb
+++ b/test/components/previews/viral_button_component_preview/small.html.erb
@@ -1,1 +1,1 @@
-<%= render Viral::ButtonComponent.new(size: :small) { "Create user" } %>
+<%= render(Viral::ButtonComponent.new(size: :small)) { "Create user" } %>

--- a/test/components/previews/viral_card_component_preview/default.html.erb
+++ b/test/components/previews/viral_card_component_preview/default.html.erb
@@ -1,3 +1,3 @@
-<%= viral_card(title: 'Simple card with Title') do %>
+<%= render Viral::CardComponent.new(title: 'Simple card with Title') do %>
   This is the content of the card
 <% end %>

--- a/test/components/previews/viral_card_component_preview/section_with_action.html.erb
+++ b/test/components/previews/viral_card_component_preview/section_with_action.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::CardComponent.new(title: "Card with section actions") do |card| %>
   <% card.with_section(title: "First Section", border_top: true) do |section| %>
     <% section.with_action do %>
-      <%= link_to "Delete", "/", class: "text-red-500 dark:text-red-400" %>
+      <%= link_to "Delete", "#delete-action-preview", class: "text-red-500 dark:text-red-400" %>
     <% end %>
 
     <p class="text-base text-slate-900 dark:text-white">First Section Content</p>

--- a/test/components/previews/viral_card_component_preview/section_with_action.html.erb
+++ b/test/components/previews/viral_card_component_preview/section_with_action.html.erb
@@ -1,8 +1,9 @@
-<%= viral_card(title: "Card with section actions") do |card| %>
+<%= render Viral::CardComponent.new(title: "Card with section actions") do |card| %>
   <% card.with_section(title: "First Section", border_top: true) do |section| %>
     <% section.with_action do %>
-      <%= link_to "Delete", "#", class: "text-red-500 dark:text-red-400" %>
+      <%= link_to "Delete", "/", class: "text-red-500 dark:text-red-400" %>
     <% end %>
+
     <p class="text-base text-slate-900 dark:text-white">First Section Content</p>
   <% end %>
 <% end %>

--- a/test/components/previews/viral_card_component_preview/simple_header.html.erb
+++ b/test/components/previews/viral_card_component_preview/simple_header.html.erb
@@ -1,4 +1,3 @@
-<%= viral_card do |card| %>
-  <% card.with_header(title: "Card with a simple header") %>
-  Body content here
+<%= render Viral::CardComponent.new do |card| %>
+  <% card.with_header(title: "Card with a simple header") %> Body content here
 <% end %>

--- a/test/components/previews/viral_card_component_preview/titled_sections.html.erb
+++ b/test/components/previews/viral_card_component_preview/titled_sections.html.erb
@@ -1,10 +1,12 @@
-<%= viral_card(title: "Card with multiple titled sections") do |card| %>
+<%= render Viral::CardComponent.new(title: "Card with multiple titled sections") do |card| %>
   <% card.with_section(title: "First Sections") do %>
     <p class="text-base text-slate-900 dark:text-white">First Section Content</p>
   <% end %>
+
   <% card.with_section(title: "Second Sections") do %>
     <p class="text-base text-slate-900 dark:text-white">Second Section Content</p>
   <% end %>
+
   <% card.with_section(title: "Third Sections") do %>
     <p class="text-base text-slate-900 dark:text-white">Third Section Content</p>
   <% end %>

--- a/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
+++ b/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
@@ -1,7 +1,7 @@
 <%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: 'Card Header') do |header| %>
     <% header.with_action do %>
-      <%= link_to "Delete", "/", class: "button button-default" %>
+      <%= button_tag "Delete", type: "button", class: "button button-default" %>
     <% end %>
   <% end %>
   Content body here

--- a/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
+++ b/test/components/previews/viral_card_component_preview/with_header_actions.html.erb
@@ -1,7 +1,7 @@
-<%= viral_card do |card| %>
+<%= render Viral::CardComponent.new do |card| %>
   <% card.with_header(title: 'Card Header') do |header| %>
     <% header.with_action do %>
-      <%= link_to "Delete", "#", class: "button button-default" %>
+      <%= link_to "Delete", "/", class: "button button-default" %>
     <% end %>
   <% end %>
   Content body here

--- a/test/components/previews/viral_card_component_preview/with_multiple_sections.html.erb
+++ b/test/components/previews/viral_card_component_preview/with_multiple_sections.html.erb
@@ -1,7 +1,8 @@
-<%= viral_card(title: "Card with multiple sections") do |card| %>
+<%= render Viral::CardComponent.new(title: "Card with multiple sections") do |card| %>
   <% card.with_section(border_bottom: true, border_top: true, title: "Section 1") do %>
     <p class="text-base text-slate-900 dark:text-white">Some content</p>
   <% end %>
+
   <% card.with_section(title: "Section 2") do %>
     <p class="text-base text-slate-900 dark:text-white">Some content</p>
   <% end %>

--- a/test/components/previews/viral_data_table_component_preview/default.html.erb
+++ b/test/components/previews/viral_data_table_component_preview/default.html.erb
@@ -15,26 +15,31 @@
   },
 ] %>
 
-<%= viral_data_table(table_data, id: 'preview_table') do |table| %>
+<%= render Viral::DataTableComponent.new(table_data, id: 'preview_table') do |table| %>
   <% table.with_column("id") do |row| %>
     <%= row[:id] %>
   <% end %>
+
   <% table.with_column("name") do |row| %>
     <%= row[:name] %>
   <% end %>
+
   <% table.with_column("pill with conditional") do |row| %>
     <% if row[:pill] == 'green' %>
-      <%= viral_pill(text: "this pill is green", color: :green, border: true) %>
+      <%= render Viral::PillComponent.new(text: "this pill is green", color: :green, border: true) %>
     <% elsif row[:pill] == 'blue' %>
-      <%= viral_pill(text: "this pill is blue", color: :blue, border: true) %>
+      <%= render Viral::PillComponent.new(text: "this pill is blue", color: :blue, border: true) %>
     <% end %>
   <% end %>
+
   <% table.with_column("date") do |row| %>
     <%= local_date(row[:date], :long) %>
   <% end %>
+
   <% table.with_column("time ago") do |row| %>
     <%= local_time_ago(row[:time_ago_date]) %>
   <% end %>
+
   <% table.with_column(I18n.t('workflow_executions.table_component.actions'), sticky_key: :right) do |row| %>
     <%= link_to(
       "#{row[:name]} Action1",
@@ -42,6 +47,7 @@
       class:
         "font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer",
     ) %>
+
     <%= link_to(
       "#{row[:name]} Action2",
       "",

--- a/test/components/previews/viral_data_table_component_preview/overflow_x.html.erb
+++ b/test/components/previews/viral_data_table_component_preview/overflow_x.html.erb
@@ -16,26 +16,31 @@
   },
 ] %>
 
-<%= viral_data_table(table_data, id: 'preview_table') do |table| %>
+<%= render Viral::DataTableComponent.new(table_data, id: 'preview_table') do |table| %>
   <% table.with_column("id") do |row| %>
     <%= row[:id] %>
   <% end %>
+
   <% table.with_column("name") do |row| %>
     <%= row[:name] %>
   <% end %>
+
   <% table.with_column("pill with conditional") do |row| %>
     <% if row[:pill] == 'green' %>
-      <%= viral_pill(text: "this pill is green", color: :green, border: true) %>
+      <%= render Viral::PillComponent.new(text: "this pill is green", color: :green, border: true) %>
     <% elsif row[:pill] == 'blue' %>
-      <%= viral_pill(text: "this pill is blue", color: :blue, border: true) %>
+      <%= render Viral::PillComponent.new(text: "this pill is blue", color: :blue, border: true) %>
     <% end %>
   <% end %>
+
   <% table.with_column("date") do |row| %>
     <%= local_date(row[:date], :long) %>
   <% end %>
+
   <% table.with_column("time ago") do |row| %>
     <%= local_time_ago(row[:time_ago_date]) %>
   <% end %>
+
   <% table.with_column(I18n.t('workflow_executions.table_component.actions'), sticky_key: :right) do |row| %>
     <%= link_to(
       "Action 1",
@@ -43,6 +48,7 @@
       class:
         "font-medium text-blue-600 underline dark:text-blue-400 hover:decoration-2 cursor-pointer",
     ) %>
+
     <%= link_to(
       "Action 2",
       "",

--- a/test/components/previews/viral_dialog_component_preview/confirmation.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/confirmation.html.erb
@@ -1,12 +1,15 @@
-<%= viral_dialog(open: true) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true) do |dialog| %>
   <% dialog.with_header(title: "Confirmation required") %>
+
   <p class="text-base text-slate-900 dark:text-white">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+    aliqua.
   </p>
+
   <% dialog.with_primary_action { "Confirm" } %>
+
   <% dialog.with_secondary_action do %>
-    <%= viral_button(data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(data: { action: 'click->viral--dialog#close' }) do %>
       Cancel
     <% end %>
   <% end %>

--- a/test/components/previews/viral_dialog_component_preview/default.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/default.html.erb
@@ -1,17 +1,14 @@
-<%= viral_dialog(open: true) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true) do |dialog| %>
   <% dialog.with_header(title: "This is the default dialog") %>
+
   <p class="mb-3 text-slate-500 dark:text-slate-400">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Dignissim cras
-    tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus
-    et netus et malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh
-    venenatis cras sed felis eget. Sapien eget mi proin sed libero enim sed
-    faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec
-    sagittis aliquam malesuada bibendum. Convallis convallis tellus id
-    interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit tellus
-    mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing.
-    Faucibus scelerisque eleifend donec pretium vulputate sapien. Vestibulum
-    mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at
-    tempor commodo ullamcorper.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+    aliqua. Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus et netus et
+    malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh venenatis cras sed felis eget. Sapien eget mi proin
+    sed libero enim sed faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec sagittis aliquam
+    malesuada bibendum. Convallis convallis tellus id interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit
+    tellus mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing. Faucibus scelerisque eleifend donec
+    pretium vulputate sapien. Vestibulum mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at tempor
+    commodo ullamcorper.
   </p>
 <% end %>

--- a/test/components/previews/viral_dialog_component_preview/extra_large.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/extra_large.html.erb
@@ -1,17 +1,14 @@
-<%= viral_dialog(open: true, size: :extra_large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :extra_large) do |dialog| %>
   <% dialog.with_header(title: "This is the extra large dialog") %>
+
   <p class="mb-3 text-slate-500 dark:text-slate-400">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Dignissim cras
-    tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus
-    et netus et malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh
-    venenatis cras sed felis eget. Sapien eget mi proin sed libero enim sed
-    faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec
-    sagittis aliquam malesuada bibendum. Convallis convallis tellus id
-    interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit tellus
-    mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing.
-    Faucibus scelerisque eleifend donec pretium vulputate sapien. Vestibulum
-    mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at
-    tempor commodo ullamcorper.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+    aliqua. Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus et netus et
+    malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh venenatis cras sed felis eget. Sapien eget mi proin
+    sed libero enim sed faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec sagittis aliquam
+    malesuada bibendum. Convallis convallis tellus id interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit
+    tellus mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing. Faucibus scelerisque eleifend donec
+    pretium vulputate sapien. Vestibulum mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at tempor
+    commodo ullamcorper.
   </p>
 <% end %>

--- a/test/components/previews/viral_dialog_component_preview/large.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/large.html.erb
@@ -1,17 +1,14 @@
-<%= viral_dialog(open: true, size: :large) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :large) do |dialog| %>
   <% dialog.with_header(title: "This is the large dialog") %>
+
   <p class="mb-3 text-slate-500 dark:text-slate-400">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Dignissim cras
-    tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus
-    et netus et malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh
-    venenatis cras sed felis eget. Sapien eget mi proin sed libero enim sed
-    faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec
-    sagittis aliquam malesuada bibendum. Convallis convallis tellus id
-    interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit tellus
-    mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing.
-    Faucibus scelerisque eleifend donec pretium vulputate sapien. Vestibulum
-    mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at
-    tempor commodo ullamcorper.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+    aliqua. Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus et netus et
+    malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh venenatis cras sed felis eget. Sapien eget mi proin
+    sed libero enim sed faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec sagittis aliquam
+    malesuada bibendum. Convallis convallis tellus id interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit
+    tellus mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing. Faucibus scelerisque eleifend donec
+    pretium vulputate sapien. Vestibulum mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at tempor
+    commodo ullamcorper.
   </p>
 <% end %>

--- a/test/components/previews/viral_dialog_component_preview/non_closable.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/non_closable.html.erb
@@ -1,18 +1,17 @@
-<%= viral_dialog(open: true, size: :small, closable: false) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :small, closable: false) do |dialog| %>
   <% dialog.with_header(title: "This dialog is not closable") %>
+
   <div>
-    <label
-      for="first_name"
-      class="block mb-2 text-sm font-medium text-slate-900 dark:text-white"
-    >First name</label>
+    <label for="first_name" class="mb-2 block text-sm font-medium text-slate-900 dark:text-white">First name</label>
+
     <input
       type="text"
       id="first_name"
+      autocomplete="given-name"
       class="
-        bg-slate-50 border border-slate-300 text-slate-900 text-sm rounded-lg block
-        w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400
-        dark:text-white
+        block w-full rounded-lg border border-slate-300 bg-slate-50 p-2.5 text-sm text-slate-900
+        dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400
       "
-    />
+    >
   </div>
 <% end %>

--- a/test/components/previews/viral_dialog_component_preview/small.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/small.html.erb
@@ -1,17 +1,14 @@
-<%= viral_dialog(open: true, size: :small) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true, size: :small) do |dialog| %>
   <% dialog.with_header(title: "This is the small dialog") %>
+
   <p class="mb-3 text-slate-500 dark:text-slate-400">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Dignissim cras
-    tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus
-    et netus et malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh
-    venenatis cras sed felis eget. Sapien eget mi proin sed libero enim sed
-    faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec
-    sagittis aliquam malesuada bibendum. Convallis convallis tellus id
-    interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit tellus
-    mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing.
-    Faucibus scelerisque eleifend donec pretium vulputate sapien. Vestibulum
-    mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at
-    tempor commodo ullamcorper.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+    aliqua. Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus et netus et
+    malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh venenatis cras sed felis eget. Sapien eget mi proin
+    sed libero enim sed faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec sagittis aliquam
+    malesuada bibendum. Convallis convallis tellus id interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit
+    tellus mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing. Faucibus scelerisque eleifend donec
+    pretium vulputate sapien. Vestibulum mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at tempor
+    commodo ullamcorper.
   </p>
 <% end %>

--- a/test/components/previews/viral_dialog_component_preview/with_action_buttons.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/with_action_buttons.html.erb
@@ -1,22 +1,21 @@
-<%= viral_dialog(open: true) do |dialog| %>
+<%= render Viral::DialogComponent.new(open: true) do |dialog| %>
   <% dialog.with_header(title: "This dialog has action buttons") %>
+
   <p class="mb-3 text-slate-500 dark:text-slate-400">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Dignissim cras
-    tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus
-    et netus et malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh
-    venenatis cras sed felis eget. Sapien eget mi proin sed libero enim sed
-    faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec
-    sagittis aliquam malesuada bibendum. Convallis convallis tellus id
-    interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit tellus
-    mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing.
-    Faucibus scelerisque eleifend donec pretium vulputate sapien. Vestibulum
-    mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at
-    tempor commodo ullamcorper.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+    aliqua. Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus et netus et
+    malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh venenatis cras sed felis eget. Sapien eget mi proin
+    sed libero enim sed faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec sagittis aliquam
+    malesuada bibendum. Convallis convallis tellus id interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit
+    tellus mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing. Faucibus scelerisque eleifend donec
+    pretium vulputate sapien. Vestibulum mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at tempor
+    commodo ullamcorper.
   </p>
+
   <% dialog.with_primary_action { "Primary button" } %>
+
   <% dialog.with_secondary_action do %>
-    <%= viral_button(data: { action: 'click->viral--dialog#close' }) do %>
+    <%= render Viral::ButtonComponent.new(data: { action: 'click->viral--dialog#close' }) do %>
       Secondary button
     <% end %>
   <% end %>

--- a/test/components/previews/viral_dialog_component_preview/with_trigger.html.erb
+++ b/test/components/previews/viral_dialog_component_preview/with_trigger.html.erb
@@ -1,22 +1,20 @@
-<%= viral_dialog do |dialog| %>
+<%= render Viral::DialogComponent.new do |dialog| %>
   <% dialog.with_trigger do %>
-    <%= viral_button(data: { action: "click->viral--dialog#open" }) do %>
+    <%= render Viral::ButtonComponent.new(data: { action: "click->viral--dialog#open" }) do %>
       Open dialog
     <% end %>
   <% end %>
+
   <% dialog.with_header(title: "This is a dialog with a trigger") %>
+
   <p class="mb-3 text-slate-500 dark:text-slate-400">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Dignissim cras
-    tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus
-    et netus et malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh
-    venenatis cras sed felis eget. Sapien eget mi proin sed libero enim sed
-    faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec
-    sagittis aliquam malesuada bibendum. Convallis convallis tellus id
-    interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit tellus
-    mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing.
-    Faucibus scelerisque eleifend donec pretium vulputate sapien. Vestibulum
-    mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at
-    tempor commodo ullamcorper.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+    aliqua. Dignissim cras tincidunt lobortis feugiat vivamus at augue eget arcu. Tristique senectus et netus et
+    malesuada. Orci dapibus ultrices in iaculis nunc. Id porta nibh venenatis cras sed felis eget. Sapien eget mi proin
+    sed libero enim sed faucibus. Sit amet nisl suscipit adipiscing bibendum est ultricies. Nec sagittis aliquam
+    malesuada bibendum. Convallis convallis tellus id interdum. Nunc faucibus a pellentesque sit. Nisi vitae suscipit
+    tellus mauris a diam maecenas sed enim. Iaculis at erat pellentesque adipiscing. Faucibus scelerisque eleifend donec
+    pretium vulputate sapien. Vestibulum mattis ullamcorper velit sed ullamcorper morbi. In ante metus dictum at tempor
+    commodo ullamcorper.
   </p>
 <% end %>

--- a/test/components/previews/viral_empty_component_preview/default.html.erb
+++ b/test/components/previews/viral_empty_component_preview/default.html.erb
@@ -1,4 +1,4 @@
-<%= viral_empty(
+<%= render Viral::EmptyStateComponent.new(
   title: t(:"groups.show.shared_namespaces.no_shared.title"),
   description: t(:"groups.show.shared_namespaces.no_shared.description"),
   icon_name: :ticket,

--- a/test/components/previews/viral_form_prefixed_boolean_component_preview/default.html.erb
+++ b/test/components/previews/viral_form_prefixed_boolean_component_preview/default.html.erb
@@ -1,8 +1,9 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_boolean(form: form, name: "prefixed" , value: true) do |checkbox| %>
+  <%= render Viral::Form::Prefixed::BooleanComponent.new(form: form, name: "prefixed" , value: true) do |checkbox| %>
     <%= checkbox.with_legend do %>
       This is the group legend
     <% end %>
+
     <%= checkbox.with_prefix do %>
       --prefix
     <% end %>

--- a/test/components/previews/viral_form_prefixed_boolean_component_preview/with_false_value.html.erb
+++ b/test/components/previews/viral_form_prefixed_boolean_component_preview/with_false_value.html.erb
@@ -1,8 +1,9 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_boolean(form: form, name: "prefixed", value: false) do |checkbox| %>
+  <%= render Viral::Form::Prefixed::BooleanComponent.new(form: form, name: "prefixed", value: false) do |checkbox| %>
     <%= checkbox.with_legend do %>
       This is the group legend
     <% end %>
+
     <%= checkbox.with_prefix do %>
       --prefix
     <% end %>

--- a/test/components/previews/viral_form_prefixed_boolean_component_preview/with_icon.html.erb
+++ b/test/components/previews/viral_form_prefixed_boolean_component_preview/with_icon.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_boolean(form: form, name: "prefixed", value: true) do |checkbox| %>
+  <%= render Viral::Form::Prefixed::BooleanComponent.new(form: form, name: "prefixed", value: true) do |checkbox| %>
     <%= checkbox.with_legend do %>
       This is the group legend
     <% end %>

--- a/test/components/previews/viral_form_prefixed_select_component_preview/default.html.erb
+++ b/test/components/previews/viral_form_prefixed_select_component_preview/default.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_select(form:, name: "prefixed-select", options: [['Lisbon', 1], ['Madrid', 2]]) do |select| %>
+  <%= render Viral::Form::Prefixed::SelectComponent.new(form:, name: "prefixed-select", options: [['Lisbon', 1], ['Madrid', 2]]) do |select| %>
     <%= select.with_prefix do %>
       --prefix
     <% end %>

--- a/test/components/previews/viral_form_prefixed_select_component_preview/with_icon.html.erb
+++ b/test/components/previews/viral_form_prefixed_select_component_preview/with_icon.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_select(form:, name: "prefixed-select", options: [['Lisbon', 1], ['Madrid', 2]]) do |select| %>
+  <%= render Viral::Form::Prefixed::SelectComponent.new(form:, name: "prefixed-select", options: [['Lisbon', 1], ['Madrid', 2]]) do |select| %>
     <%= select.with_prefix do %>
       <%= icon(:warning_circle, size: :sm, color: :warning) %>
     <% end %>

--- a/test/components/previews/viral_form_prefixed_text_input_component_preview/default.html.erb
+++ b/test/components/previews/viral_form_prefixed_text_input_component_preview/default.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_text_input(form: form, name: "prefixed") do |input| %>
+  <%= render Viral::Form::Prefixed::TextInputComponent.new(form: form, name: "prefixed") do |input| %>
     <%= input.with_prefix do %>
       --prefix
     <% end %>

--- a/test/components/previews/viral_form_prefixed_text_input_component_preview/with_icon.html.erb
+++ b/test/components/previews/viral_form_prefixed_text_input_component_preview/with_icon.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: '#' do |form| %>
-  <%= viral_prefixed_text_input(form: form, name: "prefixed") do |input| %>
+  <%= render Viral::Form::Prefixed::TextInputComponent.new(form: form, name: "prefixed") do |input| %>
     <%= input.with_prefix do %>
       <%= icon(:warning_circle, size: :sm, color: :warning) %>
     <% end %>

--- a/test/components/previews/viral_icon_component_preview/critical.html.erb
+++ b/test/components/previews/viral_icon_component_preview/critical.html.erb
@@ -1,1 +1,1 @@
-<%= viral_icon(name: 'user', color: :critical) %>
+<%= render Viral::IconComponent.new(name: 'user', color: :critical) %>

--- a/test/components/previews/viral_icon_component_preview/default.html.erb
+++ b/test/components/previews/viral_icon_component_preview/default.html.erb
@@ -1,1 +1,1 @@
-<%= viral_icon(name: 'user') %>
+<%= render Viral::IconComponent.new(name: 'user') %>

--- a/test/components/previews/viral_icon_component_preview/larger_size_icon.html.erb
+++ b/test/components/previews/viral_icon_component_preview/larger_size_icon.html.erb
@@ -1,1 +1,1 @@
-<%= viral_icon(name: 'user', classes: 'w-16 h-16') %>
+<%= render Viral::IconComponent.new(name: 'user', classes: 'w-16 h-16') %>

--- a/test/components/previews/viral_icon_component_preview/primary.html.erb
+++ b/test/components/previews/viral_icon_component_preview/primary.html.erb
@@ -1,1 +1,1 @@
-<%= viral_icon(name: 'user', color: :primary) %>
+<%= render Viral::IconComponent.new(name: 'user', color: :primary) %>

--- a/test/components/previews/viral_icon_component_preview/subdued.html.erb
+++ b/test/components/previews/viral_icon_component_preview/subdued.html.erb
@@ -1,1 +1,1 @@
-<%= viral_icon(name: 'user', color: :subdued) %>
+<%= render Viral::IconComponent.new(name: 'user', color: :subdued) %>

--- a/test/components/previews/viral_icon_component_preview/success.html.erb
+++ b/test/components/previews/viral_icon_component_preview/success.html.erb
@@ -1,1 +1,1 @@
-<%= viral_icon(name: 'user', color: :success) %>
+<%= render Viral::IconComponent.new(name: 'user', color: :success) %>

--- a/test/components/previews/viral_icon_component_preview/warning.html.erb
+++ b/test/components/previews/viral_icon_component_preview/warning.html.erb
@@ -1,1 +1,1 @@
-<%= viral_icon(name: 'user', color: :warning) %>
+<%= render Viral::IconComponent.new(name: 'user', color: :warning) %>

--- a/test/components/previews/viral_page_header_component_preview/default.html.erb
+++ b/test/components/previews/viral_page_header_component_preview/default.html.erb
@@ -1,2 +1,2 @@
-<%= viral_pageheader(title: 'Page header',
+<%= render Viral::PageHeaderComponent.new(title: 'Page header',
                      subtitle: 'This is a page header') %>

--- a/test/components/previews/viral_page_header_component_preview/with_avatar.html.erb
+++ b/test/components/previews/viral_page_header_component_preview/with_avatar.html.erb
@@ -1,6 +1,6 @@
-<%= viral_pageheader(title: 'Page header with Icons', subtitle: 'This is a page header') do |header| %>
+<%= render Viral::PageHeaderComponent.new(title: 'Page header with Icons', subtitle: 'This is a page header') do |header| %>
   <% header.with_icon do %>
-    <%= viral_avatar(
+    <%= render Viral::AvatarComponent.new(
       name: "Outbreak 2021",
       colour_string: "Streptococcus / Streptococcus pyogenes / Outbreak 2021",
       size: :large,

--- a/test/components/previews/viral_page_header_component_preview/with_buttons.html.erb
+++ b/test/components/previews/viral_page_header_component_preview/with_buttons.html.erb
@@ -1,5 +1,5 @@
-<%= viral_pageheader(title: 'Page header with buttons', subtitle: 'This is a page header') do |header| %>
+<%= render Viral::PageHeaderComponent.new(title: 'Page header with buttons', subtitle: 'This is a page header') do |header| %>
   <%= header.with_buttons do %>
-    <%= viral_button { "Button" } %>
+    <%= render Viral::ButtonComponent.new { "Button" } %>
   <% end %>
 <% end %>

--- a/test/components/previews/viral_page_header_component_preview/with_buttons.html.erb
+++ b/test/components/previews/viral_page_header_component_preview/with_buttons.html.erb
@@ -1,5 +1,5 @@
 <%= render Viral::PageHeaderComponent.new(title: 'Page header with buttons', subtitle: 'This is a page header') do |header| %>
   <%= header.with_buttons do %>
-    <%= render Viral::ButtonComponent.new { "Button" } %>
+    <%= render(Viral::ButtonComponent.new) { "Button" } %>
   <% end %>
 <% end %>

--- a/test/components/previews/viral_page_header_component_preview/with_icon.html.erb
+++ b/test/components/previews/viral_page_header_component_preview/with_icon.html.erb
@@ -1,5 +1,5 @@
-<%= viral_pageheader(title: 'Page header with Icons', subtitle: 'This is a page header') do |header| %>
+<%= render Viral::PageHeaderComponent.new(title: 'Page header with Icons', subtitle: 'This is a page header') do |header| %>
   <% header.with_icon do %>
-    <%= viral_icon(name: "users", classes: "h-14 w-14 text-primary-700") %>
+    <%= render Viral::IconComponent.new(name: "users", classes: "h-14 w-14 text-primary-700") %>
   <% end %>
 <% end %>

--- a/test/components/previews/viral_pill_component_preview/default.html.erb
+++ b/test/components/previews/viral_pill_component_preview/default.html.erb
@@ -1,3 +1,3 @@
-<%= viral_pill(text: "This is blue", color: "blue")  %>
-<%= viral_pill(text: "This is green", color: "green") %>
-<%= viral_pill(text: "This has much more text and is purple", color: "purple") %>
+<%= render Viral::PillComponent.new(text: "This is blue", color: "blue") %>
+<%= render Viral::PillComponent.new(text: "This is green", color: "green") %>
+<%= render Viral::PillComponent.new(text: "This has much more text and is purple", color: "purple") %>

--- a/test/components/previews/viral_pill_component_preview/with_border.html.erb
+++ b/test/components/previews/viral_pill_component_preview/with_border.html.erb
@@ -1,6 +1,7 @@
-<%= viral_pill(text: "This is blue", color: "blue", border: true) %>
-<%= viral_pill(text: "This is green", color: "green", border: true) %>
-<%= viral_pill(
+<%= render Viral::PillComponent.new(text: "This is blue", color: "blue", border: true) %>
+<%= render Viral::PillComponent.new(text: "This is green", color: "green", border: true) %>
+
+<%= render Viral::PillComponent.new(
   text: "This has much more text and is purple",
   color: "purple",
   border: true

--- a/test/components/previews/viral_pill_component_preview/with_classes.html.erb
+++ b/test/components/previews/viral_pill_component_preview/with_classes.html.erb
@@ -1,4 +1,4 @@
-<%= viral_pill(text: "This is slate and underlined", color: "slate", classes: "underline") %>
-<%= viral_pill(text: "This is yellow and striked through", color: "yellow", classes: "line-through") %>
-<%= viral_pill(text: "This is indigo and overlined", color: "indigo", classes: "overline") %>
-<%= viral_pill(text: "This is pink and has multiple added classes", color: "pink", classes: "underline decoration-wavy decoration-black") %>
+<%= render Viral::PillComponent.new(text: "This is slate and underlined", color: "slate", classes: "underline") %>
+<%= render Viral::PillComponent.new(text: "This is yellow and striked through", color: "yellow", classes: "line-through") %>
+<%= render Viral::PillComponent.new(text: "This is indigo and overlined", color: "indigo", classes: "overline") %>
+<%= render Viral::PillComponent.new(text: "This is pink and has multiple added classes", color: "pink", classes: "underline decoration-wavy decoration-black") %>

--- a/test/components/previews/viral_pill_component_preview/with_content.html.erb
+++ b/test/components/previews/viral_pill_component_preview/with_content.html.erb
@@ -1,3 +1,3 @@
-<%= viral_pill(color: :primary) do %>
+<%= render Viral::PillComponent.new(color: :primary) do %>
   This is the content
 <% end %>


### PR DESCRIPTION
## What does this PR do and why?

- Removes the `viral_*` view helper methods (and the `VIRAL_HELPERS` metaprogramming that generated them) so views call their components directly.
- Replaces every `viral_*` call across components, views, and previews with an explicit `render(Viral::...Component.new(...))`.
- No behavior change — this is a mechanical refactor to make component usage explicit and easier to trace.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally

1. Check out this branch and run `bin/dev`.
2. Confirm no `viral_*` helper calls remain: `git grep -n "viral_" -- 'app/**/*.erb' 'app/helpers'`.
3. Run the component and preview tests: `PARALLEL_WORKERS=4 bin/rails test test/components`.
4. Spot-check a few rendered pages (a group show page, a project samples page, a workflow execution dialog) to confirm UI is unchanged.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
