### PR TITLE
chore: refactor policy scopes to reduce code duplication

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -166,8 +166,7 @@ class GroupsController < Groups::ApplicationController # rubocop:disable Metrics
   end
 
   def authorized_namespaces
-    @authorized_namespaces = authorized_scope(Namespace,
-                                              type: :relation, as: :manageable).where.not(type: Namespaces::UserNamespace.sti_name)
+    @authorized_namespaces = authorized_scope(Group, type: :relation, as: :manageable)
   end
 
   def tab

--- a/app/models/concerns/archivable.rb
+++ b/app/models/concerns/archivable.rb
@@ -5,7 +5,7 @@ module Archivable
   extend ActiveSupport::Concern
 
   included do
-    scope :archived, -> { where.not(archived_at: nil) }
+    scope :archived, ->(archived = true) { archived ? where.not(archived_at: nil) : where(archived_at: nil) }
     scope :not_archived, -> { where(archived_at: nil) }
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -228,6 +228,10 @@ class Member < ApplicationRecord # rubocop:disable Metrics/ClassLength
       def manageable
         [MAINTAINER, OWNER]
       end
+
+      def accessible
+        [GUEST, UPLOADER, ANALYST, MAINTAINER, OWNER]
+      end
     end
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -347,13 +347,13 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     relation.where(
       id: authorized_scope(Namespace, type: :relation),
       public: false
-    )
+    ).include_route
   end
 
   scope_for :relation, :manageable do |relation|
     relation.where(
       id: authorized_scope(Namespace, type: :relation, as: :manageable, scope_options: { include_route: false })
-    )
+    ).include_route
   end
 
   scope_for :relation, :public_groups do |relation|
@@ -363,6 +363,6 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
       Arel.sql(
         'namespaces.id in (SELECT id FROM public_groups)'
       )
-    )
+    ).include_route
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -344,19 +344,9 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
   end
 
   scope_for :relation do |relation|
-    relation.with(
-      user_groups: relation.where(id: user.members.not_expired.select(:namespace_id),
-                                  public: false).self_and_descendant_ids,
-      linked_groups: relation.where(id: NamespaceGroupLink.not_expired
-                                                          .where(
-                                                            group_id: Group.from('user_groups').select(:id)
-                                                          ).select(:namespace_id), public: false)
-                             .self_and_descendant_ids
-    ).where(
-      Arel.sql(
-        'namespaces.id in (select * from user_groups)
-        or namespaces.id in (select * from linked_groups)'
-      )
+    relation.where(
+      id: authorized_scope(Namespace, type: :relation),
+      public: false
     )
   end
 
@@ -365,7 +355,7 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
       public_groups: relation.where(public: true).self_and_descendant_ids
     ).where(
       Arel.sql(
-        'namespaces.id in (select * from public_groups)'
+        'namespaces.id in (SELECT id FROM public_groups)'
       )
     )
   end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -352,8 +352,7 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
 
   scope_for :relation, :manageable do |relation|
     relation.where(
-      id: authorized_scope(Namespace, type: :relation, as: :manageable),
-      public: false
+      id: authorized_scope(Namespace, type: :relation, as: :manageable, scope_options: { include_route: false })
     )
   end
 

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -345,8 +345,7 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
 
   scope_for :relation do |relation|
     relation.where(
-      id: authorized_scope(Namespace, type: :relation),
-      public: false
+      id: authorized_scope(Namespace, type: :relation)
     ).include_route
   end
 

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -350,6 +350,13 @@ class GroupPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     )
   end
 
