### PR TITLE
Add admin page to manage opt-in experimental features

### DIFF
--- a/app/admin/feature_flags.rb
+++ b/app/admin/feature_flags.rb
@@ -73,6 +73,7 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
 
   page_action :update_global_state, method: :patch do
     target_state = params[:target_state].to_s
+    feature_name = Irida::SystemFeatureFlagsCatalog.fetch(params[:feature_key])&.fetch(:name)
     result = SystemFeatureFlags::UpdateGlobalState.new(
       feature_key: params[:feature_key],
       target_state: target_state,
@@ -80,11 +81,12 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
     ).execute
 
     redirect_to admin_feature_flags_path,
-                **feature_flag_flash(result, success_key: "global_#{target_state}")
+                **feature_flag_flash(result, success_key: "global_#{target_state}", feature_name: feature_name)
   end
 
   page_action :update_opt_in_availability, method: :patch do
     available = { 'true' => true, 'false' => false }[params[:available].to_s]
+    feature_name = Irida::SystemFeatureFlagsCatalog.fetch(params[:feature_key])&.fetch(:name)
     result = SystemFeatureFlags::UpdateOptInAvailability.new(
       feature_key: params[:feature_key],
       available: available,
@@ -92,7 +94,9 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
     ).execute
 
     redirect_to admin_feature_flags_path,
-                **feature_flag_flash(result, success_key: available ? 'opt_in_enabled' : 'opt_in_disabled')
+                **feature_flag_flash(result,
+                                     success_key: available ? 'opt_in_enabled' : 'opt_in_disabled',
+                                     feature_name: feature_name)
   end
 
   controller do # rubocop:disable Metrics/BlockLength
@@ -170,11 +174,11 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
       "/-/system/flipper/features/#{feature_key}"
     end
 
-    def feature_flag_flash(result, success_key:)
+    def feature_flag_flash(result, success_key:, feature_name:)
       if result.success?
-        { notice: t("active_admin.feature_flags.flash.#{success_key}") }
+        { notice: t("active_admin.feature_flags.flash.#{success_key}", name: feature_name) }
       elsif result.no_op?
-        { notice: t('active_admin.feature_flags.flash.no_change') }
+        { notice: t('active_admin.feature_flags.flash.no_change', name: feature_name) }
       else
         { alert: t("active_admin.feature_flags.flash.errors.#{result.error}",
                    default: t('active_admin.feature_flags.flash.errors.generic')) }

--- a/app/admin/feature_flags.rb
+++ b/app/admin/feature_flags.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
     else
       table_for entries, class: 'index_table' do # rubocop:disable Metrics/BlockLength
         column I18n.t('active_admin.feature_flags.columns.feature') do |entry|
-          div do
+          div class: 'max-w-md' do
             div entry[:name], class: 'font-semibold text-gray-900 dark:text-gray-100'
             div entry[:description], class: 'text-sm text-gray-500 dark:text-gray-400'
           end
@@ -47,18 +47,18 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
           div class: 'flex flex-col items-start gap-2' do
             global = global_toggle_for(entry)
             link_to global[:label], global[:path],
-                    class: 'action-item-button',
+                    class: 'action-item-button whitespace-nowrap',
                     method: :patch,
                     data: { confirm: global[:confirm] }
 
             opt_in = opt_in_toggle_for(entry)
             if opt_in[:disabled]
               span opt_in[:label],
-                   class: 'text-sm text-gray-500 dark:text-gray-400 cursor-not-allowed',
+                   class: 'text-sm text-gray-500 dark:text-gray-400 cursor-not-allowed whitespace-nowrap',
                    title: opt_in[:disabled_reason]
             else
               link_to opt_in[:label], opt_in[:path],
-                      class: 'action-item-button',
+                      class: 'action-item-button whitespace-nowrap',
                       method: :patch,
                       data: { confirm: opt_in[:confirm] }
             end

--- a/app/admin/feature_flags.rb
+++ b/app/admin/feature_flags.rb
@@ -54,7 +54,7 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
             opt_in = opt_in_toggle_for(entry)
             if opt_in[:disabled]
               span opt_in[:label],
-                   class: 'text-sm text-gray-400 cursor-not-allowed',
+                   class: 'text-sm text-gray-500 dark:text-gray-400 cursor-not-allowed',
                    title: opt_in[:disabled_reason]
             else
               link_to opt_in[:label], opt_in[:path],

