### PR TITLE
Replace Pathogen helper calls with explicit component renders

### DIFF
--- a/app/components/viral/page_header_component.html.erb
+++ b/app/components/viral/page_header_component.html.erb
@@ -11,7 +11,7 @@
         <% end %>
 
         <div class="min-w-0 flex-1">
-          <%= pathogen_heading(level: 1, class: "break-words") do %>
+          <%= render Pathogen::Typography::Heading.new(level: 1, class: "break-words") do %>
             <%= title %>
           <% end %>
         </div>
@@ -20,7 +20,7 @@
       <!-- Subtitle -->
       <% if subtitle.present? %>
         <div class="<%= icon? ? 'pl-12' : '' %>">
-          <%= pathogen_supporting(variant: :muted, class: "break-words") do %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "break-words") do %>
             <%= subtitle %>
           <% end %>
         </div>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -3,7 +3,7 @@
     <%= render Viral::PageHeaderComponent.new(title: t(".details.title")) %>
 
     <%= render Viral::CardComponent.new do |card| %>
-      <% _ = card.with_header(title: t(:"groups.edit.details.subtitle")) %>
+      <% card.with_header(title: t(:"groups.edit.details.subtitle")) %>
 
       <% card.with_section do %>
         <%= turbo_frame_tag("group_name_and_description_form") do %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -3,7 +3,7 @@
     <%= render Viral::PageHeaderComponent.new(title: t(".details.title")) %>
 
     <%= render Viral::CardComponent.new do |card| %>
-      <% card.with_header(title: t(:"groups.edit.details.subtitle")) %>
+      <% _ = card.with_header(title: t(:"groups.edit.details.subtitle")) %>
 
       <% card.with_section do %>
         <%= turbo_frame_tag("group_name_and_description_form") do %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -16,7 +16,7 @@
       <% end %>
     <% end %>
 
-    <%= pathogen_heading(level: 2) do %>
+    <%= render Pathogen::Typography::Heading.new(level: 2) do %>
       <%= t(".advanced.title") %>
     <% end %>
 

--- a/app/views/pages/accessibility_statement.en.html.erb
+++ b/app/views/pages/accessibility_statement.en.html.erb
@@ -4,7 +4,7 @@
   <%= render Pathogen::Typography::Section.new(level: 1) do |section| %>
     <% section.with_heading { "Accessibility Statement for IRIDA Next" } %>
 
-    <%= render Pathogen::Typography::Text.new { "Health Canada and the Public Health Agency of Canada is committed to making its websites and mobile applications accessible, in accordance with the Accessible Canada Regulations." } %>
+    <%= render Pathogen::Typography::Text.new { "Health Canada and the Public Health Agency of Canada are committed to making their websites and mobile applications accessible, in accordance with the Accessible Canada Regulations." } %>
   <% end %>
 
   <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>

--- a/app/views/pages/accessibility_statement.en.html.erb
+++ b/app/views/pages/accessibility_statement.en.html.erb
@@ -1,40 +1,40 @@
 <% external_link_classes = "min-w-0 font-semibold wrap-anywhere underline hover:decoration-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:rounded-sm dark:text-white" %>
 
 <div class="mx-auto max-w-7xl space-y-12">
-  <%= pathogen_section(level: 1) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 1) do |section| %>
     <% section.with_heading { "Accessibility Statement for IRIDA Next" } %>
 
-    <%= pathogen_text { "Health Canada and the Public Health Agency of Canada is committed to making its websites and mobile applications accessible, in accordance with the Accessible Canada Regulations." } %>
+    <%= render Pathogen::Typography::Text.new { "Health Canada and the Public Health Agency of Canada is committed to making its websites and mobile applications accessible, in accordance with the Accessible Canada Regulations." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "Compliance status" } %>
 
-    <%= pathogen_text { "The website has been tested against the Web Content Accessibility Guidelines (WCAG) 2.2 AA standard as per Canada's adopted accessibility standard EN 301 549."} %>
-    <%= pathogen_text { "IRIDA Next is fully compliant with the Web Content Accessibility Guidelines (WCAG) version 2.2 AA standard." } %>
-    <%= pathogen_text { "IRIDA Next is partially compliant with the Web Content Accessibility Guidelines version 2.2 AA standard. For more details please see the included Accessibility Conformance Report (ACR)." } %>
-    <%= pathogen_text { "IRIDA Next is not compliant with the Web Content Accessibility Guidelines version 2.2 AA standard. For more details please see the included Accessibility Conformance Report (ACR)." } %>
+    <%= render Pathogen::Typography::Text.new { "The website has been tested against the Web Content Accessibility Guidelines (WCAG) 2.2 AA standard as per Canada's adopted accessibility standard EN 301 549."} %>
+    <%= render Pathogen::Typography::Text.new { "IRIDA Next is fully compliant with the Web Content Accessibility Guidelines (WCAG) version 2.2 AA standard." } %>
+    <%= render Pathogen::Typography::Text.new { "IRIDA Next is partially compliant with the Web Content Accessibility Guidelines version 2.2 AA standard. For more details please see the included Accessibility Conformance Report (ACR)." } %>
+    <%= render Pathogen::Typography::Text.new { "IRIDA Next is not compliant with the Web Content Accessibility Guidelines version 2.2 AA standard. For more details please see the included Accessibility Conformance Report (ACR)." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "What we are doing to improve accessibility" } %>
 
-    <%= pathogen_text { "Our accessibility roadmap [add link to roadmap] shows how and when we plan to improve accessibility on this website." } %>
+    <%= render Pathogen::Typography::Text.new { "Our accessibility roadmap [add link to roadmap] shows how and when we plan to improve accessibility on this website." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "Preparation of this accessibility statement" } %>
 
-    <%= pathogen_text { "This statement was prepared on [date when it was first published]." } %>
-    <%= pathogen_text { "This website was last tested on [date] against the WCAG 2.2 AA standard." } %>
-    <%= pathogen_text { "The test was carried out by [add name of organisation that carried out the assessment, or indicate that you did your own testing/assessment]." } %>
-    <%= pathogen_text { "You can read the full accessibility test report [add link to report]." } %>
+    <%= render Pathogen::Typography::Text.new { "This statement was prepared on [date when it was first published]." } %>
+    <%= render Pathogen::Typography::Text.new { "This website was last tested on [date] against the WCAG 2.2 AA standard." } %>
+    <%= render Pathogen::Typography::Text.new { "The test was carried out by [add name of organisation that carried out the assessment, or indicate that you did your own testing/assessment]." } %>
+    <%= render Pathogen::Typography::Text.new { "You can read the full accessibility test report [add link to report]." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "Feedback and contact information" } %>
 
-    <%= pathogen_text do %>
+    <%= render Pathogen::Typography::Text.new do %>
       To provide feedback or to report a barrier, you can use the Health Canada
       <a href="https://health.canada.ca/en/accessibility-form/hc-external" class="<%= external_link_classes %>">accessibility feedback form</a>
       or call 1-833-725-2751.

--- a/app/views/pages/accessibility_statement.fr.html.erb
+++ b/app/views/pages/accessibility_statement.fr.html.erb
@@ -1,46 +1,46 @@
 <% external_link_classes = "min-w-0 font-semibold wrap-anywhere underline hover:decoration-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:rounded-sm dark:text-white" %>
 
 <div class="mx-auto max-w-7xl space-y-12">
-  <%= pathogen_section(level: 1) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 1) do |section| %>
     <% section.with_heading { "Déclaration d'accessibilité pour IRIDA Next" } %>
 
-    <%= pathogen_text { "Santé Canada et l'Agence de la santé publique du Canada s'engagent à rendre leurs sites Web et applications mobiles accessibles, conformément au Règlement sur l'accessibilité du Canada." } %>
+    <%= render Pathogen::Typography::Text.new { "Santé Canada et l'Agence de la santé publique du Canada s'engagent à rendre leurs sites Web et applications mobiles accessibles, conformément au Règlement sur l'accessibilité du Canada." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "état de conformité" } %>
 
-    <%= pathogen_text { "Le site Web a été testé conformément aux Règles pour l'accessibilité du contenu Web (WCAG) 2.2 AA, conformément à la norme canadienne d'accessibilité EN 301 549."} %>
+    <%= render Pathogen::Typography::Text.new { "Le site Web a été testé conformément aux Règles pour l'accessibilité du contenu Web (WCAG) 2.2 AA, conformément à la norme canadienne d'accessibilité EN 301 549."} %>
 
-    <%= pathogen_text { "IRIDA Next est entièrement conforme aux Règles pour l'accessibilité du contenu Web (WCAG) version 2.2 AA." } %>
+    <%= render Pathogen::Typography::Text.new { "IRIDA Next est entièrement conforme aux Règles pour l'accessibilité du contenu Web (WCAG) version 2.2 AA." } %>
 
-    <%= pathogen_text { "IRIDA Next est partiellement conforme aux Règles pour l'accessibilité du contenu Web version 2.2 AA. Pour plus de détails, veuillez consulter le rapport de conformité à l'accessibilité (RCA) inclus." } %>
+    <%= render Pathogen::Typography::Text.new { "IRIDA Next est partiellement conforme aux Règles pour l'accessibilité du contenu Web version 2.2 AA. Pour plus de détails, veuillez consulter le rapport de conformité à l'accessibilité (RCA) inclus." } %>
 
-    <%= pathogen_text { "IRIDA Next n'est pas conforme aux Règles pour l'accessibilité du contenu Web version 2.2 AA. Pour plus de détails, veuillez consulter le rapport de conformité à l'accessibilité (RCA) inclus." } %>
+    <%= render Pathogen::Typography::Text.new { "IRIDA Next n'est pas conforme aux Règles pour l'accessibilité du contenu Web version 2.2 AA. Pour plus de détails, veuillez consulter le rapport de conformité à l'accessibilité (RCA) inclus." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "Ce qu'on fait pour améliorer l'accessibilité" } %>
 
-    <%= pathogen_text { "Notre feuille de route pour l'accessibilité [ajouter le lien vers la feuille de route] explique comment et quand nous prévoyons d'améliorer l'accessibilité de ce site web." } %>
+    <%= render Pathogen::Typography::Text.new { "Notre feuille de route pour l'accessibilité [ajouter le lien vers la feuille de route] explique comment et quand nous prévoyons d'améliorer l'accessibilité de ce site web." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "Préparation de cette déclaration d'accessibilité" } %>
 
-    <%= pathogen_text { "Cette déclaration a été préparée le [date de sa première publication]." } %>
+    <%= render Pathogen::Typography::Text.new { "Cette déclaration a été préparée le [date de sa première publication]." } %>
 
-    <%= pathogen_text { "Ce site Web a été testé pour la dernière fois le [date] selon la norme WCAG 2.2 AA." } %>
+    <%= render Pathogen::Typography::Text.new { "Ce site Web a été testé pour la dernière fois le [date] selon la norme WCAG 2.2 AA." } %>
 
-    <%= pathogen_text { "Le test a été effectué par [ajouter le nom de l'organisation qui a réalisé l'évaluation, ou indiquer que vous avez effectué vos propres tests/évaluations]." } %>
+    <%= render Pathogen::Typography::Text.new { "Le test a été effectué par [ajouter le nom de l'organisation qui a réalisé l'évaluation, ou indiquer que vous avez effectué vos propres tests/évaluations]." } %>
 
-    <%= pathogen_text { "Vous pouvez consulter le rapport complet du test d'accessibilité [ajouter le lien vers le rapport]." } %>
+    <%= render Pathogen::Typography::Text.new { "Vous pouvez consulter le rapport complet du test d'accessibilité [ajouter le lien vers le rapport]." } %>
   <% end %>
 
-  <%= pathogen_section(level: 2) do |section| %>
+  <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
     <% section.with_heading { "Commentaires et coordonnées" } %>
 
-    <%= pathogen_text do %>
+    <%= render Pathogen::Typography::Text.new do %>
       Pour nous faire part de vos commentaires ou signaler un obstacle, vous pouvez utiliser le formulaire de
       commentaires sur l'accessibilité de Santé Canada :
       <a href="https://health.canada.ca/fr/accessibility-form/hc-external" class="<%= external_link_classes %>">formulaire de commentaires sur l'accessibilité</a>

--- a/app/views/pages/accessibility_statement.fr.html.erb
+++ b/app/views/pages/accessibility_statement.fr.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
-    <% section.with_heading { "état de conformité" } %>
+    <% section.with_heading { "État de conformité" } %>
 
     <%= render Pathogen::Typography::Text.new { "Le site Web a été testé conformément aux Règles pour l'accessibilité du contenu Web (WCAG) 2.2 AA, conformément à la norme canadienne d'accessibilité EN 301 549."} %>
 

