### PR TITLE
fix(tables): use outlined pathogen row action buttons

### DIFF
--- a/app/components/attachments/table_component.html.erb
+++ b/app/components/attachments/table_component.html.erb
@@ -265,7 +265,7 @@
                       },
                       method: :get,
                       tone: :neutral,
-                      emphasis: :ghost,
+                      emphasis: :outline,
                       size: :small,
                     ) %>
                     <% end %>
@@ -297,7 +297,7 @@
                       },
                       method: :get,
                       tone: :danger,
-                      emphasis: :ghost,
+                      emphasis: :outline,
                       size: :small,
                     ) %>
                     <% end %>

--- a/app/components/bots/table_component.html.erb
+++ b/app/components/bots/table_component.html.erb
@@ -66,7 +66,7 @@
       <% end %>
 
       <% table.with_column(t("bots.index.table.header.actions"),
-        classes: "flex justify-start"
+        classes: "flex justify-start gap-1"
       ) do |row| %>
         <% if @abilities[:generate_token] %>
           <%= pathogen_button_to t("bots.index.table.actions.generate_new_token"),

--- a/app/components/bots/table_component.html.erb
+++ b/app/components/bots/table_component.html.erb
@@ -19,7 +19,7 @@
         },
         method: :get,
         tone: :neutral,
-        emphasis: :ghost,
+        emphasis: :outline,
         size: :small %>
         <% else %>
           0
@@ -40,7 +40,7 @@
         },
         method: :get,
         tone: :neutral,
-        emphasis: :ghost,
+        emphasis: :outline,
         size: :small %>
         <% else %>
           0
@@ -83,7 +83,7 @@
             ),
         },
         tone: :neutral,
-        emphasis: :ghost,
+        emphasis: :outline,
         size: :small %>
         <% end %>
 
@@ -98,7 +98,7 @@
           label: t("bots.index.table.actions.destroy_aria_label", name: row.user.email),
         },
         tone: :danger,
-        emphasis: :ghost,
+        emphasis: :outline,
         size: :small %>
         <% end %>
       <% end %>

--- a/app/components/data_exports/table_component.html.erb
+++ b/app/components/data_exports/table_component.html.erb
@@ -98,7 +98,7 @@
                       ),
                   },
                   tone: :neutral,
-                  emphasis: :ghost,
+                  emphasis: :outline,
                   size: :small %>
                 <% end %>
 
@@ -125,7 +125,7 @@
                     ),
                 },
                 tone: :danger,
-                emphasis: :ghost,
+                emphasis: :outline,
                 size: :small %>
               </td>
             <% end %>

--- a/app/components/groups/table_component.html.erb
+++ b/app/components/groups/table_component.html.erb
@@ -111,7 +111,7 @@
                     ),
                 },
                 tone: :danger,
-                emphasis: :ghost,
+                emphasis: :outline,
                 size: :small %>
                 <% end %>
               </div>

--- a/app/components/metadata_templates/row_component.html.erb
+++ b/app/components/metadata_templates/row_component.html.erb
@@ -46,7 +46,7 @@
             ),
         },
         tone: :neutral,
-        emphasis: :ghost,
+        emphasis: :outline,
         size: :small %>
       <% end %>
 
@@ -74,7 +74,7 @@
             ),
         },
         tone: :danger,
-        emphasis: :ghost,
+        emphasis: :outline,
         size: :small %>
       <% end %>
     <% end %>

--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -68,7 +68,7 @@
             label: t(:"personal_access_tokens.table.revoke_aria_label", name: row[:name]),
           },
           tone: :danger,
-          emphasis: :ghost,
+          emphasis: :outline,
           size: :small %>
         <% end %>
 
@@ -81,7 +81,7 @@
             label: t(:"personal_access_tokens.table.rotate_aria_label", name: row[:name]),
           },
           tone: :neutral,
-          emphasis: :ghost,
+          emphasis: :outline,
           size: :small %>
         <% end %>
       <% end %>

--- a/app/components/personal_access_tokens/table_component.html.erb
+++ b/app/components/personal_access_tokens/table_component.html.erb
@@ -57,7 +57,7 @@
 
     <% if !@actions.empty? %>
       <% table.with_column(t("personal_access_tokens.table.header.action"),
-          classes: "flex justify-start"
+          classes: "flex justify-start gap-1"
         ) do |row| %>
         <% if @actions[:revoke] %>
           <%= pathogen_button_to t("personal_access_tokens.table.revoke"),

--- a/app/components/workflow_executions/table_component.html.erb
+++ b/app/components/workflow_executions/table_component.html.erb
@@ -195,7 +195,7 @@
                             ),
                         },
                         tone: :neutral,
-                        emphasis: :ghost,
+                        emphasis: :outline,
                         size: :small %>
                       <% end %>
                       <% if workflow_execution.deletable? && @row_actions.key?(:destroy) %>
@@ -213,7 +213,7 @@
                             ),
                         },
                         tone: :danger,
-                        emphasis: :ghost,
+                        emphasis: :outline,
                         size: :small %>
                       <% end %>
                     <% end %>

