### PR TITLE
Bug: Fix file selection on shared sample

### DIFF
--- a/app/controllers/workflow_executions/file_selector_controller.rb
+++ b/app/controllers/workflow_executions/file_selector_controller.rb
@@ -68,13 +68,16 @@ module WorkflowExecutions
         @attachable = authorized_scope(Sample, type: :relation, as: :namespace_samples,
                                                scope_options: { namespace: @namespace })
                       .where(id: attachable_id).first
+
       when Namespaces::ProjectNamespace.sti_name, Group.sti_name
         @attachable = Namespace.where(id: authorized_namespace_ids)
                                .where(type: file_selector_params[:attachable_type])
                                .find(attachable_id)
-      else
-        raise ActiveRecord::RecordNotFound
       end
+
+      return unless @attachable.nil?
+
+      raise ActiveRecord::RecordNotFound
     end
 
     def attachments

--- a/app/controllers/workflow_executions/file_selector_controller.rb
+++ b/app/controllers/workflow_executions/file_selector_controller.rb
@@ -67,17 +67,15 @@ module WorkflowExecutions
       when Sample.sti_name
         @attachable = authorized_scope(Sample, type: :relation, as: :namespace_samples,
                                                scope_options: { namespace: @namespace })
-                      .where(id: attachable_id).first
+                      .find(attachable_id)
 
       when Namespaces::ProjectNamespace.sti_name, Group.sti_name
         @attachable = Namespace.where(id: authorized_namespace_ids)
                                .where(type: file_selector_params[:attachable_type])
                                .find(attachable_id)
+      else
+        raise ActiveRecord::RecordNotFound
       end
-
-      return unless @attachable.nil?
-
-      raise ActiveRecord::RecordNotFound
     end
 
     def attachments

--- a/app/controllers/workflow_executions/file_selector_controller.rb
+++ b/app/controllers/workflow_executions/file_selector_controller.rb
@@ -62,6 +62,7 @@ module WorkflowExecutions
       authorize! @namespace, to: :update_samplesheet_data?
 
       attachable_id = file_selector_params[:attachable_id]