--- a/app/views/profiles/personal_access_tokens/_access_token_section.html.erb
+++ b/app/views/profiles/personal_access_tokens/_access_token_section.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (token:) %>
+
 <%= turbo_frame_tag "access-token-section" do %>
   <div
     data-turbo-temporary

--- a/app/views/profiles/personal_access_tokens/_access_token_section.html.erb
+++ b/app/views/profiles/personal_access_tokens/_access_token_section.html.erb
@@ -6,7 +6,7 @@
       dark:bg-slate-800
     "
   >
-    <%= pathogen_heading(level: 2) do %>
+    <%= render Pathogen::Typography::Heading.new(level: 2) do %>
       <%= t(".label") %>
     <% end %>
 

--- a/app/views/profiles/preferences/show.html.erb
+++ b/app/views/profiles/preferences/show.html.erb
@@ -19,7 +19,7 @@
         <%= t(".theme_title") %>
       </div>
 
-      <%= pathogen_radio_button(
+      <%= render Pathogen::Form::RadioButton.new(
         attribute: :color_theme,
         value: "system",
         input_name: "color-theme",
@@ -33,7 +33,7 @@
         },
       ) %>
 
-      <%= pathogen_radio_button(
+      <%= render Pathogen::Form::RadioButton.new(
         attribute: :color_theme,
         value: "dark",
         input_name: "color-theme",
@@ -46,7 +46,7 @@
         },
       ) %>
 
-      <%= pathogen_radio_button(
+      <%= render Pathogen::Form::RadioButton.new(
         attribute: :color_theme,
         value: "light",
         input_name: "color-theme",

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -3,7 +3,7 @@
     <%= render Viral::PageHeaderComponent.new(title: t(".general.title")) %>
 
     <%= render Viral::CardComponent.new do |card| %>
-      <% _ = card.with_header(title: t(".general.heading")) %>
+      <% card.with_header(title: t(".general.heading")) %>
 
       <% card.with_section do %>
         <%= turbo_frame_tag("project_name_and_description_form") do %>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -12,7 +12,7 @@
       <% end %>
     <% end %>
 
-    <%= pathogen_heading(level: 2) do %>
+    <%= render Pathogen::Typography::Heading.new(level: 2) do %>
       <%= t(".advanced.title") %>
     <% end %>
 

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -3,7 +3,7 @@
     <%= render Viral::PageHeaderComponent.new(title: t(".general.title")) %>
 
     <%= render Viral::CardComponent.new do |card| %>
-      <% card.with_header(title: t(".general.heading")) %>
+      <% _ = card.with_header(title: t(".general.heading")) %>
 
       <% card.with_section do %>
         <%= turbo_frame_tag("project_name_and_description_form") do %>

--- a/test/components/previews/pathogen/button_preview.rb
+++ b/test/components/previews/pathogen/button_preview.rb
@@ -11,7 +11,7 @@ module Pathogen
     #   descendants."
     # @param block toggle "If true, the button will take up the full width of its container."
     def playground(scheme: :default, size: :medium, disabled: false, block: false)
-      pathogen_button(scheme:, size:, disabled:, block:, test_selector: 'playground') do
+      render Pathogen::Button.new(scheme:, size:, disabled:, block:, test_selector: 'playground') do
         'Button'
       end
     end
@@ -20,7 +20,7 @@ module Pathogen
     #   or even submitted with the form. The user can neither edit nor focus on the control, nor its form control
     #   descendants."
     def default(disabled: false)
-      pathogen_button(disabled:, test_selector: 'default') do
+      render Pathogen::Button.new(disabled:, test_selector: 'default') do
         'Button'
       end
     end
@@ -30,7 +30,7 @@ module Pathogen
     #   descendants."
     # @param block toggle "If true, the button will take up the full width of its container."
     def primary(disabled: false, block: false)
-      pathogen_button(scheme: :primary, disabled:, block:, test_selector: 'primary') do
+      render Pathogen::Button.new(scheme: :primary, disabled:, block:, test_selector: 'primary') do
         'Button'
       end
     end
@@ -40,7 +40,7 @@ module Pathogen
     #   descendants."
     # @param block toggle "If true, the button will take up the full width of its container."
     def danger(disabled: false, block: false)
-      pathogen_button(scheme: :danger, disabled:, block:, test_selector: 'danger') do
+      render Pathogen::Button.new(scheme: :danger, disabled:, block:, test_selector: 'danger') do
         'Button'
       end
     end
@@ -48,7 +48,7 @@ module Pathogen
     def all_schemes; end
 
     def full_width
-      pathogen_button(block: true, test_selector: 'full-width') do
+      render Pathogen::Button.new(block: true, test_selector: 'full-width') do
         'Button'
       end
     end
@@ -59,7 +59,7 @@ module Pathogen
     #   or even submitted with the form. The user can neither edit nor focus on the control, nor its form control
     #   descendants."
     def link_as_a_button(scheme: :default, href: '#', disabled: false)
-      pathogen_button(scheme:, href:, tag: :a, disabled:, test_selector: 'link-as-a-button') do
+      render Pathogen::Button.new(scheme:, href:, tag: :a, disabled:, test_selector: 'link-as-a-button') do
         'Button'
       end
     end

--- a/test/components/previews/pathogen/form/radio_button_preview.rb
+++ b/test/components/previews/pathogen/form/radio_button_preview.rb
@@ -10,7 +10,7 @@ module Pathogen
 
       # @label Default Radio Button
       def default
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'light',
           label: 'Light Theme'
@@ -19,7 +19,7 @@ module Pathogen
 
       # @label Radio Button with Help Text
       def with_help_text
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'Dark Theme',
@@ -29,7 +29,7 @@ module Pathogen
 
       # @label Radio Button with Custom Classes
       def with_custom_classes
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'system',
           label: 'System Theme',
@@ -43,7 +43,7 @@ module Pathogen
 
       # @label Checked State
       def checked
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'Dark Theme',
@@ -53,7 +53,7 @@ module Pathogen
 
       # @label Disabled State
       def disabled
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'Dark Theme',
@@ -63,7 +63,7 @@ module Pathogen
 
       # @label Checked and Disabled
       def checked_and_disabled
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'Dark Theme',
@@ -102,7 +102,7 @@ module Pathogen
 
       # @label With ARIA Attributes
       def with_aria_attributes
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'Dark Theme',
@@ -112,7 +112,7 @@ module Pathogen
 
       # @label With Help Text and ARIA
       def with_help_text_and_aria
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'Dark Theme',
@@ -127,7 +127,7 @@ module Pathogen
 
       # @label Without Label
       def without_label
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark'
         )
@@ -135,7 +135,7 @@ module Pathogen
 
       # @label With Long Label
       def with_long_label
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'This is a very long label that might wrap to multiple lines and ' \
@@ -145,7 +145,7 @@ module Pathogen
 
       # @label With Special Characters
       def with_special_characters
-        pathogen_radio_button(
+        render Pathogen::Form::RadioButton.new(
           attribute: :theme,
           value: 'dark',
           label: 'Dark Theme (Recommended) ⭐'

--- a/test/components/previews/pathogen/link_preview.rb
+++ b/test/components/previews/pathogen/link_preview.rb
@@ -5,20 +5,20 @@ module Pathogen
     include Pathogen::ViewHelper
 
     def default
-      pathogen_link(href: '#') do
+      render Pathogen::Link.new(href: '#') do
         'This is a link'
       end
     end
 
     def external_link
-      pathogen_link(href: 'http://google.com') do
+      render Pathogen::Link.new(href: 'http://google.com') do
         'This is an external link'
       end
     end
 
     # @label With Tooltip
     def tooltip
-      pathogen_link(href: '#') do |component|
+      render Pathogen::Link.new(href: '#') do |component|
         component.with_tooltip(text: 'Tooltip text')
         'This is a link with tooltip'
       end

--- a/test/components/previews/pathogen/typography_preview/accessibility.html.erb
+++ b/test/components/previews/pathogen/typography_preview/accessibility.html.erb
@@ -1,11 +1,11 @@
 <div class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-8 dark:from-slate-900 dark:to-slate-800">
   <!-- Header -->
   <div class="mb-12 text-center">
-    <%= pathogen_heading(level: 1, class: "mb-4") do %>
+    <%= render Pathogen::Typography::Heading.new(level: 1, class: "mb-4") do %>
       <%= icon(:wheelchair, color: :primary, size: :xl, class: "inline mr-3") %> Accessibility Features
     <% end %>
 
-    <%= pathogen_text(variant: :muted, class: "text-lg max-w-3xl mx-auto") do %>
+    <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-lg max-w-3xl mx-auto") do %>
       Typography components are built with accessibility in mind, using semantic HTML and proper ARIA patterns.
     <% end %>
   </div>
@@ -13,17 +13,17 @@
   <!-- Semantic HTML -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:code, color: :primary, class: "mr-3") %> Semantic HTML
       <% end %>
 
-      <%= pathogen_text(class: "mb-6") do %>
+      <%= render Pathogen::Typography::Text.new(class: "mb-6") do %>
         All typography components use semantic HTML elements that convey meaning to assistive technologies. Headings
         always render actual h1-h6 tags, never divs with heading styles.
       <% end %>
 
       <div class="overflow-x-auto rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-        <pre class="text-sm"><code class="text-slate-800 dark:text-slate-200">&lt;%= render pathogen_heading(level: 1) do %&gt; Main Title &lt;% end %&gt; &lt;%= render pathogen_text do %&gt; Body paragraph &lt;% end %&gt;        </code></pre>
+        <pre class="text-sm"><code class="text-slate-800 dark:text-slate-200">&lt;%= render Pathogen::Typography::Heading.new(level: 1) do %&gt; Main Title &lt;% end %&gt; &lt;%= render Pathogen::Typography::Text.new do %&gt; Body paragraph &lt;% end %&gt;        </code></pre>
       </div>
 
       <div class="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
@@ -49,33 +49,33 @@
   <!-- Heading Hierarchy -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:list_numbers, color: :primary, class: "mr-3") %> Proper Heading Hierarchy
       <% end %>
 
-      <%= pathogen_text(class: "mb-6") do %>
+      <%= render Pathogen::Typography::Text.new(class: "mb-6") do %>
         Screen readers use heading structure to navigate content. Always maintain a logical hierarchy without skipping
         levels.
       <% end %>
 
       <div class="max-w-3xl space-y-4">
-        <%= pathogen_heading(level: 1) do %>
+        <%= render Pathogen::Typography::Heading.new(level: 1) do %>
           Main Page Title (H1)
         <% end %>
 
-        <%= pathogen_text(variant: :muted, class: "text-sm mb-4") do %>
+        <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-sm mb-4") do %>
           Only one H1 per page
         <% end %>
 
-        <%= pathogen_heading(level: 2) do %>
+        <%= render Pathogen::Typography::Heading.new(level: 2) do %>
           Section Heading (H2)
         <% end %>
 
-        <%= pathogen_heading(level: 3) do %>
+        <%= render Pathogen::Typography::Heading.new(level: 3) do %>
           Subsection Heading (H3)
         <% end %>
 
-        <%= pathogen_heading(level: 2) do %>
+        <%= render Pathogen::Typography::Heading.new(level: 2) do %>
           Another Section (H2)
         <% end %>
       </div>
@@ -100,11 +100,11 @@
   <!-- Contrast Ratios -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:eye, color: :primary, class: "mr-3") %> Color Contrast
       <% end %>
 
-      <%= pathogen_text(class: "mb-6") do %>
+      <%= render Pathogen::Typography::Text.new(class: "mb-6") do %>
         All typography components meet WCAG AA contrast requirements for readability.
       <% end %>
 
@@ -148,37 +148,37 @@
   <!-- Screen Reader Support -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:speaker_high, color: :primary, class: "mr-3") %> Screen Reader Support
       <% end %>
 
       <div class="space-y-6">
         <div>
-          <%= pathogen_heading(level: 3, class: "mb-3") do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-3") do %>
             Semantic Structure
           <% end %>
 
-          <%= pathogen_text do %>
+          <%= render Pathogen::Typography::Text.new do %>
             Screen readers announce headings with their level, helping users understand document structure.
           <% end %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 3, class: "mb-3") do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-3") do %>
             Navigation
           <% end %>
 
-          <%= pathogen_text do %>
+          <%= render Pathogen::Typography::Text.new do %>
             Users can jump between headings using screen reader shortcuts (e.g., H key in NVDA/JAWS).
           <% end %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 3, class: "mb-3") do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-3") do %>
             Lists
           <% end %>
 
-          <%= pathogen_text do %>
+          <%= render Pathogen::Typography::Text.new do %>
             List components render proper &lt;ul&gt; and &lt;ol&gt; tags, allowing screen readers to announce list
             structure and item count.
           <% end %>