--- a/app/admin/feature_flags.rb
+++ b/app/admin/feature_flags.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLength
+  menu priority: 20, label: proc { I18n.t('active_admin.feature_flags.title') }
+
+  content title: proc { I18n.t('active_admin.feature_flags.title') } do # rubocop:disable Metrics/BlockLength
+    para I18n.t('active_admin.feature_flags.description'),
+         class: 'mb-4 text-sm text-gray-600 dark:text-gray-400'
+
+    entries = Irida::SystemFeatureFlagsCatalog.entries
+
+    if entries.empty?
+      div class: 'py-12 text-center text-sm text-gray-500 dark:text-gray-400' do
+        text_node I18n.t('active_admin.feature_flags.empty')
+      end
+    else
+      table_for entries, class: 'index_table' do # rubocop:disable Metrics/BlockLength
+        column I18n.t('active_admin.feature_flags.columns.feature') do |entry|
+          div do
+            div entry[:name], class: 'font-semibold text-gray-900 dark:text-gray-100'
+            div entry[:description], class: 'text-sm text-gray-500 dark:text-gray-400'
+          end
+        end
+
+        column I18n.t('active_admin.feature_flags.columns.global_state') do |entry|
+          status_tag I18n.t("active_admin.feature_flags.state.#{entry[:global_state]}"),
+                     class: global_state_class(entry[:global_state])
+        end
+
+        column I18n.t('active_admin.feature_flags.columns.opt_in') do |entry|
+          status_tag I18n.t("active_admin.feature_flags.opt_in.#{entry[:opt_in_state]}")
+        end
+
+        column I18n.t('active_admin.feature_flags.columns.gates') do |entry|
+          div do
+            div gate_summary_text(entry[:gate_summary]),
+                class: 'text-sm text-gray-600 dark:text-gray-300'
+            link_to I18n.t('active_admin.feature_flags.manage_gates'),
+                    flipper_feature_url(entry[:key]),
+                    class: 'text-sm text-indigo-600 dark:text-indigo-400',
+                    target: '_blank',
+                    rel: 'noopener'
+          end
+        end
+
+        column I18n.t('active_admin.feature_flags.columns.actions') do |entry|
+          div class: 'flex flex-col items-start gap-2' do
+            global = global_toggle_for(entry)
+            link_to global[:label], global[:path],
+                    class: 'action-item-button',
+                    method: :patch,
+                    data: { confirm: global[:confirm] }
+
+            opt_in = opt_in_toggle_for(entry)
+            if opt_in[:disabled]
+              span opt_in[:label],
+                   class: 'text-sm text-gray-400 cursor-not-allowed',
+                   title: opt_in[:disabled_reason]
+            else
+              link_to opt_in[:label], opt_in[:path],
+                      class: 'action-item-button',
+                      method: :patch,
+                      data: { confirm: opt_in[:confirm] }
+            end
+          end
+        end
+      end
+    end
+  end
+
+  page_action :update_global_state, method: :patch do
+    target_state = params[:target_state].to_s
+    result = SystemFeatureFlags::UpdateGlobalState.new(
+      feature_key: params[:feature_key],
+      target_state: target_state,
+      user: current_user
+    ).execute
+
+    redirect_to admin_feature_flags_path,
+                **feature_flag_flash(result, success_key: "global_#{target_state}")
+  end
+
+  page_action :update_opt_in_availability, method: :patch do
+    available = params[:available].to_s == 'true'
+    result = SystemFeatureFlags::UpdateOptInAvailability.new(
+      feature_key: params[:feature_key],
+      available: available,
+      user: current_user
+    ).execute
+
+    redirect_to admin_feature_flags_path,
+                **feature_flag_flash(result, success_key: available ? 'opt_in_enabled' : 'opt_in_disabled')
+  end
+
+  controller do # rubocop:disable Metrics/BlockLength
+    helper_method :global_toggle_for, :opt_in_toggle_for, :gate_summary_text,
+                  :global_state_class, :flipper_feature_url
+
+    def global_toggle_for(entry)
+      if entry[:global_state] == 'enabled'
+        {
+          label: t('active_admin.feature_flags.actions.disable_globally'),
+          path: admin_feature_flags_update_global_state_path(feature_key: entry[:key], target_state: 'disabled'),
+          confirm: t('active_admin.feature_flags.actions.disable_globally_confirm', name: entry[:name])
+        }
+      else
+        {
+          label: t('active_admin.feature_flags.actions.enable_globally'),
+          path: admin_feature_flags_update_global_state_path(feature_key: entry[:key], target_state: 'enabled'),
+          confirm: t('active_admin.feature_flags.actions.enable_globally_confirm', name: entry[:name])
+        }
+      end
+    end
+
+    def opt_in_toggle_for(entry)
+      return locked_opt_in_toggle if entry[:global_state] == 'enabled'
+
+      available = entry[:opt_in_state] == 'off'
+      action = available ? 'enable_opt_in' : 'disable_opt_in'
+      {
+        label: t("active_admin.feature_flags.actions.#{action}"),
+        path: admin_feature_flags_update_opt_in_availability_path(feature_key: entry[:key], available: available),
+        confirm: t("active_admin.feature_flags.actions.#{action}_confirm", name: entry[:name])
+      }
+    end
+
+    def locked_opt_in_toggle
+      {
+        disabled: true,
+        label: t('active_admin.feature_flags.actions.enable_opt_in'),
+        disabled_reason: t('active_admin.feature_flags.actions.opt_in_locked')
+      }
+    end
+
+    def gate_summary_text(summary)
+      fields = [
+        ['actors', 'actors', :count],
+        ['groups', 'groups', :count],
+        ['percentage_of_actors', 'percentage_of_actors', :percent],
+        ['percentage_of_time', 'percentage_of_time', :percent]
+      ]
+      parts = fields.filter_map do |gate_key, i18n_key, arg|
+        value = summary[gate_key].to_i
+        t("active_admin.feature_flags.gates.#{i18n_key}", arg => value) if value.positive?
+      end
+      parts.presence&.join(' · ') || t('active_admin.feature_flags.gates.none')
+    end
+
+    def global_state_class(state)
+      { 'enabled' => 'ok', 'conditional' => 'warning', 'disabled' => 'no' }.fetch(state, 'no')
+    end
+
+    def flipper_feature_url(feature_key)
+      "/-/system/flipper/features/#{feature_key}"
+    end
+
+    def feature_flag_flash(result, success_key:)
+      if result.success?
+        { notice: t("active_admin.feature_flags.flash.#{success_key}") }
+      elsif result.no_op?
+        { notice: t('active_admin.feature_flags.flash.no_change') }
+      else
+        { alert: t("active_admin.feature_flags.flash.errors.#{result.error}",
+                   default: t('active_admin.feature_flags.flash.errors.generic')) }
+      end
+    end
+  end
+end

