### PR TITLE
tests(js): Cover expandable navigation and correct native hidden state

### DIFF
--- a/app/javascript/controllers/collapsible_controller.js
+++ b/app/javascript/controllers/collapsible_controller.js
@@ -44,7 +44,9 @@ export default class extends Controller {
     }
 
     // Check if the collapsible item is initially hidden (collapsed)
-    const isInitiallyCollapsed = this.itemTarget.classList.contains("hidden");
+    const isInitiallyCollapsed =
+      this.itemTarget.classList.contains("hidden") ||
+      this.itemTarget.hasAttribute("hidden");
 
     // 🗣️ Set initial ARIA state for screen readers
     this.buttonTarget.setAttribute(

--- a/test/javascript/controllers/collapsible_controller.test.js
+++ b/test/javascript/controllers/collapsible_controller.test.js
@@ -1,0 +1,121 @@
+import { startApplication, stopApplication } from "../helpers/stimulus.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CollapsibleController from "../../../app/javascript/controllers/collapsible_controller.js";
+
+describe("collapsible controller", () => {
+  let application;
+  let root;
+  let controller;
+  const target = (name) =>
+    root.querySelector(`[data-collapsible-target="${name}"]`);
+
+  async function mount({
+    attributes = 'class="hidden"',
+    icon = true,
+    id = 'id="section"',
+    button = true,
+    item = true,
+  } = {}) {
+    document.body.innerHTML = `<div data-controller="collapsible">
+      ${button ? '<button data-collapsible-target="button" data-action="collapsible#toggle">Toggle</button>' : ""}
+      ${item ? `<div data-collapsible-target="item" ${id} ${attributes}>Content</div>` : ""}
+      ${icon ? '<span data-collapsible-target="icon" class="rotate-0"></span>' : ""}
+    </div>`;
+    root = document.body.firstElementChild;
+    application = startApplication();
+    application.register("collapsible", CollapsibleController);
+    await Promise.resolve();
+    controller = application.getControllerForElementAndIdentifier(
+      root,
+      "collapsible",
+    );
+  }
+
+  afterEach(async () => {
+    await stopApplication(application);
+  });
+
+  it("expands and collapses through the button, updating semantics and events", async () => {
+    await mount();
+    const expanded = vi.fn();
+    const collapsed = vi.fn();
+    root.addEventListener("collapsible:expanded", expanded);
+    root.addEventListener("collapsible:collapsed", collapsed);
+    expect(target("button")).toHaveAttribute("aria-controls", "section");
+    expect(target("button")).toHaveAttribute("aria-expanded", "false");
+    target("button").click();
+    expect(target("item")).not.toHaveClass("hidden");
+    expect(target("item")).toHaveAttribute("aria-hidden", "false");
+    expect(target("item")).not.toHaveAttribute("hidden");
+    expect(target("item")).not.toHaveAttribute("tabindex");
+    expect(target("button")).toHaveAttribute("aria-expanded", "true");
+    expect(target("icon")).toHaveClass("rotate-180");
+    expect(expanded).toHaveBeenCalledOnce();
+    target("button").click();
+    expect(target("item")).toHaveClass("hidden");
+    expect(target("item")).toHaveAttribute("hidden");
+    expect(target("item")).toHaveAttribute("aria-hidden", "true");
+    expect(target("button")).toHaveAttribute("aria-expanded", "false");
+    expect(target("icon")).toHaveClass("rotate-0");
+    expect(collapsed).toHaveBeenCalledOnce();
+  });
+
+  it("recognizes native hidden markup on connection", async () => {
+    await mount({ attributes: "hidden" });
+    expect(target("button")).toHaveAttribute("aria-expanded", "false");
+    expect(target("icon")).not.toHaveClass("rotate-180");
+    controller.toggle();
+    expect(target("item")).not.toHaveAttribute("hidden");
+  });
+
+  it("preserves opt-in focusability only while expanded without requiring an icon", async () => {
+    await mount({
+      attributes: 'class="hidden" data-collapsible-focusable',
+      icon: false,
+      id: 'data-id="fallback"',
+    });
+    expect(target("button")).toHaveAttribute("aria-controls", "fallback");
+    controller.toggle();
+    expect(target("item")).toHaveAttribute("tabindex", "0");
+    controller.toggle();
+    expect(target("item")).not.toHaveAttribute("tabindex");
+  });
+
+  it("initializes expanded sections and cancels the toggle event", async () => {
+    await mount({ attributes: "", id: "" });
+    expect(target("button")).toHaveAttribute("aria-expanded", "true");
+    expect(target("button")).toHaveAttribute("aria-controls", "");
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    const bubbled = vi.fn();
+    root.addEventListener("click", bubbled);
+    target("button").dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(bubbled).not.toHaveBeenCalled();
+  });
+  it("keeps the expanded icon state when the same section reconnects", async () => {
+    await mount({ attributes: "" });
+    root.remove();
+    await Promise.resolve();
+    await Promise.resolve();
+    document.body.append(root);
+    await Promise.resolve();
+    expect(target("button")).toHaveAttribute("aria-expanded", "true");
+    expect(target("icon")).toHaveClass("rotate-180");
+    controller.toggle();
+    expect(target("icon")).toHaveClass("rotate-0");
+  });
+
+  it.each(["item", "button"])(
+    "reports a missing required %s target",
+    async (missing) => {
+      const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await mount({ [missing]: false });
+      expect(warning).toHaveBeenCalledWith(
+        `⚠️ Collapsible controller missing ${missing} target`,
+      );
+      const stopped = stopApplication(application);
+      application = undefined;
+      await expect(stopped).rejects.toThrow();
+    },
+  );
+});

--- a/test/javascript/controllers/sidebar_item_controller.test.js
+++ b/test/javascript/controllers/sidebar_item_controller.test.js
@@ -1,0 +1,47 @@
+import { startApplication, stopApplication } from "../helpers/stimulus.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SidebarItemController from "../../../app/javascript/controllers/sidebar_item_controller.js";
+
+describe("sidebar item controller", () => {
+  let application;
+  async function mount(disabled = false) {
+    document.body.innerHTML = `<div data-controller="sidebar-item" ${disabled ? "data-disabled" : ""}><a href="#page" data-action="sidebar-item#onClick">Page</a></div>`;
+    application = startApplication();
+    application.register("sidebar-item", SidebarItemController);
+    await Promise.resolve();
+    return document.body.firstElementChild;
+  }
+  afterEach(async () => {
+    await stopApplication(application);
+  });
+
+  it.each([true, false])(
+    "cancels navigation and propagation only when disabled=%s",
+    async (disabled) => {
+      const root = await mount(disabled);
+      const bubbled = vi.fn();
+      root.addEventListener("click", bubbled);
+      const event = new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+      });
+      root.querySelector("a").dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(disabled);
+      expect(bubbled).toHaveBeenCalledTimes(disabled ? 0 : 1);
+    },
+  );
+
+  it("keeps the active class and current-page semantics in sync", async () => {
+    const root = await mount();
+    const controller = application.getControllerForElementAndIdentifier(
+      root,
+      "sidebar-item",
+    );
+    controller.setActive(true);
+    expect(root).toHaveClass("active");
+    expect(root).toHaveAttribute("aria-current", "page");
+    controller.setActive(false);
+    expect(root).not.toHaveClass("active");
+    expect(root).not.toHaveAttribute("aria-current");
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -59,6 +59,19 @@ export default defineConfig({
       ],
       // Ratchet allowlist: add a file/glob here once it reaches full coverage.
       thresholds: {
+        "app/javascript/controllers/collapsible_controller.js": {
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100,
+        },
+        "app/javascript/controllers/sidebar_item_controller.js": {
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100,
+        },
+
         "app/javascript/controllers/sortable_lists/v1/two_lists_selection_controller.js":
           {
             statements: 100,


### PR DESCRIPTION
## What does this PR do and why?

Add Stimulus behavior tests for collapsible sections and sidebar items, and enforce 100% statements, branches, functions and lines for both controllers. Fix the initial expanded state of sections using the native `hidden` attribute; previously they were announced as expanded even though they were hidden.

Tests cover button actions, ARIA state, optional icons, focusability, lifecycle reconnection, disabled navigation and active-page state. The native-hidden regression failed before the fix. Part of #2233; based directly on main after #2269.

## Screenshots or screen recordings

No visual redesign. The production change corrects initial ARIA and icon state for native-hidden sections. Validation in this PR is automated DOM testing; no browser screenshots were captured.

## How to set up and validate locally

1. Run `pnpm install --frozen-lockfile`.
2. Run `pnpm run test:js:coverage` — 319 tests pass with shuffled order, including 10 new tests. Both selected controllers meet all four 100% coverage thresholds.
3. Check the new mirrored controller tests under `test/javascript/controllers`.

Changed JavaScript passes ESLint and Prettier. Independent code review found no blockers. No Rails or real-browser tests were run for this branch.

## PR acceptance checklist

- [x] I have evaluated the [PR acceptance checklist](https://phac-nml.github.io/irida-next/docs/development/development_processes/code_review#acceptance-checklist) for this PR.