+  scope_for :relation, :manageable do |relation|
+    relation.where(
+      id: authorized_scope(Namespace, type: :relation, as: :manageable),
+      public: false
+    )
+  end
+
   scope_for :relation, :public_groups do |relation|
     relation.with(
       public_groups: relation.where(public: true).self_and_descendant_ids

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -5,18 +5,26 @@ class NamespacePolicy < ApplicationPolicy
   # rubocop:disable-next Metrics/BlockLength
   scope_for :relation do |relation,
                           access_level: Member::AccessLevel.accessible,
+                          include_project_namespaces: false,
                           include_route: true,
                           include_shared_links: true|
+    type = [Group.sti_name, Namespaces::UserNamespace.sti_name]
+    type << Namespaces::ProjectNamespace.sti_name if include_project_namespaces
+
     scope = relation
             .with(
               # 1. The users personal namespace and its descendants
               user_namespaces: Namespace
                 .where(id: user.namespace&.id)
-                .self_and_descendant_ids,
+                .self_and_descendants
+                .where(type: type)
+                .select(:id),
               # 2. Accessible namespace IDs for the user based on their memberships
               accessible_namespaces: Namespace
                 .where(id: user.members.not_expired.with_access_level(access_level).select(:namespace_id))
-                .self_and_descendant_ids,
+                .self_and_descendants
+                .where(type: type)
+                .select(:id),
               # 3. Accessible linked namespaces for the user based on group links
               accessible_linked_namespaces:
                 if include_shared_links
@@ -26,7 +34,9 @@ class NamespacePolicy < ApplicationPolicy
                       .where(Arel.sql('group_id IN (SELECT id FROM accessible_namespaces)'))
                       .with_group_access_level(access_level)
                       .select(:namespace_id))
-                    .self_and_descendant_ids
+                    .self_and_descendants
+                    .where(type: type)
+                    .select(:id)
                 else
                   Namespace.none.select(:id)
                 end
@@ -45,7 +55,9 @@ class NamespacePolicy < ApplicationPolicy
     scope
   end
 
-  scope_for :relation, :manageable do |relation|
-    authorized_scope(relation, type: :relation, scope_options: { access_level: Member::AccessLevel.manageable })
+  scope_for :relation, :manageable do |relation, include_project_namespaces: false|
+    authorized_scope(relation, type: :relation,
+                               scope_options: { access_level: Member::AccessLevel.manageable,
+                                                include_project_namespaces: include_project_namespaces })
   end
 end

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -2,32 +2,49 @@
 
 # Base policy for namespace authorization
 class NamespacePolicy < ApplicationPolicy
-  scope_for :relation, :manageable do |relation| # rubocop:disable Metrics/BlockLength
-    relation.with(
-      personal_namespaces: relation.where(id: user.namespace&.id).select(:id),
-      membership_in_namespaces: relation.where(type: Group.sti_name,
-                                               id: user.members.not_expired.joins(:namespace).where(
-                                                 access_level: Member::AccessLevel.manageable,
-                                                 namespace: { type: Group.sti_name }
-                                               ).select(:namespace_id)).self_and_descendants.where.not(
-                                                 type: Namespaces::ProjectNamespace.sti_name
-                                               ).select(:id),
-      linked_namespaces: relation.where(id: NamespaceGroupLink.where(
-        group: user.groups.where(id: user.members.not_expired.joins(:namespace)
-                                         .where(
-                                           access_level: Member::AccessLevel.manageable, namespace: { type: Group.sti_name }
-                                         )
-                                         .select(:namespace_id)).self_and_descendants,
-        group_access_level: Member::AccessLevel.manageable,
-        namespace_type: Group.sti_name
-      ).not_expired.select(:namespace_id)).self_and_descendants.where.not(type: Namespaces::ProjectNamespace.sti_name)
-                                 .select(:id)
-    ).where(
-      Arel.sql(
-        'namespaces.id in (select * from personal_namespaces)
-        or namespaces.id in (select * from membership_in_namespaces)
-        or namespaces.id in (select * from linked_namespaces)'
-      )
-    ).include_route
+  # rubocop:disable-next Metrics/BlockLength
+  scope_for :relation do |relation,
+                          access_level: Member::AccessLevel.accessible,
+                          include_route: true,
+                          include_shared_links: true|
+    scope = relation
+            .with(
+              user_namespaces: Namespace
+                .where(id: user.namespace&.id)
+                .self_and_descendant_ids,
+              # 1. Accessible namespace IDs for the user based on their memberships
+              accessible_namespaces: Namespace
+                .where(id: user.members.not_expired.with_access_level(access_level).select(:namespace_id))
+                .self_and_descendant_ids,
+              # 5. Accessible linked namespaces for the user based on group links
+              accessible_linked_namespaces:
+                if include_shared_links
+                  Namespace
+                    .where(id: NamespaceGroupLink
+                      .not_expired
+                      .where(Arel.sql('group_id IN (SELECT id FROM accessible_namespaces)'))
+                      .with_group_access_level(access_level)
+                      .select(:namespace_id))
+                    .self_and_descendant_ids
+                else
+                  Namespace.none.select(:id)
+                end
+            ).where(
+              Arel.sql(
+                'namespaces.id IN (
+                  SELECT id FROM user_namespaces
+                  UNION ALL
+                  SELECT id FROM accessible_namespaces
+                  UNION ALL
+                  SELECT id FROM accessible_linked_namespaces
+                )'
+              )
+            )
+    scope = scope.include_route if include_route
+    scope
+  end
+
+  scope_for :relation, :manageable do |relation|
+    authorized_scope(relation, type: :relation, scope_options: { access_level: Member::AccessLevel.manageable })
   end
 end

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -55,9 +55,10 @@ class NamespacePolicy < ApplicationPolicy
     scope
   end
 
