### PR TITLE
Add coverage tests for four JavaScript utility helpers

### DIFF
--- a/test/javascript/utilities/dialog.test.js
+++ b/test/javascript/utilities/dialog.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  closeDialog,
+  openDialog,
+  ensureDialog,
+} from "../../../app/javascript/utilities/dialog.js";
+
+function renderDialogFixture() {
+  document.body.innerHTML = `
+    <section data-controller="viral--dialog" id="dialog-host">
+      <button id="dialog-trigger" type="button">Open</button>
+      <div data-viral--dialog-target="dialog" id="dialog-element"></div>
+    </section>
+  `;
+
+  return {
+    host: document.getElementById("dialog-host"),
+    trigger: document.getElementById("dialog-trigger"),
+    dialogElement: document.getElementById("dialog-element"),
+  };
+}
+
+function buildApplication(controller = null) {
+  return {
+    getControllerForElementAndIdentifier: vi.fn(() => controller),
+  };
+}
+
+describe("dialog", () => {
+  describe("closeDialog", () => {
+    it("is a no-op when no viral dialog host exists", () => {
+      const button = document.createElement("button");
+      const application = buildApplication();
+
+      closeDialog(button, application);
+
+      expect(
+        application.getControllerForElementAndIdentifier,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("prefers the viral dialog controller close action", () => {
+      const { host, trigger, dialogElement } = renderDialogFixture();
+      dialogElement.close = vi.fn();
+      const close = vi.fn();
+      const application = buildApplication({ close });
+
+      closeDialog(trigger, application);
+
+      expect(
+        application.getControllerForElementAndIdentifier,
+      ).toHaveBeenCalledWith(host, "viral--dialog");
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(dialogElement.close).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the native dialog close method", () => {
+      const { trigger, dialogElement } = renderDialogFixture();
+      dialogElement.close = vi.fn();
+
+      closeDialog(trigger, buildApplication());
+
+      expect(dialogElement.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not throw when fallback target has no close method", () => {
+      const { trigger } = renderDialogFixture();
+
+      expect(() => closeDialog(trigger, buildApplication())).not.toThrow();
+    });
+  });
+
+  describe("openDialog", () => {
+    it("is a no-op when no viral dialog host exists", () => {
+      const button = document.createElement("button");
+      const application = buildApplication();
+
+      openDialog(button, application);
+
+      expect(
+        application.getControllerForElementAndIdentifier,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("prefers the viral dialog controller open action", () => {
+      const { host, trigger } = renderDialogFixture();
+      const open = vi.fn();
+      const application = buildApplication({ open });
+
+      openDialog(trigger, application);
+
+      expect(
+        application.getControllerForElementAndIdentifier,
+      ).toHaveBeenCalledWith(host, "viral--dialog");
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(trigger.getAttribute("data-viral--dialog-open-value")).toBeNull();
+    });
+
+    it("falls back to setting the open value attribute on the element", () => {
+      const { trigger } = renderDialogFixture();
+
+      openDialog(trigger, buildApplication());
+
+      expect(trigger.getAttribute("data-viral--dialog-open-value")).toBe(
+        "true",
+      );
+    });
+  });
+
+  describe("ensureDialog", () => {
+    it("returns null when operation id is missing", () => {
+      expect(
+        ensureDialog({
+          _operationId: null,
+          identifier: "test",
+        }),
+      ).toBeNull();
+    });
+
+    it("creates a dialog from template when absent", () => {
+      const template = document.createElement("template");
+      template.innerHTML =
+        '<div data-viral--dialog-target="dialog">Dialog</div>';
+      const controller = {
+        _operationId: "456",
+        identifier: "samples",
+        dialogTemplateTarget: template,
+      };
+
+      const dialog = ensureDialog(controller);
+
+      expect(dialog).toBeInTheDocument();
+      expect(dialog.id).toBe("samples-dialog-456");
+    });
+
+    it("returns an existing dialog instead of creating a new one", () => {
+      const existing = document.createElement("div");
+      existing.id = "samples-dialog-999";
+      document.body.appendChild(existing);
+
+      const template = document.createElement("template");
+      template.innerHTML =
+        '<div data-viral--dialog-target="dialog">Dialog</div>';
+
+      const dialog = ensureDialog({
+        _operationId: "999",
+        identifier: "samples",
+        dialogTemplateTarget: template,
+      });
+
+      expect(dialog).toBe(existing);
+      expect(document.querySelectorAll("#samples-dialog-999")).toHaveLength(1);
+    });
+  });
+});

--- a/test/javascript/utilities/flash.test.js
+++ b/test/javascript/utilities/flash.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { ensureFlash } from "../../../app/javascript/utilities/flash.js";
+
+function buildController() {
+  const template = document.createElement("template");
+  template.innerHTML = '<div class="flash">Saved</div>';
+
+  return {
+    _operationId: "123",
+    identifier: "samples",
+    flashTemplateTarget: template,
+  };
+}
+
+describe("flash", () => {
+  describe("ensureFlash", () => {
+    it("returns null when operation id is missing", () => {
+      const controller = buildController();
+      controller._operationId = null;
+
+      expect(ensureFlash(controller)).toBeNull();
+    });
+
+    it("returns an existing flash element when present", () => {
+      const controller = buildController();
+      const existing = document.createElement("div");
+      existing.id = "samples-flash-123";
+      document.body.appendChild(existing);
+
+      expect(ensureFlash(controller)).toBe(existing);
+    });
+
+    it("creates and appends a flash inside #flashes", () => {
+      document.body.innerHTML = '<div id="flashes"></div>';
+      const controller = buildController();
+
+      ensureFlash(controller);
+
+      const flash = document.getElementById("samples-flash-123");
+      expect(flash).toBeInTheDocument();
+      expect(flash.textContent).toContain("Saved");
+    });
+
+    it("returns null when the flashes container does not exist", () => {
+      const controller = buildController();
+
+      expect(ensureFlash(controller)).toBeNull();
+      expect(document.getElementById("samples-flash-123")).toBeNull();
+    });
+  });
+});

--- a/test/javascript/utilities/focus.test.js
+++ b/test/javascript/utilities/focus.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  isVisible,
+  focusWhenVisible,
+} from "../../../app/javascript/utilities/focus.js";
+
+function buildElement({
+  connected = true,
+  hasOffsetParent = true,
+  rectCount = 1,
+  style = {},
+} = {}) {
+  const element = document.createElement("button");
+
+  if (connected) {
+    document.body.appendChild(element);
+  }
+
+  Object.defineProperty(element, "offsetParent", {
+    configurable: true,
+    get: () => (hasOffsetParent ? document.body : null),
+  });
+
+  element.getClientRects = () =>
+    Array.from({ length: rectCount }, () => ({ width: 10, height: 10 }));
+
+  Object.assign(element.style, style);
+
+  return element;
+}
+
+describe("focus", () => {
+  describe("isVisible", () => {
+    it("returns false when element is not connected", () => {
+      const element = buildElement({ connected: false });
+
+      expect(isVisible(element)).toBe(false);
+    });
+
+    it("returns false when element has no offset parent", () => {
+      const element = buildElement({ hasOffsetParent: false });
+
+      expect(isVisible(element)).toBe(false);
+    });
+
+    it("returns false when display is none", () => {
+      const element = buildElement({ style: { display: "none" } });
+
+      expect(isVisible(element)).toBe(false);
+    });
+
+    it("returns false when visibility is hidden", () => {
+      const element = buildElement({ style: { visibility: "hidden" } });
+
+      expect(isVisible(element)).toBe(false);
+    });
+
+    it("returns false when opacity is 0", () => {
+      const element = buildElement({ style: { opacity: "0" } });
+
+      expect(isVisible(element)).toBe(false);
+    });
+
+    it("returns false when there are no client rects", () => {
+      const element = buildElement({ rectCount: 0 });
+
+      expect(isVisible(element)).toBe(false);
+    });
+
+    it("returns true for a connected rendered element", () => {
+      const element = buildElement();
+
+      expect(isVisible(element)).toBe(true);
+    });
+  });
+
+  describe("focusWhenVisible", () => {
+    it("returns early when element is missing", () => {
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+
+      focusWhenVisible(null);
+
+      expect(rafSpy).not.toHaveBeenCalled();
+    });
+
+    it("focuses immediately when element is already visible", () => {
+      const element = buildElement();
+      const focusSpy = vi.spyOn(element, "focus");
+      vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+        cb();
+        return 1;
+      });
+
+      focusWhenVisible(element, { focusOptions: { preventScroll: true } });
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it("keeps checking frames until the element becomes visible", () => {
+      const element = document.createElement("button");
+      document.body.appendChild(element);
+
+      let isNowVisible = false;
+      Object.defineProperty(element, "offsetParent", {
+        configurable: true,
+        get: () => (isNowVisible ? document.body : null),
+      });
+      element.getClientRects = () => (isNowVisible ? [{ width: 10 }] : []);
+
+      const focusSpy = vi.spyOn(element, "focus");
+      let frame = 0;
+      vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+        frame += 1;
+        if (frame === 2) {
+          isNowVisible = true;
+        }
+        cb();
+        return frame;
+      });
+
+      focusWhenVisible(element, { maxFrames: 5 });
+
+      expect(frame).toBe(2);
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops retrying after maxFrames when element stays hidden", () => {
+      const element = buildElement({ hasOffsetParent: false });
+      const focusSpy = vi.spyOn(element, "focus");
+      let frame = 0;
+      vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+        frame += 1;
+        cb();
+        return frame;
+      });
+
+      focusWhenVisible(element, { maxFrames: 3 });
+
+      expect(frame).toBe(3);
+      expect(focusSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/javascript/utilities/refresh.test.js
+++ b/test/javascript/utilities/refresh.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { notifyRefreshControllers } from "../../../app/javascript/utilities/refresh.js";
+
+describe("refresh", () => {
+  describe("notifyRefreshControllers", () => {
+    it("is a no-op when the controller has no refresh outlet", () => {
+      const outlet = { ignoreNextRefresh: vi.fn() };
+
+      notifyRefreshControllers({
+        hasRefreshOutlet: false,
+        refreshOutlets: [outlet],
+      });
+
+      expect(outlet.ignoreNextRefresh).not.toHaveBeenCalled();
+    });
+
+    it("notifies each refresh outlet that exposes ignoreNextRefresh", () => {
+      const firstOutlet = { ignoreNextRefresh: vi.fn() };
+      const secondOutlet = { ignoreNextRefresh: vi.fn() };
+
+      notifyRefreshControllers({
+        hasRefreshOutlet: true,
+        refreshOutlets: [firstOutlet, null, {}, secondOutlet],
+      });
+
+      expect(firstOutlet.ignoreNextRefresh).toHaveBeenCalledTimes(1);
+      expect(secondOutlet.ignoreNextRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -101,6 +101,30 @@ export default defineConfig({
           functions: 100,
           lines: 100,
         },
+        "app/javascript/utilities/dialog.js": {
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100,
+        },
+        "app/javascript/utilities/flash.js": {
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100,
+        },
+        "app/javascript/utilities/focus.js": {
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100,
+        },
+        "app/javascript/utilities/refresh.js": {
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100,
+        },
         "app/javascript/controllers/experimental_feature_toggle_controller.js":
           {
             statements: 100,


### PR DESCRIPTION
## What does this PR do and why?
- Adds focused Vitest coverage for four small JavaScript utility modules: dialog, flash, focus, and refresh.
- Locks these files into the per-file 100% coverage ratchet so coverage cannot regress in future changes.

## Screenshots or screen recordings
- N/A (no user-interface changes).

## How to set up and validate locally
1. pnpm exec vitest run test/javascript/utilities/refresh.test.js test/javascript/utilities/flash.test.js test/javascript/utilities/dialog.test.js test/javascript/utilities/focus.test.js
2. pnpm run test:js:coverage

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