--- a/app/views/groups/group_links/_edit.html.erb
+++ b/app/views/groups/group_links/_edit.html.erb
@@ -8,5 +8,5 @@ aria: {
   label: t(:"groups.group_links.index.actions.edit_aria_label", group_name: namespace_group_link.group.name),
 },
 tone: :neutral,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/groups/members/_current_user_is_member.html.erb
+++ b/app/views/groups/members/_current_user_is_member.html.erb
@@ -10,5 +10,5 @@ aria: {
   label: t(:"groups.members.index.actions.leave_group_aria_label"),
 },
 tone: :danger,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/groups/members/_current_user_is_not_member.html.erb
+++ b/app/views/groups/members/_current_user_is_not_member.html.erb
@@ -13,5 +13,5 @@ aria: {
     ),
 },
 tone: :danger,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/groups/members/_edit.html.erb
+++ b/app/views/groups/members/_edit.html.erb
@@ -9,5 +9,5 @@ aria: {
       member: member.user.email),
 },
 tone: :neutral,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/projects/automated_workflow_executions/_table.html.erb
+++ b/app/views/projects/automated_workflow_executions/_table.html.erb
@@ -56,7 +56,7 @@
             ),
         },
         tone: :neutral,
-        emphasis: :ghost,
+        emphasis: :outline,
         size: :small %>
       <% end %>
 
@@ -80,7 +80,7 @@
           ),
       },
       tone: :danger,
-      emphasis: :ghost,
+      emphasis: :outline,
       size: :small %>
     <% end %>
   <% end %>

--- a/app/views/projects/automated_workflow_executions/_table.html.erb
+++ b/app/views/projects/automated_workflow_executions/_table.html.erb
@@ -35,7 +35,7 @@
     <% end %>
 
     <% table.with_column(t(".headers.actions"),
-        classes: "flex justify-start"
+        classes: "flex justify-start gap-1"
       ) do |row| %>
       <% unless row.disabled %>
         <%= pathogen_button_to t("common.actions.edit"),

--- a/app/views/projects/group_links/_edit.html.erb
+++ b/app/views/projects/group_links/_edit.html.erb
@@ -8,5 +8,5 @@ aria: {
   label: t(:"projects.group_links.index.actions.edit_aria_label", group_name: namespace_group_link.group.name),
 },
 tone: :neutral,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/projects/members/_current_user_is_member.html.erb
+++ b/app/views/projects/members/_current_user_is_member.html.erb
@@ -10,5 +10,5 @@ aria: {
   label: t(:"projects.members.index.actions.leave_project_aria_label"),
 },
 tone: :danger,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/projects/members/_current_user_is_not_member.html.erb
+++ b/app/views/projects/members/_current_user_is_not_member.html.erb
@@ -13,5 +13,5 @@ aria: {
     ),
 },
 tone: :danger,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/projects/members/_edit.html.erb
+++ b/app/views/projects/members/_edit.html.erb
@@ -9,5 +9,5 @@ aria: {
       member: member.user.email),
 },
 tone: :neutral,
-emphasis: :ghost,
+emphasis: :outline,
 size: :small %>

--- a/app/views/projects/samples/attachments/_attachment.html.erb
+++ b/app/views/projects/samples/attachments/_attachment.html.erb
@@ -107,7 +107,7 @@
       ),
       method: :get,
       tone: :danger,
-      emphasis: :ghost,
+      emphasis: :outline,
       size: :small %>
     <% end %>
   </td>

--- a/app/views/projects/samples/metadata/_table.html.erb
+++ b/app/views/projects/samples/metadata/_table.html.erb
@@ -108,7 +108,7 @@
                     },
                     method: :get,
                     tone: :neutral,
-                    emphasis: :ghost,
+                    emphasis: :outline,
                     size: :small %>
                   <% end %>
 
@@ -142,7 +142,7 @@
                       ),
                   },
                   tone: :danger,
-                  emphasis: :ghost,
+                  emphasis: :outline,
                   size: :small %>
                 </td>
               <% end %>


### PR DESCRIPTION
## What does this PR do and why?
This PR updates table and data-grid row action buttons from Pathogen `emphasis: :ghost` to `emphasis: :outline`.

The change is a follow-up to the recent table button migration and applies only to table-related actions (edit/delete/leave/remove/etc.) across components and partials that render table rows.

Non-table ghost buttons in layout/sidebar controls were intentionally left unchanged.

## Screenshots or screen recordings
UI style-only update across existing table actions. If reviewers want specific before/after screens for particular tables, I can add them in PR comments.

## How to set up and validate locally
1. `git checkout chore/table-buttons-outline`
2. `bin/dev`
3. Visit affected tables (attachments, bots, data exports, groups, metadata templates, personal access tokens, workflow executions, group/project links, group/project members, project automated workflow executions).
4. Verify row action buttons use outlined emphasis.
5. Run targeted tests:
   - `PARALLEL_WORKERS=4 bin/rails test test/components/attachments/table_component_test.rb test/components/groups/table_component_test.rb test/components/members/table_component_test.rb test/integration/groups/group_links_test.rb test/integration/groups/members_test.rb test/integration/projects/group_links_test.rb test/integration/projects/members_test.rb test/integration/projects/samples/attachments_test.rb test/system/projects/automated_workflow_executions_test.rb`

## PR acceptance checklist
- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