-  scope_for :relation, :manageable do |relation, include_project_namespaces: false|
+  scope_for :relation, :manageable do |relation, include_project_namespaces: false, include_route: true|
     authorized_scope(relation, type: :relation,
                                scope_options: { access_level: Member::AccessLevel.manageable,
-                                                include_project_namespaces: include_project_namespaces })
+                                                include_project_namespaces: include_project_namespaces,
+                                                include_route: include_route })
   end
 end

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -9,14 +9,15 @@ class NamespacePolicy < ApplicationPolicy
                           include_shared_links: true|
     scope = relation
             .with(
+              # 1. The users personal namespace and its descendants
               user_namespaces: Namespace
                 .where(id: user.namespace&.id)
                 .self_and_descendant_ids,
-              # 1. Accessible namespace IDs for the user based on their memberships
+              # 2. Accessible namespace IDs for the user based on their memberships
               accessible_namespaces: Namespace
                 .where(id: user.members.not_expired.with_access_level(access_level).select(:namespace_id))
                 .self_and_descendant_ids,
-              # 5. Accessible linked namespaces for the user based on group links
+              # 3. Accessible linked namespaces for the user based on group links
               accessible_linked_namespaces:
                 if include_shared_links
                   Namespace

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -217,6 +217,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
         accessible_namespaces: authorized_scope(
           Namespace, type: :relation,
                      scope_options: { access_level: access_level,
+                                      include_project_namespaces: true,
                                       include_route: false,
                                       include_shared_links: include_shared_links }
         ),

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -228,7 +228,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
             .where(Arel.sql('id IN (SELECT id FROM accessible_namespaces)'))
             .select(:id),
 
-        # 8. Public project namespaces
+        # 3. Public project namespaces
         public_project_namespaces:
           if access_level.include?(Member::AccessLevel::GUEST)
             Namespaces::ProjectNamespace

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -206,65 +206,33 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
     false
   end
 
-  scope_for :relation do |relation, options = {}| # rubocop:disable Metrics/BlockLength
-    access_level = if options.key?(:access_level)
-                     options[:access_level]
-                   else
-                     Member::AccessLevel.all_values_with_owner
-                                        .filter { |level| level != Member::AccessLevel::NO_ACCESS }
-                   end
-
+  # rubocop:disable-next Metrics/BlockLength
+  scope_for :relation do |relation,
+                          archived: false,
+                          access_level: Member::AccessLevel.accessible,
+                          include_shared_links: true|
     relation
       .with(
-        # 1. Accessible namespace IDs for the user based on their memberships
-        accessible_namespace_ids: Namespace
-          .where(id: user.members.not_expired.with_access_level(access_level).select(:namespace_id))
-          .self_and_descendant_ids,
+        # 1. Accessible namespaces for the user based on their memberships
+        accessible_namespaces: authorized_scope(
+          Namespace, type: :relation,
+                     scope_options: { access_level: access_level,
+                                      include_route: false,
+                                      include_shared_links: include_shared_links }
+        ),
 
-        # 2. User's personal project namespaces
-        personal_project_namespaces: Namespaces::ProjectNamespace
-          .not_archived
-          .where(parent_id: user.namespace&.id)
-          .select(:id),
-
-        # 3. Direct project namespaces the user has access to
-        direct_project_namespaces: Namespaces::ProjectNamespace
-          .not_archived
-          .where(Arel.sql('id IN (SELECT id FROM accessible_namespace_ids)'))
-          .select(:id),
-
-        # 4. Project namespaces the user has access to through groups
-        group_project_namespaces: Namespaces::ProjectNamespace
-          .not_archived
-          .where(Arel.sql('parent_id IN (SELECT id FROM accessible_namespace_ids)'))
-          .select(:id),
-
-        # 5. Accessible linked namespaces for the user based on group links
-        accessible_linked_namespace_ids: Namespace
-          .where(id: NamespaceGroupLink
-            .not_expired
-            .where(Arel.sql('group_id IN (SELECT id FROM accessible_namespace_ids)'))
-            .with_group_access_level(access_level)
-            .select(:namespace_id))
-          .self_and_descendant_ids,
-
-        # 6. Directly linked project namespaces the user has access to
-        direct_linked_project_namespaces: Namespaces::ProjectNamespace
-          .not_archived
-          .where(Arel.sql('id IN (SELECT id FROM accessible_linked_namespace_ids)'))
-          .select(:id),
-
-        # 7. Project namespaces linked through accessible linked namespaces
-        group_linked_project_namespaces: Namespaces::ProjectNamespace
-          .not_archived
-          .where(Arel.sql('parent_id IN (SELECT id FROM accessible_linked_namespace_ids)'))
-          .select(:id),
+        # 2. Private project namespaces
+        private_project_namespaces:
+          Namespaces::ProjectNamespace
+            .archived(archived)
+            .where(Arel.sql('id IN (SELECT id FROM accessible_namespaces)'))
+            .select(:id),
 
         # 8. Public project namespaces
         public_project_namespaces:
           if access_level.include?(Member::AccessLevel::GUEST)
             Namespaces::ProjectNamespace
-              .not_archived
+              .archived(archived)
               .where(public: true)
               .select(:id)
           else
@@ -273,93 +241,7 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
       ).where(
         Arel.sql(
           'projects.namespace_id IN (
-            SELECT id FROM personal_project_namespaces
-            UNION ALL
-            SELECT id FROM direct_project_namespaces
-            UNION ALL
-            SELECT id FROM group_project_namespaces
-            UNION ALL
-            SELECT id FROM group_linked_project_namespaces
-            UNION ALL
-            SELECT id FROM direct_linked_project_namespaces
-            UNION ALL
-            SELECT id FROM public_project_namespaces
-          )'
-        )
-      ).include_route
-  end
-
-  scope_for :relation, :archived_projects do |relation| # rubocop:disable Metrics/BlockLength
-    access_level = Member::AccessLevel.all_values_with_owner.filter { |level| level != Member::AccessLevel::NO_ACCESS }
-
-    relation
-      .with(
-        # 1. Accessible namespace IDs for the user based on their memberships
-        accessible_namespace_ids: Namespace
-          .where(id: user.members.not_expired.with_access_level(access_level).select(:namespace_id))
-          .self_and_descendant_ids,
-
-        # 2. User's personal project namespaces
-        personal_project_namespaces: Namespaces::ProjectNamespace
-          .archived
-          .where(parent_id: user.namespace&.id)
-          .select(:id),
-
-        # 3. Direct project namespaces the user has access to
-        direct_project_namespaces: Namespaces::ProjectNamespace
-          .archived
-          .where(Arel.sql('id IN (SELECT id FROM accessible_namespace_ids)'))
-          .select(:id),
-
-        # 4. Project namespaces the user has access to through groups
-        group_project_namespaces: Namespaces::ProjectNamespace
-          .archived
-          .where(Arel.sql('parent_id IN (SELECT id FROM accessible_namespace_ids)'))
-          .select(:id),
-
-        # 5. Accessible linked namespaces for the user based on group links
-        accessible_linked_namespace_ids: Namespace
-          .where(id: NamespaceGroupLink
-            .not_expired
-            .with_group_access_level(access_level)
-            .where(Arel.sql('group_id IN (SELECT id FROM accessible_namespace_ids)'))
-            .select(:namespace_id))
-          .self_and_descendant_ids,
-
-        # 6. Directly linked project namespaces the user has access to
-        direct_linked_project_namespaces: Namespaces::ProjectNamespace
-          .archived
-          .where(Arel.sql('id IN (SELECT id FROM accessible_linked_namespace_ids)'))
-          .select(:id),
-
-        # 7. Project namespaces linked through accessible linked namespaces
-        group_linked_project_namespaces: Namespaces::ProjectNamespace
-          .archived
-          .where(Arel.sql('parent_id IN (SELECT id FROM accessible_linked_namespace_ids)'))
-          .select(:id),
-
-        # 8. Public project namespaces
-        public_project_namespaces:
-          if access_level.include?(Member::AccessLevel::GUEST)
-            Namespaces::ProjectNamespace
-              .archived
-              .where(public: true)
-              .select(:id)
-          else
-            Namespaces::ProjectNamespace.none.select(:id)
-          end
-      ).where(
-        Arel.sql(
-          'projects.namespace_id IN (
-            SELECT id FROM personal_project_namespaces
-            UNION ALL
-            SELECT id FROM direct_project_namespaces
-            UNION ALL
-            SELECT id FROM group_project_namespaces
-            UNION ALL
-            SELECT id FROM group_linked_project_namespaces
-            UNION ALL
-            SELECT id FROM direct_linked_project_namespaces
+            SELECT id FROM private_project_namespaces
             UNION ALL
             SELECT id FROM public_project_namespaces
           )'
@@ -390,29 +272,15 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
   end
 
   scope_for :relation, :manageable_without_shared_links do |relation|
-    relation.with(
-      direct_project_namespaces: Namespaces::ProjectNamespace.not_archived.where(
-        id: user.members.not_expired.where(access_level: Member::AccessLevel.manageable).select(:namespace_id)
-      ),
-      group_project_namespaces: Namespaces::ProjectNamespace.not_archived.where(parent: Namespace.where(id:
-        user.members.not_expired.joins(:namespace).where(
-          namespace_id: user.groups.self_and_descendants,
-          access_level: Member::AccessLevel.manageable,
-          namespace: { type: Group.sti_name }
-        ).select(:namespace_id), type: Group.sti_name).self_and_descendant_ids).select(:id)
-    ).where(
-      Arel.sql(
-        'projects.namespace_id in (
-          SELECT namespace_id FROM direct_project_namespaces
-          UNION ALL
-          SELECT id FROM group_project_namespaces
-        )'
-      )
-    ).include_route
+    authorized_scope(relation, type: :relation,
+                               scope_options: { access_level: Member::AccessLevel.manageable,
+                                                include_shared_links: false })
   end
 