@@ -190,11 +190,11 @@
   <!-- Keyboard Navigation -->
   <div>
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:keyboard, color: :primary, class: "mr-3") %> Keyboard Navigation
       <% end %>
 
-      <%= pathogen_text(class: "mb-6") do %>
+      <%= render Pathogen::Typography::Text.new(class: "mb-6") do %>
         Screen reader users can navigate through headings, lists, and other semantic elements using standard keyboard
         shortcuts.
       <% end %>

--- a/test/components/previews/pathogen/typography_preview/body_text.html.erb
+++ b/test/components/previews/pathogen/typography_preview/body_text.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-6xl space-y-12">
     <!-- Header -->
     <div class="text-center">
-      <%= pathogen_heading_group(level: 1) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1) do |group| %>
         <%= group.with_eyebrow { "Typography Components" } %>
         <%= group.with_heading { "Body Text" } %>
         <%= group.with_metadata { "Text, Lead, and Callout components with responsive sizing" } %>
@@ -12,82 +12,82 @@
     <!-- Text Components -->
     <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
       <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 3, class: "mb-4") { "Text (16px)" } %>
-        <%= pathogen_text { "Standard body text for paragraphs and main content. Optimized for readability." } %>
-        <%= pathogen_code(class: "mt-4") { "pathogen_text" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Text (16px)" } %>
+        <%= render Pathogen::Typography::Text.new { "Standard body text for paragraphs and main content. Optimized for readability." } %>
+        <%= render Pathogen::Typography::Code.new(class: "mt-4") { "render Pathogen::Typography::Text.new" } %>
       </div>
 
       <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 3, class: "mb-4") { "Callout (18px)" } %>
-        <%= pathogen_callout { "Emphasized paragraphs between body and lead. Perfect for pull quotes." } %>
-        <%= pathogen_code(class: "mt-4") { "pathogen_callout" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Callout (18px)" } %>
+        <%= render Pathogen::Typography::Callout.new { "Emphasized paragraphs between body and lead. Perfect for pull quotes." } %>
+        <%= render Pathogen::Typography::Code.new(class: "mt-4") { "render Pathogen::Typography::Callout.new" } %>
       </div>
 
       <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 3, class: "mb-4") { "Lead (20px)" } %>
-        <%= pathogen_lead { "Larger introductory paragraphs that draw attention and provide context." } %>
-        <%= pathogen_code(class: "mt-4") { "pathogen_lead" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Lead (20px)" } %>
+        <%= render Pathogen::Typography::Lead.new { "Larger introductory paragraphs that draw attention and provide context." } %>
+        <%= render Pathogen::Typography::Code.new(class: "mt-4") { "render Pathogen::Typography::Lead.new" } %>
       </div>
     </div>
 
     <!-- Responsive Sizing -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Responsive Sizing" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Enable responsive sizing to scale text from mobile to desktop" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Responsive Sizing" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Enable responsive sizing to scale text from mobile to desktop" } %>
 
       <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Fixed Size (Default)" } %>
-          <%= pathogen_text { "This text stays at 16px on all screen sizes. Consistent across devices." } %>
-          <%= pathogen_code(class: "mt-3") { "responsive: false" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Fixed Size (Default)" } %>
+          <%= render Pathogen::Typography::Text.new { "This text stays at 16px on all screen sizes. Consistent across devices." } %>
+          <%= render Pathogen::Typography::Code.new(class: "mt-3") { "responsive: false" } %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Responsive" } %>
-          <%= pathogen_text(responsive: true) { "This text scales from 14px (mobile) to 16px (desktop). Better mobile readability." } %>
-          <%= pathogen_code(class: "mt-3") { "responsive: true" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Responsive" } %>
+          <%= render Pathogen::Typography::Text.new(responsive: true) { "This text scales from 14px (mobile) to 16px (desktop). Better mobile readability." } %>
+          <%= render Pathogen::Typography::Code.new(class: "mt-3") { "responsive: true" } %>
         </div>
       </div>
     </div>
 
     <!-- Color Variants -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Color Variants" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Color Variants" } %>
       <div class="space-y-4">
-        <%= pathogen_text(variant: :default) { "Default variant - Primary text color for maximum readability" } %>
-        <%= pathogen_text(variant: :muted) { "Muted variant - Secondary text color for less emphasis" } %>
-        <%= pathogen_text(variant: :subdued) { "Subdued variant - Medium contrast for subtle information" } %>
+        <%= render Pathogen::Typography::Text.new(variant: :default) { "Default variant - Primary text color for maximum readability" } %>
+        <%= render Pathogen::Typography::Text.new(variant: :muted) { "Muted variant - Secondary text color for less emphasis" } %>
+        <%= render Pathogen::Typography::Text.new(variant: :subdued) { "Subdued variant - Medium contrast for subtle information" } %>
         <div class="rounded-lg bg-slate-900 p-4 dark:bg-slate-50">
-          <%= pathogen_text(variant: :inverse) { "Inverse variant - Light text for dark backgrounds" } %>
+          <%= render Pathogen::Typography::Text.new(variant: :inverse) { "Inverse variant - Light text for dark backgrounds" } %>
         </div>
       </div>
     </div>
 
     <!-- Article Example -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Article Example" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Article Example" } %>
 
-      <%= pathogen_lead(class: "mb-6") { "IRIDA Next is a comprehensive bioinformatics platform designed for genomic analysis and pathogen surveillance. This lead paragraph introduces the article." } %>
+      <%= render Pathogen::Typography::Lead.new(class: "mb-6") { "IRIDA Next is a comprehensive bioinformatics platform designed for genomic analysis and pathogen surveillance. This lead paragraph introduces the article." } %>
 
-      <%= pathogen_text(class: "mb-4") { "The platform provides researchers with powerful tools for sample management, workflow execution, and data visualization. IRIDA Next integrates seamlessly with existing laboratory information management systems." } %>
+      <%= render Pathogen::Typography::Text.new(class: "mb-4") { "The platform provides researchers with powerful tools for sample management, workflow execution, and data visualization. IRIDA Next integrates seamlessly with existing laboratory information management systems." } %>
 
-      <%= pathogen_callout(class: "mb-4") { "\"IRIDA Next has transformed how we handle genomic data in our lab, reducing analysis time by 60%\" - Research Team Lead" } %>
+      <%= render Pathogen::Typography::Callout.new(class: "mb-4") { "\"IRIDA Next has transformed how we handle genomic data in our lab, reducing analysis time by 60%\" - Research Team Lead" } %>
 
-      <%= pathogen_text { "With support for multiple sequencing platforms and automated quality control, IRIDA Next streamlines the entire genomic analysis pipeline from sample receipt to final report generation." } %>
+      <%= render Pathogen::Typography::Text.new { "With support for multiple sequencing platforms and automated quality control, IRIDA Next streamlines the entire genomic analysis pipeline from sample receipt to final report generation." } %>
     </div>
 
     <!-- Usage Example -->
     <div class="rounded-2xl bg-gradient-to-br from-primary-50 to-primary-100 p-8 dark:from-primary-900/20 dark:to-primary-800/20">
-      <%= pathogen_heading(level: 3, class: "mb-4") { "Usage Example" } %>
-      <%= pathogen_code_block(language: "erb") do %><%%= pathogen_lead do %>
+      <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Usage Example" } %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb") do %><%%= render Pathogen::Typography::Lead.new do %>
   Introductory paragraph
 <%% end %>
 
-<%%= pathogen_text(responsive: true) do %>
+<%%= render Pathogen::Typography::Text.new(responsive: true) do %>
   Body paragraph
 <%% end %>
 
-<%%= pathogen_callout(variant: :muted) do %>
+<%%= render Pathogen::Typography::Callout.new(variant: :muted) do %>
   Pull quote or callout
 <%% end %>
       <% end %>

--- a/test/components/previews/pathogen/typography_preview/dark_mode.html.erb
+++ b/test/components/previews/pathogen/typography_preview/dark_mode.html.erb
@@ -1,11 +1,11 @@
 <div class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-8 dark:from-slate-900 dark:to-slate-800">
   <!-- Header -->
   <div class="mb-12 text-center">
-    <%= pathogen_heading(level: 1, class: "mb-4") do %>
+    <%= render Pathogen::Typography::Heading.new(level: 1, class: "mb-4") do %>
       <%= icon(:moon, color: :primary, size: :xl, class: "inline mr-3") %> Dark Mode Typography
     <% end %>
 
-    <%= pathogen_text(variant: :muted, class: "text-lg max-w-3xl mx-auto") do %>
+    <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-lg max-w-3xl mx-auto") do %>
       All typography components automatically adapt to light and dark modes with proper contrast ratios and readable
       colors.
     <% end %>
@@ -14,11 +14,11 @@
   <!-- Side-by-Side Comparison -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:squares_four, color: :primary, class: "mr-3") %> Light vs Dark Mode
       <% end %>
 
-      <%= pathogen_text(variant: :muted, class: "mb-8") do %>
+      <%= render Pathogen::Typography::Text.new(variant: :muted, class: "mb-8") do %>
         Toggle your system's dark mode preference to see how components adapt. All components maintain WCAG AA contrast
         ratios in both themes.
       <% end %>
@@ -30,11 +30,11 @@
             <span class="font-semibold text-slate-900">Light Mode</span>
           </div>
 
-          <%= pathogen_heading(level: 3) do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3) do %>
             Heading in Light Mode
           <% end %>
 
-          <%= pathogen_text do %>
+          <%= render Pathogen::Typography::Text.new do %>
             Body text automatically adjusts to dark slate-900 in light mode for optimal readability.
           <% end %>
         </div>
@@ -45,11 +45,11 @@
             <span class="font-semibold text-white">Dark Mode</span>
           </div>
 
-          <%= pathogen_heading(level: 3, variant: :inverse) do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, variant: :inverse) do %>
             Heading in Dark Mode
           <% end %>
 
-          <%= pathogen_text(variant: :inverse) do %>
+          <%= render Pathogen::Typography::Text.new(variant: :inverse) do %>
             Body text automatically adjusts to white in dark mode for optimal readability.
           <% end %>
         </div>
@@ -60,47 +60,47 @@
   <!-- Color Variants in Dark Mode -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:palette, color: :primary, class: "mr-3") %> Color Variants
       <% end %>
 
       <div class="space-y-6">
         <div>
-          <%= pathogen_heading(level: 3, variant: :default) do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, variant: :default) do %>
             Default Variant
           <% end %>
 
-          <%= pathogen_text(variant: :default) do %>
+          <%= render Pathogen::Typography::Text.new(variant: :default) do %>
             Primary text color - slate-900 in light mode, white in dark mode
           <% end %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 3, variant: :muted) do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, variant: :muted) do %>
             Muted Variant
           <% end %>
 
-          <%= pathogen_text(variant: :muted) do %>
+          <%= render Pathogen::Typography::Text.new(variant: :muted) do %>
             Secondary text color - slate-500 in light mode, slate-400 in dark mode
           <% end %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 3, variant: :subdued) do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, variant: :subdued) do %>
             Subdued Variant
           <% end %>
 
-          <%= pathogen_text(variant: :subdued) do %>
+          <%= render Pathogen::Typography::Text.new(variant: :subdued) do %>
             Medium contrast - slate-700 in light mode, slate-300 in dark mode
           <% end %>
         </div>
 
         <div class="rounded-lg bg-slate-900 p-6 dark:bg-slate-100">
-          <%= pathogen_heading(level: 3, variant: :inverse) do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, variant: :inverse) do %>
             Inverse Variant
           <% end %>
 
-          <%= pathogen_text(variant: :inverse) do %>
+          <%= render Pathogen::Typography::Text.new(variant: :inverse) do %>
             Light text for dark backgrounds - white in light mode, slate-900 in dark mode
           <% end %>
         </div>
@@ -111,31 +111,31 @@
   <!-- Code Components -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:code, color: :primary, class: "mr-3") %> Code Components
       <% end %>
 
       <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
         <div>
-          <%= pathogen_heading(level: 3, class: "mb-4") do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") do %>
             Inline Code
           <% end %>
 
-          <%= pathogen_text do %>
+          <%= render Pathogen::Typography::Text.new do %>
             Use
-            <%= pathogen_code do %>
-              pathogen_code
+            <%= render Pathogen::Typography::Code.new do %>
+              render Pathogen::Typography::Code.new
             <% end %>
             for inline code snippets. The background adapts to both themes.
           <% end %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 3, class: "mb-4") do %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") do %>
             Code Blocks
           <% end %>
 