--- a/app/admin/feature_flags.rb
+++ b/app/admin/feature_flags.rb
@@ -35,21 +35,21 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
           div do
             div gate_summary_text(entry[:gate_summary]),
                 class: 'text-sm text-gray-600 dark:text-gray-300'
-            link_to I18n.t('active_admin.feature_flags.manage_gates'),
-                    flipper_feature_url(entry[:key]),
-                    class: 'text-sm text-indigo-600 dark:text-indigo-400',
-                    target: '_blank',
-                    rel: 'noopener'
+            text_node link_to I18n.t('active_admin.feature_flags.manage_gates'),
+                              flipper_feature_url(entry[:key]),
+                              class: 'text-sm text-indigo-600 dark:text-indigo-400',
+                              target: '_blank',
+                              rel: 'noopener'
           end
         end
 
         column I18n.t('active_admin.feature_flags.columns.actions') do |entry|
           div class: 'flex flex-col items-start gap-2' do
             global = global_toggle_for(entry)
-            link_to global[:label], global[:path],
-                    class: 'action-item-button whitespace-nowrap',
-                    method: :patch,
-                    data: { confirm: global[:confirm] }
+            text_node link_to global[:label], global[:path],
+                              class: 'action-item-button whitespace-nowrap',
+                              method: :patch,
+                              data: { confirm: global[:confirm] }
 
             opt_in = opt_in_toggle_for(entry)
             if opt_in[:disabled]
@@ -57,10 +57,10 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
                    class: 'text-sm text-gray-500 dark:text-gray-400 cursor-not-allowed whitespace-nowrap',
                    title: opt_in[:disabled_reason]
             else
-              link_to opt_in[:label], opt_in[:path],
-                      class: 'action-item-button whitespace-nowrap',
-                      method: :patch,
-                      data: { confirm: opt_in[:confirm] }
+              text_node link_to opt_in[:label], opt_in[:path],
+                                class: 'action-item-button whitespace-nowrap',
+                                method: :patch,
+                                data: { confirm: opt_in[:confirm] }
             end
           end
         end
@@ -81,7 +81,7 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
   end
 
   page_action :update_opt_in_availability, method: :patch do
-    available = params[:available].to_s == 'true'
+    available = { 'true' => true, 'false' => false }[params[:available].to_s]
     result = SystemFeatureFlags::UpdateOptInAvailability.new(
       feature_key: params[:feature_key],
       available: available,
@@ -137,7 +137,8 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
         ['actors', 'actors', :count],
         ['groups', 'groups', :count],
         ['percentage_of_actors', 'percentage_of_actors', :percent],
-        ['percentage_of_time', 'percentage_of_time', :percent]
+        ['percentage_of_time', 'percentage_of_time', :percent],
+        ['expression', 'expression', :count]
       ]
       parts = fields.filter_map do |gate_key, i18n_key, arg|
         value = summary[gate_key].to_i

--- a/app/admin/feature_flags.rb
+++ b/app/admin/feature_flags.rb
@@ -28,7 +28,8 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
         end
 
         column I18n.t('active_admin.feature_flags.columns.opt_in') do |entry|
-          status_tag I18n.t("active_admin.feature_flags.opt_in.#{entry[:opt_in_state]}")
+          status_tag I18n.t("active_admin.feature_flags.opt_in.#{entry[:opt_in_state]}"),
+                     class: opt_in_state_class(entry[:opt_in_state])
         end
 
         column I18n.t('active_admin.feature_flags.columns.gates') do |entry|
@@ -43,7 +44,7 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
           end
         end
 
-        column I18n.t('active_admin.feature_flags.columns.actions') do |entry|
+        column I18n.t('active_admin.feature_flags.columns.actions') do |entry| # rubocop:disable Metrics/BlockLength
           div class: 'flex flex-col items-start gap-2' do
             global = global_toggle_for(entry)
             text_node link_to global[:label], global[:path],
@@ -53,9 +54,11 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
 
             opt_in = opt_in_toggle_for(entry)
             if opt_in[:disabled]
-              span opt_in[:label],
-                   class: 'text-sm text-gray-500 dark:text-gray-400 cursor-not-allowed whitespace-nowrap',
-                   title: opt_in[:disabled_reason]
+              text_node button_tag(opt_in[:label],
+                                   type: 'button',
+                                   disabled: true,
+                                   class: 'action-item-button whitespace-nowrap',
+                                   title: opt_in[:disabled_reason])
             else
               text_node link_to opt_in[:label], opt_in[:path],
                                 class: 'action-item-button whitespace-nowrap',
