### PR TITLE
test(attachments): fix zero-padded date assertion in deletion dialog test

### DIFF
--- a/test/system/projects/samples/attachments_test.rb
+++ b/test/system/projects/samples/attachments_test.rb
@@ -140,7 +140,7 @@ module Projects
               assert_selector 'td:nth-child(2)', text: attachment.file.filename.to_s
               assert_selector 'td:nth-child(3)', text: attachment.metadata['format']
               assert_selector 'td:nth-child(4)', text: number_to_human_size(attachment.file.byte_size)
-              assert_selector 'td:last-child', text: attachment.created_at.strftime('%B %-d, %Y')
+              assert_selector 'td:last-child', text: attachment.created_at.strftime('%B %d, %Y')
             end
           end
           click_on I18n.t('common.actions.delete')


### PR DESCRIPTION
## What does this PR do and why?

Fixes a date-formatting bug in the `should be able to delete multiple attachments` system test that makes CI fail on the 1st through 9th of any month.

The attachment deletion confirmation dialog renders the `created_at` column via `local_time_ago`, which uses the `:long` date format (`%B %d, %Y`) and produces a **zero-padded** day (e.g. `September 01, 2026`). The test assertion, however, used `strftime('%B %-d, %Y')`, which produces a **non-padded** day (`September 1, 2026`). These only match on days 10–31, so the test passed most of the month but failed on single-digit days.

This aligns the assertion with the app's actual rendering by using `%d` instead of `%-d`.

```diff
-              assert_selector 'td:last-child', text: attachment.created_at.strftime('%B %-d, %Y')
+              assert_selector 'td:last-child', text: attachment.created_at.strftime('%B %d, %Y')
```

## Screenshots or screen recordings

_Not applicable — test-only change, no UI changes._

## How to set up and validate locally

1. Check out this branch.
2. Run the previously flaky system test:
   ```
   PARALLEL_WORKERS=1 bin/rails test:system test/system/projects/samples/attachments_test.rb -n test_should_be_able_to_delete_multiple_attachments
   ```
3. Confirm it passes. (Before this change, it fails on days 1–9 of the month because the rendered date is zero-padded, e.g. `September 01, 2026`.)

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