-          <%= pathogen_code_block(language: "ruby") do %>
+          <%= render Pathogen::Typography::CodeBlock.new(language: "ruby") do %>
             def example puts "Code blocks have dark backgrounds" puts "that work in both light and dark mode" end
           <% end %>
         </div>
@@ -146,11 +146,11 @@
   <!-- Contrast Ratios -->
   <div>
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:check_circle, color: :success, class: "mr-3") %> WCAG AA Compliance
       <% end %>
 
-      <%= pathogen_text(variant: :muted, class: "mb-6") do %>
+      <%= render Pathogen::Typography::Text.new(variant: :muted, class: "mb-6") do %>
         All typography components meet WCAG AA contrast requirements in both light and dark modes.
       <% end %>
 

--- a/test/components/previews/pathogen/typography_preview/dark_mode.html.erb
+++ b/test/components/previews/pathogen/typography_preview/dark_mode.html.erb
@@ -135,9 +135,13 @@
             Code Blocks
           <% end %>
 
-          <%= render Pathogen::Typography::CodeBlock.new(language: "ruby") do %>
-            def example puts "Code blocks have dark backgrounds" puts "that work in both light and dark mode" end
-          <% end %>
+          <%= render Pathogen::Typography::CodeBlock.new(language: "ruby") { <<~RUBY.chomp
+            def example
+              puts "Code blocks have dark backgrounds"
+              puts "that work in both light and dark mode"
+            end
+          RUBY
+          } %>
         </div>
       </div>
     </div>

--- a/test/components/previews/pathogen/typography_preview/dos_and_donts.html.erb
+++ b/test/components/previews/pathogen/typography_preview/dos_and_donts.html.erb
@@ -1,11 +1,11 @@
 <div class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-8 dark:from-slate-900 dark:to-slate-800">
   <!-- Header -->
   <div class="mb-12 text-center">
-    <%= pathogen_heading(level: 1, class: "mb-4") do %>
+    <%= render Pathogen::Typography::Heading.new(level: 1, class: "mb-4") do %>
       <%= icon(:lightbulb, color: :primary, size: :xl, class: "inline mr-3") %> Do's and Don'ts
     <% end %>
 
-    <%= pathogen_text(variant: :muted, class: "text-lg max-w-3xl mx-auto") do %>
+    <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-lg max-w-3xl mx-auto") do %>
       Best practices and common mistakes when using typography components.
     <% end %>
   </div>
@@ -13,7 +13,7 @@
   <!-- Heading Hierarchy -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:list_numbers, color: :primary, class: "mr-3") %> Heading Hierarchy
       <% end %>
 
@@ -26,23 +26,23 @@
           </div>
 
           <div class="space-y-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Use Sequential Levels
             <% end %>
 
-            <%= pathogen_heading(level: 1) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 1) do %>
               Main Title
             <% end %>
 
-            <%= pathogen_heading(level: 2) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 2) do %>
               Section
             <% end %>
 
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Subsection
             <% end %>
 
-            <%= pathogen_text(variant: :muted, class: "text-sm mt-3") do %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-sm mt-3") do %>
               Use headings in order (h1 → h2 → h3) without skipping levels
             <% end %>
           </div>
@@ -56,19 +56,19 @@
           </div>
 
           <div class="space-y-3 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Skip Heading Levels
             <% end %>
 
-            <%= pathogen_heading(level: 1) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 1) do %>
               Main Title
             <% end %>
 
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Skipped H2
             <% end %>
 
-            <%= pathogen_text(variant: :muted, class: "text-sm mt-3") do %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-sm mt-3") do %>
               Never skip heading levels - it breaks accessibility and SEO
             <% end %>
           </div>
@@ -80,7 +80,7 @@
   <!-- Color Usage -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:palette, color: :primary, class: "mr-3") %> Color Variants
       <% end %>
 
@@ -93,15 +93,15 @@
           </div>
 
           <div class="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Use Variants Appropriately
             <% end %>
 
-            <%= pathogen_text(variant: :default) do %>
+            <%= render Pathogen::Typography::Text.new(variant: :default) do %>
               Default for primary content
             <% end %>
 
-            <%= pathogen_text(variant: :muted) do %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted) do %>
               Muted for secondary information
             <% end %>
           </div>
@@ -115,15 +115,15 @@
           </div>
 
           <div class="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Overuse Muted Text
             <% end %>
 
-            <%= pathogen_text(variant: :muted) do %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted) do %>
               Don't make everything muted - it reduces readability
             <% end %>
 
-            <%= pathogen_text(variant: :muted) do %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted) do %>
               Use muted sparingly for less important content
             <% end %>
           </div>
@@ -135,7 +135,7 @@
   <!-- Code Usage -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:code, color: :primary, class: "mr-3") %> Code Component Usage
       <% end %>
 
@@ -148,19 +148,19 @@
           </div>
 
           <div class="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Use Appropriate Component
             <% end %>
 
-            <%= pathogen_text do %>
+            <%= render Pathogen::Typography::Text.new do %>
               Use
-              <%= pathogen_code do %>
+              <%= render Pathogen::Typography::Code.new do %>
                 inline code
               <% end %>
               for short snippets
             <% end %>
 
-            <%= pathogen_code_block(language: "ruby") do %>
+            <%= render Pathogen::Typography::CodeBlock.new(language: "ruby") do %>
               def example # Use code_block for multi-line code end
             <% end %>
           </div>
@@ -174,11 +174,11 @@
           </div>
 
           <div class="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Mix Inline and Block
             <% end %>
 
-            <%= pathogen_text do %>
+            <%= render Pathogen::Typography::Text.new do %>
               Don't use code_block for single words - use inline code instead
             <% end %>
           </div>
@@ -190,7 +190,7 @@
   <!-- Responsive Sizing -->
   <div class="mb-12">
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:device_mobile, color: :primary, class: "mr-3") %> Responsive Behavior
       <% end %>
 
@@ -203,11 +203,11 @@
           </div>
 
           <div class="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Let Headings Scale
             <% end %>
 
-            <%= pathogen_text(variant: :muted, class: "text-sm") do %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-sm") do %>
               Allow headings to scale responsively by default for better mobile experience
             <% end %>
           </div>
@@ -221,15 +221,15 @@
           </div>
 
           <div class="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
-            <%= pathogen_heading(level: 3) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 3) do %>
               Disable Responsive Unnecessarily
             <% end %>
 
-            <%= pathogen_heading(level: 1, responsive: false) do %>
+            <%= render Pathogen::Typography::Heading.new(level: 1, responsive: false) do %>
               Fixed Size Heading
             <% end %>
 
-            <%= pathogen_text(variant: :muted, class: "text-sm mt-3") do %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted, class: "text-sm mt-3") do %>
               Only disable responsive sizing when you have a specific design requirement
             <% end %>
           </div>
@@ -241,7 +241,7 @@
   <!-- Best Practices Summary -->
   <div>
     <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <%= pathogen_heading(level: 2, class: "mb-6 flex items-center") do %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6 flex items-center") do %>
         <%= icon(:star, color: :warning, class: "mr-3") %> Best Practices Summary
       <% end %>
 
@@ -251,7 +251,7 @@
             <%= icon(:check_circle, color: :success, class: "mr-2") %> Do's
           </div>
 
-          <%= pathogen_list do |list| %>
+          <%= render Pathogen::Typography::List.new do |list| %>
             <%= list.with_item { 'Maintain proper heading hierarchy (h1 → h2 → h3)' } %>
             <%= list.with_item { 'Choose appropriate components for content type' } %>
             <%= list.with_item { 'Let headings scale responsively by default' } %>
@@ -265,7 +265,7 @@
             <%= icon(:x_circle, color: :danger, class: "mr-2") %> Don'ts
           </div>
 
-          <%= pathogen_list do |list| %>
+          <%= render Pathogen::Typography::List.new do |list| %>
             <%= list.with_item { "Don't skip heading levels" } %>
             <%= list.with_item { "Don't overuse muted text variants" } %>
             <%= list.with_item { "Don't disable responsive sizing unnecessarily" } %>

--- a/test/components/previews/pathogen/typography_preview/dos_and_donts.html.erb
+++ b/test/components/previews/pathogen/typography_preview/dos_and_donts.html.erb
@@ -160,9 +160,12 @@
               for short snippets
             <% end %>
 
-            <%= render Pathogen::Typography::CodeBlock.new(language: "ruby") do %>
-              def example # Use code_block for multi-line code end
-            <% end %>
+            <%= render Pathogen::Typography::CodeBlock.new(language: "ruby") { <<~RUBY.chomp
+              def example
+                # Use code_block for multi-line code
+              end
+            RUBY
+            } %>
           </div>
         </div>
 

--- a/test/components/previews/pathogen/typography_preview/headings.html.erb
+++ b/test/components/previews/pathogen/typography_preview/headings.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-6xl space-y-12">
     <!-- Header -->
     <div class="text-center">
-      <%= pathogen_heading_group(level: 1) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1) do |group| %>
         <%= group.with_eyebrow { "Typography Components" } %>
         <%= group.with_heading { "Headings" } %>
         <%= group.with_metadata { "Semantic h1-h6 with responsive sizing and color variants" } %>
@@ -11,65 +11,65 @@
 
     <!-- All Levels -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Heading Levels (Responsive)" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Heading Levels (Responsive)" } %>
       <div class="space-y-6">
-        <%= pathogen_heading(level: 1) { "Heading 1" } %>
-        <%= pathogen_heading(level: 2) { "Heading 2" } %>
-        <%= pathogen_heading(level: 3) { "Heading 3" } %>
-        <%= pathogen_heading(level: 4) { "Heading 4" } %>
-        <%= pathogen_heading(level: 5) { "Heading 5" } %>
-        <%= pathogen_heading(level: 6) { "Heading 6" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 1) { "Heading 1" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 2) { "Heading 2" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3) { "Heading 3" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 4) { "Heading 4" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 5) { "Heading 5" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 6) { "Heading 6" } %>
       </div>
     </div>
 
     <!-- Responsive vs Fixed -->
     <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
       <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 2, class: "mb-6") { "Responsive (Default)" } %>
-        <%= pathogen_supporting(variant: :muted, class: "mb-4") { "Scales from mobile to desktop" } %>
-        <%= pathogen_heading(level: 1, responsive: true) { "Responsive H1" } %>
-        <%= pathogen_code(class: "mt-3") { "responsive: true" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Responsive (Default)" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-4") { "Scales from mobile to desktop" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 1, responsive: true) { "Responsive H1" } %>
+        <%= render Pathogen::Typography::Code.new(class: "mt-3") { "responsive: true" } %>
       </div>
 
       <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 2, class: "mb-6") { "Fixed Size" } %>
-        <%= pathogen_supporting(variant: :muted, class: "mb-4") { "Same size on all devices" } %>
-        <%= pathogen_heading(level: 1, responsive: false) { "Fixed H1" } %>
-        <%= pathogen_code(class: "mt-3") { "responsive: false" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Fixed Size" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-4") { "Same size on all devices" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 1, responsive: false) { "Fixed H1" } %>
+        <%= render Pathogen::Typography::Code.new(class: "mt-3") { "responsive: false" } %>
       </div>
     </div>
 
     <!-- Color Variants -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Color Variants" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Color Variants" } %>
       <div class="space-y-4">
-        <%= pathogen_heading(level: 3, variant: :default) { "Default Heading" } %>
-        <%= pathogen_heading(level: 3, variant: :muted) { "Muted Heading" } %>
-        <%= pathogen_heading(level: 3, variant: :subdued) { "Subdued Heading" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, variant: :default) { "Default Heading" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, variant: :muted) { "Muted Heading" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, variant: :subdued) { "Subdued Heading" } %>
         <div class="rounded-lg bg-slate-900 p-4 dark:bg-slate-50">
-          <%= pathogen_heading(level: 3, variant: :inverse) { "Inverse Heading" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, variant: :inverse) { "Inverse Heading" } %>
         </div>
       </div>
     </div>
 
     <!-- Tracking Options -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Letter Tracking" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Letter Tracking" } %>
       <div class="space-y-4">
-        <%= pathogen_heading(level: 3, tracking: :tight) { "Tight Tracking" } %>
-        <%= pathogen_heading(level: 3, tracking: :normal) { "Normal Tracking" } %>
-        <%= pathogen_heading(level: 3, tracking: :wide) { "Wide Tracking" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, tracking: :tight) { "Tight Tracking" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, tracking: :normal) { "Normal Tracking" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, tracking: :wide) { "Wide Tracking" } %>
       </div>
     </div>
 
     <!-- Usage Example -->
     <div class="rounded-2xl bg-gradient-to-br from-primary-50 to-primary-100 p-8 dark:from-primary-900/20 dark:to-primary-800/20">