@@ -63,7 +66,7 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
                                 data: { confirm: opt_in[:confirm] }
             end
           end
-        end
+        end # rubocop:enable Metrics/BlockLength
       end
     end
   end
@@ -94,7 +97,7 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
 
   controller do # rubocop:disable Metrics/BlockLength
     helper_method :global_toggle_for, :opt_in_toggle_for, :gate_summary_text,
-                  :global_state_class, :flipper_feature_url
+                  :global_state_class, :opt_in_state_class, :flipper_feature_url
 
     def global_toggle_for(entry)
       if entry[:global_state] == 'enabled'
@@ -148,7 +151,19 @@ ActiveAdmin.register_page 'Feature Flags' do # rubocop:disable Metrics/BlockLeng
     end
 
     def global_state_class(state)
-      { 'enabled' => 'ok', 'conditional' => 'warning', 'disabled' => 'no' }.fetch(state, 'no')
+      {
+        'enabled' => 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+        'conditional' => 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+        'disabled' => 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+      }.fetch(state, 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300')
+    end
+
+    def opt_in_state_class(state)
+      {
+        'all_users' => 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+        'allowlist' => 'bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300',
+        'off' => 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+      }.fetch(state, 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300')
     end
 
     def flipper_feature_url(feature_key)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -158,6 +158,8 @@ ignore_unused:
   - "{action_policy,activemodel,activerecord,date,datetime,devise,errors,helpers,number,support,time}.*"
   - "*.sorting.*"
   - "activity.*"
+  # Built dynamically in app/admin/feature_flags.rb via t("...gates.#{key}", count:)
+  - "active_admin.feature_flags.gates.*"
   - "components.viral.data_table_component.*"
   - "components.workflow_executions.table_component.counts*"
   - "samples.table_component.namespaces.puid"

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -30,11 +30,11 @@ en:
           invalid_target_state: Invalid global state requested.
           mutation_failed: The feature could not be updated. Please try again.
           unauthorized: You are not authorized to change this feature.
-        global_disabled: Feature disabled globally.
-        global_enabled: Feature enabled globally.
-        no_change: No change was needed.
-        opt_in_disabled: Profile opt-in is now disabled.
-        opt_in_enabled: Profile opt-in is now available.
+        global_disabled: "%{name} disabled globally."
+        global_enabled: "%{name} enabled globally."
+        no_change: No change was needed for %{name}.
+        opt_in_disabled: Profile opt-in for %{name} is now disabled.
+        opt_in_enabled: Profile opt-in for %{name} is now available.
       gates:
         actors:
           one: "%{count} actor"

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -2,6 +2,59 @@
 en:
   active_admin:
     dashboard: Dashboard
+    feature_flags:
+      actions:
+        disable_globally: Disable globally
+        disable_globally_confirm: Disable %{name} globally? This clears its gates.
+        disable_opt_in: Disable opt-in
+        disable_opt_in_confirm: Stop offering %{name} as a profile opt-in? This revokes existing opt-ins.
+        enable_globally: Enable globally
+        enable_globally_confirm: Enable %{name} globally for all users?
+        enable_opt_in: Enable opt-in
+        enable_opt_in_confirm: Allow users to opt in to %{name} from their profile?
+        opt_in_locked: Opt-in is unavailable while the feature is enabled globally.
+      columns:
+        actions: Actions
+        feature: Feature
+        gates: Gates
+        global_state: Global state
+        opt_in: Opt-in availability
+      description: Manage admin-manageable experimental features. Enable or disable a feature globally, or make it available for users to opt in from their profile. Use "Manage gates" for advanced Flipper configuration.
+      empty: No admin-manageable features are configured.
+      flash:
+        errors:
+          generic: The feature could not be updated.
+          globally_enabled: Opt-in cannot change while the feature is enabled globally.
+          invalid_availability: Invalid opt-in availability requested.
+          invalid_feature: This feature cannot be managed here.
+          invalid_target_state: Invalid global state requested.
+          mutation_failed: The feature could not be updated. Please try again.
+          unauthorized: You are not authorized to change this feature.
+        global_disabled: Feature disabled globally.
+        global_enabled: Feature enabled globally.
+        no_change: No change was needed.
+        opt_in_disabled: Profile opt-in is now disabled.
+        opt_in_enabled: Profile opt-in is now available.
+      gates:
+        actors:
+          one: "%{count} actor"
+          other: "%{count} actors"
+        groups:
+          one: "%{count} group"
+          other: "%{count} groups"
+        none: No active gates
+        percentage_of_actors: "%{percent}% of actors"
+        percentage_of_time: "%{percent}% of time"
+      manage_gates: Manage gates
+      opt_in:
+        all_users: Available to all users
+        allowlist: Allowlist
+        'false': false
+      state:
+        conditional: Conditional
+        disabled: Disabled
+        enabled: Enabled
+      title: Feature Flags
     logout: Sign out
     site_banners:
       disable: Disable

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -19,7 +19,7 @@ en:
         gates: Gates
         global_state: Global state
         opt_in: Opt-in availability
-      description: Manage admin-manageable experimental features. Enable or disable a feature globally, or make it available for users to opt in from their profile. Use "Manage gates" for advanced Flipper configuration.
+      description: Manage admin-manageable experimental features. Global state controls access for everyone. When a feature is disabled globally, gates can provide access to selected users or groups, while opt-in availability lets users enable the feature from their profile. Use "Manage gates" for advanced Flipper configuration.
       empty: No admin-manageable features are configured.
       flash:
         errors:

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -39,6 +39,7 @@ en:
         actors:
           one: "%{count} actor"
           other: "%{count} actors"
+        expression: Expression gate
         groups:
           one: "%{count} group"
           other: "%{count} groups"

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -49,7 +49,7 @@ en:
       opt_in:
         all_users: Available to all users
         allowlist: Allowlist
-        'false': false
+        'off': 'Off'
       state:
         conditional: Conditional
         disabled: Disabled

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -19,7 +19,7 @@ fr:
         gates: Indicateurs
         global_state: État global
         opt_in: Disponibilité de l'adhésion
-      description: Gérer les fonctionnalités expérimentales administrables. Activez ou désactivez une fonctionnalité globalement, ou rendez-la disponible pour que les utilisateurs y adhèrent depuis leur profil. Utilisez « Gérer les indicateurs » pour la configuration avancée de Flipper.
+      description: Gérer les fonctionnalités expérimentales administrables. L'état global contrôle l'accès pour tous les utilisateurs. Lorsqu'une fonctionnalité est désactivée globalement, les indicateurs peuvent en autoriser l'accès à certains utilisateurs ou groupes, tandis que la disponibilité de l'adhésion permet aux utilisateurs de l'activer depuis leur profil. Utilisez « Gérer les indicateurs » pour la configuration avancée de Flipper.
       empty: Aucune fonctionnalité administrable n'est configurée.
       flash:
         errors:

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -2,6 +2,59 @@
 fr:
   active_admin:
     dashboard: Tableau de bord
+    feature_flags:
+      actions:
+        disable_globally: Désactiver globalement
+        disable_globally_confirm: Désactiver %{name} globalement? Cela efface ses indicateurs.
+        disable_opt_in: Désactiver l'adhésion
+        disable_opt_in_confirm: Cesser d'offrir %{name} comme adhésion de profil? Cela révoque les adhésions existantes.
+        enable_globally: Activer globalement
+        enable_globally_confirm: Activer %{name} globalement pour tous les utilisateurs?
+        enable_opt_in: Activer l'adhésion
+        enable_opt_in_confirm: Permettre aux utilisateurs d'adhérer à %{name} depuis leur profil?
+        opt_in_locked: L'adhésion est indisponible lorsque la fonctionnalité est activée globalement.
+      columns:
+        actions: Actions
+        feature: Fonctionnalité
+        gates: Indicateurs
+        global_state: État global
+        opt_in: Disponibilité de l'adhésion
+      description: Gérer les fonctionnalités expérimentales administrables. Activez ou désactivez une fonctionnalité globalement, ou rendez-la disponible pour que les utilisateurs y adhèrent depuis leur profil. Utilisez « Gérer les indicateurs » pour la configuration avancée de Flipper.
+      empty: Aucune fonctionnalité administrable n'est configurée.
+      flash:
+        errors:
+          generic: La fonctionnalité n'a pas pu être mise à jour.
+          globally_enabled: L'adhésion ne peut pas changer lorsque la fonctionnalité est activée globalement.
+          invalid_availability: Disponibilité d'adhésion demandée invalide.
+          invalid_feature: Cette fonctionnalité ne peut pas être gérée ici.
+          invalid_target_state: État global demandé invalide.
+          mutation_failed: La fonctionnalité n'a pas pu être mise à jour. Veuillez réessayer.
+          unauthorized: Vous n'êtes pas autorisé à modifier cette fonctionnalité.
+        global_disabled: Fonctionnalité désactivée globalement.
+        global_enabled: Fonctionnalité activée globalement.
+        no_change: Aucun changement n'était nécessaire.
+        opt_in_disabled: L'adhésion au profil est maintenant désactivée.
+        opt_in_enabled: L'adhésion au profil est maintenant disponible.
+      gates:
+        actors:
+          one: "%{count} acteur"
+          other: "%{count} acteurs"
+        groups:
+          one: "%{count} groupe"
+          other: "%{count} groupes"
+        none: Aucun indicateur actif
+        percentage_of_actors: "%{percent} % des acteurs"
+        percentage_of_time: "%{percent} % du temps"
+      manage_gates: Gérer les indicateurs
+      opt_in:
+        all_users: Disponible pour tous les utilisateurs
+        allowlist: Liste d'autorisation
+        'false': Désactivée
+      state:
+        conditional: Conditionnelle
+        disabled: Désactivée
+        enabled: Activée
+      title: Fonctionnalités
     logout: Déconnexion
     site_banners:
       disable: Désactiver

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -30,11 +30,11 @@ fr:
           invalid_target_state: État global demandé invalide.
           mutation_failed: La fonctionnalité n'a pas pu être mise à jour. Veuillez réessayer.
           unauthorized: Vous n'êtes pas autorisé à modifier cette fonctionnalité.
-        global_disabled: Fonctionnalité désactivée globalement.
-        global_enabled: Fonctionnalité activée globalement.
-        no_change: Aucun changement n'était nécessaire.
-        opt_in_disabled: L'adhésion au profil est maintenant désactivée.
-        opt_in_enabled: L'adhésion au profil est maintenant disponible.
+        global_disabled: "%{name} désactivée globalement."
+        global_enabled: "%{name} activée globalement."
+        no_change: Aucun changement n'était nécessaire pour %{name}.
+        opt_in_disabled: L'adhésion au profil pour %{name} est maintenant désactivée.
+        opt_in_enabled: L'adhésion au profil pour %{name} est maintenant disponible.
       gates:
         actors:
           one: "%{count} acteur"

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -39,6 +39,7 @@ fr:
         actors:
           one: "%{count} acteur"
           other: "%{count} acteurs"
+        expression: Indicateur d’expression
         groups:
           one: "%{count} groupe"
           other: "%{count} groupes"

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -49,7 +49,7 @@ fr:
       opt_in:
         all_users: Disponible pour tous les utilisateurs
         allowlist: Liste d'autorisation
-        'false': Désactivée
+        'off': Désactivée
       state:
         conditional: Conditionnelle
         disabled: Désactivée

--- a/test/controllers/admin/feature_flags_test.rb
+++ b/test/controllers/admin/feature_flags_test.rb
@@ -35,7 +35,7 @@ module Admin
       patch admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state: 'enabled')
 
       assert_redirected_to admin_feature_flags_path
-      assert_equal I18n.t('active_admin.feature_flags.flash.global_enabled'), flash[:notice]
+      assert_equal I18n.t('active_admin.feature_flags.flash.global_enabled', name: @feature_name), flash[:notice]
       assert_equal 'enabled', Irida::SystemFeatureFlagsCatalog.global_state(@feature_key)
     end
 
@@ -106,7 +106,7 @@ module Admin
       patch admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state: 'disabled')
 
       assert_redirected_to admin_feature_flags_path