-  scope_for :relation, :manageable do |relation|
-    authorized_scope(relation, type: :relation, scope_options: { access_level: Member::AccessLevel.manageable })
+  scope_for :relation, :manageable do |relation, include_shared_links: true|
+    authorized_scope(relation, type: :relation,
+                               scope_options: { access_level: Member::AccessLevel.manageable,
+                                                include_shared_links: include_shared_links })
   end
 
   scope_for :relation, :personal do |relation|

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -252,7 +252,10 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
 
   scope_for :relation, :project_samples_transferable do |relation, options|
     obj = options.key?(:group) ? options[:group] : options[:project]
-    if Member.effective_access_level(obj, user) == Member::AccessLevel::MAINTAINER
+    access_level = Member.effective_access_level(obj, user)
+
+    case access_level
+    when Member::AccessLevel::MAINTAINER
       return relation.none if obj.project_namespace? && obj.parent.user_namespace?
 
       top_level_ancestor = if obj.project_namespace?
@@ -267,8 +270,10 @@ class ProjectPolicy < NamespacePolicy # rubocop:disable Metrics/ClassLength
                                  as: :manageable_without_shared_links)
         .where(namespace: { parent_id: group_and_subgroup_ids })
 
-    else
+    when Member::AccessLevel::OWNER
       authorized_scope(relation, type: :relation, as: :manageable)