-      <%= pathogen_heading(level: 3, class: "mb-4") { "Usage Example" } %>
-      <%= pathogen_code_block(language: "erb") do %><%%= pathogen_heading(level: 1, responsive: true) do %>
+      <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Usage Example" } %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb") do %><%%= render Pathogen::Typography::Heading.new(level: 1, responsive: true) do %>
   Page Title
 <%% end %>
 
-<%%= pathogen_heading(level: 2, variant: :muted) do %>
+<%%= render Pathogen::Typography::Heading.new(level: 2, variant: :muted) do %>
   Section Heading
 <%% end %>
       <% end %>

--- a/test/components/previews/pathogen/typography_preview/in_context.html.erb
+++ b/test/components/previews/pathogen/typography_preview/in_context.html.erb
@@ -48,9 +48,14 @@
 
           <%= render Pathogen::Typography::Text.new(class: "mb-4") { "The platform is built on Ruby on Rails 8.0 with a modern ViewComponent-based architecture. Here's an example of how to render a sample list:" } %>
 
-          <%= render Pathogen::Typography::CodeBlock.new(language: "ruby", class: "mb-4") do %>
-            def index @samples = Sample.includes(:project) .order(created_at: :desc) .page(params[:page]) end
-          <% end %>
+          <%= render Pathogen::Typography::CodeBlock.new(language: "ruby", class: "mb-4") { <<~RUBY.chomp
+            def index
+              @samples = Sample.includes(:project)
+                               .order(created_at: :desc)
+                               .page(params[:page])
+            end
+          RUBY
+          } %>
 
           <%= render Pathogen::Typography::Text.new { "This approach ensures optimal performance even with large datasets." } %>
         <% end %>

--- a/test/components/previews/pathogen/typography_preview/in_context.html.erb
+++ b/test/components/previews/pathogen/typography_preview/in_context.html.erb
@@ -111,6 +111,7 @@
               type="text"
               class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
               placeholder="e.g., SAMPLE-2024-001"
+              autocomplete="off"
             >
 
             <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mt-1") { "Enter a unique identifier for this sample" } %>
@@ -119,10 +120,12 @@
           <div>
             <label class="mb-1 block text-sm font-medium">Project *</label>
 
-            <select class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700">
-              <option>COVID-19 Analysis</option>
-              <option>Influenza Study</option>
-            </select>
+            <input
+              type="text"
+              class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
+              value="COVID-19 Analysis"
+              autocomplete="off"
+            >
           </div>
 
           <div>
@@ -148,6 +151,7 @@
             <input
               type="date"
               class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
+              autocomplete="off"
             >
           </div>
 
@@ -158,6 +162,7 @@
               type="text"
               class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
               placeholder="e.g., SARS-CoV-2"
+              autocomplete="off"
             >
           </div>
         </div>

--- a/test/components/previews/pathogen/typography_preview/in_context.html.erb
+++ b/test/components/previews/pathogen/typography_preview/in_context.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-7xl space-y-12">
     <!-- Header -->
     <div class="text-center">
-      <%= pathogen_heading_group(level: 1) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1) do |group| %>
         <%= group.with_eyebrow { "Typography System" } %>
         <%= group.with_heading { "In Context" } %>
         <%= group.with_metadata { "Real-world examples of typography in page layouts" } %>
@@ -11,68 +11,64 @@
 
     <!-- Article Page Layout -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Article Page Layout" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Article Page Layout" } %>
 
       <div class="mx-auto max-w-3xl">
-        <%= pathogen_typography_preset(:article) do |group| %>
+        <%= render Pathogen::Typography::HeadingGroup.new(level: 1, heading_variant: :default, spacing: :default) do |group| %>
           <%= group.with_eyebrow { "Research" } %>
           <%= group.with_heading { "Genomic Surveillance in Public Health" } %>
           <%= group.with_metadata { "Published January 15, 2024 · 12 min read · Dr. Sarah Johnson" } %>
         <% end %>
 
-        <%= pathogen_lead(class: "mt-8 mb-6") { "Genomic surveillance has become an essential tool in tracking and understanding pathogen evolution, particularly in the context of emerging infectious diseases." } %>
+        <%= render Pathogen::Typography::Lead.new(class: "mt-8 mb-6") { "Genomic surveillance has become an essential tool in tracking and understanding pathogen evolution, particularly in the context of emerging infectious diseases." } %>
 
-        <%= pathogen_section(level: 2, class: "mt-8") do |section| %>
+        <%= render Pathogen::Typography::Section.new(level: 2, class: "mt-8") do |section| %>
           <% section.with_heading { "Introduction" } %>
 
-          <%= pathogen_text(class: "mb-4") { "IRIDA Next provides researchers with comprehensive tools for genomic analysis and pathogen surveillance. The platform integrates sample management, workflow execution, and data visualization in a unified interface." } %>
+          <%= render Pathogen::Typography::Text.new(class: "mb-4") { "IRIDA Next provides researchers with comprehensive tools for genomic analysis and pathogen surveillance. The platform integrates sample management, workflow execution, and data visualization in a unified interface." } %>
 
-          <%= pathogen_text(class: "mb-4") { "By leveraging modern bioinformatics approaches, teams can process samples more efficiently and generate actionable insights faster than traditional methods." } %>
+          <%= render Pathogen::Typography::Text.new(class: "mb-4") { "By leveraging modern bioinformatics approaches, teams can process samples more efficiently and generate actionable insights faster than traditional methods." } %>
         <% end %>
 
-        <%= pathogen_section(level: 2, class: "mt-8") do |section| %>
+        <%= render Pathogen::Typography::Section.new(level: 2, class: "mt-8") do |section| %>
           <% section.with_heading { "Key Features" } %>
 
-          <%= pathogen_list(class: "mb-6") do |list| %>
+          <%= render Pathogen::Typography::List.new(class: "mb-6") do |list| %>
             <%= list.with_item { "Automated sample intake and tracking" } %>
             <%= list.with_item { "Workflow orchestration and execution" } %>
             <%= list.with_item { "Real-time quality control monitoring" } %>
             <%= list.with_item { "Interactive data visualization" } %>
           <% end %>
 
-          <%= pathogen_callout(class: "my-6") { "IRIDA Next processes over 10,000 samples per month across research institutions worldwide, enabling rapid response to emerging health threats." } %>
+          <%= render Pathogen::Typography::Callout.new(class: "my-6") { "IRIDA Next processes over 10,000 samples per month across research institutions worldwide, enabling rapid response to emerging health threats." } %>
         <% end %>
 
-        <%= pathogen_section(level: 2, class: "mt-8") do |section| %>
+        <%= render Pathogen::Typography::Section.new(level: 2, class: "mt-8") do |section| %>
           <% section.with_heading { "Technical Implementation" } %>
 
-          <%= pathogen_text(class: "mb-4") { "The platform is built on Ruby on Rails 8.0 with a modern ViewComponent-based architecture. Here's an example of how to render a sample list:" } %>
+          <%= render Pathogen::Typography::Text.new(class: "mb-4") { "The platform is built on Ruby on Rails 8.0 with a modern ViewComponent-based architecture. Here's an example of how to render a sample list:" } %>
 
-          <%= pathogen_code_block(language: "ruby", class: "mb-4") do %>
-def index
-  @samples = Sample.includes(:project)
-                   .order(created_at: :desc)
-                   .page(params[:page])
-end
+          <%= render Pathogen::Typography::CodeBlock.new(language: "ruby", class: "mb-4") do %>
+            def index @samples = Sample.includes(:project) .order(created_at: :desc) .page(params[:page]) end
           <% end %>
 
-          <%= pathogen_text { "This approach ensures optimal performance even with large datasets." } %>
+          <%= render Pathogen::Typography::Text.new { "This approach ensures optimal performance even with large datasets." } %>
         <% end %>
       </div>
     </div>
 
     <!-- Dashboard Layout -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Dashboard Layout" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Dashboard Layout" } %>
 
-      <%= pathogen_typography_preset(:section) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 2, heading_variant: :default, spacing: :default) do |group| %>
         <%= group.with_heading { "Active Projects" } %>
         <%= group.with_metadata { "Last updated 2 minutes ago" } %>
       <% end %>
 
       <div class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3">
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-          <%= pathogen_typography_preset(:card) do |group| %>
+          <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
             <%= group.with_eyebrow { "Workflow" } %>
             <%= group.with_heading { "COVID-19 Analysis" } %>
             <%= group.with_metadata { "45 samples · Running" } %>
@@ -80,7 +76,7 @@ end
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-          <%= pathogen_typography_preset(:card) do |group| %>
+          <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
             <%= group.with_eyebrow { "Project" } %>
             <%= group.with_heading { "Influenza Study" } %>
             <%= group.with_metadata { "128 samples · Active" } %>
@@ -88,7 +84,7 @@ end
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-          <%= pathogen_typography_preset(:card) do |group| %>
+          <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
             <%= group.with_eyebrow { "Analysis" } %>
             <%= group.with_heading { "Pathogen Typing" } %>
             <%= group.with_metadata { "Completed 1h ago" } %>
@@ -99,10 +95,10 @@ end
 
     <!-- Form Layout -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Form Layout" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Form Layout" } %>
 
       <div class="mx-auto max-w-2xl space-y-8">
-        <%= pathogen_typography_preset(:form_section) do |group| %>
+        <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
           <%= group.with_heading { "Sample Information" } %>
           <%= group.with_metadata { "All fields marked with * are required" } %>
         <% end %>
@@ -110,12 +106,19 @@ end
         <div class="space-y-4">
           <div>
             <label class="mb-1 block text-sm font-medium">Sample Name *</label>
-            <input type="text" class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700" placeholder="e.g., SAMPLE-2024-001">
-            <%= pathogen_supporting(variant: :muted, class: "mt-1") { "Enter a unique identifier for this sample" } %>
+
+            <input
+              type="text"
+              class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
+              placeholder="e.g., SAMPLE-2024-001"
+            >
+
+            <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mt-1") { "Enter a unique identifier for this sample" } %>
           </div>
 
           <div>
             <label class="mb-1 block text-sm font-medium">Project *</label>
+
             <select class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700">
               <option>COVID-19 Analysis</option>
               <option>Influenza Study</option>
@@ -124,11 +127,16 @@ end
 
           <div>
             <label class="mb-1 block text-sm font-medium">Description</label>
-            <textarea class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700" rows="3" placeholder="Optional description of the sample"></textarea>
+
+            <textarea
+              class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
+              rows="3"
+              placeholder="Optional description of the sample"
+            ></textarea>
           </div>
         </div>
 
-        <%= pathogen_typography_preset(:form_section, class: "mt-8") do |group| %>
+        <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact, class: "mt-8") do |group| %>
           <%= group.with_heading { "Sample Metadata" } %>
           <%= group.with_metadata { "Additional information for analysis" } %>
         <% end %>
@@ -136,12 +144,21 @@ end
         <div class="space-y-4">
           <div>
             <label class="mb-1 block text-sm font-medium">Collection Date</label>
-            <input type="date" class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700">
+
+            <input
+              type="date"
+              class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
+            >
           </div>
 
           <div>
             <label class="mb-1 block text-sm font-medium">Organism</label>
-            <input type="text" class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700" placeholder="e.g., SARS-CoV-2">
+
+            <input
+              type="text"
+              class="block w-full rounded-lg border border-slate-300 p-2.5 dark:border-slate-600 dark:bg-slate-700"
+              placeholder="e.g., SARS-CoV-2"
+            >
           </div>
         </div>
       </div>
@@ -149,38 +166,56 @@ end
 
     <!-- List Page Layout -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "List Page Layout" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "List Page Layout" } %>
 
-      <%= pathogen_section(level: 2) do |section| %>
+      <%= render Pathogen::Typography::Section.new(level: 2) do |section| %>
         <% section.with_heading { "Recent Samples" } %>
 
         <div class="mt-6 space-y-4">
           <div class="flex items-center justify-between rounded-lg border border-slate-200 p-4 dark:border-slate-700">
             <div>
-              <%= pathogen_heading(level: 4, class: "mb-1") { "SAMPLE-2024-045" } %>
-              <%= pathogen_supporting(variant: :muted) { "COVID-19 Analysis · Created 2 hours ago" } %>
+              <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-1") { "SAMPLE-2024-045" } %>
+              <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "COVID-19 Analysis · Created 2 hours ago" } %>
             </div>
-            <div class="rounded-full bg-green-100 px-3 py-1 text-sm font-medium text-green-800 dark:bg-green-900/20 dark:text-green-400">
+
+            <div
+              class="
+                rounded-full bg-green-100 px-3 py-1 text-sm font-medium text-green-800 dark:bg-green-900/20
+                dark:text-green-400
+              "
+            >
               Complete
             </div>
           </div>
 
           <div class="flex items-center justify-between rounded-lg border border-slate-200 p-4 dark:border-slate-700">
             <div>
