### PR TITLE
Harden JavaScript test isolation and enforce coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           cache: true
 
       - name: Run JavaScript tests
-        run: pnpm run test:js
+        run: pnpm run test:js:coverage
 
   test:
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
           runtime: node@24.14.1
           cache: true
 
-      - name: Run JavaScript tests with shuffled order and coverage
-        run: pnpm run test:js:coverage --sequence.shuffle --sequence.seed=2233
+      - name: Run JavaScript tests
+        run: pnpm run test:js:coverage
 
   test:
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
           runtime: node@24.14.1
           cache: true
 
-      - name: Run JavaScript tests
-        run: pnpm run test:js:coverage
+      - name: Run JavaScript tests with shuffled order and coverage
+        run: pnpm run test:js:coverage --sequence.shuffle --sequence.seed=2233
 
   test:
     timeout-minutes: 15

--- a/docs/testing/javascript.md
+++ b/docs/testing/javascript.md
@@ -2,7 +2,10 @@
 
 Run `pnpm run test:js` for fast feedback. Run `pnpm run test:js:coverage`
 before opening a PR; CI runs this command and enforces the existing per-file
-coverage thresholds. Test discovery must find at least one test.
+coverage thresholds. CI also shuffles test order with the fixed seed `2233` so
+failures are reproducible. Run the exact CI command locally with
+`pnpm run test:js:coverage --sequence.shuffle --sequence.seed=2233`.
+Test discovery must find at least one test.
 
 ## Controller fixtures and lifecycle
 

--- a/docs/testing/javascript.md
+++ b/docs/testing/javascript.md
@@ -1,0 +1,57 @@
+# JavaScript and Stimulus tests
+
+Run `pnpm run test:js` for fast feedback. Run `pnpm run test:js:coverage`
+before opening a PR; CI runs this command and enforces the existing per-file
+coverage thresholds. Test discovery must find at least one test.
+
+## Controller fixtures and lifecycle
+
+Mirror implementation paths under `test/javascript`. Use a real Stimulus
+application and representative DOM markup, including actions, targets and outlets.
+Import `startApplication` and `stopApplication` from `test/javascript/helpers/stimulus.js`.
+Register controllers after starting the application, then await connection before
+interacting. For asynchronous rendering, wait for an observable state rather than
+sleeping for an arbitrary interval.
+
+Always await `stopApplication(application)` in an async `afterEach` callback,
+before restoring mocks or returning to real timers. The helper removes fixtures,
+lets Stimulus disconnect controllers, and only then stops its observers. It also
+fails the test if Stimulus caught an unexpected lifecycle or action error.
+Calling `application.stop()` alone does not disconnect controllers.
+
+For lifecycle regressions, remove and reinsert the fixture while the application
+is running. Assert observable cleanup: document events no longer act on removed
+controllers, pending timers cannot update detached UI, and reconnecting does not
+duplicate listeners. Do not substitute a direct `disconnect()` call for these tests.
+
+## Assertions and mocks
+
+Prefer `@testing-library/user-event` for ordinary clicks, typing and keyboard
+interaction. Use explicit DOM events for Turbo events and precise event details.
+Assert visible state, submitted values, focus, ARIA attributes and external effects.
+Direct method calls are appropriate for deliberate controller APIs and pure utilities.
+Avoid assertions that merely repeat an implementation or count internal calls.
+
+Use `vi.spyOn` for existing methods, and `vi.stubGlobal` for globals such as `Turbo`.
+Global stubs are restored after each test. Do not assign mocks directly to browser
+objects or prototypes. The shared `scrollIntoView` shim supplies a method to spy on;
+it does not simulate scrolling. The default `matchMedia` shim is static; tests of
+media-query changes must supply an event-capable mock.
+
+Keep mocks local and minimal. Mock external boundaries, not the controller being
+tested. Every test must create the state it needs, including storage and mock
+implementations. Pair fake timers with explicit advancement and restore real timers
+after lifecycle cleanup. Test rejected promises and disconnects during pending work.
+
+## Coverage and browser checks
+
+Add a per-file threshold only after meaningful tests reach 100% statements,
+branches, functions and lines. Review every coverage exclusion; do not hide a
+reachable branch to satisfy a percentage. Coverage is evidence of execution, not
+proof that assertions detect regressions.
+
+Keep focused Rails/browser tests for real rendering, positioning, native dialogs,
+scrolling and end-to-end Turbo behavior. jsdom does not perform layout. Maintain
+small, independently reviewable PRs by subsystem. Refactor production code only
+when a demonstrated defect or a concrete testing boundary justifies the change;
+do not expose private methods solely to test them.