+    else
+      relation.none
     end
   end
 

--- a/test/graphql/groups_query_test.rb
+++ b/test/graphql/groups_query_test.rb
@@ -70,7 +70,7 @@ class GroupsQueryTest < ActiveSupport::TestCase
                                                        .where(group: @user.groups.self_and_descendants)
                                                        .not_expired.select(:namespace_id), public: false)
 
-    groups = @user.groups.self_and_descendants.where(public: false).or(groups_via_namespace_group_links)
+    groups = @user.groups.self_and_descendants.or(groups_via_namespace_group_links)
 
     groups_count = groups.uniq.count
 

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -152,6 +152,15 @@ class GroupPolicyTest < ActiveSupport::TestCase
     assert_equal 11, scoped_groups.count
   end
 
+  test 'scoped manageable groups' do
+    user = users(:david_doe)
+    policy = GroupPolicy.new(user:)
+    manageable_group = groups(:david_doe_group_four)
+    scoped_groups = policy.apply_scope(Group, type: :relation, name: :manageable)
+    assert_includes scoped_groups, manageable_group
+    assert_equal 1, scoped_groups.count
+  end
+
   test 'scoped public groups' do
     user = users(:david_doe)
     policy = GroupPolicy.new(user:)
@@ -160,6 +169,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
     assert_includes scoped_groups, public_group
     assert_equal 11, scoped_groups.count
   end