-              <%= pathogen_heading(level: 4, class: "mb-1") { "SAMPLE-2024-044" } %>
-              <%= pathogen_supporting(variant: :muted) { "Influenza Study · Created 5 hours ago" } %>
+              <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-1") { "SAMPLE-2024-044" } %>
+              <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Influenza Study · Created 5 hours ago" } %>
             </div>
-            <div class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900/20 dark:text-blue-400">
+
+            <div
+              class="
+                rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900/20
+                dark:text-blue-400
+              "
+            >
               Processing
             </div>
           </div>
 
           <div class="flex items-center justify-between rounded-lg border border-slate-200 p-4 dark:border-slate-700">
             <div>
-              <%= pathogen_heading(level: 4, class: "mb-1") { "SAMPLE-2024-043" } %>
-              <%= pathogen_supporting(variant: :muted) { "Pathogen Typing · Created yesterday" } %>
+              <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-1") { "SAMPLE-2024-043" } %>
+              <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Pathogen Typing · Created yesterday" } %>
             </div>
-            <div class="rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-800 dark:bg-slate-900/20 dark:text-slate-400">
+
+            <div
+              class="
+                rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-800 dark:bg-slate-900/20
+                dark:text-slate-400
+              "
+            >
               Pending
             </div>
           </div>

--- a/test/components/previews/pathogen/typography_preview/overview.html.erb
+++ b/test/components/previews/pathogen/typography_preview/overview.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-7xl space-y-12">
     <!-- Header -->
     <div class="text-center">
-      <%= pathogen_typography_preset(:article) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1, heading_variant: :default, spacing: :default) do |group| %>
         <%= group.with_eyebrow { "Pathogen Design System" } %>
         <%= group.with_heading { "Typography System" } %>
         <%= group.with_metadata { "A comprehensive, accessible typography system built on Tailwind CSS 4.0" } %>
@@ -13,82 +13,94 @@
     <div class="grid grid-cols-2 gap-6 md:grid-cols-4">
       <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
         <div class="text-4xl font-bold text-primary-600 dark:text-primary-400">11</div>
-        <%= pathogen_supporting(variant: :muted) { "Components" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Components" } %>
       </div>
+
       <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
         <div class="text-4xl font-bold text-primary-600 dark:text-primary-400">6</div>
-        <%= pathogen_supporting(variant: :muted) { "Heading Levels" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Heading Levels" } %>
       </div>
+
       <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
         <div class="text-4xl font-bold text-primary-600 dark:text-primary-400">5</div>
-        <%= pathogen_supporting(variant: :muted) { "Presets" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Presets" } %>
       </div>
+
       <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
         <div class="text-4xl font-bold text-primary-600 dark:text-primary-400">4</div>
-        <%= pathogen_supporting(variant: :muted) { "Color Variants" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Color Variants" } %>
       </div>
     </div>
 
     <!-- Typography Scale -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-2") { "Typography Scale" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Modular scale with ~1.25 ratio, optimized for readability" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-2") { "Typography Scale" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Modular scale with ~1.25 ratio, optimized for readability" } %>
 
       <div class="space-y-6">
         <div class="flex items-baseline gap-6 border-b border-slate-200 pb-4 dark:border-slate-700">
-          <%= pathogen_heading(level: 1, responsive: false) { "Heading 1" } %>
-          <%= pathogen_supporting(variant: :muted) { "31px mobile, 49px desktop" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 1, responsive: false) { "Heading 1" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "31px mobile, 49px desktop" } %>
         </div>
+
         <div class="flex items-baseline gap-6 border-b border-slate-200 pb-4 dark:border-slate-700">
-          <%= pathogen_heading(level: 2, responsive: false) { "Heading 2" } %>
-          <%= pathogen_supporting(variant: :muted) { "25px mobile, 39px desktop" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 2, responsive: false) { "Heading 2" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "25px mobile, 39px desktop" } %>
         </div>
+
         <div class="flex items-baseline gap-6 border-b border-slate-200 pb-4 dark:border-slate-700">
-          <%= pathogen_heading(level: 3, responsive: false) { "Heading 3" } %>
-          <%= pathogen_supporting(variant: :muted) { "20px mobile, 31px desktop" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, responsive: false) { "Heading 3" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "20px mobile, 31px desktop" } %>
         </div>
+
         <div class="flex items-baseline gap-6 border-b border-slate-200 pb-4 dark:border-slate-700">
-          <%= pathogen_lead { "Lead Paragraph" } %>
-          <%= pathogen_supporting(variant: :muted) { "20px (18px responsive)" } %>
+          <%= render Pathogen::Typography::Lead.new { "Lead Paragraph" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "20px (18px responsive)" } %>
         </div>
+
         <div class="flex items-baseline gap-6 border-b border-slate-200 pb-4 dark:border-slate-700">
-          <%= pathogen_callout { "Callout Text" } %>
-          <%= pathogen_supporting(variant: :muted) { "18px (16px responsive)" } %>
+          <%= render Pathogen::Typography::Callout.new { "Callout Text" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "18px (16px responsive)" } %>
         </div>
+
         <div class="flex items-baseline gap-6 border-b border-slate-200 pb-4 dark:border-slate-700">
-          <%= pathogen_text { "Body Text" } %>
-          <%= pathogen_supporting(variant: :muted) { "16px (14px responsive)" } %>
+          <%= render Pathogen::Typography::Text.new { "Body Text" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "16px (14px responsive)" } %>
         </div>
+
         <div class="flex items-baseline gap-6">
-          <%= pathogen_supporting { "Supporting Text" } %>
-          <%= pathogen_supporting(variant: :muted) { "14px (12px responsive)" } %>
+          <%= render Pathogen::Typography::Supporting.new { "Supporting Text" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "14px (12px responsive)" } %>
         </div>
       </div>
     </div>
 
     <!-- Color Variants -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Color Variants" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Color Variants" } %>
 
       <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
         <div class="space-y-3">
           <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-            <%= pathogen_text(variant: :default) { "Default variant" } %>
-            <%= pathogen_code(class: "mt-2") { "variant: :default" } %>
+            <%= render Pathogen::Typography::Text.new(variant: :default) { "Default variant" } %>
+            <%= render Pathogen::Typography::Code.new(class: "mt-2") { "variant: :default" } %>
           </div>
+
           <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-            <%= pathogen_text(variant: :muted) { "Muted variant" } %>
-            <%= pathogen_code(class: "mt-2") { "variant: :muted" } %>
+            <%= render Pathogen::Typography::Text.new(variant: :muted) { "Muted variant" } %>
+            <%= render Pathogen::Typography::Code.new(class: "mt-2") { "variant: :muted" } %>
           </div>
         </div>
+
         <div class="space-y-3">
           <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-            <%= pathogen_text(variant: :subdued) { "Subdued variant" } %>
-            <%= pathogen_code(class: "mt-2") { "variant: :subdued" } %>
+            <%= render Pathogen::Typography::Text.new(variant: :subdued) { "Subdued variant" } %>
+            <%= render Pathogen::Typography::Code.new(class: "mt-2") { "variant: :subdued" } %>
           </div>
+
           <div class="rounded-lg border border-slate-200 bg-slate-900 p-4 dark:border-white dark:bg-slate-50">
-            <%= pathogen_text(variant: :inverse) { "Inverse variant" } %>
-            <%= pathogen_code(class: "mt-2") { "variant: :inverse" } %>
+            <%= render Pathogen::Typography::Text.new(variant: :inverse) { "Inverse variant" } %>
+            <%= render Pathogen::Typography::Code.new(class: "mt-2") { "variant: :inverse" } %>
           </div>
         </div>
       </div>
@@ -96,18 +108,19 @@
 
     <!-- Core Components -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Core Components" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Core Components" } %>
 
       <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">Heading</div>
-          <%= pathogen_heading(level: 3) { "Sample Heading" } %>
-          <%= pathogen_supporting(variant: :muted, class: "mt-2") { "6 levels, responsive sizing" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 3) { "Sample Heading" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mt-2") { "6 levels, responsive sizing" } %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">HeadingGroup</div>
-          <%= pathogen_heading_group(level: 3, spacing: :compact) do |group| %>
+
+          <%= render Pathogen::Typography::HeadingGroup.new(level: 3, spacing: :compact) do |group| %>
             <%= group.with_eyebrow { "Component" } %>
             <%= group.with_heading { "Compound Component" } %>
           <% end %>
@@ -115,41 +128,43 @@
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">Section</div>
-          <%= pathogen_section(level: 3, spacing: :compact) do |section| %>
+
+          <%= render Pathogen::Typography::Section.new(level: 3, spacing: :compact) do |section| %>
             <% section.with_heading { "Section Wrapper" } %>
-            <%= pathogen_supporting(variant: :muted) { "With hierarchy validation" } %>
+            <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "With hierarchy validation" } %>
           <% end %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">Text</div>
-          <%= pathogen_text { "Standard body text for paragraphs and main content." } %>
+          <%= render Pathogen::Typography::Text.new { "Standard body text for paragraphs and main content." } %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">Lead</div>
-          <%= pathogen_lead { "Introductory paragraph that draws attention." } %>
+          <%= render Pathogen::Typography::Lead.new { "Introductory paragraph that draws attention." } %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">Callout</div>
-          <%= pathogen_callout { "Emphasized text between body and lead." } %>
+          <%= render Pathogen::Typography::Callout.new { "Emphasized text between body and lead." } %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">Supporting</div>
-          <%= pathogen_supporting { "Captions, labels, and secondary information." } %>
+          <%= render Pathogen::Typography::Supporting.new { "Captions, labels, and secondary information." } %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">Eyebrow</div>
-          <%= pathogen_eyebrow { "Category Label" } %>
-          <%= pathogen_supporting(variant: :muted, class: "mt-2") { "Uppercase, wide tracking" } %>
+          <%= render Pathogen::Typography::Eyebrow.new { "Category Label" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mt-2") { "Uppercase, wide tracking" } %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
           <div class="mb-2 font-mono text-sm text-primary-600 dark:text-primary-400">List</div>
-          <%= pathogen_list do |list| %>
+
+          <%= render Pathogen::Typography::List.new do |list| %>
             <%= list.with_item { "Feature one" } %>
             <%= list.with_item { "Feature two" } %>
             <%= list.with_item { "Feature three" } %>
@@ -160,19 +175,24 @@
 
     <!-- Key Features -->
     <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
-      <div class="rounded-2xl bg-gradient-to-br from-primary-50 to-primary-100 p-8 dark:from-primary-900/20 dark:to-primary-800/20">
-        <%= pathogen_heading(level: 3, class: "mb-3") { "Responsive Sizing" } %>
-        <%= pathogen_text { "All components support optional responsive sizing with mobile-first approach." } %>
+      <div
+        class="
+          rounded-2xl bg-gradient-to-br from-primary-50 to-primary-100 p-8 dark:from-primary-900/20
+          dark:to-primary-800/20
+        "
+      >
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-3") { "Responsive Sizing" } %>
+        <%= render Pathogen::Typography::Text.new { "All components support optional responsive sizing with mobile-first approach." } %>
       </div>
 
       <div class="rounded-2xl bg-gradient-to-br from-blue-50 to-blue-100 p-8 dark:from-blue-900/20 dark:to-blue-800/20">
-        <%= pathogen_heading(level: 3, class: "mb-3") { "Accessibility First" } %>
-        <%= pathogen_text { "Semantic HTML, WCAG AA compliance, and hierarchy validation built-in." } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-3") { "Accessibility First" } %>
+        <%= render Pathogen::Typography::Text.new { "Semantic HTML, WCAG AA compliance, and hierarchy validation built-in." } %>
       </div>
 
       <div class="rounded-2xl bg-gradient-to-br from-purple-50 to-purple-100 p-8 dark:from-purple-900/20 dark:to-purple-800/20">
-        <%= pathogen_heading(level: 3, class: "mb-3") { "Preset Patterns" } %>
-        <%= pathogen_text { "5 pre-configured presets for common UI patterns: article, card, section, dialog, form." } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-3") { "Preset Patterns" } %>
+        <%= render Pathogen::Typography::Text.new { "5 pre-configured presets for common UI patterns: article, card, section, dialog, form." } %>
       </div>
     </div>
   </div>

--- a/test/components/previews/pathogen/typography_preview/presets.html.erb
+++ b/test/components/previews/pathogen/typography_preview/presets.html.erb
@@ -146,7 +146,7 @@
         <div class="mt-4 space-y-4">
           <div>
             <label class="mb-1 block text-sm font-medium">Sample Name *</label>
-            <input type="text" class="block w-full rounded-lg border border-slate-300 p-2 dark:border-slate-600 dark:bg-slate-700" placeholder="Enter sample name">
+            <input type="text" class="block w-full rounded-lg border border-slate-300 p-2 dark:border-slate-600 dark:bg-slate-700" placeholder="Enter sample name" autocomplete="off">
           </div>
           <div>
             <label class="mb-1 block text-sm font-medium">Description</label>

--- a/test/components/previews/pathogen/typography_preview/presets.html.erb
+++ b/test/components/previews/pathogen/typography_preview/presets.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-7xl space-y-12">
     <!-- Header -->
     <div class="text-center">
-      <%= pathogen_heading_group(level: 1) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1) do |group| %>
         <%= group.with_eyebrow { "Typography System" } %>
         <%= group.with_heading { "Typography Presets" } %>
         <%= group.with_metadata { "Pre-configured patterns for common UI scenarios" } %>
@@ -12,39 +12,39 @@
     <!-- Presets Overview -->
     <div class="grid grid-cols-1 gap-6 md:grid-cols-5">
       <div class="rounded-xl bg-white p-4 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 4, class: "mb-2") { "Article" } %>
-        <%= pathogen_supporting(variant: :muted) { "h1, responsive" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-2") { "Article" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "h1, responsive" } %>
       </div>
       <div class="rounded-xl bg-white p-4 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 4, class: "mb-2") { "Card" } %>
-        <%= pathogen_supporting(variant: :muted) { "h3, compact" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-2") { "Card" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "h3, compact" } %>
       </div>
       <div class="rounded-xl bg-white p-4 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 4, class: "mb-2") { "Section" } %>
-        <%= pathogen_supporting(variant: :muted) { "h2, responsive" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-2") { "Section" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "h2, responsive" } %>
       </div>
       <div class="rounded-xl bg-white p-4 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 4, class: "mb-2") { "Dialog" } %>
-        <%= pathogen_supporting(variant: :muted) { "h2, compact" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-2") { "Dialog" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "h2, compact" } %>
       </div>
       <div class="rounded-xl bg-white p-4 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 4, class: "mb-2") { "Form" } %>
-        <%= pathogen_supporting(variant: :muted) { "h3, compact" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-2") { "Form" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "h3, compact" } %>
       </div>
     </div>
 
     <!-- Article Preset -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Article Preset" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Blog posts, documentation, and long-form content" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Article Preset" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Blog posts, documentation, and long-form content" } %>
 
-      <%= pathogen_typography_preset(:article) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1, heading_variant: :default, spacing: :default) do |group| %>
         <%= group.with_eyebrow { "Tutorial" } %>
         <%= group.with_heading { "Getting Started with IRIDA Next" } %>
         <%= group.with_metadata { "Published January 15, 2024 · 8 min read · Bioinformatics Team" } %>
       <% end %>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-8") do %><%%= pathogen_typography_preset(:article) do |group| %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-8") do %><%%= render Pathogen::Typography::HeadingGroup.new(level: 1, heading_variant: :default, spacing: :default) do |group| %>
   <%%= group.with_eyebrow { "Category" } %>
   <%%= group.with_heading { "Article Title" } %>
   <%%= group.with_metadata { "Date · Read time" } %>
@@ -54,19 +54,19 @@
 
     <!-- Card Preset -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Card Preset" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Cards, compact headers with eyebrow and metadata" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Card Preset" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Cards, compact headers with eyebrow and metadata" } %>
 
       <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-          <%= pathogen_typography_preset(:card) do |group| %>
+          <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
             <%= group.with_heading { "Sample Analysis" } %>
             <%= group.with_metadata { "3 samples · Active" } %>
           <% end %>
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-          <%= pathogen_typography_preset(:card) do |group| %>
+          <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
             <%= group.with_eyebrow { "Workflow" } %>
             <%= group.with_heading { "COVID-19 Analysis" } %>
             <%= group.with_metadata { "Completed 2h ago" } %>
@@ -74,7 +74,7 @@
         </div>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
-          <%= pathogen_typography_preset(:card) do |group| %>
+          <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
             <%= group.with_eyebrow { "Project" } %>
             <%= group.with_heading { "Research Study" } %>
             <%= group.with_metadata { "12 members" } %>
@@ -82,7 +82,7 @@
         </div>
       </div>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-8") do %><%%= pathogen_typography_preset(:card) do |group| %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-8") do %><%%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
   <%%= group.with_heading { "Card Title" } %>
   <%%= group.with_metadata { "Metadata" } %>
 <%% end %>
@@ -91,17 +91,17 @@
 
     <!-- Section Preset -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Section Preset" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Page sections with heading and metadata" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Section Preset" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Page sections with heading and metadata" } %>
 