-      assert_equal I18n.t('active_admin.feature_flags.flash.global_disabled'), flash[:notice]
+      assert_equal I18n.t('active_admin.feature_flags.flash.global_disabled', name: @feature_name), flash[:notice]
       assert_equal 'disabled', Irida::SystemFeatureFlagsCatalog.global_state(@feature_key)
     end
 
@@ -115,7 +115,7 @@ module Admin
 
       patch admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state: 'disabled')
 
-      assert_equal I18n.t('active_admin.feature_flags.flash.no_change'), flash[:notice]
+      assert_equal I18n.t('active_admin.feature_flags.flash.no_change', name: @feature_name), flash[:notice]
     end
 
     test 'system user enables profile opt-in availability' do
@@ -125,7 +125,7 @@ module Admin
         patch admin_feature_flags_update_opt_in_availability_path(feature_key: @feature_key, available: true)
 
         assert_redirected_to admin_feature_flags_path
-        assert_equal I18n.t('active_admin.feature_flags.flash.opt_in_enabled'), flash[:notice]
+        assert_equal I18n.t('active_admin.feature_flags.flash.opt_in_enabled', name: @feature_name), flash[:notice]
         assert_equal 'all_users', settings.reload.opt_in_state(@feature_key)
       end
     end
@@ -136,7 +136,7 @@ module Admin
       with_user_opt_in_features(user_opt_in_feature_config) do |settings|
         patch admin_feature_flags_update_opt_in_availability_path(feature_key: @feature_key, available: false)
 