--- a/docs/testing/javascript.md
+++ b/docs/testing/javascript.md
@@ -2,9 +2,9 @@
 
 Run `pnpm run test:js` for fast feedback. Run `pnpm run test:js:coverage`
 before opening a PR; CI runs this command and enforces the existing per-file
-coverage thresholds. CI also shuffles test order with the fixed seed `2233` so
-failures are reproducible. Run the exact CI command locally with
-`pnpm run test:js:coverage --sequence.shuffle --sequence.seed=2233`.
+coverage thresholds. Vitest shuffles test order by default, using a new seed for
+each run. To reproduce a failure, use the seed printed in the test output:
+`pnpm run test:js:coverage --sequence.seed=<reported-seed>`.
 Test discovery must find at least one test.
 
 ## Controller fixtures and lifecycle

--- a/test/javascript/controllers/combobox/v1_controller.test.js
+++ b/test/javascript/controllers/combobox/v1_controller.test.js
@@ -1,4 +1,4 @@
-import { Application } from "@hotwired/stimulus";
+import { startApplication, stopApplication } from "../../helpers/stimulus.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { announce } from "utilities/live_region";
 import ComboboxController from "../../../../app/javascript/controllers/combobox/v1_controller.js";
@@ -152,7 +152,7 @@ function renderFixture({
 }
 
 async function startController() {
-  const application = Application.start();
+  const application = startApplication();
   application.register("combobox--v1", ComboboxController);
   await Promise.resolve();
   return application;
@@ -244,16 +244,13 @@ describe("combobox v1 controller", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     scrollIntoView = vi.fn();
-    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(
+      scrollIntoView,
+    );
   });
 
   afterEach(async () => {
-    // Remove the controller element and flush microtasks so Stimulus runs
-    // disconnect(), detaching the document-level listeners before the next test.
-    document.body.innerHTML = "";
-    await Promise.resolve();
-    await Promise.resolve();
-    application?.stop();
+    await stopApplication(application);
     vi.useRealTimers();
   });
 

--- a/test/javascript/controllers/experimental_feature_toggle_controller.test.js
+++ b/test/javascript/controllers/experimental_feature_toggle_controller.test.js
@@ -1,4 +1,4 @@
-import { Application } from "@hotwired/stimulus";
+import { startApplication, stopApplication } from "../helpers/stimulus.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import ExperimentalFeatureToggleController from "../../../app/javascript/controllers/experimental_feature_toggle_controller.js";
 
@@ -57,7 +57,7 @@ function renderFixture({
 }
 
 async function startController() {
-  const application = Application.start();
+  const application = startApplication();
   application.register(
     "experimental-feature-toggle",
     ExperimentalFeatureToggleController,
@@ -92,8 +92,8 @@ function controllerFor(application) {
 describe("experimental feature toggle controller", () => {
   let application;
 
-  afterEach(() => {
-    application?.stop();
+  afterEach(async () => {
+    await stopApplication(application);
     vi.useRealTimers();
   });
 

--- a/test/javascript/controllers/nextflow/v2/samplesheet_controller.test.js
+++ b/test/javascript/controllers/nextflow/v2/samplesheet_controller.test.js
@@ -1,4 +1,7 @@
-import { Application } from "@hotwired/stimulus";
+import {
+  startApplication,
+  stopApplication,
+} from "../../../helpers/stimulus.js";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import SamplesheetController from "../../../../../app/javascript/controllers/nextflow/v2/samplesheet_controller.js";
 import SelectionController from "../../../../../app/javascript/controllers/selection_controller.js";
@@ -678,7 +681,7 @@ function renderBaseFixture() {
 /* eslint-enable no-useless-escape */
 
 async function startController() {
-  const application = Application.start();
+  const application = startApplication();
   application.register("nextflow--v2--samplesheet", SamplesheetController);
   application.register("selection", SelectionController);
   await Promise.resolve();
@@ -695,15 +698,17 @@ describe("nextflow v2 samplesheet controller", () => {
   };
 
   beforeEach(() => {
-    window.requestAnimationFrame = (callback) => setTimeout(callback, 0);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) =>
+      setTimeout(callback, 0),
+    );
     clearStorage(window.localStorage);
     clearStorage(sessionStorage);
-    Element.prototype.scrollIntoView = vi.fn();
+    vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => {});
     vi.useFakeTimers();
   });
 
-  afterEach(() => {
-    application?.stop();
+  afterEach(async () => {
+    await stopApplication(application);
     vi.useRealTimers();
   });
 
@@ -1654,10 +1659,10 @@ describe("nextflow v2 samplesheet controller", () => {
   });
 
   it("renders the Turbo response when fetching sample attributes", async () => {
-    globalThis.fetch = vi.fn();
-    globalThis.Turbo = {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.stubGlobal("Turbo", {
       renderStreamMessage: vi.fn(),
-    };
+    });
     const allSamples = range(1, 2);
     setupStandardSamplesheetAttributes(allSamples);
 
@@ -1729,6 +1734,7 @@ describe("nextflow v2 samplesheet controller", () => {
   });
 
   it("fetch sample attributes error state", async () => {
+    vi.stubGlobal("Turbo", { renderStreamMessage: vi.fn() });
     const allSamples = range(1, 2);
     setupStandardSamplesheetAttributes(allSamples);
 

--- a/test/javascript/controllers/selection_controller.test.js
+++ b/test/javascript/controllers/selection_controller.test.js
@@ -1,10 +1,10 @@
-import { Application } from "@hotwired/stimulus";
+import { startApplication, stopApplication } from "../helpers/stimulus.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import SelectionController from "../../../app/javascript/controllers/selection_controller.js";
 
 async function startController(options = {}) {
   document.body.innerHTML = renderFixtureHtml(options);
-  const application = Application.start();
+  const application = startApplication();
   application.register("selection", SelectionController);
   await Promise.resolve();
   await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -81,8 +81,8 @@ function controllerFor(application) {
 describe("selection controller", () => {
   let application;
 
-  afterEach(() => {
-    application?.stop();
+  afterEach(async () => {
+    await stopApplication(application);
     sessionStorage.clear();
   });
 

--- a/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
+++ b/test/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.test.js
@@ -1,4 +1,7 @@
-import { Application } from "@hotwired/stimulus";
+import {
+  startApplication,
+  stopApplication,
+} from "../../../helpers/stimulus.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import SortableListsController from "../../../../../app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js";
 
@@ -207,7 +210,7 @@ function activeOptionIds(listbox) {
 }
 
 async function startController() {
-  const application = Application.start();
+  const application = startApplication();
   application.register(
     "sortable-lists--v1--two-lists-selection",
     SortableListsController,
@@ -234,8 +237,8 @@ function itemTexts(id) {
 describe("sortable lists two-lists selection controller", () => {
   let application;
 
-  afterEach(() => {
-    application?.stop();
+  afterEach(async () => {
+    await stopApplication(application);
     vi.useRealTimers();
   });
 
@@ -1027,6 +1030,19 @@ describe("sortable lists two-lists selection controller", () => {
   });
 
   describe("list titles and scrolling", () => {
+    it("updates the active option when scrolling is unavailable", async () => {
+      renderFixture();
+      application = await startController();
+      const availableList = list("available-list");
+      for (const option of availableList.children) {
+        Object.defineProperty(option, "scrollIntoView", { value: undefined });
+      }
+      availableList.focus();
+      expect(activeId(availableList)).toBe("available-alpha");
+      keydown(availableList, "ArrowDown");
+      expect(activeId(availableList)).toBe("available-beta");
+    });
+
     it("tolerates lists without a data-title attribute", async () => {
       renderFixture({ titles: false });
       application = await startController();
@@ -1044,14 +1060,12 @@ describe("sortable lists two-lists selection controller", () => {
       application = await startController();
 
       const scrollSpy = vi.fn();
-      window.HTMLElement.prototype.scrollIntoView = scrollSpy;
+      vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(
+        scrollSpy,
+      );
 
-      try {
-        list("available-list").focus();
-        expect(scrollSpy).toHaveBeenCalled();
-      } finally {
-        delete window.HTMLElement.prototype.scrollIntoView;
-      }
+      list("available-list").focus();
+      expect(scrollSpy).toHaveBeenCalled();
     });
   });
 

--- a/test/javascript/controllers/treegrid_controller.test.js
+++ b/test/javascript/controllers/treegrid_controller.test.js
@@ -1,4 +1,4 @@
-import { Application } from "@hotwired/stimulus";
+import { startApplication, stopApplication } from "../helpers/stimulus.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import TreegridController from "../../../app/javascript/controllers/treegrid_controller.js";
@@ -167,14 +167,14 @@ describe("treegrid controller", () => {
   let application;
 
   beforeEach(() => {
-    globalThis.fetch = vi.fn();
-    globalThis.Turbo = {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.stubGlobal("Turbo", {
       renderStreamMessage: vi.fn(),
-    };
+    });
   });
 
-  afterEach(() => {
-    application?.stop();
+  afterEach(async () => {
+    await stopApplication(application);
     document.body.innerHTML = "";
     vi.restoreAllMocks();
   });
@@ -189,7 +189,7 @@ describe("treegrid controller", () => {
       const addSpy = vi.spyOn(element, "addEventListener");
       const removeSpy = vi.spyOn(element, "removeEventListener");
 
-      application = Application.start();
+      application = startApplication();
       application.register("treegrid", TreegridController);
       await flushStimulus();
 
@@ -228,7 +228,7 @@ describe("treegrid controller", () => {
         </div>
       `;
 
-      application = Application.start();
+      application = startApplication();
       application.register("treegrid", TreegridController);
       await flushStimulus();
 
@@ -264,7 +264,7 @@ describe("treegrid controller", () => {
 
   describe("Toggle row button behaviour", () => {
     beforeEach(() => {
-      application = Application.start();
+      application = startApplication();
       application.register("treegrid", TreegridController);
     });
 
@@ -350,7 +350,7 @@ describe("treegrid controller", () => {
 
   describe("keyboard navigation", () => {
     beforeEach(() => {
-      application = Application.start();
+      application = startApplication();
       application.register("treegrid", TreegridController);
     });
 

--- a/test/javascript/controllers/workflow_selection_controller.test.js
+++ b/test/javascript/controllers/workflow_selection_controller.test.js
@@ -1,4 +1,5 @@
-import { Application, Controller } from "@hotwired/stimulus";
+import { startApplication, stopApplication } from "../helpers/stimulus.js";
+import { Controller } from "@hotwired/stimulus";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import WorkflowSelectionController from "../../../app/javascript/controllers/workflow_selection_controller.js";
 
@@ -11,7 +12,7 @@ class SelectionOutletStubController extends Controller {
 async function startController(options = {}) {
   document.body.innerHTML = renderFixture(options);
 
-  const application = Application.start();
+  const application = startApplication();
   application.register("workflow-selection", WorkflowSelectionController);
   application.register("selection", SelectionOutletStubController);
 
@@ -109,8 +110,8 @@ function dispatchKeydown(key) {
 describe("workflow selection controller", () => {
   let application;
 
-  afterEach(() => {
-    application?.stop();
+  afterEach(async () => {
+    await stopApplication(application);
     document.body.innerHTML = "";
   });
 
@@ -236,7 +237,9 @@ describe("workflow selection controller", () => {
     controller.preventClosingDialog();
     expect(dispatchKeydown("Escape").defaultPrevented).toBe(true);
 
-    controller.disconnect();
+    controller.element.remove();
+    await Promise.resolve();
+    await Promise.resolve();
 
     // Escape handling stops and the form is no longer amended after disconnect.
     expect(dispatchKeydown("Escape").defaultPrevented).toBe(false);
@@ -245,7 +248,5 @@ describe("workflow selection controller", () => {
     const event = dispatchBeforeFetch(form, resume);
     expect(event.detail.fetchOptions.body).toBeUndefined();
     expect(resume).not.toHaveBeenCalled();
-
-    application = undefined;
   });
 });

--- a/test/javascript/helpers/stimulus.js
+++ b/test/javascript/helpers/stimulus.js
@@ -1,0 +1,22 @@
+import { Application } from "@hotwired/stimulus";
+import { expect } from "vitest";
+
+const errors = new WeakMap();
+
+export function startApplication() {
+  const application = Application.start();
+  const captured = [];
+  errors.set(application, captured);
+  application.handleError = (error) => captured.push(error);
+  return application;
+}
+
+export async function stopApplication(application) {
+  if (!application) return;
+  // Stimulus must observe removal before its observers are stopped.
+  document.body.replaceChildren();
+  await Promise.resolve();
+  await Promise.resolve();
+  application.stop();
+  expect(errors.get(application)).toEqual([]);
+}

--- a/test/javascript/helpers/stimulus.test.js
+++ b/test/javascript/helpers/stimulus.test.js
@@ -1,0 +1,71 @@
+import { Controller } from "@hotwired/stimulus";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startApplication, stopApplication } from "./stimulus.js";
+
+describe("Stimulus test lifecycle", () => {
+  let application;
+  afterEach(async () => {
+    await stopApplication(application);
+  });
+
+  it("disconnects controllers and releases document listeners before stopping", async () => {
+    const disconnected = vi.fn();
+    const listener = vi.fn();
+    class Probe extends Controller {
+      connect() {
+        document.addEventListener("probe", listener);
+      }
+      disconnect() {
+        document.removeEventListener("probe", listener);
+        disconnected();
+      }
+    }
+    document.body.innerHTML = '<div data-controller="probe"></div>';
+    application = startApplication();
+    application.register("probe", Probe);
+    await Promise.resolve();
+    document.dispatchEvent(new Event("probe"));
+    expect(listener).toHaveBeenCalledOnce();
+    await stopApplication(application);
+    application = undefined;
+    expect(disconnected).toHaveBeenCalledOnce();
+    document.dispatchEvent(new Event("probe"));
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it("reports an action error instead of silently logging it", async () => {
+    class BrokenAction extends Controller {
+      run() {
+        throw new Error("Broken action");
+      }
+    }
+    document.body.innerHTML =
+      '<button data-controller="broken" data-action="broken#run">Run</button>';
+    application = startApplication();
+    application.register("broken", BrokenAction);
+    await Promise.resolve();
+    document.querySelector("button").click();
+    const stopping = stopApplication(application);
+    application = undefined;
+    await expect(stopping).rejects.toThrow();
+  });
+
+  it.each(["connect", "disconnect"])(
+    "fails the test when Stimulus catches a %s error",
+    async (callback) => {
+      const failure = new Error("Broken lifecycle");
+      class Broken extends Controller {
+        [callback]() {
+          throw failure;
+        }
+      }
+      document.body.innerHTML = '<div data-controller="broken"></div>';
+      application = startApplication();
+      application.register("broken", Broken);
+      await Promise.resolve();
+      const stopping = stopApplication(application);
+      application = undefined;
+      await expect(stopping).rejects.toThrow();
+    },
+  );
+});

--- a/test/javascript/setup.js
+++ b/test/javascript/setup.js
@@ -1,5 +1,38 @@
-import { afterEach } from "vitest";
+import { beforeEach, onTestFinished, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
+
+function ensureStorage(storageName) {
+  const storage = window[storageName];
+  if (storage && typeof storage.clear === "function") return;
+
+  const values = new Map();
+
+  Object.defineProperty(window, storageName, {
+    configurable: true,
+    value: {
+      clear() {
+        values.clear();
+      },
+      getItem(key) {
+        return values.has(key) ? values.get(key) : null;
+      },
+      setItem(key, value) {
+        values.set(key, String(value));
+      },
+      removeItem(key) {
+        values.delete(key);
+      },
+      key(index) {
+        return Array.from(values.keys())[index] ?? null;
+      },
+      get length() {
+        return values.size;
+      },
+    },
+  });
+}
+
+ensureStorage("localStorage");
 
 // jsdom does not implement window.matchMedia
 if (!window.matchMedia) {
@@ -18,7 +51,23 @@ if (!window.matchMedia) {
   });
 }
 
-afterEach(() => {
-  document.body.innerHTML = "";
-  sessionStorage.clear();
+// jsdom has no layout or scrolling implementation. Tests may spy on this shim.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// Test-finished callbacks still run when a suite's afterEach throws.
+beforeEach(() => {
+  onTestFinished(async () => {
+    document.body.replaceChildren();
+    await Promise.resolve();
+    await Promise.resolve();
+    try {
+      sessionStorage.clear();
+      localStorage.clear();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -38,9 +38,9 @@ export default defineConfig({
     },
     include: ["test/javascript/**/*.{test,spec}.{js,ts}"],
     setupFiles: ["./test/javascript/setup.js"],
-    passWithNoTests: true,
     clearMocks: true,
     restoreMocks: true,
+    unstubGlobals: true,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -30,6 +30,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    sequence: { shuffle: true },
     environment: "jsdom",
     environmentOptions: {
       jsdom: {


### PR DESCRIPTION
## What does this PR do and why?

Make the JavaScript test setup reliable before expanding coverage for #2233. Controller suites now remove their fixtures and await Stimulus disconnect callbacks before stopping the application. Unexpected Stimulus lifecycle/action errors fail the test, and final browser-state cleanup still runs after failed teardown.

Restore browser mocks between tests, clear both storage areas, and fix two existing order dependencies in samplesheet and workflow-selection tests. CI now runs coverage and enforces the existing per-file thresholds; empty test discovery fails. Add helper regression tests and a short JavaScript testing guide.

The localStorage fallback matches the setup change in #2265. This branch starts from main and does not require the other coverage PRs. No production JavaScript changes.

## Screenshots or screen recordings

Not applicable: test infrastructure and documentation only.

## How to set up and validate locally

1. Install the locked dependencies with `pnpm install --frozen-lockfile`.
2. Run `pnpm run test:js:coverage` — 309 tests across 19 files pass; all configured coverage thresholds pass.
3. Run `pnpm exec vitest run --sequence.shuffle --sequence.seed=2233` — the same 309 tests pass in shuffled order.
4. Read `docs/testing/javascript.md` for controller lifecycle, mock, coverage and browser-test guidance.

Changed JavaScript files pass ESLint and Prettier. An additional temporary failure probe confirmed that a captured controller error fails teardown while the following test receives real timers, restored globals and empty storage. Overall application coverage remains about 31%; this PR enforces the existing per-file targets rather than claiming global 100% coverage.

## PR acceptance checklist

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