-      <%= pathogen_typography_preset(:section) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 2, heading_variant: :default, spacing: :default) do |group| %>
         <%= group.with_heading { "Recent Activity" } %>
         <%= group.with_metadata { "Last updated 5 minutes ago" } %>
       <% end %>
 
-      <%= pathogen_text(class: "mt-4") { "List of recent activities and changes in your workspace." } %>
+      <%= render Pathogen::Typography::Text.new(class: "mt-4") { "List of recent activities and changes in your workspace." } %>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-8") do %><%%= pathogen_typography_preset(:section) do |group| %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-8") do %><%%= render Pathogen::Typography::HeadingGroup.new(level: 2, heading_variant: :default, spacing: :default) do |group| %>
   <%%= group.with_heading { "Section Title" } %>
   <%%= group.with_metadata { "Updated time" } %>
 <%% end %>
@@ -110,15 +110,15 @@
 
     <!-- Dialog Preset -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Dialog Preset" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Modal dialogs and compact headers" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Dialog Preset" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Modal dialogs and compact headers" } %>
 
       <div class="mx-auto max-w-md rounded-lg border border-slate-200 bg-slate-50 p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
-        <%= pathogen_typography_preset(:dialog) do |group| %>
+        <%= render Pathogen::Typography::HeadingGroup.new(level: 2, heading_variant: :default, spacing: :compact) do |group| %>
           <%= group.with_heading { "Confirm Deletion" } %>
         <% end %>
 
-        <%= pathogen_text(variant: :muted, class: "mt-4") { "Are you sure you want to delete this sample? This action cannot be undone." } %>
+        <%= render Pathogen::Typography::Text.new(variant: :muted, class: "mt-4") { "Are you sure you want to delete this sample? This action cannot be undone." } %>
 
         <div class="mt-6 flex gap-3">
           <button class="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white">Delete</button>
@@ -126,7 +126,7 @@
         </div>
       </div>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-8") do %><%%= pathogen_typography_preset(:dialog) do |group| %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-8") do %><%%= render Pathogen::Typography::HeadingGroup.new(level: 2, heading_variant: :default, spacing: :compact) do |group| %>
   <%%= group.with_heading { "Dialog Title" } %>
 <%% end %>
       <% end %>
@@ -134,11 +134,11 @@
 
     <!-- Form Section Preset -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Form Section Preset" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Form groups with helper text" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Form Section Preset" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Form groups with helper text" } %>
 
       <div class="max-w-2xl">
-        <%= pathogen_typography_preset(:form_section) do |group| %>
+        <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
           <%= group.with_heading { "Sample Information" } %>
           <%= group.with_metadata { "Required fields are marked with *" } %>
         <% end %>
@@ -155,7 +155,7 @@
         </div>
       </div>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-8") do %><%%= pathogen_typography_preset(:form_section) do |group| %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-8") do %><%%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :default, spacing: :compact) do |group| %>
   <%%= group.with_heading { "Form Section" } %>
   <%%= group.with_metadata { "Helper text" } %>
 <%% end %>
@@ -164,15 +164,16 @@
 
     <!-- Custom Overrides -->
     <div class="rounded-2xl bg-gradient-to-br from-primary-50 to-primary-100 p-8 dark:from-primary-900/20 dark:to-primary-800/20">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Custom Overrides" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Customize any preset by passing override options" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Custom Overrides" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Customize any preset by passing override options" } %>
 
-      <%= pathogen_typography_preset(:card, heading_variant: :subdued, spacing: :spacious) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 3, heading_variant: :subdued, spacing: :spacious) do |group| %>
         <%= group.with_heading { "Custom Styled Card" } %>
         <%= group.with_metadata { "Using card preset with custom variant and spacing" } %>
       <% end %>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-8") do %><%%= pathogen_typography_preset(:card,
+        <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-8") do %><%%= render Pathogen::Typography::HeadingGroup.new(
+      level: 3,
   heading_variant: :subdued,
   spacing: :spacious
 ) do |group| %>

--- a/test/components/previews/pathogen/typography_preview/special_components.html.erb
+++ b/test/components/previews/pathogen/typography_preview/special_components.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-6xl space-y-12">
     <!-- Header -->
     <div class="text-center">
-      <%= pathogen_heading_group(level: 1) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1) do |group| %>
         <%= group.with_eyebrow { "Typography Components" } %>
         <%= group.with_heading { "Special Components" } %>
         <%= group.with_metadata { "Code, lists, heading groups, and sections" } %>
@@ -11,22 +11,22 @@
 
     <!-- HeadingGroup Component -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "HeadingGroup Component" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Compound component coordinating eyebrow, heading, and metadata" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "HeadingGroup Component" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Compound component coordinating eyebrow, heading, and metadata" } %>
 
       <div class="space-y-8">
-        <%= pathogen_heading_group(level: 2) do |group| %>
+        <%= render Pathogen::Typography::HeadingGroup.new(level: 2) do |group| %>
           <%= group.with_eyebrow { "Tutorial" } %>
           <%= group.with_heading { "Getting Started" } %>
           <%= group.with_metadata { "Last updated January 15, 2024" } %>
         <% end %>
 
-        <%= pathogen_heading_group(level: 3, spacing: :compact) do |group| %>
+        <%= render Pathogen::Typography::HeadingGroup.new(level: 3, spacing: :compact) do |group| %>
           <%= group.with_heading { "Compact Spacing" } %>
           <%= group.with_metadata(variant: :muted) { "3 samples processed" } %>
         <% end %>
 
-        <%= pathogen_code_block(language: "erb", class: "mt-6") do %><%%= pathogen_heading_group(level: 2) do |group| %>
+        <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-6") do %><%%= render Pathogen::Typography::HeadingGroup.new(level: 2) do |group| %>
   <%%= group.with_eyebrow { "Category" } %>
   <%%= group.with_heading { "Title" } %>
   <%%= group.with_metadata { "Metadata" } %>
@@ -37,15 +37,15 @@
 
     <!-- Section Component -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Section Component" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Semantic wrapper with heading hierarchy validation" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Section Component" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Semantic wrapper with heading hierarchy validation" } %>
 
-      <%= pathogen_section(level: 3) do |section| %>
+      <%= render Pathogen::Typography::Section.new(level: 3) do |section| %>
         <% section.with_heading { "Section with Heading" } %>
-        <%= pathogen_text { "Section content goes here. The Section component validates heading hierarchy in development mode." } %>
+        <%= render Pathogen::Typography::Text.new { "Section content goes here. The Section component validates heading hierarchy in development mode." } %>
       <% end %>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-6") do %><%%= pathogen_section(level: 2, spacing: :spacious) do |section| %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-6") do %><%%= render Pathogen::Typography::Section.new(level: 2, spacing: :spacious) do |section| %>
   <%%= section.with_heading { "Features" } %>
   <p>Section content...</p>
 <%% end %>
@@ -54,21 +54,21 @@
 
     <!-- Code Components -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Code Components" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Code Components" } %>
 
       <div class="space-y-6">
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Inline Code" } %>
-          <%= pathogen_text { "Use " } %>
-          <%= pathogen_code { "pathogen_text" } %>
-          <%= pathogen_text { " for paragraphs and " } %>
-          <%= pathogen_code { "pathogen_heading" } %>
-          <%= pathogen_text { " for headings." } %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Inline Code" } %>
+          <%= render Pathogen::Typography::Text.new { "Use " } %>
+          <%= render Pathogen::Typography::Code.new { "render Pathogen::Typography::Text.new" } %>
+          <%= render Pathogen::Typography::Text.new { " for paragraphs and " } %>
+          <%= render Pathogen::Typography::Code.new { "render Pathogen::Typography::Heading.new" } %>
+          <%= render Pathogen::Typography::Text.new { " for headings." } %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Code Block" } %>
-          <%= pathogen_code_block(language: "ruby") do %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Code Block" } %>
+          <%= render Pathogen::Typography::CodeBlock.new(language: "ruby") do %>
 def example
   puts "Hello, World!"
 end
@@ -79,12 +79,12 @@ end
 
     <!-- List Components -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "List Components" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "List Components" } %>
 
       <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Unordered List" } %>