-        assert_equal I18n.t('active_admin.feature_flags.flash.opt_in_disabled'), flash[:notice]
+        assert_equal I18n.t('active_admin.feature_flags.flash.opt_in_disabled', name: @feature_name), flash[:notice]
         assert_equal 'off', settings.reload.opt_in_state(@feature_key)
       end
     end

--- a/test/controllers/admin/feature_flags_test.rb
+++ b/test/controllers/admin/feature_flags_test.rb
@@ -20,6 +20,9 @@ module Admin
       assert_includes response.body, @feature_name
       assert_includes response.body, I18n.t('active_admin.feature_flags.state.disabled')
       assert_includes response.body, I18n.t('active_admin.feature_flags.opt_in.off')
+      assert_select 'tr', text: /#{Regexp.escape(@feature_name)}/ do
+        assert_select 'span.status-tag.bg-gray-100.text-gray-700', count: 2
+      end
       # Guard against missing i18n keys rendering on the page.
       assert_no_match(/translation missing/i, response.body)
       # Operational (non admin-manageable) features are not listed.
@@ -45,12 +48,21 @@ module Admin
         get admin_feature_flags_path
 
         target_state = state == 'enabled' ? 'disabled' : 'enabled'
-        assert_select 'a[href=?][data-method="patch"]',
-                      admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state:), count: 1
-        assert_select 'a[href=?]', "/-/system/flipper/features/#{@feature_key}", count: 1
-        next if state == 'enabled'
+        global_action = target_state == 'disabled' ? 'disable_globally' : 'enable_globally'
+        assert_select 'tr', text: /#{Regexp.escape(@feature_name)}/ do
+          assert_select 'a', text: I18n.t("active_admin.feature_flags.actions.#{global_action}"), count: 1
+          assert_select 'a[href=?]', "/-/system/flipper/features/#{@feature_key}", count: 1
+        end
+        if state == 'enabled'
+          assert_select 'button[disabled]', text: I18n.t('active_admin.feature_flags.actions.enable_opt_in'), count: 1
+          assert_select 'form[action*="update_opt_in_availability"] button:not([disabled])', count: 0
+          next
+        end
 