+
   test 'scope with expired group member' do
     group_member = members(:group_one_member_john_doe)
     group_member.expires_at = 10.days.ago.to_date

--- a/test/policies/group_policy_test.rb
+++ b/test/policies/group_policy_test.rb
@@ -144,7 +144,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
   test 'scope' do
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    assert_equal 32, scoped_groups.count
+    assert_equal 34, scoped_groups.count
 
     user = users(:david_doe)
     policy = GroupPolicy.new(user:)
@@ -177,7 +177,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    assert_equal 30, scoped_groups.count
+    assert_equal 32, scoped_groups.count
     scoped_groups_names = scoped_groups.pluck(:name)
     assert_not scoped_groups_names.include?(groups(:group_one).name)
     assert_not scoped_groups_names.include?(groups(:david_doe_group_four).name)
@@ -188,7 +188,7 @@ class GroupPolicyTest < ActiveSupport::TestCase
 
     scoped_groups = @policy.apply_scope(Group, type: :relation)
 
-    assert_equal 29, scoped_groups.count
+    assert_equal 31, scoped_groups.count
     scoped_groups_names = scoped_groups.pluck(:name)
     assert_not scoped_groups_names.include?(groups(:namespace_group_link_group_one).name)
   end

--- a/test/policies/namespace_policy_test.rb
+++ b/test/policies/namespace_policy_test.rb
@@ -8,6 +8,34 @@ class NamespacePolicyTest < ActiveSupport::TestCase
     @policy = NamespacePolicy.new(user: @user)
   end
 
+  test 'scope' do
+    scoped_namespaces = @policy.apply_scope(Namespace, type: :relation)
+
+    assert_equal 12, scoped_namespaces.count
+
+    # by default project namespaces are not included
+    assert_not scoped_namespaces.include?(namespaces_project_namespaces(:project28_namespace))
+  end
+
+  test 'scope without shared links' do
+    scoped_namespaces = @policy.apply_scope(Namespace, type: :relation, scope_options: { include_shared_links: false })
+
+    assert_equal 2, scoped_namespaces.count
+
+    # should not include group which is only accessible through link
+    assert_not scoped_namespaces.include?(groups(:group_one))
+  end
+
+  test 'scope with project namespaces' do
+    scoped_namespaces = @policy.apply_scope(Namespace, type: :relation,
+                                                       scope_options: { include_project_namespaces: true })
+
+    assert_equal 34, scoped_namespaces.count
+
+    # should include project namespace
+    assert scoped_namespaces.include?(namespaces_project_namespaces(:project28_namespace))
+  end
+
   test 'named scope with expired memberships' do
     group_member = members(:group_four_member_david_doe)
     group_member.expires_at = 10.days.ago.to_date

--- a/test/policies/namespace_policy_test.rb
+++ b/test/policies/namespace_policy_test.rb
@@ -30,14 +30,6 @@ class NamespacePolicyTest < ActiveSupport::TestCase
 
     assert scoped_namespaces.include?(user_namespace)
     assert scoped_namespaces.include?(group)
-
-    assert_equal scoped_namespaces[0].type, Namespaces::UserNamespace.sti_name
-    assert_equal scoped_namespaces[0].name, 'david.doe@localhost'
-    assert_equal scoped_namespaces[0].path, 'david.doe_at_localhost'
-
-    assert_equal scoped_namespaces[1].type, Group.sti_name
-    assert_equal scoped_namespaces[1].name, 'Group 4'
-    assert_equal scoped_namespaces[1].path, 'group-4'
   end
 
   test 'named scope with modify access to namespace via many namespace group links' do

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -281,7 +281,7 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     project.namespace.archived_at = Time.zone.now
     project.namespace.save
 