+
       case file_selector_params[:attachable_type]
       when Sample.sti_name
         @attachable = authorized_scope(Sample, type: :relation, as: :namespace_samples,

--- a/app/controllers/workflow_executions/file_selector_controller.rb
+++ b/app/controllers/workflow_executions/file_selector_controller.rb
@@ -64,9 +64,9 @@ module WorkflowExecutions
       attachable_id = file_selector_params[:attachable_id]
       case file_selector_params[:attachable_type]
       when Sample.sti_name
-        @attachable = Sample.joins(:project)
-                            .where(projects: { namespace_id: authorized_namespace_ids })
-                            .find(attachable_id)
+        @attachable = authorized_scope(Sample, type: :relation, as: :namespace_samples,
+                                               scope_options: { namespace: @namespace })
+                      .where(id: attachable_id).first
       when Namespaces::ProjectNamespace.sti_name, Group.sti_name
         @attachable = Namespace.where(id: authorized_namespace_ids)
                                .where(type: file_selector_params[:attachable_type])

--- a/test/controllers/workflow_executions/file_selector_controller_test.rb
+++ b/test/controllers/workflow_executions/file_selector_controller_test.rb
@@ -146,15 +146,6 @@ module WorkflowExecutions
       assert_response :ok
     end
 
-    test 'new file selection with attachable outside authorized namespace responds not found' do
-      get new_workflow_executions_file_selector_path(
-        file_selector: @expected_fastq_params.merge(attachable_id: samples(:sample1).id),
-        format: :turbo_stream
-      )
-
-      assert_response :not_found
-    end
-
     test 'create file selection with other params' do
       attachment = attachments(:attachment1)
 

--- a/test/controllers/workflow_executions/file_selector_controller_test.rb
+++ b/test/controllers/workflow_executions/file_selector_controller_test.rb
@@ -187,6 +187,34 @@ module WorkflowExecutions
       assert_response :unauthorized
     end
 
+    test 'new file selection with invalid attachable_id and attachable type Sample' do
+      get new_workflow_executions_file_selector_path(
+        file_selector: @expected_fastq_params.merge(attachable_id: 'invalid id'),
+        format: :turbo_stream
+      )
+
+      assert_response :not_found
+    end
+
+    test 'new file selection with invalid attachable_id and attachable type Namespace' do
+      sign_in users(:snvphyl_user)
+      get new_workflow_executions_file_selector_path(
+        file_selector: @project_ref_params.merge(attachable_id: 'invalid id'),
+        format: :turbo_stream
+      )
+
+      assert_response :not_found
+    end
+
+    test 'new file selection with invalid attachable_type' do
+      get new_workflow_executions_file_selector_path(
+        file_selector: @expected_fastq_params.merge(attachable_type: 'invalid type'),
+        format: :turbo_stream
+      )
+
+      assert_response :not_found
+    end
+
     private
 
     def parsed_files_payload

--- a/test/integration/workflow_executions/file_selector_test.rb
+++ b/test/integration/workflow_executions/file_selector_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WorkflowExecutions
+  class FileSelectorTest < ActionDispatch::IntegrationTest
+    include ActionView::Helpers::NumberHelper
+
+    test 'can select attachment on shared sample' do
+      sign_in users(:subgroup_sample_actions_doe)
+
+      group = groups(:subgroup_sample_actions)
+      sample = samples(:sample71)
+      sample.attachments.create!(
+        file: Rails.root.join('test/fixtures/files/08-5578-small_S1_L001_R1_001.fastq')
+      )
+      sample.attachments.create!(
+        file: Rails.root.join('test/fixtures/files/08-5923-small_S1_L001_R1_001.fastq')
+      )
+      first_attachment = sample.attachments.first
+      last_attachment = sample.attachments.last
+      get new_workflow_executions_file_selector_path(
+        params: {
+          file_selector: { attachable_id: sample.id, attachable_type: 'Sample',
+                           pattern: '^\\S+\\.f(ast)?q(\\.gz)?$',
+                           property: 'fastq_1',
+                           selected_id: last_attachment.id,
+                           namespace_id: group.id, required_properties: %w[fastq_1 sample] }
+        }
+      )
+
+      assert_response :success
+
+      attachments = [first_attachment, last_attachment]
+      assert_select 'table' do
+        assert_select 'tbody' do
+          attachments.each do |attachment|
+            assert_select 'tr' do
+              assert_select 'td', text: attachment.file.filename.to_s
+              assert_select 'td', text: attachment.metadata['format']
+              assert_select 'td', text: attachment.metadata['type']
+              assert_select 'td', number_to_human_size(attachment.file.byte_size)
+              assert_select 'td' do
+                assert_select 'time[datetime=?]', attachment.created_at.iso8601
+              end
+              if attachment == last_attachment
+                assert_select "input[id='attachment_id_#{attachment.id}'][checked]"
+              else
+                assert_select "input[id='attachment_id_#{attachment.id}'][checked]", count: 0
+              end
+            end
+          end
+          # required property so no "No File" selection option available
+          assert_select 'td', text: I18n.t('workflow_executions.file_selector.file_selector_dialog.no_file'), count: 0
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do and why?
This PR fixes a bug where the sample (attachable) query for the file selector excluded  shared samples

## Screenshots or screen recordings
Before:

[Screencast from 2026-08-31 11-30-28.webm](https://github.com/user-attachments/assets/4eecb6bc-b696-427d-8905-afb00964facd)

Now:

[Screencast from 2026-08-31 11-33-42.webm](https://github.com/user-attachments/assets/941bcd25-3990-4c3e-9412-522d3787168f)


## How to set up and validate locally
1. Decide on a group that contains shared samples, and on the sample(s) you plan to test, add additional files for file selection
2. Navigate to the group's sample page that contains the shared sample, and launch a workflow that has file selection on the shared sample
3. Try selecting a file and verify the file selector dialog opens, and you can select files and they populate the samplesheet as expected

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