-        assert_select 'a[href*="update_opt_in_availability"][data-method="patch"]'
+        assert_select 'tr', text: /#{Regexp.escape(@feature_name)}/ do
+          assert_select 'a:not([aria-disabled="true"])',
+                        text: I18n.t('active_admin.feature_flags.actions.enable_opt_in'), count: 1
+        end
       end
     end
 

--- a/test/controllers/admin/feature_flags_test.rb
+++ b/test/controllers/admin/feature_flags_test.rb
@@ -11,11 +11,17 @@ module Admin
     end
 
     test 'system user can view feature flags index' do
+      Flipper.disable(@feature_key)
+
       get admin_feature_flags_path
 
       assert_response :success
       assert_includes response.body, I18n.t('active_admin.feature_flags.title')
       assert_includes response.body, @feature_name
+      assert_includes response.body, I18n.t('active_admin.feature_flags.state.disabled')
+      assert_includes response.body, I18n.t('active_admin.feature_flags.opt_in.off')
+      # Guard against missing i18n keys rendering on the page.
+      assert_no_match(/translation missing/i, response.body)
       # Operational (non admin-manageable) features are not listed.
       assert_not_includes response.body, Irida::ExperimentalFeatureCatalog.fetch('compose_with_retry')[:description]
     end

--- a/test/controllers/admin/feature_flags_test.rb
+++ b/test/controllers/admin/feature_flags_test.rb
@@ -36,6 +36,58 @@ module Admin
       assert_equal 'enabled', Irida::SystemFeatureFlagsCatalog.global_state(@feature_key)
     end
 
+    test 'index renders global and gate links in every global state' do
+      %w[enabled conditional disabled].each do |state|
+        Flipper.disable(@feature_key)
+        Flipper.enable(@feature_key) if state == 'enabled'
+        Flipper.enable_actor(@feature_key, users(:john_doe)) if state == 'conditional'
+
+        get admin_feature_flags_path
+
+        target_state = state == 'enabled' ? 'disabled' : 'enabled'
+        assert_select 'a[href=?][data-method="patch"]',
+                      admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state:), count: 1
+        assert_select 'a[href=?]', "/-/system/flipper/features/#{@feature_key}", count: 1
+        next if state == 'enabled'
+
+        assert_select 'a[href*="update_opt_in_availability"][data-method="patch"]'
+      end
+    end
+
+    test 'invalid opt-in availability preserves configuration and existing actor gates' do
+      Flipper.disable(@feature_key)
+      user = users(:john_doe)
+      Flipper.enable_actor(@feature_key, user)
+
+      with_user_opt_in_features(user_opt_in_feature_config) do |settings|
+        original_config = settings.user_opt_in_features.deep_dup
+        [nil, '', 'invalid', '1'].each do |available|
+          patch admin_feature_flags_update_opt_in_availability_path,
+                params: { feature_key: @feature_key, available: }.compact
+
+          assert_redirected_to admin_feature_flags_path
+          assert_equal I18n.t('active_admin.feature_flags.flash.errors.invalid_availability'), flash[:alert]
+          assert_equal original_config, settings.reload.user_opt_in_features
+          assert_includes Flipper[@feature_key].actors_value, user.flipper_id
+        end
+      end
+    end
+
+    test 'index describes an expression-only gate in each locale' do
+      Flipper.disable(@feature_key)
+      Flipper[@feature_key].enable_expression(Flipper::Expression.build('Equal' => [1, 1]))
+
+      %i[en fr].each do |locale|
+        get admin_feature_flags_path, params: { locale: }
+
+        feature_name = Irida::ExperimentalFeatureCatalog.fetch(@feature_key, locale:)[:name]
+        assert_select 'tr', text: /#{Regexp.escape(feature_name)}/ do
+          assert_select 'div', text: I18n.t('active_admin.feature_flags.gates.expression', locale:)
+          assert_select 'div', text: I18n.t('active_admin.feature_flags.gates.none', locale:), count: 0
+        end
+      end
+    end
+
     test 'system user disables a feature globally' do
       Flipper.enable(@feature_key)
 