-    scoped_projects = @policy.apply_scope(Project, type: :relation, name: :archived_projects)
+    scoped_projects = @policy.apply_scope(Project, type: :relation, scope_options: { archived: true })
 
     # John doe has access to 1 archived project
     assert_equal 1, scoped_projects.count

--- a/test/policies/project_policy_test.rb
+++ b/test/policies/project_policy_test.rb
@@ -494,4 +494,71 @@ class ProjectPolicyTest < ActiveSupport::TestCase
     assert scoped_projects.include?(projects(:projectBravo))
     assert scoped_projects.include?(projects(:projectCharlie))
   end
+
+  test 'project_samples_transferable scope includes all manageable projects for an owner' do
+    user = users(:user27)
+    policy = ProjectPolicy.new(user:)
+
+    scoped_projects = policy.apply_scope(Project, type: :relation, name: :project_samples_transferable,
+                                                  scope_options: {
+                                                    project: namespaces_project_namespaces(:user27_project1_namespace)
+                                                  })
+    manageable_scoped_projects = policy.apply_scope(Project, type: :relation, name: :manageable)
+
+    assert_equal manageable_scoped_projects.pluck(:id).sort, scoped_projects.pluck(:id).sort
+    assert_equal manageable_scoped_projects.count, scoped_projects.count
+  end
+
+  test 'project_samples_transferable scope includes all manageable projects under a top-level group for a maintainer' do
+    user = users(:joan_doe)
+    group = groups(:group_one)
+    policy = ProjectPolicy.new(user:)
+
+    scoped_projects = policy.apply_scope(Project, type: :relation, name: :project_samples_transferable,
+                                                  scope_options: { group: group })
+
+    manageable_scoped_projects = policy.apply_scope(Project, type: :relation,
+                                                             name: :manageable_without_shared_links)
+                                       .where(namespace: { parent_id: group.self_and_descendant_ids })
+
+    # does not include project outside of group hierarchy that the user has manageble access to
+    assert_not scoped_projects.include?(projects(:project32))
+
+    assert_equal manageable_scoped_projects.pluck(:id).sort, scoped_projects.pluck(:id).sort
+    assert_equal manageable_scoped_projects.count, scoped_projects.count
+  end
+
+  test 'project_samples_transferable scope returns an empty relation for a user with ' \
+       'maintainer access on a personal project' do
+    user = users(:joan_doe)
+    project = namespaces_project_namespaces(:john_doe_project4_namespace)
+    policy = ProjectPolicy.new(user:)
+
+    scoped_projects = policy.apply_scope(Project, type: :relation, name: :project_samples_transferable,
+                                                  scope_options: { project: project })
+
+    assert scoped_projects.empty?
+  end
+
+  test 'personal scope returns only projects under the user\'s personal namespace' do
+    user = users(:john_doe)
+    policy = ProjectPolicy.new(user:)
+
+    scoped_projects = policy.apply_scope(Project, type: :relation, name: :personal)
+
+    scoped_projects.each do |project|
+      assert_equal user.namespace.id, project.namespace.parent_id
+    end
+  end
+
+  test 'group_projects scope returns empty relation for a user without access to the group' do
+    user = users(:john_doe)
+    group = groups(:group_two)
+    policy = ProjectPolicy.new(user:)
+
+    scoped_projects = policy.apply_scope(Project, type: :relation, name: :group_projects,
+                                                  scope_options: { group: group })
+
+    assert scoped_projects.empty?
+  end
 end


### PR DESCRIPTION
## What does this PR do and why?
_Describe in detail what your merge request does and why._

This PR is a followup to #2263, this is a further refactor of more policy scopes to reduce query duplication by moving common queries into NamespacePolicy, which is then used by ProjectPolicy and GroupPolicy.

Locally testing the performance looks to be the same, so the speedups from the previous PR are maintained.

## Screenshots or screen recordings
_Screenshots are required for UI changes, and strongly recommended for all other pull requests._

## How to set up and validate locally
_Numbered steps to set up and validate the change are strongly suggested._

1. Confirm that tests pass

## PR acceptance checklist
This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