-          <%= pathogen_list do |list| %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Unordered List" } %>
+          <%= render Pathogen::Typography::List.new do |list| %>
             <%= list.with_item { "Sample management" } %>
             <%= list.with_item { "Workflow execution" } %>
             <%= list.with_item { "Data visualization" } %>
@@ -93,8 +93,8 @@ end
         </div>
 
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Ordered List" } %>
-          <%= pathogen_list(ordered: true) do |list| %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Ordered List" } %>
+          <%= render Pathogen::Typography::List.new(ordered: true) do |list| %>
             <%= list.with_item { "Upload samples" } %>
             <%= list.with_item { "Select workflow" } %>
             <%= list.with_item { "Configure parameters" } %>
@@ -103,13 +103,13 @@ end
         </div>
       </div>
 
-      <%= pathogen_code_block(language: "erb", class: "mt-6") do %><%%= pathogen_list do |list| %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb", class: "mt-6") do %><%%= render Pathogen::Typography::List.new do |list| %>
   <%%= list.with_item { "Item 1" } %>
   <%%= list.with_item { "Item 2" } %>
   <%%= list.with_item { "Item 3" } %>
 <%% end %>
 
-<%%= pathogen_list(ordered: true) do |list| %>
+<%%= render Pathogen::Typography::List.new(ordered: true) do |list| %>
   <%%= list.with_item { "Step 1" } %>
   <%%= list.with_item { "Step 2" } %>
 <%% end %>
@@ -118,29 +118,29 @@ end
 
     <!-- Combined Example -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Combined Example" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Combined Example" } %>
 
-      <%= pathogen_section(level: 3, spacing: :default) do |section| %>
+      <%= render Pathogen::Typography::Section.new(level: 3, spacing: :default) do |section| %>
         <% section.with_heading { "Installation Guide" } %>
 
-        <%= pathogen_lead(class: "mb-6") { "Follow these steps to set up IRIDA Next in your environment." } %>
+        <%= render Pathogen::Typography::Lead.new(class: "mb-6") { "Follow these steps to set up IRIDA Next in your environment." } %>
 
-        <%= pathogen_heading(level: 4, class: "mb-3") { "Prerequisites" } %>
-        <%= pathogen_list do |list| %>
+        <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Prerequisites" } %>
+        <%= render Pathogen::Typography::List.new do |list| %>
           <%= list.with_item { "Ruby 3.4.4 or higher" } %>
           <%= list.with_item { "PostgreSQL 14 or higher" } %>
           <%= list.with_item { "Node.js 20 LTS or higher" } %>
         <% end %>
 
-        <%= pathogen_heading(level: 4, class: "mb-3 mt-6") { "Installation Steps" } %>
-        <%= pathogen_list(ordered: true) do |list| %>
+        <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3 mt-6") { "Installation Steps" } %>
+        <%= render Pathogen::Typography::List.new(ordered: true) do |list| %>
           <%= list.with_item { "Clone the repository" } %>
           <%= list.with_item { "Install dependencies with bundle install" } %>
           <%= list.with_item { "Set up the database with bin/setup" } %>
           <%= list.with_item { "Start the server with bin/dev" } %>
         <% end %>
 
-        <%= pathogen_callout(class: "mt-6") { "Note: Make sure all prerequisites are installed before proceeding with the installation." } %>
+        <%= render Pathogen::Typography::Callout.new(class: "mt-6") { "Note: Make sure all prerequisites are installed before proceeding with the installation." } %>
       <% end %>
     </div>
   </div>

--- a/test/components/previews/pathogen/typography_preview/supporting_text.html.erb
+++ b/test/components/previews/pathogen/typography_preview/supporting_text.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-6xl space-y-12">
     <!-- Header -->
     <div class="text-center">
-      <%= pathogen_heading_group(level: 1) do |group| %>
+      <%= render Pathogen::Typography::HeadingGroup.new(level: 1) do |group| %>
         <%= group.with_eyebrow { "Typography Components" } %>
         <%= group.with_heading { "Supporting Text" } %>
         <%= group.with_metadata { "Captions, labels, eyebrow text, and metadata with responsive sizing" } %>
@@ -12,118 +12,118 @@
     <!-- Component Grid -->
     <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
       <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 3, class: "mb-4") { "Supporting (14px)" } %>
-        <%= pathogen_supporting { "Captions, labels, and secondary information at 14px" } %>
-        <%= pathogen_code(class: "mt-4") { "pathogen_supporting" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Supporting (14px)" } %>
+        <%= render Pathogen::Typography::Supporting.new { "Captions, labels, and secondary information at 14px" } %>
+        <%= render Pathogen::Typography::Code.new(class: "mt-4") { "render Pathogen::Typography::Supporting.new" } %>
       </div>
 
       <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <%= pathogen_heading(level: 3, class: "mb-4") { "Eyebrow (12px)" } %>
-        <%= pathogen_eyebrow { "Category Label" } %>
-        <%= pathogen_supporting(variant: :muted, class: "mt-4") { "Small uppercase text above headings" } %>
-        <%= pathogen_code(class: "mt-2") { "pathogen_eyebrow" } %>
+        <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Eyebrow (12px)" } %>
+        <%= render Pathogen::Typography::Eyebrow.new { "Category Label" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mt-4") { "Small uppercase text above headings" } %>
+        <%= render Pathogen::Typography::Code.new(class: "mt-2") { "render Pathogen::Typography::Eyebrow.new" } %>
       </div>
     </div>
 
     <!-- Responsive Sizing -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Responsive Supporting Text" } %>
-      <%= pathogen_supporting(variant: :muted, class: "mb-8") { "Scale from 12px (mobile) to 14px (desktop)" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Responsive Supporting Text" } %>
+      <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mb-8") { "Scale from 12px (mobile) to 14px (desktop)" } %>
 
       <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Fixed (Default)" } %>
-          <%= pathogen_supporting { "This supporting text stays at 14px on all screen sizes." } %>
-          <%= pathogen_code(class: "mt-3") { "responsive: false" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Fixed (Default)" } %>
+          <%= render Pathogen::Typography::Supporting.new { "This supporting text stays at 14px on all screen sizes." } %>
+          <%= render Pathogen::Typography::Code.new(class: "mt-3") { "responsive: false" } %>
         </div>
 
         <div>
-          <%= pathogen_heading(level: 4, class: "mb-3") { "Responsive" } %>
-          <%= pathogen_supporting(responsive: true) { "This supporting text scales from 12px to 14px for better mobile readability." } %>
-          <%= pathogen_code(class: "mt-3") { "responsive: true" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 4, class: "mb-3") { "Responsive" } %>
+          <%= render Pathogen::Typography::Supporting.new(responsive: true) { "This supporting text scales from 12px to 14px for better mobile readability." } %>
+          <%= render Pathogen::Typography::Code.new(class: "mt-3") { "responsive: true" } %>
         </div>
       </div>
     </div>
 
     <!-- Color Variants -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Color Variants" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Color Variants" } %>
       <div class="space-y-4">
-        <%= pathogen_supporting(variant: :default) { "Default variant - Standard supporting text color" } %>
-        <%= pathogen_supporting(variant: :muted) { "Muted variant - Most common for captions and metadata" } %>
-        <%= pathogen_supporting(variant: :subdued) { "Subdued variant - Medium emphasis supporting information" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :default) { "Default variant - Standard supporting text color" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Muted variant - Most common for captions and metadata" } %>
+        <%= render Pathogen::Typography::Supporting.new(variant: :subdued) { "Subdued variant - Medium emphasis supporting information" } %>
         <div class="rounded-lg bg-slate-900 p-4 dark:bg-slate-50">
-          <%= pathogen_supporting(variant: :inverse) { "Inverse variant - Light text for dark backgrounds" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :inverse) { "Inverse variant - Light text for dark backgrounds" } %>
         </div>
       </div>
     </div>
 
     <!-- Use Cases -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Common Use Cases" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Common Use Cases" } %>
 
       <div class="space-y-8">
         <!-- Image caption -->
         <div>
           <div class="mb-2 h-48 rounded-lg bg-gradient-to-r from-primary-100 to-primary-200 dark:from-primary-900/40 dark:to-primary-800/40"></div>
-          <%= pathogen_supporting(variant: :muted) { "Figure 1: Genomic analysis workflow showing sample intake through final report generation" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Figure 1: Genomic analysis workflow showing sample intake through final report generation" } %>
         </div>
 
         <!-- Metadata -->
         <div>
-          <%= pathogen_heading(level: 3, class: "mb-2") { "Research Article" } %>
-          <%= pathogen_supporting(variant: :muted) { "Published January 15, 2024 · 12 min read · Research Team" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-2") { "Research Article" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Published January 15, 2024 · 12 min read · Research Team" } %>
         </div>
 
         <!-- Form label helper -->
         <div>
           <label class="mb-1 block text-sm font-medium">Sample Name</label>
-          <%= pathogen_supporting(variant: :muted) { "Enter a unique identifier for this sample" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted) { "Enter a unique identifier for this sample" } %>
         </div>
 
         <!-- Card metadata -->
         <div class="rounded-lg border border-slate-200 p-4 dark:border-slate-700">
-          <%= pathogen_eyebrow(class: "mb-2") { "Workflow" } %>
-          <%= pathogen_heading(level: 4) { "COVID-19 Analysis" } %>
-          <%= pathogen_supporting(variant: :muted, class: "mt-2") { "Last run 2 hours ago · 45 samples processed" } %>
+          <%= render Pathogen::Typography::Eyebrow.new(class: "mb-2") { "Workflow" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 4) { "COVID-19 Analysis" } %>
+          <%= render Pathogen::Typography::Supporting.new(variant: :muted, class: "mt-2") { "Last run 2 hours ago · 45 samples processed" } %>
         </div>
       </div>
     </div>
 
     <!-- Eyebrow Examples -->
     <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <%= pathogen_heading(level: 2, class: "mb-6") { "Eyebrow Text Examples" } %>
+      <%= render Pathogen::Typography::Heading.new(level: 2, class: "mb-6") { "Eyebrow Text Examples" } %>
 
       <div class="space-y-6">
         <div>
-          <%= pathogen_eyebrow { "Tutorial" } %>
-          <%= pathogen_heading(level: 3) { "Getting Started with IRIDA Next" } %>
+          <%= render Pathogen::Typography::Eyebrow.new { "Tutorial" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 3) { "Getting Started with IRIDA Next" } %>
         </div>
 
         <div>
-          <%= pathogen_eyebrow(variant: :subdued) { "Case Study" } %>
-          <%= pathogen_heading(level: 3) { "Pathogen Surveillance in Action" } %>
+          <%= render Pathogen::Typography::Eyebrow.new(variant: :subdued) { "Case Study" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 3) { "Pathogen Surveillance in Action" } %>
         </div>
 
         <div>
-          <%= pathogen_eyebrow { "Documentation" } %>
-          <%= pathogen_heading(level: 3) { "API Reference Guide" } %>
+          <%= render Pathogen::Typography::Eyebrow.new { "Documentation" } %>
+          <%= render Pathogen::Typography::Heading.new(level: 3) { "API Reference Guide" } %>
         </div>
       </div>
     </div>
 
     <!-- Usage Example -->
     <div class="rounded-2xl bg-gradient-to-br from-primary-50 to-primary-100 p-8 dark:from-primary-900/20 dark:to-primary-800/20">
-      <%= pathogen_heading(level: 3, class: "mb-4") { "Usage Example" } %>
-      <%= pathogen_code_block(language: "erb") do %><%%= pathogen_eyebrow do %>
+      <%= render Pathogen::Typography::Heading.new(level: 3, class: "mb-4") { "Usage Example" } %>
+      <%= render Pathogen::Typography::CodeBlock.new(language: "erb") do %><%%= render Pathogen::Typography::Eyebrow.new do %>
   Category
 <%% end %>
 
-<%%= pathogen_heading(level: 2) do %>
+<%%= render Pathogen::Typography::Heading.new(level: 2) do %>
   Article Title
 <%% end %>
 
-<%%= pathogen_supporting(variant: :muted, responsive: true) do %>
+<%%= render Pathogen::Typography::Supporting.new(variant: :muted, responsive: true) do %>
   Published Jan 15, 2024
 <%% end %>
       <% end %>


### PR DESCRIPTION
## What does this PR do and why?
- Replaces `pathogen_*` helper calls with explicit `render Pathogen::*` component calls in app views and Pathogen previews.
- Updates preview examples so legacy helper names are replaced with explicit render syntax.
- Keeps behavior the same while matching the Pathogen helper-removal changes from the design-system repo.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
1. Search project for `pathogen_` --> nothing should show up
2. Ensure test pass.

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