--- a/test/controllers/admin/feature_flags_test.rb
+++ b/test/controllers/admin/feature_flags_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class FeatureFlagsTest < ActionDispatch::IntegrationTest
+    setup do
+      sign_in users(:system_user)
+      @feature_key = 'data_grid_samples_table'
+      @feature_name = Irida::ExperimentalFeatureCatalog.fetch(@feature_key)[:name]
+    end
+
+    test 'system user can view feature flags index' do
+      get admin_feature_flags_path
+
+      assert_response :success
+      assert_includes response.body, I18n.t('active_admin.feature_flags.title')
+      assert_includes response.body, @feature_name
+      # Operational (non admin-manageable) features are not listed.
+      assert_not_includes response.body, Irida::ExperimentalFeatureCatalog.fetch('compose_with_retry')[:description]
+    end
+
+    test 'system user enables a feature globally' do
+      Flipper.disable(@feature_key)
+
+      patch admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state: 'enabled')
+
+      assert_redirected_to admin_feature_flags_path
+      assert_equal I18n.t('active_admin.feature_flags.flash.global_enabled'), flash[:notice]
+      assert_equal 'enabled', Irida::SystemFeatureFlagsCatalog.global_state(@feature_key)
+    end
+
+    test 'system user disables a feature globally' do
+      Flipper.enable(@feature_key)
+
+      patch admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state: 'disabled')
+
+      assert_redirected_to admin_feature_flags_path
+      assert_equal I18n.t('active_admin.feature_flags.flash.global_disabled'), flash[:notice]
+      assert_equal 'disabled', Irida::SystemFeatureFlagsCatalog.global_state(@feature_key)
+    end
+
+    test 'a no-op global change reports no change' do
+      Flipper.disable(@feature_key)
+
+      patch admin_feature_flags_update_global_state_path(feature_key: @feature_key, target_state: 'disabled')
+
+      assert_equal I18n.t('active_admin.feature_flags.flash.no_change'), flash[:notice]
+    end
+
+    test 'system user enables profile opt-in availability' do
+      Flipper.disable(@feature_key)
+
+      with_user_opt_in_features({}) do |settings|
+        patch admin_feature_flags_update_opt_in_availability_path(feature_key: @feature_key, available: true)
+
+        assert_redirected_to admin_feature_flags_path
+        assert_equal I18n.t('active_admin.feature_flags.flash.opt_in_enabled'), flash[:notice]
+        assert_equal 'all_users', settings.reload.opt_in_state(@feature_key)
+      end
+    end
+
+    test 'system user disables profile opt-in availability' do
+      Flipper.disable(@feature_key)
+
+      with_user_opt_in_features(user_opt_in_feature_config) do |settings|
+        patch admin_feature_flags_update_opt_in_availability_path(feature_key: @feature_key, available: false)
+
+        assert_equal I18n.t('active_admin.feature_flags.flash.opt_in_disabled'), flash[:notice]
+        assert_equal 'off', settings.reload.opt_in_state(@feature_key)
+      end
+    end
+
+    test 'opt-in availability cannot change while the feature is enabled globally' do
+      Flipper.enable(@feature_key)
+
+      with_user_opt_in_features({}) do |settings|
+        patch admin_feature_flags_update_opt_in_availability_path(feature_key: @feature_key, available: true)
+
+        assert_redirected_to admin_feature_flags_path
+        assert_equal I18n.t('active_admin.feature_flags.flash.errors.globally_enabled'), flash[:alert]
+        assert_equal 'off', settings.reload.opt_in_state(@feature_key)
+      end
+    end
+
+    test 'a feature that is not admin-manageable is rejected' do
+      patch admin_feature_flags_update_global_state_path(feature_key: 'compose_with_retry', target_state: 'enabled')
+
+      assert_equal I18n.t('active_admin.feature_flags.flash.errors.invalid_feature'), flash[:alert]
+    end
+  end
+end

--- a/test/services/system_feature_flags/update_global_state_test.rb
+++ b/test/services/system_feature_flags/update_global_state_test.rb
@@ -72,6 +72,21 @@ module SystemFeatureFlags
       assert_equal 'disabled', Irida::SystemFeatureFlagsCatalog.global_state(:data_grid_samples_table)
     end
 
+    test 'preserves profile opt-in availability when disabling global state' do
+      Flipper.enable(:data_grid_samples_table)
+
+      with_user_opt_in_features(user_opt_in_feature_config) do |settings|
+        result = UpdateGlobalState.new(
+          feature_key: :data_grid_samples_table,
+          target_state: :disabled,
+          user: @administrator
+        ).execute
+
+        assert result.success?
+        assert_equal 'all_users', settings.reload.opt_in_state(:data_grid_samples_table)
+      end
+    end
+
     test 'returns no-op when already in target state' do
       Flipper.enable(:data_grid_samples_table)
 


### PR DESCRIPTION
## What does this PR do and why?

- Adds a **Feature Flags** admin page (ActiveAdmin, under `/-/system/admin`) so system users can enable/disable admin-manageable experimental features globally and control whether each is offered as a per-user profile opt-in.
- Wires the page to the existing feature-flag catalog and mutation services (read-only view + thin controller actions).

## Screenshots or screen recordings

<img width="1880" height="2585" alt="image" src="https://github.com/user-attachments/assets/8ceab7ea-e205-4717-845d-845a1aabfebd" />

- Each row shows the feature, its global state (Enabled/Conditional/Disabled), opt-in availability (Available to all users/Allowlist/Off), a compact gate summary with a "Manage gates" link to the Flipper UI, and toggle actions.
- Opt-in toggling is disabled with an explanatory tooltip when a feature is already enabled globally.

## How to set up and validate locally

1. Sign in as a system user and visit `/-/system/admin/feature_flags`.
2. Toggle a feature's global state and confirm the badge and flash update.
3. For a globally disabled feature, enable/disable profile opt-in and confirm it appears/disappears on the user Experimental Features profile page.
4. Run the tests: `PARALLEL_WORKERS=4 bin/rails test test/controllers/admin/feature_flags_test.rb`

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.