### PR TITLE
chore: Upgrade to devenv 2.2.2 and lock python version to 3.13

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1785772008,
-        "narHash": "sha256-xVVP8WR9/yQ0AvvVQMeMQbHrHXJTKBq7dqcPyphXDek=",
+        "lastModified": 1788819331,
+        "narHash": "sha256-PXClmncMTmWutJvFGrA6rKyvxWtUwaMUT615XrDHdB8=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "9d93b838def889d5bcff302cac49c9322d34d33c",
+        "rev": "190959a9a4bb52d4802f076a90c3c4e3aa2e6fa2",
         "type": "github"
       },
       "original": {
@@ -18,6 +18,22 @@
       }
     },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -72,11 +88,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1785104946,
-        "narHash": "sha256-VLSslwCjlsICjyaUfrS7lGMypmO03fzmDAqhD85Ae84=",
+        "lastModified": 1787753358,
+        "narHash": "sha256-Tl77VbWyAKrOfRNQhL6JbQtb/MLzbYa/1RG1gWWfICk=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "c946ff36bf193309589932c371bd5ae6653c912e",
+        "rev": "256551e45f6303e142ab4a98be1bf243feb77dc0",
         "type": "github"
       },
       "original": {
@@ -86,20 +102,41 @@
         "type": "github"
       }
     },
-    "nixpkgs-ruby": {
+    "nixpkgs-python": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786471740,
+        "narHash": "sha256-9PEUIbLorWC455Oa/4dxuLh+PFPfENBOgEN52gw+Onk=",
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "4d2bd16c09baaa04f4045f16f6a5574654aaba16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "nixpkgs-ruby": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1784765297,
-        "narHash": "sha256-ozaZxgtAcwCcf8IsUTwn39oLnRITt1i9U9VyD6ahRw4=",
+        "lastModified": 1788343730,
+        "narHash": "sha256-96bJQQjL9KNuvwbpGs81Y1dsKAAgmDKfxGdzDo1Qcow=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "3f194ed1d05a97bd5f0306296a310ee66d305e3c",
+        "rev": "73a97f0be7df878d9656b937b8a5cda58a04bb26",
         "type": "github"
       },
       "original": {
@@ -111,11 +148,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784783405,
-        "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
+        "lastModified": 1787394516,
+        "narHash": "sha256-pRGOQSClnXNI2iLUG6DYpsGvYcuw0drOutVZFTJNw90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
+        "rev": "c8f90650c15282fa8656a041bfbbd2403997a9a7",
         "type": "github"
       },
       "original": {
@@ -130,6 +167,7 @@
         "devenv": "devenv",
         "nextflow-pin": "nextflow-pin",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python",
         "nixpkgs-ruby": "nixpkgs-ruby"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -59,6 +59,7 @@ lib.mkMerge [
 
     languages.python = {
       enable = true;
+      version = "3.13";
       venv.enable = true;
       venv.requirements = ''
         poetry

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,11 +1,17 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 inputs:
   nextflow-pin:
     url: github:nixos/nixpkgs/1f6deaff6d3c8546398eadc710c3fb6fbcaf45e4
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling
-  nixpkgs-ruby:
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python
     inputs:
       nixpkgs:
         follows: nixpkgs
+  nixpkgs-ruby:
     url: github:bobvanderlinden/nixpkgs-ruby
-strictPorts: true
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+strict_ports: true


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

Update devenv to 2.2.2 and lock python version to 3.13 to fix issues with sapporo-service after update.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Outside of repo run `nix profile upgrade devenv`
2. Inside repo run `direnv reload`
3. Then run sapporo setup task `devenv tasks run sapporo:setup-data` and confirm that suceeds

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
